### PR TITLE
fix(deploy) use hash urls for github pages

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { bootstrap } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';
 import { disableDeprecatedForms, provideForms } from '@angular/forms';
+import { LocationStrategy, HashLocationStrategy } from '@angular/common';
 
 import { MdIconRegistry } from '@angular2-material/icon';
 import { HTTP_PROVIDERS } from '@angular/http';
@@ -20,4 +21,6 @@ bootstrap(DocsAppComponent, [
   HTTP_PROVIDERS,
   APP_ROUTER_PROVIDERS,
   TD_MEDIA_PROVIDERS,
+  // Sets the app to use /#/ hash urls for github pages
+  { provide: LocationStrategy, useClass: HashLocationStrategy },
 ]);


### PR DESCRIPTION
## Description

Use the `/#/` strategy for url routing to work with github pages since it doesn't support url rewrites.

Fixes #33 

### What's included?

- Hash Strategy

#### Test Steps

- [x] View app, should have `/#/` in URL