### PR TITLE
ship scss files when building platform

### DIFF
--- a/build.conf.js
+++ b/build.conf.js
@@ -26,6 +26,8 @@ module.exports = {
       'src/**/MaterialIcons-Regular.ttf',
       'src/**/MaterialIcons-Regular.woff',
       'src/**/MaterialIcons-Regular.woff2',
+      'src/**/**.scss',
+      '!src/app/**/**.scss',
       'src/**/**.html',
       'src/**/**.md',
       'src/**/**.js',


### PR DESCRIPTION
## Description

Moving scss files to `./deploy` so they get packaged when releasing to npm.
https://github.com/Teradata/covalent/issues/28

### What's included?

- scss files on release build

#### Test Steps

- [x] `npm run build`
- [x] Go to file `./deploy/platform` and browser for the scss files.
- [x] :boom: 