### PR TITLE
Feature/td media

### DIFF
--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -55,10 +55,10 @@ export class ComponentsComponent {
     route: 'markdown',
     title: 'Markdown',
   }, {
-    description: 'Check media query for responsive apps.',
+    description: 'Responsive service & directive',
     icon: 'devices',
     route: 'media',
-    title: 'Media',
+    title: 'Media Queries',
   }, {
     description: 'Custom Angular pipes (filters)',
     icon: 'filter_list',

--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -55,6 +55,11 @@ export class ComponentsComponent {
     route: 'markdown',
     title: 'Markdown',
   }, {
+    description: 'Check media query for responsive apps.',
+    icon: 'devices',
+    route: 'media',
+    title: 'Media',
+  }, {
     description: 'Custom Angular pipes (filters)',
     icon: 'filter_list',
     route: 'pipes',

--- a/src/app/components/components/components.routes.ts
+++ b/src/app/components/components/components.routes.ts
@@ -8,6 +8,7 @@ import { ExpansionPanelDemoComponent } from './expansion-panel';
 import { FileUploadDemoComponent } from './file-upload';
 import { LoadingDemoComponent } from './loading';
 import { MarkdownDemoComponent } from './markdown';
+import { MediaDemoComponent } from './media';
 import { PipesComponent } from './pipes';
 
 export const componentsRoutes: RouterConfig = [{
@@ -32,6 +33,9 @@ export const componentsRoutes: RouterConfig = [{
     }, {
       component: MarkdownDemoComponent,
       path: 'markdown',
+    }, {
+      component: MediaDemoComponent,
+      path: 'media',
     }, {
       component: PipesComponent,
       path: 'pipes',

--- a/src/app/components/components/media/index.ts
+++ b/src/app/components/components/media/index.ts
@@ -1,0 +1,1 @@
+export { MediaDemoComponent } from './media.component';

--- a/src/app/components/components/media/media.component.html
+++ b/src/app/components/components/media/media.component.html
@@ -1,6 +1,6 @@
 <md-card>
-  <md-card-title>Media</md-card-title>
-  <md-card-subtitle>Check media query for responsive apps</md-card-subtitle>
+  <md-card-title>Media Queries</md-card-title>
+  <md-card-subtitle>Responsive service & directive (for attributes)</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
     <p>Media Queries:</p>

--- a/src/app/components/components/media/media.component.html
+++ b/src/app/components/components/media/media.component.html
@@ -1,0 +1,134 @@
+<md-card>
+  <md-card-title>Media</md-card-title>
+  <md-card-subtitle>Check media query for responsive apps</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p>Media Queries:</p>
+    <md-list>
+      <template let-demo let-last="demo" ngFor [ngForOf]="mediaDemo">
+        <a md-list-item layout-align="row">
+          <h3 [tdMediaToggle]="demo.query" [mediaStyles]="{color: 'red'}" [mediaAttributes]="{title: 'It matches!!!'}" md-line> {{demo.query}}</h3>
+          <p md-line> matches: {{demo.value}} </p>
+        </a>
+        <md-divider *ngIf="!last"></md-divider>
+      </template>
+    </md-list>    
+  </md-card-content>
+</md-card>
+<md-card>
+  <md-card-title>TdMediaService</md-card-title>
+  <md-card-subtitle>How to use this service</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <h2><code>TdMediaService</code></h2>
+    <p>This service is designed to provide basic media query evaluation for responsive applications.</p>
+    <p>It has pre-programmed support for media queries that match the layout 
+      <a href="https://material.google.com/layout/responsive-ui.html" target="_blank">breakpoints</a>:
+    </p>
+    <md-list>
+      <template let-bpoint let-last="bpoint" ngFor [ngForOf]="mediaBreakpoints">
+        <a md-list-item layout-align="row">
+          <h3 md-line> {{bpoint.breakpoint}}</h3>
+          <p md-line> {{bpoint.query}} </p>
+        </a>
+        <md-divider *ngIf="!last"></md-divider>
+      </template>
+    </md-list>
+    <h3>Methods:</h3>
+    <p>The <code>TdMediaService</code> service has {{mediaServiceMethods.length}} properties:</p>
+    <md-list>
+      <template let-attr let-last="attr" ngFor [ngForOf]="mediaServiceMethods">
+        <a md-list-item layout-align="row">
+          <h3 md-line> {{attr.name}}: <span>{{attr.type}}</span></h3>
+          <p md-line> {{attr.description}} </p>
+        </a>
+        <md-divider *ngIf="!last"></md-divider>
+      </template>
+    </md-list>
+    <h3>Example:</h3>
+    <p>Typescript:</p>
+    <td-highlight lang="typescript">
+      <![CDATA[
+        import { Component, NgZone, OnInit, OnDestroy } from '@angular/core';
+        import { TdMediaService } from '@covalent/core';
+        import { Subscription } from 'rxjs/Subscription';
+        ...
+          providers: [ TdMediaService ]
+        })
+        export class Demo implements OnInit, OnDestroy {
+          isSmallScreen: boolean = false;
+          private _querySubscription: Subscription;
+
+          constructor(private _mediaService: TdMediaService, private _ngZone: NgZone) { 
+          }
+
+          checkScreen(): void {
+            this._ngZone.run(() => {
+              this.isSmallScreen = this._mediaService.query('sm'); // or '(min-width: 960px) and (max-width: 1279px)'
+            });
+          }
+
+          watchScreen(): void {
+            this._querySubscription = this._mediaService.registerQuery('sm').subscribe((matches: boolean) => {
+              this._ngZone.run(() => {
+                this.isSmallScreen = matches;
+              });
+            });
+          }
+
+          ngOnInit(): void {
+            this.watchScreen();
+          }
+
+          ngOnDestroy(): void {
+            this._querySubscription.unsubscribe();
+          }
+        }
+      ]]>
+    </td-highlight>
+    <p>Note: Always unsubscribe from [Observable] objects when not using them anymore.</p>
+    <p>A good way of doing it is in the <code>ngOnDestroy</code> component life-cycle hook provided by the [OnDestroy] interface.</p>
+  </md-card-content>
+</md-card>
+<md-card>
+  <md-card-title>TdMediaToggleDirective</md-card-title>
+  <md-card-subtitle>How to use this directive</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <h2><code>tdMediaToggle</code></h2>
+    <p>Simply add the <code>tdMediaToggle</code> attibute with a "media query" value to the element you want to modify depending on screen size.</p>
+    <h3>Properties:</h3>
+    <p>The <code>tdMediaToggle</code> directive has {{mediaAttrs.length}} properties:</p>
+    <md-list>
+      <template let-attr let-last="attr" ngFor [ngForOf]="mediaAttrs">
+        <a md-list-item layout-align="row">
+          <h3 md-line> {{attr.name}}: <span>{{attr.type}}</span></h3>
+          <p md-line> {{attr.description}} </p>
+        </a>
+        <md-divider *ngIf="!last"></md-divider>
+      </template>
+    </md-list>
+    <h3>Example:</h3>
+    <p>HTML:</p>
+    <td-highlight lang="html">
+      <![CDATA[
+        <div tdMediaToggle="sm" [mediaClasses]="['classOne', 'classTwo']" 
+          [mediaAttributes]="{title: 'tooltip'}" [mediaStyles]="{color: 'red'}">
+          ...
+        </div>
+      ]]>
+    </td-highlight>
+    <p>Typescript:</p>
+    <td-highlight lang="typescript">
+      <![CDATA[
+        import { TdMediaToggleDirective, TdMediaService } from '@covalent/core';
+        ...
+          directives: [ TdMediaToggleDirective ],
+          providers: [ TdMediaService ]
+        })
+        export class Demo {
+        }
+      ]]>
+    </td-highlight>
+  </md-card-content>
+ </md-card>

--- a/src/app/components/components/media/media.component.spec.ts
+++ b/src/app/components/components/media/media.component.spec.ts
@@ -1,0 +1,49 @@
+import {
+  beforeEach,
+  addProviders,
+  describe,
+  expect,
+  it,
+  inject,
+} from '@angular/core/testing';
+import { ComponentFixture, TestComponentBuilder } from '@angular/compiler/testing';
+import { Component, DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { MediaDemoComponent } from './media.component';
+
+describe('Component: MediaDemo', () => {
+  let builder: TestComponentBuilder;
+
+  beforeEach(() => {
+    addProviders([
+      MediaDemoComponent,
+    ]);
+  });
+
+  beforeEach(inject([TestComponentBuilder], function (tcb: TestComponentBuilder): void {
+    builder = tcb;
+  }));
+
+  it('should inject the component', inject([MediaDemoComponent], (component: MediaDemoComponent) => {
+    expect(component).toBeTruthy();
+  }));
+
+  it('should create the component', inject([], () => {
+    return builder.createAsync(MediaDemoTestControllerComponent)
+      .then((fixture: ComponentFixture<any>) => {
+        let query: DebugElement = fixture.debugElement.query(By.directive(MediaDemoComponent));
+        expect(query).toBeTruthy();
+        expect(query.componentInstance).toBeTruthy();
+      });
+  }));
+});
+
+@Component({
+  directives: [MediaDemoComponent],
+  selector: 'td-test',
+  template: `
+    <td-media-demo></td-media-demo>
+  `,
+})
+class MediaDemoTestControllerComponent {
+}

--- a/src/app/components/components/media/media.component.spec.ts
+++ b/src/app/components/components/media/media.component.spec.ts
@@ -10,6 +10,7 @@ import { ComponentFixture, TestComponentBuilder } from '@angular/compiler/testin
 import { Component, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { MediaDemoComponent } from './media.component';
+import { TdMediaService } from '../../../../platform/core';
 
 describe('Component: MediaDemo', () => {
   let builder: TestComponentBuilder;
@@ -17,6 +18,7 @@ describe('Component: MediaDemo', () => {
   beforeEach(() => {
     addProviders([
       MediaDemoComponent,
+      TdMediaService,
     ]);
   });
 

--- a/src/app/components/components/media/media.component.ts
+++ b/src/app/components/components/media/media.component.ts
@@ -1,0 +1,164 @@
+import { Component, OnInit, NgZone, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
+
+import { MD_CARD_DIRECTIVES } from '@angular2-material/card';
+import { MD_LIST_DIRECTIVES } from '@angular2-material/list';
+import { MdButton } from '@angular2-material/button';
+import { MD_INPUT_DIRECTIVES } from '@angular2-material/input';
+
+import { TdMediaToggleDirective, TdMediaService } from '../../../../platform/core';
+import { TdHighlightComponent } from '../../../../platform/highlight';
+
+@Component({
+  directives: [
+    MD_CARD_DIRECTIVES,
+    MD_LIST_DIRECTIVES,
+    MdButton,
+    MD_INPUT_DIRECTIVES,
+    TdMediaToggleDirective,
+    TdHighlightComponent,
+  ],
+  moduleId: module.id,
+  selector: 'td-media-demo',
+  styleUrls: [ 'media.component.css' ],
+  templateUrl: 'media.component.html',
+})
+export class MediaDemoComponent implements OnInit, OnDestroy {
+
+  private _subcriptions: Subscription[] = [];
+
+  mediaDemo: any[] = [{
+    query: 'xs',
+    value: false,
+  }, {
+    query: 'gt-xs',
+    value: false,
+  }, {
+    query: 'sm',
+    value: false,
+  }, {
+    query: 'gt-sm',
+    value: false,
+  }, {
+    query: 'md',
+    value: false,
+  }, {
+    query: 'gt-gm',
+    value: false,
+  }, {
+    query: 'lg',
+    value: false,
+  }, {
+    query: 'gt-lg',
+    value: false,
+  }, {
+    query: 'xl',
+    value: false,
+  }, {
+    query: 'landscape',
+    value: false,
+  }, {
+    query: 'portrait',
+    value: false,
+  }, {
+    query: 'print',
+    value: false,
+  }, {
+    query: '(max-width: 800px)',
+    value: false,
+  }, {
+    query: '(min-width: 700px)',
+    value: false,
+  }];
+
+  mediaServiceMethods: Object[] = [{
+    description: `Used to evaluate whether a given media query is true or false given the 
+                  current device's screen / window size.`,
+    name: 'query',
+    type: 'function(query: string)',
+  }, {
+    description: `Registers a media query and returns an [Observable] that will re-evaluate and 
+                  return if the given media query matches on window resize.`,
+    name: 'registerQuery',
+    type: 'function(query: string)',
+  }];
+
+  mediaBreakpoints: Object[] = [{
+    breakpoint: 'xs',
+    query: '(max-width: 599px)',
+  }, {
+    breakpoint: 'gt-xs',
+    query: '(min-width: 600px)',
+  }, {
+    breakpoint: 'sm',
+    query: '(min-width: 600px) and (max-width: 959px)',
+  }, {
+    breakpoint: 'gt-sm',
+    query: '(min-width: 960px)',
+  }, {
+    breakpoint: 'md',
+    query: '(min-width: 960px) and (max-width: 1279px)',
+  }, {
+    breakpoint: 'gt-gm',
+    query: '(min-width: 1280px)',
+  }, {
+    breakpoint: 'lg',
+    query: '(min-width: 1280px) and (max-width: 1919px)',
+  }, {
+    breakpoint: 'gt-lg',
+    query: '(min-width: 1920px)',
+  }, {
+    breakpoint: 'xl',
+    query: '(min-width: 1920px)',
+  }, {
+    breakpoint: 'landscape',
+    query: 'landscape',
+  }, {
+    breakpoint: 'portrait',
+    query: 'portrait',
+  }, {
+    breakpoint: 'print',
+    query: 'print',
+  }];
+
+  mediaAttrs: Object[] = [{
+    description: `Media query used to evaluate screen/window size.
+                  Toggles attributes, classes and styles if media query is matched.`,
+    name: 'tdMediaToggle',
+    type: 'string',
+  }, {
+    description: 'Attributes to be toggled when media query matches',
+    name: 'mediaAttributes?',
+    type: '{[key: string]: string}',
+  }, {
+    description: 'CSS Classes to be toggled when media query matches',
+    name: 'mediaClasses?',
+    type: 'string[]',
+  }, {
+    description: 'CSS Styles to be toggled when media query matches',
+    name: 'mediaStyles?',
+    type: '{[key: string]: string}',
+  }];
+
+  constructor(private _mediaService: TdMediaService, private _ngZone: NgZone) { }
+
+  ngOnInit(): void {
+    for (let demoObj of this.mediaDemo) {
+      this._ngZone.run(() => {
+        demoObj.value = this._mediaService.query(demoObj.query);
+      });
+      this._subcriptions.push(this._mediaService.registerQuery(demoObj.query).subscribe((matches: boolean) => {
+        this._ngZone.run(() => {
+          demoObj.value = matches;
+        });
+      }));
+    }
+  }
+
+  ngOnDestroy(): void {
+    this._subcriptions.forEach((subs: Subscription) => {
+      subs.unsubscribe();
+    });
+  }
+
+}

--- a/src/app/components/components/overview/overview.component.html
+++ b/src/app/components/components/overview/overview.component.html
@@ -8,7 +8,7 @@
   <div layout="row" layout-wrap hide-xs hide-sm class="push-sm">
     <template let-item let-last="last" ngFor [ngForOf]="items">
       <div flex-md="50" flex-gt-md="25" layout="column">
-        <md-card [routerLink]="[item.route]" class="md-card-colored" flex>
+        <md-card href [routerLink]="[item.route]" class="md-card-colored" flex>
           <md-toolbar class="bgc-{{item.color}} " layout="column" layout-align="center center" layout-padding>
             <md-icon class="md-icon-font-xl tc-white">{{item.icon}}</md-icon>
           </md-toolbar>

--- a/src/app/components/components/overview/overview.component.ts
+++ b/src/app/components/components/overview/overview.component.ts
@@ -48,6 +48,11 @@ export class OverviewComponent {
       route: 'markdown',
       title: 'Markdown',
     }, {
+      color: 'red-700',
+      icon: 'devices',
+      route: 'media',
+      title: 'Media',
+    }, {
       color: 'deep-orange-700',
       icon: 'filter_list',
       route: 'pipes',

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -21,7 +21,7 @@
     <div layout="row" layout-wrap hide-xs hide-sm class="push-sm">
       <template let-item let-last="last" ngFor [ngForOf]="items">
         <div flex-md="50" flex-gt-md="25" layout="column">
-          <md-card [routerLink]="[item.route]" class="md-card-colored" flex>
+          <md-card href [routerLink]="[item.route]" class="md-card-colored" flex>
             <md-toolbar class="bgc-{{item.color}} " layout="column" layout-align="center center" layout-padding>
               <md-icon class="md-icon-font-xl tc-white">{{item.icon}}</md-icon>
             </md-toolbar>

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { HTTP_PROVIDERS } from '@angular/http';
 
 import { DocsAppComponent, environment } from './app/';
 import { APP_ROUTER_PROVIDERS } from './app/app.routes';
+import { TD_MEDIA_PROVIDERS } from './platform/core';
 
 if (environment.production) {
   enableProdMode();
@@ -18,4 +19,5 @@ bootstrap(DocsAppComponent, [
   MdIconRegistry,
   HTTP_PROVIDERS,
   APP_ROUTER_PROVIDERS,
+  TD_MEDIA_PROVIDERS,
 ]);

--- a/src/platform/core/index.ts
+++ b/src/platform/core/index.ts
@@ -70,3 +70,14 @@ export { TdDigitsPipe } from './pipes/digits/digits.pipe';
  * SERVICES
  */
 export { RESTService, IRestTransform, IRestConfig, IRestQuery, IHttp } from './services/rest.service';
+
+/**
+ * MEDIA
+ */
+import { TdMediaService } from './media/services/media.service';
+
+export const TD_MEDIA_PROVIDERS: Type[] = [
+  TdMediaService,
+];
+export { TdMediaService } from './media/services/media.service';
+export { TdMediaToggleDirective } from './media/directives/media-toggle.directive';

--- a/src/platform/core/media/directives/media-toggle.directive.ts
+++ b/src/platform/core/media/directives/media-toggle.directive.ts
@@ -1,0 +1,99 @@
+import { Directive, ElementRef, Input, OnInit, OnDestroy } from '@angular/core';
+import { Renderer } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
+
+import { TdMediaService } from '../services/media.service';
+
+@Directive({
+  selector: '[tdMediaToggle]',
+})
+export class TdMediaToggleDirective implements OnInit, OnDestroy {
+
+  private _subscription: Subscription;
+
+  private _query: string;
+  private _matches: boolean = false;
+  private _attributes: {[key: string]: string} = {};
+  private _styles: {[key: string]: string} = {};
+  private _classes: string[] = [];
+
+  /**
+   * tdMediaToggle: MediaQuery
+   * Toggles attributes, classes and styles if query is matched or not'.
+   */
+  @Input('tdMediaToggle')
+  set query(query: string) {
+    if (!query) {
+      throw 'Query needed for [tdMediaToggle] directive.';
+    }
+    this._query = query;
+  }
+
+  /**
+   * attributes: {[key: string]: string}
+   * Attributes to be toggled'.
+   */
+  @Input('mediaAttributes')
+  set attributes(attributes: any) {
+    this._attributes = attributes;
+  }
+
+  /**
+   * classes: string[]
+   * CSS Classes to be toggled'.
+   */
+  @Input('mediaClasses')
+  set classes(classes: string[]) {
+    this._classes = classes;
+  }
+
+  /**
+   * styles: {[key: string]: string}
+   * CSS Styles to be toggled'.
+   */
+  @Input('mediaStyles')
+  set styles(styles: any) {
+    this._styles = styles;
+  }
+
+  constructor(private _renderer: Renderer, private _elementRef: ElementRef, private _mediaService: TdMediaService) { }
+
+  ngOnInit(): void {
+    this._mediaChange(this._mediaService.evaluate(this._query));
+    this._subscription = this._mediaService.register(this._query).subscribe((matches: boolean) => {
+      this._mediaChange(matches);
+    });
+  }
+
+  ngOnDestroy(): void {
+    this._subscription.unsubscribe();
+  }
+
+  private _mediaChange(matches: boolean): void {
+    this._matches = matches;
+    this._changeAttributes();
+    this._changeClasses();
+    this._changeStyles();
+  }
+
+  private _changeAttributes(): void {
+    for (let attr in this._attributes) {
+      this._renderer.setElementAttribute(this._elementRef.nativeElement, attr,
+                                         this._matches ? this._attributes[attr] : undefined);
+    }
+  }
+
+  private _changeClasses(): void {
+    this._classes.forEach((className: string) => {
+      this._renderer.setElementClass(this._elementRef.nativeElement, className, this._matches);
+    });
+  }
+
+  private _changeStyles(): void {
+    for (let style in this._styles) {
+      this._renderer.setElementStyle(this._elementRef.nativeElement, style,
+                                         this._matches ? this._styles[style] : undefined);
+    }
+  }
+
+}

--- a/src/platform/core/media/directives/media-toggle.directive.ts
+++ b/src/platform/core/media/directives/media-toggle.directive.ts
@@ -18,8 +18,9 @@ export class TdMediaToggleDirective implements OnInit, OnDestroy {
   private _classes: string[] = [];
 
   /**
-   * tdMediaToggle: MediaQuery
-   * Toggles attributes, classes and styles if query is matched or not'.
+   * tdMediaToggle: string
+   * Media query used to evaluate screen/window size.
+   * Toggles attributes, classes and styles if media query is matched.
    */
   @Input('tdMediaToggle')
   set query(query: string) {
@@ -30,8 +31,8 @@ export class TdMediaToggleDirective implements OnInit, OnDestroy {
   }
 
   /**
-   * attributes: {[key: string]: string}
-   * Attributes to be toggled'.
+   * mediaAttributes: {[key: string]: string}
+   * Attributes to be toggled when media query matches.
    */
   @Input('mediaAttributes')
   set attributes(attributes: any) {
@@ -39,8 +40,8 @@ export class TdMediaToggleDirective implements OnInit, OnDestroy {
   }
 
   /**
-   * classes: string[]
-   * CSS Classes to be toggled'.
+   * mediaClasses: string[]
+   * CSS Classes to be toggled when media query matches.
    */
   @Input('mediaClasses')
   set classes(classes: string[]) {
@@ -48,8 +49,8 @@ export class TdMediaToggleDirective implements OnInit, OnDestroy {
   }
 
   /**
-   * styles: {[key: string]: string}
-   * CSS Styles to be toggled'.
+   * mediaStyles: {[key: string]: string}
+   * CSS Styles to be toggled when media query matches.
    */
   @Input('mediaStyles')
   set styles(styles: any) {
@@ -59,8 +60,8 @@ export class TdMediaToggleDirective implements OnInit, OnDestroy {
   constructor(private _renderer: Renderer, private _elementRef: ElementRef, private _mediaService: TdMediaService) { }
 
   ngOnInit(): void {
-    this._mediaChange(this._mediaService.evaluate(this._query));
-    this._subscription = this._mediaService.register(this._query).subscribe((matches: boolean) => {
+    this._mediaChange(this._mediaService.query(this._query));
+    this._subscription = this._mediaService.registerQuery(this._query).subscribe((matches: boolean) => {
       this._mediaChange(matches);
     });
   }

--- a/src/platform/core/media/services/media.service.ts
+++ b/src/platform/core/media/services/media.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs/Subject';
+import { Observable } from 'rxjs/Observable';
+
+@Injectable()
+export class TdMediaService {
+
+  private _queryMap: Map<string, string> = new Map<string, string>();
+  private _querySources: {[key: string]: Subject<any>} = {};
+  private _queryObservables: {[key: string]: Observable<any>} = {};
+
+  constructor() {
+    this._queryMap.set('xs', '(max-width: 599px)');
+    this._queryMap.set('gt-xs', '(min-width: 600px)');
+    this._queryMap.set('sm', '(min-width: 600px) and (max-width: 959px)');
+    this._queryMap.set('gt-sm', '(min-width: 960px)');
+    this._queryMap.set('md', '(min-width: 960px) and (max-width: 1279px)');
+    this._queryMap.set('gt-md', '(min-width: 1280px)');
+    this._queryMap.set('lg', '(min-width: 1280px) and (max-width: 1919px)');
+    this._queryMap.set('gt-lg', '(min-width: 1920px)');
+    this._queryMap.set('xl', '(min-width: 1920px)');
+    this._queryMap.set('landscape', 'landscape');
+    this._queryMap.set('portrait', 'portrait');
+    this._queryMap.set('print', 'print');
+
+    window.onresize = () => {
+      this._onResize();
+    };
+  }
+
+  /**
+   * Evaluates the query to see if it matches the window and returns 'true' or 'false'.
+   */
+  public evaluate(query: string): boolean {
+    if (this._queryMap.get(query.toLowerCase())) {
+      query = this._queryMap.get(query);
+    }
+    return window.matchMedia(query).matches;
+  }
+
+  /**
+   * Creates an observable for the query passed as argument, and returns it.
+   */
+  public register(query: string): Observable<any> {
+    if (this._queryMap.get(query.toLowerCase())) {
+      query = this._queryMap.get(query);
+    }
+    if (!this._querySources[query]) {
+      this._querySources[query] = new Subject<any>();
+    }
+    this._queryObservables[query] = this._querySources[query].asObservable();
+    return this._queryObservables[query];
+  }
+
+  private _onResize(): void {
+    for (let key in this._querySources) {
+      this._querySources[key].next(window.matchMedia(key).matches);
+    }
+  }
+}

--- a/src/platform/core/media/services/media.service.ts
+++ b/src/platform/core/media/services/media.service.ts
@@ -29,21 +29,23 @@ export class TdMediaService {
   }
 
   /**
-   * Evaluates the query to see if it matches the window and returns 'true' or 'false'.
+   * Used to evaluate whether a given media query is true or false given the current device's screen / window size.
    */
-  public evaluate(query: string): boolean {
+  public query(query: string): boolean {
     if (this._queryMap.get(query.toLowerCase())) {
-      query = this._queryMap.get(query);
+      query = this._queryMap.get(query.toLowerCase());
     }
     return window.matchMedia(query).matches;
   }
 
   /**
-   * Creates an observable for the query passed as argument, and returns it.
+   * Registers a media query and returns an [Observable] that will re-evaluate and 
+   * return if the given media query matches on window resize.
+   * Note: don't forget to unsubscribe from [Observable] when finished watching.
    */
-  public register(query: string): Observable<any> {
+  public registerQuery(query: string): Observable<any> {
     if (this._queryMap.get(query.toLowerCase())) {
-      query = this._queryMap.get(query);
+      query = this._queryMap.get(query.toLowerCase());
     }
     if (!this._querySources[query]) {
       this._querySources[query] = new Subject<any>();

--- a/src/system-config.ts
+++ b/src/system-config.ts
@@ -46,6 +46,7 @@ const barrels: string[] = [
   'app/components/components/file-upload',
   'app/components/components/loading',
   'app/components/components/pipes',
+  'app/components/components/media',
   'app/components/components/markdown',
   'app/components/docs',
   'app/components/docs/overview',


### PR DESCRIPTION
## Description

Added a basic `query media` support inside core module. (might relocate in the future)
https://github.com/Teradata/covalent/issues/20

### What's included?

#### tdMediaService
This service is designed to provide basic media query evaluation for responsive applications.
It has pre-programmed support for media queries that match the layout breakpoints.
![image](https://cloud.githubusercontent.com/assets/5846742/16959830/b85f49e6-4d9b-11e6-9c0c-18374b8314b0.png)
Usage in Typescript:
```
constructor(private _mediaService: TdMediaService, private _ngZone: NgZone) {
  }
  checkScreen(): void {
    this._ngZone.run(() => {
      this.isSmallScreen = this._mediaService.query('md'); // or '(min-width: 960px) and (max-width: 1279px)'
    });
  }
  watchScreen(): void {
    this._querySubscription = this._mediaService.registerQuery(demoObj.query).subscribe((matches: boolean) => {
      this._ngZone.run(() => {
        this.isSmallScreen = matches;
      });
    });
  }
```
`tdMediaService` methods:
![image](https://cloud.githubusercontent.com/assets/5846742/16959851/cddd5542-4d9b-11e6-97ef-118b41d2df86.png)

#### tdMediaToggleDirective
Added `tdMediaToggleDirective` directive to leverage `tdMediaService` and toggle attributes, classes or/and styles from an element.

Usage in HTML:
```
<div tdMediaToggle="sm" [mediaClasses]="['classOne', 'classTwo'']"
  [mediaAttributes]="{title: 'tooltip'}" [mediaStyles]="{color: 'red'}">
  ...
</div>
```
Properties:
![image](https://cloud.githubusercontent.com/assets/5846742/16959937/2e66b908-4d9c-11e6-9b46-731a1cf3e686.png)

#### Test Steps

- [x] Go to `components` docs and see Media link.
- [x] Use demo and see documentation.
- [x] Try to use directive and service anywhere in app.
- [x] :v: 

##### Screenshots or link to CodePen/Plunker/JSfiddle
![media-check](https://cloud.githubusercontent.com/assets/5846742/16960006/7d2a57c0-4d9c-11e6-8cf1-57de7a6470fd.gif)
