### PR TITLE
Feature/json formatter

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -117,4 +117,12 @@ $md-warn: #C62828;
             }
         }
     }
+    md-nav-list {
+        [md-list-item].active {
+            md-icon {
+                background-color: $md-accent;
+                color: white;
+            }
+        }
+    }
 }

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -1,6 +1,6 @@
 <md-card>
-  <md-card-title>Chips</md-card-title>
-  <md-card-subtitle>Build a list of strings</md-card-subtitle>
+  <md-card-title>Chips &amp; Autocomplete</md-card-title>
+  <md-card-subtitle>Small blocks for multiple items</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
     <p>Basic Demo</p>

--- a/src/app/components/components/components.component.html
+++ b/src/app/components/components/components.component.html
@@ -1,7 +1,8 @@
 <td-layout-nav-list #list logo="app/assets/icons/teradata.svg" title="Covalent">
   <list-items>
     <template let-item let-last="last" ngFor [ngForOf]="items">
-        <a md-list-item [routerLink]="[item.route]" (click)="list.toggle()">
+        <a md-list-item [routerLink]="[item.route]" (click)="list.toggle()" [routerLinkActive]="['active']" [routerLinkActiveOptions]="{exact:
+true}">
           <md-icon md-list-avatar>{{item.icon}}</md-icon>
           <h3 md-line> {{item.title}} </h3>
           <p md-line> {{item.description}} </p>

--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -65,6 +65,11 @@ export class ComponentsComponent {
     route: 'http',
     title: 'Http',
   }, {
+    description: 'Format your JavaScript objects',
+    icon: 'input',
+    route: 'json-formatter',
+    title: 'Json Formatter',
+  }, {
     description: 'Custom Angular pipes (filters)',
     icon: 'filter_list',
     route: 'pipes',

--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -25,11 +25,6 @@ export class ComponentsComponent {
     route: '.',
     title: 'Teradata Components',
   }, {
-    description: 'Highlighting your code snippets',
-    icon: 'code',
-    route: 'syntax-highlighting',
-    title: 'Syntax Highlighting',
-  }, {
     description: 'A sequence of logical & numbered steps',
     icon: 'view_list',
     route: 'steps',
@@ -50,6 +45,16 @@ export class ComponentsComponent {
     route: 'loading',
     title: 'Loading',
   }, {
+    description: 'Highlighting your code snippets',
+    icon: 'code',
+    route: 'syntax-highlighting',
+    title: 'Syntax Highlighting',
+  }, {
+    description: 'JSON object tree with collapsible nodes',
+    icon: 'format_indent_increase',
+    route: 'json-formatter',
+    title: 'JSON Formatter',
+  }, {
     description: 'Parse markdown files.',
     icon: 'chrome_reader_mode',
     route: 'markdown',
@@ -64,11 +69,6 @@ export class ComponentsComponent {
     icon: 'http',
     route: 'http',
     title: 'Http',
-  }, {
-    description: 'Format your JavaScript objects',
-    icon: 'input',
-    route: 'json-formatter',
-    title: 'Json Formatter',
   }, {
     description: 'Custom Angular pipes (filters)',
     icon: 'filter_list',

--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -40,10 +40,10 @@ export class ComponentsComponent {
     route: 'file-upload',
     title: 'File Upload',
   }, {
-    description: 'Build a list of strings',
-    icon: 'playlist_add',
+    description: 'Small blocks for multiple items',
+    icon: 'label_outline',
     route: 'chips',
-    title: 'Chips',
+    title: 'Chips & Autocomplete',
   }, {
     description: 'Circular or linear progress loader',
     icon: 'hourglass_empty',

--- a/src/app/components/components/components.routes.ts
+++ b/src/app/components/components/components.routes.ts
@@ -10,6 +10,7 @@ import { LoadingDemoComponent } from './loading';
 import { MarkdownDemoComponent } from './markdown';
 import { MediaDemoComponent } from './media';
 import { HttpDemoComponent } from './http';
+import { JsonFormatterDemoComponent } from './json-formatter';
 import { PipesComponent } from './pipes';
 
 export const componentsRoutes: RouterConfig = [{
@@ -40,6 +41,9 @@ export const componentsRoutes: RouterConfig = [{
     }, {
       component: HttpDemoComponent,
       path: 'http',
+    }, {
+      component: JsonFormatterDemoComponent,
+      path: 'json-formatter',
     }, {
       component: PipesComponent,
       path: 'pipes',

--- a/src/app/components/components/json-formatter/index.ts
+++ b/src/app/components/components/json-formatter/index.ts
@@ -1,0 +1,1 @@
+export { JsonFormatterDemoComponent } from './json-formatter.component'

--- a/src/app/components/components/json-formatter/json-formatter.component.html
+++ b/src/app/components/components/json-formatter/json-formatter.component.html
@@ -8,13 +8,8 @@
       {{data | json}}
     </td-highlight>
     <p>Formatted Object:</p>
-    <td-json-formatter [data]="data" [levelsOpen]="levelsOpen"></td-json-formatter>
+    <td-json-formatter [data]="data" [levelsOpen]="1"></td-json-formatter>
   </md-card-content>
-  <md-divider></md-divider>
-  <md-card-actions>
-    <button md-button color="primary" (click)="expandLevel()">Expand Level</button>
-    <button md-button color="primary" (click)="collapseLevel()">Collapse Level</button>
-  </md-card-actions>
 </md-card>
 <md-card>
   <md-card-title>TdJsonFormatterComponent</md-card-title>

--- a/src/app/components/components/json-formatter/json-formatter.component.html
+++ b/src/app/components/components/json-formatter/json-formatter.component.html
@@ -1,0 +1,63 @@
+<md-card>
+  <md-card-title>Json Formatter</md-card-title>
+  <md-card-subtitle>Format your JavaScript objects</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p>Original Object:</p>
+    <td-highlight lang="json">
+      {{data | json}}
+    </td-highlight>
+    <p>Formatted Object:</p>
+    <td-json-formatter [data]="data" [levelsOpen]="levelsOpen"></td-json-formatter>
+  </md-card-content>
+  <md-divider></md-divider>
+  <md-card-actions>
+    <button md-button color="primary" (click)="expandLevel()">Expand Level</button>
+    <button md-button color="primary" (click)="collapseLevel()">Collapse Level</button>
+  </md-card-actions>
+</md-card>
+<md-card>
+  <md-card-title>TdJsonFormatterComponent</md-card-title>
+  <md-card-subtitle>How to use this component</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <h2><code><![CDATA[<td-json-formatter>]]></code></h2>
+    <p>Simply add the <code><![CDATA[<td-json-formatter>]]></code> element and pass the object to be formatted as a <code>[data]</code> input.</p>
+    <p>Hovering on nodes will bring out a preview tooltip of the first 5 objects/properties of the node.</p>
+    <p>The tree is collapsable/expandable so you can navigate through its nodes.</p>
+    <h3>Properties:</h3>
+    <p>The <code><![CDATA[<td-json-formatter>]]></code> component has {{jsonFormatterAttrs.length}} properties:</p>
+    <md-list>
+      <template let-attr let-last="attr" ngFor [ngForOf]="jsonFormatterAttrs">
+        <a md-list-item layout-align="row">
+          <h3 md-line> {{attr.name}}: <span>{{attr.type}}</span></h3>
+          <p md-line> {{attr.description}} </p>
+        </a>
+        <md-divider *ngIf="!last"></md-divider>
+      </template>
+    </md-list>
+    <h3>Example:</h3>
+    <p>HTML:</p>
+    <td-highlight lang="html">
+      <![CDATA[
+        <td-json-formatter [data]="object" [levelsOpen]="1">
+        </td-json-formatter>
+      ]]>
+    </td-highlight>
+    <p>Typescript:</p>
+    <td-highlight lang="typescript">
+      <![CDATA[
+        import { TdJsonFormatterComponent } from '@covalent/json-formatter';
+        ...
+          directives: [ TdJsonFormatterComponent ]
+        })
+        export class Demo {
+          object: any = {
+            property: 'value',
+            array: [1, 2, 3]
+          };
+        }
+      ]]>
+    </td-highlight>
+  </md-card-content>
+ </md-card>

--- a/src/app/components/components/json-formatter/json-formatter.component.html
+++ b/src/app/components/components/json-formatter/json-formatter.component.html
@@ -1,14 +1,16 @@
 <md-card>
-  <md-card-title>Json Formatter</md-card-title>
-  <md-card-subtitle>Format your JavaScript objects</md-card-subtitle>
+  <md-card-title>JSON Formatter</md-card-title>
+  <md-card-subtitle>JSON object tree with collapsible nodes</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
-    <p>Original Object:</p>
+    <h3 class="md-title">Object using JSON Formatting:</h3>
+    <p>(Use mouse or keyboard to expand/collapse nodes)</p>
+    <td-json-formatter [data]="data" [levelsOpen]="2"></td-json-formatter>
+    <md-divider class="push-top"></md-divider>
+    <h3 class="md-title">Original JSON Object:</h3>
     <td-highlight lang="json">
       {{data | json}}
     </td-highlight>
-    <p>Formatted Object:</p>
-    <td-json-formatter [data]="data" [levelsOpen]="1"></td-json-formatter>
   </md-card-content>
 </md-card>
 <md-card>

--- a/src/app/components/components/json-formatter/json-formatter.component.spec.ts
+++ b/src/app/components/components/json-formatter/json-formatter.component.spec.ts
@@ -1,0 +1,49 @@
+import {
+  beforeEach,
+  addProviders,
+  describe,
+  expect,
+  it,
+  inject,
+} from '@angular/core/testing';
+import { ComponentFixture, TestComponentBuilder } from '@angular/compiler/testing';
+import { Component, DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { JsonFormatterDemoComponent } from './json-formatter.component';
+
+describe('Component: JsonFormatterDemo', () => {
+  let builder: TestComponentBuilder;
+
+  beforeEach(() => {
+    addProviders([
+      JsonFormatterDemoComponent,
+    ]);
+  });
+
+  beforeEach(inject([TestComponentBuilder], function (tcb: TestComponentBuilder): void {
+    builder = tcb;
+  }));
+
+  it('should inject the component', inject([JsonFormatterDemoComponent], (component: JsonFormatterDemoComponent) => {
+    expect(component).toBeTruthy();
+  }));
+
+  it('should create the component', inject([], () => {
+    return builder.createAsync(JsonFormatterDemoTestControllerComponent)
+      .then((fixture: ComponentFixture<any>) => {
+        let query: DebugElement = fixture.debugElement.query(By.directive(JsonFormatterDemoComponent));
+        expect(query).toBeTruthy();
+        expect(query.componentInstance).toBeTruthy();
+      });
+  }));
+});
+
+@Component({
+  directives: [JsonFormatterDemoComponent],
+  selector: 'td-test',
+  template: `
+    <td-json-formatter-demo></td-json-formatter-demo>
+  `,
+})
+class JsonFormatterDemoTestControllerComponent {
+}

--- a/src/app/components/components/json-formatter/json-formatter.component.ts
+++ b/src/app/components/components/json-formatter/json-formatter.component.ts
@@ -37,7 +37,6 @@ export class JsonFormatterDemoComponent {
     type: 'number',
   }];
 
-  levelsOpen: number = 1;
   data: Object = {
     'stringProperty': 'This is a string',
     'dateProperty': new Date(),
@@ -58,17 +57,4 @@ export class JsonFormatterDemoComponent {
     },
     'emptyArray': [],
   };
-
-  expandLevel(): void {
-    if (this.levelsOpen < 3) {
-      this.levelsOpen++;
-    }
-  }
-
-  collapseLevel(): void {
-    if (this.levelsOpen > 0) {
-      this.levelsOpen--;
-    }
-  }
-
 }

--- a/src/app/components/components/json-formatter/json-formatter.component.ts
+++ b/src/app/components/components/json-formatter/json-formatter.component.ts
@@ -62,7 +62,7 @@ export class JsonFormatterDemoComponent {
   };
 
   expandLevel(): void {
-    if (this.levelsOpen < 4) {
+    if (this.levelsOpen < 3) {
       this.levelsOpen++;
     }
   }

--- a/src/app/components/components/json-formatter/json-formatter.component.ts
+++ b/src/app/components/components/json-formatter/json-formatter.component.ts
@@ -45,9 +45,7 @@ export class JsonFormatterDemoComponent {
     'booleanProperty': true,
     'numberArray': [1, 2, 3, 4, 5, 6],
     'objectArray': [{
-        prop: undefined,
-      }, {
-        prop: [1, 2],
+        'prop': undefined,
       }, {
       },
     ],

--- a/src/app/components/components/json-formatter/json-formatter.component.ts
+++ b/src/app/components/components/json-formatter/json-formatter.component.ts
@@ -1,0 +1,76 @@
+import { Component } from '@angular/core';
+
+import { MD_CARD_DIRECTIVES } from '@angular2-material/card';
+import { MD_LIST_DIRECTIVES } from '@angular2-material/list';
+import { MdButton } from '@angular2-material/button';
+
+import { TdHighlightComponent } from '../../../../platform/highlight';
+import { TdJsonFormatterComponent } from '../../../../platform/json-formatter';
+
+@Component({
+  directives: [
+    MD_CARD_DIRECTIVES,
+    MD_LIST_DIRECTIVES,
+    MdButton,
+    TdHighlightComponent,
+    TdJsonFormatterComponent,
+  ],
+  moduleId: module.id,
+  selector: 'td-json-formatter-demo',
+  styleUrls: ['json-formatter.component.css'],
+  templateUrl: 'json-formatter.component.html',
+
+})
+export class JsonFormatterDemoComponent {
+
+  jsonFormatterAttrs: Object[] = [{
+    description: `Tag to be displayed as root of formatted object.`,
+    name: 'key?',
+    type: 'string',
+  }, {
+    description: `JS object to be formatted.`,
+    name: 'data',
+    type: 'any',
+  }, {
+    description: `Levels opened by default when JS object is formatted and rendered.`,
+    name: 'levelsOpen?',
+    type: 'number',
+  }];
+
+  levelsOpen: number = 1;
+  data: Object = {
+    'stringProperty': 'This is a string',
+    'dateProperty': new Date(),
+    'numberProperty': 10000,
+    'booleanProperty': true,
+    'numberArray': [1, 2, 3, 4, 5, 6],
+    'objectArray': [{
+        prop: undefined,
+      }, {
+        prop: [1, 2],
+      }, {
+      },
+    ],
+    'functionProperty': function(arg1: any, arg2: any): void {
+      // empty
+    },
+    'undefinedProperty': undefined,
+    'longNameeeeeeeeeeeProoooopeeeeeeeeeeertyy': 'got truncated',
+    'emptyObject': {
+    },
+    'emptyArray': [],
+  };
+
+  expandLevel(): void {
+    if (this.levelsOpen < 4) {
+      this.levelsOpen++;
+    }
+  }
+
+  collapseLevel(): void {
+    if (this.levelsOpen > 0) {
+      this.levelsOpen--;
+    }
+  }
+
+}

--- a/src/app/components/components/overview/overview.component.ts
+++ b/src/app/components/components/overview/overview.component.ts
@@ -58,6 +58,11 @@ export class OverviewComponent {
       route: 'http',
       title: 'Http',
     }, {
+      color: 'teal-700',
+      icon: 'input',
+      route: 'json-formatter',
+      title: 'Json Formatter',
+    }, {
       color: 'deep-orange-700',
       icon: 'filter_list',
       route: 'pipes',

--- a/src/app/components/components/overview/overview.component.ts
+++ b/src/app/components/components/overview/overview.component.ts
@@ -34,7 +34,7 @@ export class OverviewComponent {
       title: 'File Upload',
     }, {
       color: 'grey-700',
-      icon: 'playlist_add',
+      icon: 'label',
       route: 'chips',
       title: 'Chips',
     }, {
@@ -46,12 +46,12 @@ export class OverviewComponent {
       color: 'pink-700',
       icon: 'code',
       route: 'syntax-highlighting',
-      title: 'Syntax Highlighting',
+      title: 'Highlighting',
     }, {
       color: 'teal-700',
-      icon: 'input',
+      icon: 'format_indent_increase',
       route: 'json-formatter',
-      title: 'Json Formatter',
+      title: 'JSON Formatter',
     }, {
       color: 'orange-700',
       icon: 'chrome_reader_mode',

--- a/src/app/components/components/overview/overview.component.ts
+++ b/src/app/components/components/overview/overview.component.ts
@@ -18,11 +18,6 @@ import { MdIcon } from '@angular2-material/icon';
 })
 export class OverviewComponent {
   items: Object[] = [{
-      color: 'pink-700',
-      icon: 'code',
-      route: 'syntax-highlighting',
-      title: 'Syntax Highlighting',
-    }, {
       color: 'deep-purple-700',
       icon: 'view_list',
       route: 'steps',
@@ -43,6 +38,16 @@ export class OverviewComponent {
       route: 'loading',
       title: 'Loading',
     }, {
+      color: 'pink-700',
+      icon: 'code',
+      route: 'syntax-highlighting',
+      title: 'Syntax Highlighting',
+    }, {
+      color: 'teal-700',
+      icon: 'input',
+      route: 'json-formatter',
+      title: 'Json Formatter',
+    }, {
       color: 'orange-700',
       icon: 'chrome_reader_mode',
       route: 'markdown',
@@ -57,11 +62,6 @@ export class OverviewComponent {
       icon: 'http',
       route: 'http',
       title: 'Http',
-    }, {
-      color: 'teal-700',
-      icon: 'input',
-      route: 'json-formatter',
-      title: 'Json Formatter',
     }, {
       color: 'deep-orange-700',
       icon: 'filter_list',

--- a/src/app/components/docs/docs.component.html
+++ b/src/app/components/docs/docs.component.html
@@ -1,7 +1,8 @@
 <td-layout-nav-list #list logo="app/assets/icons/teradata.svg" title="Covalent">
   <list-items>
     <template let-item let-last="last" ngFor [ngForOf]="items">
-        <a md-list-item [routerLink]="[item.route]" (click)="list.toggle()">
+        <a md-list-item [routerLink]="[item.route]" (click)="list.toggle()" [routerLinkActive]="['active']" [routerLinkActiveOptions]="{exact:
+true}">
           <md-icon md-list-avatar>{{item.icon}}</md-icon>
           <h3 md-line> {{item.title}} </h3>
           <p md-line> {{item.description}} </p>

--- a/src/app/components/style-guide/style-guide.component.html
+++ b/src/app/components/style-guide/style-guide.component.html
@@ -1,7 +1,8 @@
 <td-layout-nav-list #list logo="app/assets/icons/teradata.svg" title="Covalent">
   <list-items>
     <template let-item let-last="last" ngFor [ngForOf]="items">
-        <a md-list-item [routerLink]="[item.route]" (click)="list.toggle()">
+        <a md-list-item [routerLink]="[item.route]" (click)="list.toggle()" [routerLinkActive]="['active']" [routerLinkActiveOptions]="{exact:
+true}">
           <md-icon md-list-avatar>{{item.icon}}</md-icon>
           <h3 md-line> {{item.title}} </h3>
           <p md-line> {{item.description}} </p>

--- a/src/platform/json-formatter/README.md
+++ b/src/platform/json-formatter/README.md
@@ -1,0 +1,28 @@
+# td-json-formatter
+
+`td-json-formatter` renders a javascript object in JSON format the same way the chrome/firefox console would render it using `console.log()`.
+
+The tree is collapsable/expandable so you can navigate through its nodes.
+
+## API Summary
+
+Properties:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `key?` | `string` | Tag to be displayed as root of formatted object.
+| `data` | `any` | JS object to be formatted.
+| `levelsOpen?` | `number` | Levels opened by default when JS object is formatted and rendered.
+
+## Usage
+
+Simply add the component and pass the object to be formatted as a [data] input.
+
+Example for HTML usage:
+
+ ```html
+<td-json-formatter [data]="object" key="root" [levelsOpen]="1">
+</td-json-formatter>
+ ```
+ 
+Hovering on nodes will bring out a preview tooltip of the first 5 objects/properties of the node.

--- a/src/platform/json-formatter/README.md
+++ b/src/platform/json-formatter/README.md
@@ -2,6 +2,8 @@
 
 `td-json-formatter` renders a javascript object in Json format the same way the chrome/firefox console would render it using `console.log()`.
 
+Hovering on nodes will bring out a preview tooltip of the first 5 objects/properties of the node.
+
 The tree is collapsable/expandable so you can navigate through its nodes.
 
 ## API Summary
@@ -24,5 +26,3 @@ Example for HTML usage:
 <td-json-formatter [data]="object" key="root" [levelsOpen]="1">
 </td-json-formatter>
  ```
- 
-Hovering on nodes will bring out a preview tooltip of the first 5 objects/properties of the node.

--- a/src/platform/json-formatter/README.md
+++ b/src/platform/json-formatter/README.md
@@ -1,6 +1,6 @@
 # td-json-formatter
 
-`td-json-formatter` renders a javascript object in JSON format the same way the chrome/firefox console would render it using `console.log()`.
+`td-json-formatter` renders a javascript object in Json format the same way the chrome/firefox console would render it using `console.log()`.
 
 The tree is collapsable/expandable so you can navigate through its nodes.
 

--- a/src/platform/json-formatter/index.ts
+++ b/src/platform/json-formatter/index.ts
@@ -1,0 +1,1 @@
+export { TdJsonFormatterComponent } from './json-formatter.component';

--- a/src/platform/json-formatter/json-formatter.component.html
+++ b/src/platform/json-formatter/json-formatter.component.html
@@ -1,6 +1,7 @@
 <div class="td-json-formatter-wrapper">
   <a class="td-key"
      [class.td-key-node]="hasChildren()"
+     [class.td-key-leaf]="!hasChildren()"
      [tabIndex]="isObject()? 0 : -1"
      (keydown.enter)="toggle()"
      layout="row"

--- a/src/platform/json-formatter/json-formatter.component.html
+++ b/src/platform/json-formatter/json-formatter.component.html
@@ -1,0 +1,24 @@
+<div class="td-json-formatter-wrapper">
+  <a class="td-key"
+     [class.td-key-node]="hasChildren()"
+     [tabIndex]="isObject()? 0 : -1"
+     (keydown.enter)="toggle()"
+     layout="row"
+     layout-align="start center"
+     (click)="toggle()">
+    <md-icon class="tc-grey-600" *ngIf="hasChildren()">{{open? 'keyboard_arrow_down' : 'keyboard_arrow_right'}}</md-icon>
+    <span *ngIf="key" class="key">{{key}}:</span>
+    <span class="value">
+      <span [class.td-empty]="!hasChildren()" *ngIf="isObject()" [title]="getPreview()">
+        <span>{{getObjectName()}}</span>
+        <span *ngIf="isArray()">[{{data.length}}]</span>
+      </span>
+      <span *ngIf="!isObject()" [class]="getType(data)">{{getValue(data)}}</span>
+    </span>
+  </a>
+  <div class="td-object-children" *ngIf="hasChildren() && open">
+    <template let-key ngFor [ngForOf]="children">
+      <td-json-formatter [key]="key" [data]="data[key]" [levelsOpen]="levelsOpen - 1"></td-json-formatter>
+    </template>
+  </div>
+</div>

--- a/src/platform/json-formatter/json-formatter.component.scss
+++ b/src/platform/json-formatter/json-formatter.component.scss
@@ -1,0 +1,58 @@
+@import '../core/styles/variables';
+@import '../core/styles/default-theme';
+
+:host {
+  display: block;
+}
+.td-json-formatter-wrapper {
+  padding-top: 2px;
+  padding-bottom: 2px;
+  .td-key {
+    &.td-key-node:focus {
+      background-color: #F5F5F5
+    }
+    &.td-key-node:hover {
+      cursor: pointer;
+      background-color: rgba(158,158,158,0.2);
+    }
+  }
+  .td-object-children {
+    & .td-key,
+    & .td-object-children {
+      padding-left: 24px;
+    }
+  }
+  .key {
+    color: md-color($md-primary, default-contrast);
+  }
+  .value {
+    margin-left: 5px;
+    .td-empty {
+      opacity: .5;
+      text-decoration: line-through;
+    }
+    .string {
+      color: md-color($md-warn, default-contrast);
+      word-break: break-word;
+    }
+    .number { 
+      color: md-color($md-accent, default-contrast);
+    }
+    .boolean { 
+      color: md-color($md-accent, default-contrast);
+    }
+    .null { 
+      color: gray; 
+    }
+    .undefined { 
+      color: gray; 
+    }
+    .function { 
+      color: md-color($md-primary, default-contrast);
+    }
+    .date { 
+      color: black;
+      word-break: break-word;
+    }
+  }
+}

--- a/src/platform/json-formatter/json-formatter.component.scss
+++ b/src/platform/json-formatter/json-formatter.component.scss
@@ -8,12 +8,14 @@
   padding-top: 2px;
   padding-bottom: 2px;
   .td-key {
-    &.td-key-node:focus {
-      background-color: #F5F5F5
-    }
-    &.td-key-node:hover {
-      cursor: pointer;
-      background-color: rgba(158,158,158,0.2);
+    &.td-key-node {
+      &:focus,
+      &:hover {
+        background-color: rgba(158,158,158,0.1);
+      }
+      &:hover {
+        cursor: pointer;
+      }
     }
   }
   .td-object-children {

--- a/src/platform/json-formatter/json-formatter.component.scss
+++ b/src/platform/json-formatter/json-formatter.component.scss
@@ -20,10 +20,13 @@
     & .td-key,
     & .td-object-children {
       padding-left: 24px;
+      &.td-key-leaf {
+        padding-left: 48px;
+      }
     }
   }
   .key {
-    color: md-color($md-primary, default-contrast);
+    color: md-color($md-primary);
   }
   .value {
     margin-left: 5px;
@@ -32,14 +35,14 @@
       text-decoration: line-through;
     }
     .string {
-      color: md-color($md-warn, default-contrast);
+      color: md-color($md-warn);
       word-break: break-word;
     }
     .number { 
-      color: md-color($md-accent, default-contrast);
+      color: md-color($md-accent);
     }
     .boolean { 
-      color: md-color($md-accent, default-contrast);
+      color: md-color($md-accent);
     }
     .null { 
       color: gray; 
@@ -48,7 +51,7 @@
       color: gray; 
     }
     .function { 
-      color: md-color($md-primary, default-contrast);
+      color: md-color($md-primary);
     }
     .date { 
       color: black;

--- a/src/platform/json-formatter/json-formatter.component.ts
+++ b/src/platform/json-formatter/json-formatter.component.ts
@@ -44,7 +44,8 @@ export class TdJsonFormatterComponent {
     this._key = key;
   }
   get key(): string {
-    return this._key ? this._key.substring(0, TdJsonFormatterComponent.KEY_MAX_LENGTH) : this._key;
+    let elipsis: string = this._key && this._key.length > TdJsonFormatterComponent.KEY_MAX_LENGTH ? '…' : '';
+    return this._key ? this._key.substring(0, TdJsonFormatterComponent.KEY_MAX_LENGTH) + elipsis : this._key;
   }
 
   @Input('data')

--- a/src/platform/json-formatter/json-formatter.component.ts
+++ b/src/platform/json-formatter/json-formatter.component.ts
@@ -1,0 +1,155 @@
+import { Component, Input } from '@angular/core';
+
+import { MdIcon } from '@angular2-material/icon';
+
+@Component({
+  directives: [
+    MdIcon,
+    TdJsonFormatterComponent,
+  ],
+  moduleId: module.id,
+  selector: 'td-json-formatter',
+  styleUrls: [ 'json-formatter.component.css' ],
+  templateUrl: 'json-formatter.component.html',
+})
+export class TdJsonFormatterComponent {
+
+  private static KEY_MAX_LENGTH: number = 30;
+  private static PREVIEW_LIMIT: number = 5;
+
+  private _key: string;
+  private _data: any;
+  private _children: string[] = [];
+  private _open: boolean = false;
+  private _levelsOpen: number = 0;
+
+  @Input('levelsOpen')
+  set levelsOpen(levelsOpen: number) {
+    if (!Number.isInteger(levelsOpen)) {
+      throw '[levelsOpen] needs to be an integer.';
+    }
+    this._levelsOpen = levelsOpen;
+    this._open = levelsOpen > 0;
+  }
+  get levelsOpen(): number {
+    return this._levelsOpen;
+  }
+
+  get open(): boolean {
+    return this._open;
+  }
+
+  @Input('key')
+  set key(key: string) {
+    this._key = key;
+  }
+  get key(): string {
+    return this._key ? this._key.substring(0, TdJsonFormatterComponent.KEY_MAX_LENGTH) : this._key;
+  }
+
+  @Input('data')
+  set data(data: any) {
+    this._data = data;
+    this.parseChildren();
+  }
+  get data(): any {
+    return this._data;
+  }
+
+  get children(): string[] {
+    return this._children;
+  }
+
+  toggle(): void {
+    this._open = !this._open;
+  }
+
+  isObject(): boolean {
+    return this.getType(this._data) === 'object';
+  }
+
+  isArray(): boolean {
+    return Array.isArray(this._data);
+  }
+
+  hasChildren(): boolean {
+    return this.children.length > 0;
+  }
+
+  getValue(value: any): string {
+    let type: string = this.getType(value);
+    if (type === 'undefined' || (type === 'null')) {
+      return type;
+    } else if (type === 'date') {
+      value = new Date(value).toString();
+    } else if (type === 'string') {
+      value = '"' + value + '"';
+    } else if (type === 'function') {
+      // Remove content of the function
+      return value.toString()
+          .replace(/[\r\n]/g, '')
+          .replace(/\{.*\}/, '') + '{…}';
+    }
+    return value;
+  }
+
+  getType(object: any): string {
+    if (typeof object === 'object') {
+      if (!object) {
+        return 'null';
+      }
+      let date: Date = new Date(object);
+      if (Object.prototype.toString.call(date) === '[object Date]') {
+        if (!Number.isNaN(date.getTime())) {
+          return 'date';
+        }
+      }
+    }
+    return typeof object;
+  }
+
+  // From http://stackoverflow.com/a/332429
+  getObjectName(): string {
+    let object: any = this._data;
+    if (this.isObject() && !object.constructor) {
+        return 'Object';
+    }
+    let funcNameRegex: RegExp = /function (.{1,})\(/;
+    let results: RegExpExecArray = (funcNameRegex).exec((object).constructor.toString());
+    if (results && results.length > 1) {
+      return results[1];
+    } else {
+      return '';
+    }
+  }
+
+  getPreview(): string {
+    let previewData: string[];
+    let startChar: string = '{';
+    let endChar: string = '}';
+    if (this.isArray()) {
+      let previewArray: any[] = this._data.slice(0, TdJsonFormatterComponent.PREVIEW_LIMIT);
+      previewData = previewArray.map((obj: any) => {
+        return this.getValue(obj);
+      });
+      startChar = '[';
+      endChar = ']';
+    } else {
+      let previewKeys: string[] = this._children.slice(0, TdJsonFormatterComponent.PREVIEW_LIMIT);
+      previewData = previewKeys.map((key: string) => {
+        return key + ': ' + this.getValue(this._data[key]);
+      });
+    }
+    let ellipsis: string = previewData.length >= TdJsonFormatterComponent.PREVIEW_LIMIT ? '…' : '';
+    return startChar + previewData.join(', ') + ellipsis + endChar;
+  }
+
+  private parseChildren(): void {
+    if (this.isObject()) {
+      for (let key in this._data) {
+        this._children.push(key);
+      }
+    }
+  }
+
+}

--- a/src/platform/json-formatter/json-formatter.component.ts
+++ b/src/platform/json-formatter/json-formatter.component.ts
@@ -14,7 +14,14 @@ import { MdIcon } from '@angular2-material/icon';
 })
 export class TdJsonFormatterComponent {
 
+  /**
+   * Max length for property names. Any names bigger than this get trunctated.
+   */
   private static KEY_MAX_LENGTH: number = 30;
+
+  /**
+   * Max tooltip preview elements.
+   */
   private static PREVIEW_LIMIT: number = 5;
 
   private _key: string;
@@ -23,6 +30,10 @@ export class TdJsonFormatterComponent {
   private _open: boolean = false;
   private _levelsOpen: number = 0;
 
+  /**
+   * levelsOpen?: number
+   * Levels opened by default when JS object is formatted and rendered.
+   */
   @Input('levelsOpen')
   set levelsOpen(levelsOpen: number) {
     if (!Number.isInteger(levelsOpen)) {
@@ -39,6 +50,10 @@ export class TdJsonFormatterComponent {
     return this._open;
   }
 
+  /**
+   * key?: string
+   * Tag to be displayed next to formatted object.
+   */
   @Input('key')
   set key(key: string) {
     this._key = key;
@@ -48,6 +63,10 @@ export class TdJsonFormatterComponent {
     return this._key ? this._key.substring(0, TdJsonFormatterComponent.KEY_MAX_LENGTH) + elipsis : this._key;
   }
 
+  /**
+   * data: any
+   * JS object to be formatted.
+   */
   @Input('data')
   set data(data: any) {
     this._data = data;
@@ -61,6 +80,9 @@ export class TdJsonFormatterComponent {
     return this._children;
   }
 
+  /**
+   * Toggles collapse/expanded state of component.
+   */
   toggle(): void {
     this._open = !this._open;
   }
@@ -77,6 +99,9 @@ export class TdJsonFormatterComponent {
     return this.children.length > 0;
   }
 
+  /**
+   * Gets parsed value depending on value type.
+   */
   getValue(value: any): string {
     let type: string = this.getType(value);
     if (type === 'undefined' || (type === 'null')) {
@@ -94,6 +119,10 @@ export class TdJsonFormatterComponent {
     return value;
   }
 
+  /**
+   * Gets type of object.
+   * returns 'null' if object is null and 'date' if value is object and can be parsed to a date.
+   */
   getType(object: any): string {
     if (typeof object === 'object') {
       if (!object) {
@@ -109,7 +138,10 @@ export class TdJsonFormatterComponent {
     return typeof object;
   }
 
-  // From http://stackoverflow.com/a/332429
+  /**
+   * Generates string representation depending if its an object or function.
+   * see: http://stackoverflow.com/a/332429
+   */
   getObjectName(): string {
     let object: any = this._data;
     if (this.isObject() && !object.constructor) {
@@ -124,6 +156,9 @@ export class TdJsonFormatterComponent {
     }
   }
 
+  /**
+   * Creates preview of nodes children to render in tooltip depending if its an array or an object.
+   */
   getPreview(): string {
     let previewData: string[];
     let startChar: string = '{';

--- a/src/platform/json-formatter/package.json
+++ b/src/platform/json-formatter/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@covalent/json-formatter",
+  "version": "0.5.0",
+  "description": "Teradata UI Platform JSON Formatter Module",
+  "keywords": [
+    "angular",
+    "components",
+    "reusable",
+    "json",
+    "formatter",
+    "pretty"
+  ],
+  "scripts": {
+  },
+  "engines": {
+    "node": ">4.4 < 5",
+    "npm": ">= 3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/teradata/covalent.git"
+  },
+  "bugs": {
+    "url": "https://github.com/teradata/covalent/issues"
+  },
+  "license": "MIT",
+  "author": "Teradata UX",
+  "contributors": [
+    "Kyle Ledbetter <kyle.ledbetter@teradata.com>",
+    "Richa Vyas <richa.vyas@teradata.com>",
+    "Ed Morales <eduardo.morales@teradata.com>",
+    "Jason Weaver <jason.weaver@teradata.com>",
+    "Jeremy Wilken <jeremy.wilken@teradata.com>"
+  ],
+  "dependencies": {
+    "@covalent/core": "0.5.0"
+  }
+}

--- a/src/system-config.ts
+++ b/src/system-config.ts
@@ -35,6 +35,7 @@ const barrels: string[] = [
   'platform/file-upload',
   'platform/markdown',
   'platform/http',
+  'platform/json-formatter',
 
   // App specific barrels.
   'app',
@@ -49,6 +50,7 @@ const barrels: string[] = [
   'app/components/components/pipes',
   'app/components/components/media',
   'app/components/components/http',
+  'app/components/components/json-formatter',
   'app/components/components/markdown',
   'app/components/docs',
   'app/components/docs/overview',


### PR DESCRIPTION
## Description

First iteration of the Json Formatter Module.

### What's included?

#### TdJsonFormatterComponent

Added <td-json-formatter> component that facilitates formatting and navigation of JavaScript objects. Mimicking chrome console. This iteration contains:
- Module docs and demo.
- Added package.json
- Added README.md
- Tooltip children preview. ( max elements to render: 5)
- Basic `a11y` (enter and tabbing).




Usage:
```html
<td-json-formatter [data]="objData" [levelsOpen]="1"></td-json-formatter>
```
Properties:
![image](https://cloud.githubusercontent.com/assets/5846742/17723105/382cd9de-63ec-11e6-9973-75ace644142a.png)

#### Test Steps

- [x] `ng serve`
- [x] go to http://localhost:4200/#/components/json-formatter
- [x] Use demo and see documentation.
- [x] Try to use element following documentation anywhere in docs app.
- [x] :v: 

##### Screenshots or link to CodePen/Plunker/JSfiddle
![image](https://cloud.githubusercontent.com/assets/5846742/17723144/8d5e9b22-63ec-11e6-9b60-c0f63bbd40e5.png)

![json-formatter-demo1](https://cloud.githubusercontent.com/assets/5846742/17723159/b9ca50ca-63ec-11e6-988a-13a50091e1b8.gif)
