### PR TITLE
feature(colors): docs on font/background/fill colors

### DIFF
--- a/src/app/components/style-guide/colors/colors.component.html
+++ b/src/app/components/style-guide/colors/colors.component.html
@@ -234,6 +234,67 @@
   </md-card-content>
 </md-card>
 <md-card>
+  <md-card-title>CSS Background Colors</md-card-title>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p>To manually color a background, use our simple bgc utility class:</p>
+    <td-highlight lang="html">
+      <![CDATA[
+        <div class="bgc-green-700">green background</div>
+      ]]>
+    </td-highlight>
+    <p>choose from any of the material colors, in hues from 50, 100, 200, 300, 400, 500, 600, 700, 800, 900 (and A100, A200, A400, A700 for all except brown, grey &amp; blue-grey)</p>
+    <div layout-gt-sm="row" layout-wrap>
+      <div flex-gt-sm="20" *ngFor="let color of colors">
+        <md-card>
+          <div class="md-caption pad-xs">class="bgc-{{color}}-"</div>
+          <div class="tc-grey-800">
+            <div class="bgc-{{color}}-50 pad-xs">50</div>
+            <div class="bgc-{{color}}-100 pad-xs">100</div>
+            <div class="bgc-{{color}}-200 pad-xs">200</div>
+            <div class="bgc-{{color}}-300 pad-xs">300</div>
+          </div>
+          <div class="tc-{{color}}-50">
+            <div class="bgc-{{color}}-400 pad-xs">400</div>
+            <div class="bgc-{{color}}-500 pad-xs">500</div>
+            <div class="bgc-{{color}}-600 pad-xs">600</div>
+            <div class="bgc-{{color}}-700 pad-xs">700</div>
+            <div class="bgc-{{color}}-800 pad-xs">800</div>
+            <div class="bgc-{{color}}-900 pad-xs">900</div>
+          </div>
+          <div class="tc-grey-800">
+            <div class="bgc-{{color}}-A100 pad-xs">A100</div>
+          </div>
+          <div class="tc-{{color}}-50">
+            <div class="bgc-{{color}}-A200 pad-xs">A200</div>
+            <div class="bgc-{{color}}-A400 pad-xs">A400</div>
+            <div class="bgc-{{color}}-A700 pad-xs">A700</div>
+          </div>
+        </md-card>
+      </div>
+      <div flex-gt-sm="20" *ngFor="let color of neutrals">
+        <md-card>
+          <div class="md-caption pad-xs">class="bgc-{{color}}-"</div>
+          <div class="tc-grey-800">
+            <div class="bgc-{{color}}-50 pad-xs">50</div>
+            <div class="bgc-{{color}}-100 pad-xs">100</div>
+            <div class="bgc-{{color}}-200 pad-xs">200</div>
+            <div class="bgc-{{color}}-300 pad-xs">300</div>
+          </div>
+          <div class="tc-{{color}}-50">
+            <div class="bgc-{{color}}-400 pad-xs">400</div>
+            <div class="bgc-{{color}}-500 pad-xs">500</div>
+            <div class="bgc-{{color}}-600 pad-xs">600</div>
+            <div class="bgc-{{color}}-700 pad-xs">700</div>
+            <div class="bgc-{{color}}-800 pad-xs">800</div>
+            <div class="bgc-{{color}}-900 pad-xs">900</div>
+          </div>
+        </md-card>
+      </div>
+    </div>
+  </md-card-content>
+</md-card>
+<md-card>
   <md-card-title>Material Design Color Resources</md-card-title>
   <md-divider></md-divider>
   <md-nav-list>

--- a/src/app/components/style-guide/colors/colors.component.ts
+++ b/src/app/components/style-guide/colors/colors.component.ts
@@ -7,6 +7,8 @@ import { MdToolbar } from '@angular2-material/toolbar';
 import { MD_LIST_DIRECTIVES } from '@angular2-material/list';
 import { MD_GRID_LIST_DIRECTIVES } from '@angular2-material/grid-list';
 
+import { TdHighlightComponent } from '../../../../platform/highlight';
+
 @Component({
   directives: [
     MdButton,
@@ -16,6 +18,7 @@ import { MD_GRID_LIST_DIRECTIVES } from '@angular2-material/grid-list';
     MdToolbar,
     MD_LIST_DIRECTIVES,
     MD_GRID_LIST_DIRECTIVES,
+    TdHighlightComponent,
   ],
   moduleId: module.id,
   selector: 'td-style-guide-colors',
@@ -23,5 +26,27 @@ import { MD_GRID_LIST_DIRECTIVES } from '@angular2-material/grid-list';
   templateUrl: 'colors.component.html',
 })
 export class ColorsComponent {
-
+  colors: string[] = [
+    'red',
+    'pink',
+    'purple',
+    'deep-purple',
+    'indigo',
+    'blue',
+    'light-blue',
+    'cyan',
+    'teal',
+    'green',
+    'light-green',
+    'lime',
+    'yellow',
+    'amber',
+    'orange',
+    'deep-orange'
+  ]
+  neutrals: string[] = [
+    'brown',
+    'grey',
+    'blue-grey'
+  ]
 }

--- a/src/app/components/style-guide/colors/colors.component.ts
+++ b/src/app/components/style-guide/colors/colors.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { MdButton, MdAnchor } from '@angular2-material/button';
+import { MD_BUTTON_DIRECTIVES } from '@angular2-material/button';
 import { MD_CARD_DIRECTIVES } from '@angular2-material/card';
 import { MdIcon } from '@angular2-material/icon';
 import { MdToolbar } from '@angular2-material/toolbar';
@@ -11,8 +11,7 @@ import { TdHighlightComponent } from '../../../../platform/highlight';
 
 @Component({
   directives: [
-    MdButton,
-    MdAnchor,
+    MD_BUTTON_DIRECTIVES,
     MD_CARD_DIRECTIVES,
     MdIcon,
     MdToolbar,
@@ -42,11 +41,11 @@ export class ColorsComponent {
     'yellow',
     'amber',
     'orange',
-    'deep-orange'
-  ]
+    'deep-orange',
+  ];
   neutrals: string[] = [
     'brown',
     'grey',
-    'blue-grey'
-  ]
+    'blue-grey',
+  ];
 }

--- a/src/app/components/style-guide/iconography/iconography.component.html
+++ b/src/app/components/style-guide/iconography/iconography.component.html
@@ -41,7 +41,7 @@
         <md-icon class="tc-green-700">palette</md-icon>
 
         /* this will be  green filled SVG icon */
-        <md-icon  class="fill-green-700" svgIcon="/path/to/palette.svg"></md-icon>
+        <md-icon class="fill-green-700" svgIcon="/path/to/palette.svg"></md-icon>
       ]]>
     </td-highlight>
     <p>choose from any of the material colors, in hues from 50, 100, 200, 300, 400, 500, 600, 700, 800, 900 (and A100, A200, A400, A700 for all except brown, grey &amp; blue-grey)</p>

--- a/src/app/components/style-guide/iconography/iconography.component.html
+++ b/src/app/components/style-guide/iconography/iconography.component.html
@@ -30,7 +30,71 @@
     </a>
   </md-card-actions>
 </md-card>
+<md-card>
+  <md-card-title>CSS Icon (Font or SVG) Colors</md-card-title>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p>To manually color a fill or font color (depending if you're using a font icon or SVV icon), use our simple tc utility class:</p>
+    <td-highlight lang="html">
+      <![CDATA[
+        /* this will be  green font icon */
+        <md-icon class="tc-green-700">palette</md-icon>
 
+        /* this will be  green filled SVG icon */
+        <md-icon  class="fill-green-700" svgIcon="/path/to/palette.svg"></md-icon>
+      ]]>
+    </td-highlight>
+    <p>choose from any of the material colors, in hues from 50, 100, 200, 300, 400, 500, 600, 700, 800, 900 (and A100, A200, A400, A700 for all except brown, grey &amp; blue-grey)</p>
+    <div layout-gt-sm="row" layout-wrap>
+      <div flex-gt-sm="20" *ngFor="let color of colors">
+        <md-card>
+          <div class="md-caption pad-xs">class="tc-{{color}}-"</div>
+          <div class="bgc-{{color}}-50">
+            <md-icon><span class="tc-{{color}}-50">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-100">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-200">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-300">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-400">palette</span></md-icon>
+          </div>
+          <div class="bgc-{{color}}-50">
+            <md-icon><span class="tc-{{color}}-500">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-600">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-700">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-800">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-900">palette</span></md-icon>
+          </div>
+          <div class="bgc-{{color}}-50">
+            <md-icon><span class="tc-{{color}}-A100">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-A200">palette</span></md-icon>
+          </div>
+          <div class="bgc-{{color}}-50">
+            <md-icon><span class="tc-{{color}}-A400">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-A700">palette</span></md-icon>
+          </div>
+        </md-card>
+      </div>
+      <div flex-gt-sm="20" *ngFor="let color of neutrals">
+        <md-card>
+          <div class="md-caption pad-xs">class="tc-{{color}}-"</div>
+          <div class="bgc-{{color}}-50">
+            <md-icon><span class="tc-{{color}}-50">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-100">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-200">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-300">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-400">palette</span></md-icon>
+          </div>
+          <div class="bgc-{{color}}-50">
+            <md-icon><span class="tc-{{color}}-500">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-600">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-700">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-800">palette</span></md-icon>
+            <md-icon><span class="tc-{{color}}-900">palette</span></md-icon>
+          </div>
+        </md-card>
+      </div>
+    </div>
+  </md-card-content>
+</md-card>
 <md-card>
   <md-card-title>Search Icons</md-card-title>
   <md-card-subtitle>Current icons bundled with platform</md-card-subtitle>

--- a/src/app/components/style-guide/iconography/iconography.component.ts
+++ b/src/app/components/style-guide/iconography/iconography.component.ts
@@ -1,16 +1,16 @@
 import { Component, OnInit } from '@angular/core';
 
-import { MdAnchor } from '@angular2-material/button';
+import { MD_BUTTON_DIRECTIVES } from '@angular2-material/button';
 import { MD_CARD_DIRECTIVES } from '@angular2-material/card';
-import { MdIcon } from '@angular2-material/icon';
 import { MD_INPUT_DIRECTIVES } from '@angular2-material/input';
+import { MdIcon } from '@angular2-material/icon';
 
 import { TdHighlightComponent } from '../../../../platform/highlight';
 import { TdOrderByPipe } from '../../../../platform/core';
 
 @Component({
   directives: [
-    MdAnchor,
+    MD_BUTTON_DIRECTIVES,
     MD_CARD_DIRECTIVES,
     MD_INPUT_DIRECTIVES,
     MdIcon,
@@ -39,13 +39,13 @@ export class IconographyComponent implements OnInit {
     'yellow',
     'amber',
     'orange',
-    'deep-orange'
-  ]
+    'deep-orange',
+  ];
   neutrals: string[] = [
     'brown',
     'grey',
-    'blue-grey'
-  ]
+    'blue-grey',
+  ];
   /* TODO: Add service pulling in these icon names */
   icons: string[] = [
     'access_alarm',
@@ -837,11 +837,4 @@ export class IconographyComponent implements OnInit {
       return el.toLowerCase().indexOf(this.query.toLowerCase()) > -1;
     }.bind(this));
   }
-
-  // TODO: Add secondary action for single icon after selected
-  // select(item){
-  //   this.query = item;
-  //   this.filteredList = [];
-  // }
-
 }

--- a/src/app/components/style-guide/iconography/iconography.component.ts
+++ b/src/app/components/style-guide/iconography/iconography.component.ts
@@ -23,7 +23,29 @@ import { TdOrderByPipe } from '../../../../platform/core';
   templateUrl: 'iconography.component.html',
 })
 export class IconographyComponent implements OnInit {
-
+  colors: string[] = [
+    'red',
+    'pink',
+    'purple',
+    'deep-purple',
+    'indigo',
+    'blue',
+    'light-blue',
+    'cyan',
+    'teal',
+    'green',
+    'light-green',
+    'lime',
+    'yellow',
+    'amber',
+    'orange',
+    'deep-orange'
+  ]
+  neutrals: string[] = [
+    'brown',
+    'grey',
+    'blue-grey'
+  ]
   /* TODO: Add service pulling in these icon names */
   icons: string[] = [
     'access_alarm',

--- a/src/app/components/style-guide/product-icons/product-icons.component.html
+++ b/src/app/components/style-guide/product-icons/product-icons.component.html
@@ -28,6 +28,8 @@
     <td-highlight lang="html">
       <![CDATA[
         <md-icon svgSrc="app/assets/icons/appcenter.svg"></md-icon>
+        /* to color an SVG icon use our utility material color fill class */
+        <md-icon svgSrc="app/assets/icons/appcenter.svg" class="fill-teal-700"></md-icon>
       ]]>
     </td-highlight>
   </md-card-content>

--- a/src/app/components/style-guide/typography/typography.component.html
+++ b/src/app/components/style-guide/typography/typography.component.html
@@ -5,7 +5,7 @@
   </md-card-header>
   <md-divider></md-divider>
   <md-card-content>
-    <p class="md-body-1"><a ng-href="/styleguide/material-design">Angular Material</a> provides typography CSS classes you can use to create visual consistency across your application.</p>
+    <p class="md-body-1">Angular Material provides typography CSS classes you can use to create visual consistency across your application.</p>
     <p class="md-body-1">
       <strong>Note:</strong> 
       <span>Base font size is 10px for easy rem units (1.2rem = 12px). Body font size is 14px. sp = scalable pixels.</span>
@@ -60,16 +60,22 @@
        </div>
       <md-divider></md-divider>
     </div>
-    <p class="md-body-1"><a ng-href="/styleguide/material-design">Angular Material</a> provides typography CSS classes you can use to create visual consistency across your application. Angular Material provides typography CSS classes you can use to create visual consistency across your application.</p>
+    <h3 class="md-title">Usage</h3>
+    <td-highlight lang="html"> 
+    <![CDATA[
+      <!-- Large Heading -->
+      <h1 class="md-display-4">Roboto is the standard typeface on Android.</h1>
+      <h2 class="md-display-3">Roboto and Noto are the standard typefaces on Android and Chrome.</h2>
+      <h3 class="md-display-2">Noto is the standard typeface for all languages on Chrome and Android for all languages not covered by Roboto.</h3>
+      <!-- Medium Heading -->
+      <h1 class="md-display-1">Roboto is the standard typeface on Android.</h1>
+      <h2 class="md-headline">Roboto and Noto are the standard typefaces on Android and Chrome.</h2>
+      <h3 class="md-subhead">Noto is the standard typeface for all languages on Chrome and Android for all languages not covered by Roboto.</h3>
+    ]]>
+    </td-highlight>
   </md-card-content>
-  <md-divider></md-divider>
-  <md-card-actions>
-    <a md-button color="primary" href="http://www.google.com/design/spec/style/typography.html" target="_blank">
-    More on Material Design Typography
-    </a>
-  </md-card-actions>
 </md-card>
-<md-card class="push-bottom block">
+<md-card>
   <md-card-title>Body Copy</md-card-title>
   <md-divider></md-divider>
   <md-card-content>
@@ -95,28 +101,9 @@
       </div>
       <md-divider></md-divider>
     </div>
-  </md-card-content>
-  <md-divider></md-divider>
-  <md-card-actions>
-    <a md-button color="primary" href="http://www.google.com/design/spec/style/typography.html" target="_blank">
-      More on Material Design Typography
-    </a>
-  </md-card-actions>
-</md-card>
-<md-card>
-  <md-card-title id="examples">Examples</md-card-title>
-  <md-divider></md-divider>
-  <md-card-content>
+    <h3 class="md-title">Usage</h3>
     <td-highlight lang="html"> 
     <![CDATA[
-      <!-- Large Heading -->
-      <h1 class="md-display-4">Roboto is the standard typeface on Android.</h1>
-      <h2 class="md-display-3">Roboto and Noto are the standard typefaces on Android and Chrome.</h2>
-      <h3 class="md-display-2">Noto is the standard typeface for all languages on Chrome and Android for all languages not covered by Roboto.</h3>
-      <!-- Medium Heading -->
-      <h1 class="md-display-1">Roboto is the standard typeface on Android.</h1>
-      <h2 class="md-headline">Roboto and Noto are the standard typefaces on Android and Chrome.</h2>
-      <h3 class="md-subhead">Noto is the standard typeface for all languages on Chrome and Android for all languages not covered by Roboto.</h3>
       <!-- body copy -->
       <p class="md-body-1">Roboto is the standard typeface on Android.</p>
       <p class="md-body-2">Roboto and Noto are the standard typefaces on Android and Chrome.</p>

--- a/src/app/components/style-guide/typography/typography.component.html
+++ b/src/app/components/style-guide/typography/typography.component.html
@@ -9,7 +9,6 @@
     <p class="md-body-1">
       <strong>Note:</strong> 
       <span>Base font size is 10px for easy rem units (1.2rem = 12px). Body font size is 14px. sp = scalable pixels.</span>
-        
       </p>
   </md-card-content>
   <md-divider></md-divider>
@@ -19,62 +18,49 @@
     </a>
   </md-card-actions>
 </md-card>
-
 <md-card>
   <md-card-title>Header Styles</md-card-title>
   <md-divider></md-divider>
   <md-card-content>
-
     <p class="md-body-1">To preserve semantic structures, you can optionally style the <code>&lt;h1&gt;</code> - <code>&lt;h6&gt;</code> heading tags with the styling classes shown below:</p>
-
     <div layout-align="center end">
-
       <div layout="row" layout-align="start center">
         <code flex="15">.md-display-4</code>
         <span class="md-display-4">Light 112px</span>
       </div>
       <md-divider></md-divider>
-
       <div layout="row" layout-align="start center">
         <code flex="15">.md-display-3</code>
         <span class="md-display-3">Regular 56px</span>
       </div>
       <md-divider></md-divider>
-
       <div layout="row" layout-align="start center">
         <code flex="15">.md-display-2</code>
          <span class="md-display-2">Regular 45px</span>
        </div>
       <md-divider></md-divider>
-
       <div layout="row" layout-align="start center">
         <code flex="15">.md-display-1</code>
          <span class="md-display-1">Regular 34px</span>
        </div>
       <md-divider></md-divider>
-
       <div layout="row" layout-align="start center">
         <code flex="15">.md-headline</code>
          <span class="md-headline">Regular 24px</span>
        </div>
       <md-divider></md-divider>
-
       <div layout="row" layout-align="start center">
         <code flex="15">.md-title</code>
          <span class="md-title">Medium 20px</span>
        </div>
       <md-divider></md-divider>
-
       <div layout="row" layout-align="start center">
         <code flex="15">.md-subhead</code>
          <span class="md-subhead">Regular 16px</span>
        </div>
       <md-divider></md-divider>
-
     </div>
-
     <p class="md-body-1"><a ng-href="/styleguide/material-design">Angular Material</a> provides typography CSS classes you can use to create visual consistency across your application. Angular Material provides typography CSS classes you can use to create visual consistency across your application.</p>
-
   </md-card-content>
   <md-divider></md-divider>
   <md-card-actions>
@@ -83,40 +69,32 @@
     </a>
   </md-card-actions>
 </md-card>
-
 <md-card class="push-bottom block">
   <md-card-title>Body Copy</md-card-title>
   <md-divider></md-divider>
   <md-card-content>
-
     <div layout-align="center end">
-
       <div layout="row" layout-align="start center">
         <code flex="15">.md-body-1</code>
         <span class="md-body-1">Regular 14px</span>
       </div>
       <md-divider></md-divider>
-
       <div layout="row" layout-align="start center">
         <code flex="15">.md-body-2</code>
         <span class="md-body-2">Medium 14px</span>
       </div>
       <md-divider></md-divider>
-
       <div layout="row" layout-align="start center">
         <code flex="15">.md-button</code>
         <span class="md-button md-raised">Medium 14px</span>
       </div>
       <md-divider></md-divider>
-
       <div layout="row" layout-align="start center">
         <code flex="15">.md-caption</code>
         <span class="md-caption">Regular 12px</span>
       </div>
       <md-divider></md-divider>
-
     </div>
-
   </md-card-content>
   <md-divider></md-divider>
   <md-card-actions>
@@ -124,9 +102,7 @@
       More on Material Design Typography
     </a>
   </md-card-actions>
-
 </md-card>
-
 <md-card>
   <md-card-title id="examples">Examples</md-card-title>
   <md-divider></md-divider>
@@ -148,5 +124,66 @@
       <p class="md-caption">Noto is the standard typeface for all languages on Chrome and Android for all languages not covered by Roboto.</p>
     ]]>
     </td-highlight>
+  </md-card-content>
+</md-card>
+<md-card>
+  <md-card-title>CSS Font Colors</md-card-title>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p>To manually color a font color, use our simple tc utility class:</p>
+    <td-highlight lang="html">
+      <![CDATA[
+        <div class="tc-green-700">green font</div>
+      ]]>
+    </td-highlight>
+    <p>choose from any of the material colors, in hues from 50, 100, 200, 300, 400, 500, 600, 700, 800, 900 (and A100, A200, A400, A700 for all except brown, grey &amp; blue-grey)</p>
+    <div layout-gt-sm="row" layout-wrap>
+      <div flex-gt-sm="20" *ngFor="let color of colors">
+        <md-card>
+          <div class="md-caption pad-xs">class="tc-{{color}}-"</div>
+          <div class="bgc-grey-800">
+            <div class="tc-{{color}}-50 pad-xs">50</div>
+            <div class="tc-{{color}}-100 pad-xs">100</div>
+            <div class="tc-{{color}}-200 pad-xs">200</div>
+            <div class="tc-{{color}}-300 pad-xs">300</div>
+            <div class="tc-{{color}}-400 pad-xs">400</div>
+          </div>
+          <div class="bgc-{{color}}-50">
+            <div class="tc-{{color}}-500 pad-xs">500</div>
+            <div class="tc-{{color}}-600 pad-xs">600</div>
+            <div class="tc-{{color}}-700 pad-xs">700</div>
+            <div class="tc-{{color}}-800 pad-xs">800</div>
+            <div class="tc-{{color}}-900 pad-xs">900</div>
+          </div>
+          <div class="bgc-grey-800">
+            <div class="tc-{{color}}-A100 pad-xs">A100</div>
+            <div class="tc-{{color}}-A200 pad-xs">A200</div>
+          </div>
+          <div class="bgc-{{color}}-50">
+            <div class="tc-{{color}}-A400 pad-xs">A400</div>
+            <div class="tc-{{color}}-A700 pad-xs">A700</div>
+          </div>
+        </md-card>
+      </div>
+      <div flex-gt-sm="20" *ngFor="let color of neutrals">
+        <md-card>
+          <div class="md-caption pad-xs">class="tc-{{color}}-"</div>
+          <div class="bgc-grey-800">
+            <div class="tc-{{color}}-50 pad-xs">50</div>
+            <div class="tc-{{color}}-100 pad-xs">100</div>
+            <div class="tc-{{color}}-200 pad-xs">200</div>
+            <div class="tc-{{color}}-300 pad-xs">300</div>
+            <div class="tc-{{color}}-400 pad-xs">400</div>
+          </div>
+          <div class="bgc-{{color}}-50">
+            <div class="tc-{{color}}-500 pad-xs">500</div>
+            <div class="tc-{{color}}-600 pad-xs">600</div>
+            <div class="tc-{{color}}-700 pad-xs">700</div>
+            <div class="tc-{{color}}-800 pad-xs">800</div>
+            <div class="tc-{{color}}-900 pad-xs">900</div>
+          </div>
+        </md-card>
+      </div>
+    </div>
   </md-card-content>
 </md-card>

--- a/src/app/components/style-guide/typography/typography.component.ts
+++ b/src/app/components/style-guide/typography/typography.component.ts
@@ -19,5 +19,27 @@ import { TdHighlightComponent } from '../../../../platform/highlight';
   templateUrl: 'typography.component.html',
 })
 export class TypographyComponent {
-
+  colors: string[] = [
+    'red',
+    'pink',
+    'purple',
+    'deep-purple',
+    'indigo',
+    'blue',
+    'light-blue',
+    'cyan',
+    'teal',
+    'green',
+    'light-green',
+    'lime',
+    'yellow',
+    'amber',
+    'orange',
+    'deep-orange'
+  ]
+  neutrals: string[] = [
+    'brown',
+    'grey',
+    'blue-grey'
+  ]
 }

--- a/src/app/components/style-guide/typography/typography.component.ts
+++ b/src/app/components/style-guide/typography/typography.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { MdAnchor } from '@angular2-material/button';
+import { MD_BUTTON_DIRECTIVES } from '@angular2-material/button';
 import { MD_CARD_DIRECTIVES } from '@angular2-material/card';
 import { MdIcon } from '@angular2-material/icon';
 
@@ -8,7 +8,7 @@ import { TdHighlightComponent } from '../../../../platform/highlight';
 
 @Component({
   directives: [
-    MdAnchor,
+    MD_BUTTON_DIRECTIVES,
     MD_CARD_DIRECTIVES,
     MdIcon,
     TdHighlightComponent,
@@ -35,11 +35,11 @@ export class TypographyComponent {
     'yellow',
     'amber',
     'orange',
-    'deep-orange'
-  ]
+    'deep-orange',
+  ];
   neutrals: string[] = [
     'brown',
     'grey',
-    'blue-grey'
-  ]
+    'blue-grey',
+  ];
 }


### PR DESCRIPTION
## Description

Added docs to use our various material color utility styles

### What's included?

- Background color docs
- Typography color docs
- Iconography color docs

#### Test Steps

- [x] view > Style Guide > Colors
- [x] view > Style Guide > Typography
- [x] view > Style Guide > Iconography
- [x] view > Style Guide > Product Icons

##### Screenshots or link to CodePen/Plunker/JSfiddle

![image](https://cloud.githubusercontent.com/assets/867883/16820287/ecec1232-4915-11e6-9046-c4b3402b2f1a.png)

![image](https://cloud.githubusercontent.com/assets/867883/16820289/eff39af4-4915-11e6-820d-a2563acd0127.png)

![image](https://cloud.githubusercontent.com/assets/867883/16820294/f27eaf34-4915-11e6-84d7-04314b55320b.png)

