### PR TITLE
Feature/covalent chips

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -55,9 +55,17 @@ $md-warn: #C62828;
     .md-input-placeholder.md-focused {
         color: $md-primary !important;
     }
-    .md-progress-bar-fill::after,
+    .md-progress-bar-fill::after {
+        background-color: $md-primary !important;
+    }
     .md-input-underline .md-input-ripple {
         background-color: $md-primary !important;
+        &.md-accent {
+            background-color: $md-accent !important;
+        }
+        &.md-warn {
+            background-color: $md-warn !important;
+        }
     }
     .md-progress-bar-buffer {
         background-color: lighten($md-primary, 40%) !important;

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -29,7 +29,7 @@
   <md-card-content>
     <h2><code><![CDATA[<td-chips>]]></code></h2>
     <p>Use <code><![CDATA[<td-chips>]]></code> element to generate a list of strings as chips.</p>
-    <p>Add the [items] attribute to enable the autocomplete with a search list, and [requireMatch] to validated the input against the provided search list.</p>
+    <p>Add the [items] attribute to enable the autocomplete with a search list, and [requireMatch] to validate the input against the provided search list.</p>
     <h3>Properties:</h3>
     <p>The <code><![CDATA[<td-chips>]]></code> component has {{chipsAttrs.length}} properties:</p>
     <md-list>

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -1,0 +1,8 @@
+<md-card>
+  <md-card-title>Chips</md-card-title>
+  <md-card-subtitle>Build a list of strings</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <td-chips></td-chips>
+  </md-card-content>
+</md-card>

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -4,21 +4,23 @@
   <md-divider></md-divider>
   <md-card-content>
     <p>Basic Demo</p>
-    <td-chips></td-chips>
+    <td-chips placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
     <p>Autocomplete Demo</p>
-    <td-chips [items]="items"></td-chips>
+    <td-chips [items]="items" placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
     <p>Autocomplete and requireMatch Demo</p>
-    <td-chips [items]="items" [(ngModel)]="itemsRequireMatch" requireMatch></td-chips>
-    <p>ReadOnly Demo</p>
-    <td-chips [(ngModel)]="itemsReadOnly" [readOnly]="1"></td-chips>
+    <td-chips [items]="items" [(ngModel)]="itemsRequireMatch" placeholder="Enter autocomplete strings" [readOnly]="readOnly" requireMatch></td-chips>
     <p>Form Demo</p>
     <form #form="ngForm">
-      <td-chips #spy [items]="items" [(ngModel)]="itemsForms" name="selections" requireMatch></td-chips>
+      <td-chips #spy [items]="items" [(ngModel)]="itemsForms" name="selections" placeholder="Enter autocomplete strings" [readOnly]="readOnly" requireMatch></td-chips>
       <p>Dirty: {{form.form.dirty}}</p>
       <p>Pristine: {{form.form.pristine}}</p>
       <p>Touched: {{form.controls.selections?.touched}}</p>
     </form>
   </md-card-content>
+  <md-divider></md-divider>
+  <md-card-actions>
+    <button md-button color="primary" (click)="toggleReadOnly()">Toggle ReadOnly</button>
+  </md-card-actions>
 </md-card>
 <md-card>
   <md-card-title>TdChipsComponent</md-card-title>
@@ -43,7 +45,7 @@
     <p>HTML:</p>
     <td-highlight lang="html">
       <![CDATA[
-        <td-chips [items]="items" [(ngModel)]="model" readOnly="readOnly" (add)="add($event)" (remove)="remove($event)" requireMatch>
+        <td-chips placeholder="Enter string" [items]="items" [(ngModel)]="model" readOnly="readOnly" (add)="add($event)" (remove)="remove($event)" requireMatch>
         </td-chips>        
       ]]>
     </td-highlight>

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -3,6 +3,20 @@
   <md-card-subtitle>Build a list of strings</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
+    <p>Basic Demo</p>
     <td-chips></td-chips>
+    <p>Autocomplete Demo</p>
+    <td-chips [items]="items"></td-chips>
+    <p>Autocomplete and requireMatch Demo</p>
+    <td-chips [items]="items" [(ngModel)]="itemsRequireMatch" requireMatch></td-chips>
+    <p>ReadOnly Demo</p>
+    <td-chips [(ngModel)]="itemsReadOnly" [readOnly]="1"></td-chips>
+    <p>Form Demo</p>
+    <form #form="ngForm">
+      <td-chips #spy [items]="items" [(ngModel)]="itemsForms" name="selections" requireMatch></td-chips>
+      <p>Dirty: {{form.form.dirty}}</p>
+      <p>Pristine: {{form.form.pristine}}</p>
+      <p>Touched: {{form.controls.selections?.touched}}</p>
+    </form>
   </md-card-content>
 </md-card>

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -8,14 +8,7 @@
     <p>Autocomplete Demo</p>
     <td-chips [items]="items" placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
     <p>Autocomplete and requireMatch Demo</p>
-    <td-chips [items]="items" [(ngModel)]="itemsRequireMatch" placeholder="Enter autocomplete strings" [readOnly]="readOnly" requireMatch></td-chips>
-    <p>Form Demo</p>
-    <form #form="ngForm">
-      <td-chips #spy [items]="items" [(ngModel)]="itemsForms" name="selections" placeholder="Enter autocomplete strings" [readOnly]="readOnly" requireMatch></td-chips>
-      <p>Dirty: {{form.form.dirty}}</p>
-      <p>Pristine: {{form.form.pristine}}</p>
-      <p>Touched: {{form.controls.selections?.touched}}</p>
-    </form>
+    <td-chips [items]="items" [(ngModel)]="itemsRequireMatch" placeholder="Enter autocomplete strings" [readOnly]="readOnly" requireMatch></td-chips>      
   </md-card-content>
   <md-divider></md-divider>
   <md-card-actions>
@@ -30,6 +23,8 @@
     <h2><code><![CDATA[<td-chips>]]></code></h2>
     <p>Use <code><![CDATA[<td-chips>]]></code> element to generate a list of strings as chips.</p>
     <p>Add the [items] attribute to enable the autocomplete with a search list, and [requireMatch] to validate the input against the provided search list.</p>
+    <p>When used with <a target="_blank" href="https://angular.io/docs/ts/latest/guide/forms.html">forms</a>, you can track change-states [dirty/pristine] and [touched/untouched].</p>
+    <p>Since <code>[(ngModel)]</code> would be an array, you need to implement a custom validator for [valid/invalid] when its empty.</p>
     <h3>Properties:</h3>
     <p>The <code><![CDATA[<td-chips>]]></code> component has {{chipsAttrs.length}} properties:</p>
     <md-list>

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -43,7 +43,7 @@
     <p>HTML:</p>
     <td-highlight lang="html">
       <![CDATA[
-        <td-chips [items]="items" [(ngModel)]="model" readOnly="readOnly" requireMatch>
+        <td-chips [items]="items" [(ngModel)]="model" readOnly="readOnly" (add)="add($event)" (remove)="remove($event)" requireMatch>
         </td-chips>        
       ]]>
     </td-highlight>
@@ -62,6 +62,13 @@
             'string3'
           ];
           model: string[] = [];
+
+          add(value: string): void {
+            ...
+          }
+          remove(value: string): void {
+            ...
+          }
         }
       ]]>
     </td-highlight>

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -26,8 +26,8 @@
   <md-divider></md-divider>
   <md-card-content>
     <h2><code><![CDATA[<td-chips>]]></code></h2>
-    <p>Use <code><![CDATA[<td-chips>]]></code> element to generate a list of strings.</p>
-    <p>Add the [list] attribute to enable the autocomplete, and [requireMatch] to validated the input against the provided list.</p>
+    <p>Use <code><![CDATA[<td-chips>]]></code> element to generate a list of strings as chips.</p>
+    <p>Add the [items] attribute to enable the autocomplete with a search list, and [requireMatch] to validated the input against the provided search list.</p>
     <h3>Properties:</h3>
     <p>The <code><![CDATA[<td-chips>]]></code> component has {{chipsAttrs.length}} properties:</p>
     <md-list>

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -20,3 +20,50 @@
     </form>
   </md-card-content>
 </md-card>
+<md-card>
+  <md-card-title>TdChipsComponent</md-card-title>
+  <md-card-subtitle>How to use this component</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <h2><code><![CDATA[<td-chips>]]></code></h2>
+    <p>Use <code><![CDATA[<td-chips>]]></code> element to generate a list of strings.</p>
+    <p>Add the [list] attribute to enable the autocomplete, and [requireMatch] to validated the input against the provided list.</p>
+    <h3>Properties:</h3>
+    <p>The <code><![CDATA[<td-chips>]]></code> component has {{chipsAttrs.length}} properties:</p>
+    <md-list>
+      <template let-attr let-last="attr" ngFor [ngForOf]="chipsAttrs">
+        <a md-list-item layout-align="row">
+          <h3 md-line> {{attr.name}}: <span>{{attr.type}}</span></h3>
+          <p md-line> {{attr.description}} </p>
+        </a>
+        <md-divider *ngIf="!last"></md-divider>
+      </template>
+    </md-list>
+    <h3>Example:</h3>
+    <p>HTML:</p>
+    <td-highlight lang="html">
+      <![CDATA[
+        <td-chips [items]="items" [(ngModel)]="model" readOnly="readOnly" requireMatch>
+        </td-chips>        
+      ]]>
+    </td-highlight>
+    <p>Typescript:</p>
+    <td-highlight lang="typescript">
+      <![CDATA[
+        import { TdChipsComponent } from '@covalent/chips';
+        ...
+          directives: [ TdChipsComponent ]
+        })
+        export class Demo {
+          readOnly: boolean: false;
+          items: string[] = [
+            'string1',
+            'string2',
+            'string3'
+          ];
+          model: string[] = [];
+        }
+      ]]>
+    </td-highlight>
+  </md-card-content>
+</md-card>

--- a/src/app/components/components/chips/chips.component.spec.ts
+++ b/src/app/components/components/chips/chips.component.spec.ts
@@ -1,0 +1,49 @@
+import {
+  beforeEach,
+  addProviders,
+  describe,
+  expect,
+  it,
+  inject,
+} from '@angular/core/testing';
+import { ComponentFixture, TestComponentBuilder } from '@angular/compiler/testing';
+import { Component, DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { ChipsDemoComponent } from './chips.component';
+
+describe('Component: ChipsDemo', () => {
+  let builder: TestComponentBuilder;
+
+  beforeEach(() => {
+    addProviders([
+      ChipsDemoComponent,
+    ]);
+  });
+
+  beforeEach(inject([TestComponentBuilder], function (tcb: TestComponentBuilder): void {
+    builder = tcb;
+  }));
+
+  it('should inject the component', inject([ChipsDemoComponent], (component: ChipsDemoComponent) => {
+    expect(component).toBeTruthy();
+  }));
+
+  it('should create the component', inject([], () => {
+    return builder.createAsync(ChipsDemoTestControllerComponent)
+      .then((fixture: ComponentFixture<any>) => {
+        let query: DebugElement = fixture.debugElement.query(By.directive(ChipsDemoComponent));
+        expect(query).toBeTruthy();
+        expect(query.componentInstance).toBeTruthy();
+      });
+  }));
+});
+
+@Component({
+  directives: [ChipsDemoComponent],
+  selector: 'td-test',
+  template: `
+    <td-chips-demo></td-chips-demo>
+  `,
+})
+class ChipsDemoTestControllerComponent {
+}

--- a/src/app/components/components/chips/chips.component.ts
+++ b/src/app/components/components/chips/chips.component.ts
@@ -38,6 +38,10 @@ export class ChipsDemoComponent {
     name: 'requireMatch?',
     type: 'boolean',
   }, {
+    description: `Placeholder for the autocomplete input.`,
+    name: 'placeholder?',
+    type: 'string',
+  }, {
     description: `Method to be executed when string is added as chip through the autocomplete.
                   Sends chip value as event.`,
     name: 'add?',
@@ -48,6 +52,8 @@ export class ChipsDemoComponent {
     name: 'remove?',
     type: 'function',
   }];
+
+  readOnly: boolean = false;
 
   items: string[] = [
     'stepper',
@@ -68,5 +74,9 @@ export class ChipsDemoComponent {
   itemsReadOnly: string[] = this.items.slice(2, 8);
 
   itemsForms: string[] = this.items.slice(6, 11);
+
+  toggleReadOnly(): void {
+    this.readOnly = !this.readOnly;
+  }
 
 }

--- a/src/app/components/components/chips/chips.component.ts
+++ b/src/app/components/components/chips/chips.component.ts
@@ -24,6 +24,21 @@ import { TdHighlightComponent } from '../../../../platform/highlight';
 })
 export class ChipsDemoComponent {
 
+  chipsAttrs: Object[] = [{
+    description: `Enables Autocompletion with the provided list of strings.`,
+    name: 'items?',
+    type: 'string[]',
+  }, {
+    description: `Disables the chip input and removal.`,
+    name: 'readOnly?',
+    type: 'boolean',
+  }, {
+    description: `Validates input against the provided list before adding it to the model.
+                  If it doesnt exist, it cancels the event.`,
+    name: 'requireMatch?',
+    type: 'boolean',
+  }];
+
   items: string[] = [
     'stepper',
     'expansion-panel',

--- a/src/app/components/components/chips/chips.component.ts
+++ b/src/app/components/components/chips/chips.component.ts
@@ -33,10 +33,20 @@ export class ChipsDemoComponent {
     name: 'readOnly?',
     type: 'boolean',
   }, {
-    description: `Validates input against the provided list before adding it to the model.
+    description: `Validates input against the provided search list before adding it to the model.
                   If it doesnt exist, it cancels the event.`,
     name: 'requireMatch?',
     type: 'boolean',
+  }, {
+    description: `Method to be executed when string is added as chip through the autocomplete.
+                  Sends chip value as event.`,
+    name: 'add?',
+    type: 'function',
+  }, {
+    description: `Method to be executed when string is removed as chip with the "remove" button.
+                  Sends chip value as event.`,
+    name: 'remove?',
+    type: 'function',
   }];
 
   items: string[] = [

--- a/src/app/components/components/chips/chips.component.ts
+++ b/src/app/components/components/chips/chips.component.ts
@@ -24,4 +24,24 @@ import { TdHighlightComponent } from '../../../../platform/highlight';
 })
 export class ChipsDemoComponent {
 
+  items: string[] = [
+    'stepper',
+    'expansion-panel',
+    'markdown',
+    'highlight',
+    'loading',
+    'media',
+    'chips',
+    'http',
+    'json-formatter',
+    'pipes',
+    'need more?',
+  ];
+
+  itemsRequireMatch: string[] = this.items.slice(0, 6);
+
+  itemsReadOnly: string[] = this.items.slice(2, 8);
+
+  itemsForms: string[] = this.items.slice(6, 11);
+
 }

--- a/src/app/components/components/chips/chips.component.ts
+++ b/src/app/components/components/chips/chips.component.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+
+import { MD_CARD_DIRECTIVES } from '@angular2-material/card';
+import { MD_LIST_DIRECTIVES } from '@angular2-material/list';
+import { MdIcon } from '@angular2-material/icon';
+import { MdButton } from '@angular2-material/button';
+
+import { TdChipsComponent } from '../../../../platform/chips';
+import { TdHighlightComponent } from '../../../../platform/highlight';
+
+@Component({
+  directives: [
+    MD_CARD_DIRECTIVES,
+    MD_LIST_DIRECTIVES,
+    MdIcon,
+    MdButton,
+    TdChipsComponent,
+    TdHighlightComponent,
+  ],
+  moduleId: module.id,
+  selector: 'td-chips-demo',
+  styleUrls: ['chips.component.css'],
+  templateUrl: 'chips.component.html',
+})
+export class ChipsDemoComponent {
+
+}

--- a/src/app/components/components/chips/index.ts
+++ b/src/app/components/components/chips/index.ts
@@ -1,0 +1,1 @@
+export { ChipsDemoComponent } from './chips.component';

--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -65,6 +65,11 @@ export class ComponentsComponent {
     route: 'http',
     title: 'Http',
   }, {
+    description: 'Build a list of strings',
+    icon: 'playlist_add',
+    route: 'chips',
+    title: 'Chips',
+  }, {
     description: 'Custom Angular pipes (filters)',
     icon: 'filter_list',
     route: 'pipes',

--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -45,6 +45,11 @@ export class ComponentsComponent {
     route: 'file-upload',
     title: 'File Upload',
   }, {
+    description: 'Build a list of strings',
+    icon: 'playlist_add',
+    route: 'chips',
+    title: 'Chips',
+  }, {
     description: 'Circular or linear progress loader',
     icon: 'hourglass_empty',
     route: 'loading',
@@ -64,11 +69,6 @@ export class ComponentsComponent {
     icon: 'http',
     route: 'http',
     title: 'Http',
-  }, {
-    description: 'Build a list of strings',
-    icon: 'playlist_add',
-    route: 'chips',
-    title: 'Chips',
   }, {
     description: 'Custom Angular pipes (filters)',
     icon: 'filter_list',

--- a/src/app/components/components/components.routes.ts
+++ b/src/app/components/components/components.routes.ts
@@ -10,6 +10,7 @@ import { LoadingDemoComponent } from './loading';
 import { MarkdownDemoComponent } from './markdown';
 import { MediaDemoComponent } from './media';
 import { HttpDemoComponent } from './http';
+import { ChipsDemoComponent } from './chips';
 import { PipesComponent } from './pipes';
 
 export const componentsRoutes: RouterConfig = [{
@@ -40,6 +41,9 @@ export const componentsRoutes: RouterConfig = [{
     }, {
       component: HttpDemoComponent,
       path: 'http',
+    }, {
+      component: ChipsDemoComponent,
+      path: 'chips',
     }, {
       component: PipesComponent,
       path: 'pipes',

--- a/src/app/components/components/overview/overview.component.ts
+++ b/src/app/components/components/overview/overview.component.ts
@@ -58,6 +58,11 @@ export class OverviewComponent {
       route: 'http',
       title: 'Http',
     }, {
+      color: 'grey-700',
+      icon: 'playlist_add',
+      route: 'chips',
+      title: 'Chips',
+    }, {
       color: 'deep-orange-700',
       icon: 'filter_list',
       route: 'pipes',

--- a/src/app/components/components/overview/overview.component.ts
+++ b/src/app/components/components/overview/overview.component.ts
@@ -38,6 +38,11 @@ export class OverviewComponent {
       route: 'file-upload',
       title: 'File Upload',
     }, {
+      color: 'grey-700',
+      icon: 'playlist_add',
+      route: 'chips',
+      title: 'Chips',
+    }, {
       color: 'light-green-700',
       icon: 'hourglass_empty',
       route: 'loading',
@@ -57,11 +62,6 @@ export class OverviewComponent {
       icon: 'http',
       route: 'http',
       title: 'Http',
-    }, {
-      color: 'grey-700',
-      icon: 'playlist_add',
-      route: 'chips',
-      title: 'Chips',
     }, {
       color: 'deep-orange-700',
       icon: 'filter_list',

--- a/src/platform/chips/README.md
+++ b/src/platform/chips/README.md
@@ -13,6 +13,7 @@ Properties:
 | `items?` | `string[]` | Enables Autocompletion with the provided list of search strings.
 | `readOnly` | `boolean` | Disables the chip input and removal.
 | `requireMatch?` | `boolean` | Validates input against the provided search list before adding it to the model. If it doesnt exist, it cancels the event.
+| `placeholder?` | `string` | Placeholder for the autocomplete input.
 | `add?` | `function` | Method to be executed when string is added as chip through the autocomplete. Sends chip value as event.
 | `remove?` | `function` | Method to be executed when string is removed as chip with the "remove" button. Sends chip value as event.
 
@@ -21,6 +22,6 @@ Properties:
 Example for HTML usage:
 
  ```html
-<td-chips [items]="items" [(ngModel)]="model" readOnly="readOnly" (add)="addEvent($event)" (remove)="removeEvent($event)" requireMatch>
+<td-chips placeholder="placeholder" [items]="items" [(ngModel)]="model" readOnly="readOnly" (add)="addEvent($event)" (remove)="removeEvent($event)" requireMatch>
 </td-chips>  
  ```

--- a/src/platform/chips/README.md
+++ b/src/platform/chips/README.md
@@ -1,0 +1,26 @@
+# td-chips
+
+`td-chips` element generates a list of strings as chips.
+
+Add the [items] attribute to enable the autocomplete with a search list, and [requireMatch] to validated the input against the provided search list.
+
+## API Summary
+
+Properties:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `items?` | `string[]` | Enables Autocompletion with the provided list of search strings.
+| `readOnly` | `boolean` | Disables the chip input and removal.
+| `requireMatch?` | `boolean` | Validates input against the provided search list before adding it to the model. If it doesnt exist, it cancels the event.
+| `add?` | `function` | Method to be executed when string is added as chip through the autocomplete. Sends chip value as event.
+| `remove?` | `function` | Method to be executed when string is removed as chip with the "remove" button. Sends chip value as event.
+
+## Usage
+
+Example for HTML usage:
+
+ ```html
+<td-chips [items]="items" [(ngModel)]="model" readOnly="readOnly" (add)="addEvent($event)" (remove)="removeEvent($event)" requireMatch>
+</td-chips>  
+ ```

--- a/src/platform/chips/autocomplete/autocomplete.component.html
+++ b/src/platform/chips/autocomplete/autocomplete.component.html
@@ -1,0 +1,23 @@
+<div flex>
+  <md-input flex="100" 
+            [(ngModel)]="value"
+            [placeholder]="placeholder"
+            [autofocus]="autoFocus"
+            [list]="listName"
+            [max]="max"
+            [maxLength]="maxLength"
+            [min]="min"
+            [minLength]="minLength"
+            [readonly]="readOnly"
+            [required]="required"
+            [name]="name"
+            (keyup.enter)="handleItemSelect()"
+            (focus)="handleFocus()"
+            (blur)="handleBlur()">
+  </md-input>
+  <datalist [id]="listName">
+    <template let-item ngFor [ngForOf]="searchItems">
+      <option [value]="item"></option>
+    </template>
+  </datalist>
+</div>

--- a/src/platform/chips/autocomplete/autocomplete.component.html
+++ b/src/platform/chips/autocomplete/autocomplete.component.html
@@ -9,6 +9,7 @@
             [min]="min"
             [minLength]="minLength"
             [readonly]="readOnly"
+            [disabled]="disabled"
             [required]="required"
             [name]="name"
             (keyup.enter)="handleItemSelect()"

--- a/src/platform/chips/autocomplete/autocomplete.component.scss
+++ b/src/platform/chips/autocomplete/autocomplete.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/platform/chips/autocomplete/autocomplete.component.ts
+++ b/src/platform/chips/autocomplete/autocomplete.component.ts
@@ -1,0 +1,114 @@
+import { Component, Input, Output, forwardRef } from '@angular/core';
+import { EventEmitter } from '@angular/core';
+import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+
+import { MD_INPUT_DIRECTIVES } from '@angular2-material/input';
+
+const noop: () => void = () => {
+  // empty method
+};
+
+export const TD_AUTOCOMPLETE_CONTROL_VALUE_ACCESSOR: any = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => TdAutoCompleteComponent),
+  multi: true,
+};
+
+@Component({
+  directives: [
+    MD_INPUT_DIRECTIVES,
+  ],
+  providers: [ TD_AUTOCOMPLETE_CONTROL_VALUE_ACCESSOR ],
+  moduleId: module.id,
+  selector: 'td-autocomplete',
+  styleUrls: [ 'autocomplete.component.css' ],
+  templateUrl: 'autocomplete.component.html',
+})
+export class TdAutoCompleteComponent implements ControlValueAccessor {
+
+  private _value: any = '';
+  /** Callback registered via registerOnTouched (ControlValueAccessor) */
+  private _onTouchedCallback: () => void = noop;
+  /** Callback registered via registerOnChange (ControlValueAccessor) */
+  private _onChangeCallback: (_: any) => void = noop;
+
+  listName: string = this.randomName();
+
+  @Input('name') name: string;
+  @Input('dividerColor') dividerColor: 'primary' | 'accent' | 'warn' = 'primary';
+  @Input('placeholder') placeholder: string;
+  @Input('searchItems') searchItems: string[] = [];
+  @Input('readOnly') readOnly: boolean = false;
+  @Input('required') required: boolean = false;
+  @Input('disabled') disabled: boolean = false;
+  @Input('autoFocus') autoFocus: boolean = false;
+  @Input('max') max: string | number;
+  @Input('maxLength') maxLength: number;
+  @Input('min') min: string | number;
+  @Input('minLength') minLength: number;
+
+  get value(): any { return this._value; };
+  @Input() set value(v: any) {
+    if (v !== this._value) {
+      this._value = v;
+      this._onChangeCallback(v);
+    }
+  }
+
+  @Output('itemSelect') itemSelect: EventEmitter<string> = new EventEmitter<string>();
+  @Output('focus') focus: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output('blur') blur: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+  clear(): boolean {
+    this.writeValue('');
+    return true;
+  }
+
+  randomName(): string {
+    let text: string = '';
+    let possible: string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+    for (let i: number = 0; i < 7; i++ ) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+
+    return text;
+  }
+
+  handleItemSelect(): void {
+    this.itemSelect.emit(this._value);
+  }
+
+  handleFocus(): void {
+    this.focus.emit(true);
+  }
+
+  handleBlur(): void {
+    this.blur.emit(false);
+  }
+
+  /**
+   * Implemented as part of ControlValueAccessor.
+   * TODO: internal
+   */
+  writeValue(value: any): void {
+    this._value = value;
+  }
+
+  /**
+   * Implemented as part of ControlValueAccessor.
+   * TODO: internal
+   */
+  registerOnChange(fn: any): void {
+    this._onChangeCallback = fn;
+  }
+
+  /**
+   * Implemented as part of ControlValueAccessor.
+   * TODO: internal
+   */
+  registerOnTouched(fn: any): void {
+    this._onTouchedCallback = fn;
+  }
+
+}

--- a/src/platform/chips/chip.component.html
+++ b/src/platform/chips/chip.component.html
@@ -1,0 +1,3 @@
+<div>
+  <ng-content></ng-content>
+</div>

--- a/src/platform/chips/chip.component.html
+++ b/src/platform/chips/chip.component.html
@@ -1,3 +1,3 @@
-<div layout="row" flex>
+<span class="td-chip">
   <ng-content></ng-content>
-</div>
+</span>

--- a/src/platform/chips/chip.component.html
+++ b/src/platform/chips/chip.component.html
@@ -1,3 +1,3 @@
-<div>
+<div layout="row" flex>
   <ng-content></ng-content>
 </div>

--- a/src/platform/chips/chip.component.scss
+++ b/src/platform/chips/chip.component.scss
@@ -1,0 +1,19 @@
+:host {
+  display: block;
+}
+
+div {
+    background: rgb(224,224,224);
+    color: rgb(66,66,66);
+    cursor: default;
+    border-radius: 16px;
+    display: block;
+    height: 32px;
+    line-height: 32px;
+    margin: 8px 8px 0 0;
+    padding: 0 12px;
+    float: left;
+    box-sizing: border-box;
+    max-width: 100%;
+    position: relative;
+}

--- a/src/platform/chips/chip.component.scss
+++ b/src/platform/chips/chip.component.scss
@@ -9,7 +9,7 @@ div {
     border-radius: 16px;
     display: block;
     line-height: 32px;
-    margin: 12px 8px 0 0;
+    margin: 8px 8px 0 0;
     padding: 0 12px;
     float: left;
     box-sizing: border-box;

--- a/src/platform/chips/chip.component.scss
+++ b/src/platform/chips/chip.component.scss
@@ -8,9 +8,8 @@ div {
     cursor: default;
     border-radius: 16px;
     display: block;
-    height: 32px;
     line-height: 32px;
-    margin: 8px 8px 0 0;
+    margin: 12px 8px 0 0;
     padding: 0 12px;
     float: left;
     box-sizing: border-box;

--- a/src/platform/chips/chip.component.scss
+++ b/src/platform/chips/chip.component.scss
@@ -1,18 +1,4 @@
 :host {
   display: block;
-}
-
-div {
-    background: rgb(224,224,224);
-    color: rgb(66,66,66);
-    cursor: default;
-    border-radius: 16px;
-    display: block;
-    line-height: 32px;
-    margin: 8px 8px 0 0;
-    padding: 0 12px;
-    float: left;
-    box-sizing: border-box;
-    max-width: 100%;
-    position: relative;
+  float: left;
 }

--- a/src/platform/chips/chip.component.ts
+++ b/src/platform/chips/chip.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  moduleId: module.id,
+  selector: 'td-chip',
+  styleUrls: [ 'chip.component.css' ],
+  templateUrl: 'chip.component.html',
+})
+export class TdChipComponent {
+
+}

--- a/src/platform/chips/chips.component.html
+++ b/src/platform/chips/chips.component.html
@@ -1,6 +1,6 @@
 <div flex>
   <template let-chip ngFor [ngForOf]="value">
-    <td-chip>{{chip}}<md-icon *ngIf="!readOnly" (click)="removeItem(chip)">cancel</md-icon></td-chip>
+    <td-chip><span>{{chip}}</span><md-icon *ngIf="!readOnly" (click)="removeItem(chip)">cancel</md-icon></td-chip>
   </template>
   <td-autocomplete #autocomplete 
                    [hidden]="readOnly" 

--- a/src/platform/chips/chips.component.html
+++ b/src/platform/chips/chips.component.html
@@ -1,0 +1,17 @@
+<div flex>
+  <template let-chip ngFor [ngForOf]="value">
+    <td-chip>{{chip}}<md-icon *ngIf="!readOnly" (click)="removeItem(chip)">cancel</md-icon></td-chip>
+  </template>
+  <td-autocomplete #autocomplete 
+                   [hidden]="readOnly" 
+                   [searchItems]="filteredSearchItems"
+                   (focus)="focused = $event"
+                   (blur)="(focused = $event) || (matches = autocomplete.clear())"
+                   (itemSelect)="(matches = addItem($event)) && autocomplete.clear()"></td-autocomplete>
+  <div class="md-input-underline"
+       [class.md-disabled]="disabled">
+    <span class="md-input-ripple"
+          [class.md-focused]="focused"
+          [class.md-warn]="!matches"></span>
+  </div>
+</div>

--- a/src/platform/chips/chips.component.html
+++ b/src/platform/chips/chips.component.html
@@ -12,7 +12,7 @@
   <td-autocomplete #autocomplete 
                    [disabled]="readOnly" 
                    [searchItems]="filteredItems"
-                   [placeholder]="placeholder"
+                   [placeholder]="readOnly? '' : placeholder"
                    (focus)="handleFocus()"
                    (blur)="handleBlur() && (matches = autocomplete.clear())"
                    (itemSelect)="(matches = addItem($event)) && autocomplete.clear()"></td-autocomplete>

--- a/src/platform/chips/chips.component.html
+++ b/src/platform/chips/chips.component.html
@@ -1,6 +1,12 @@
 <div flex>
   <template let-chip ngFor [ngForOf]="value">
-    <td-chip><span>{{chip}}</span><md-icon *ngIf="!readOnly" (click)="removeItem(chip)">cancel</md-icon></td-chip>
+    <td-chip>
+      <span>{{chip}}</span>
+      <md-icon *ngIf="!readOnly"
+               [tabIndex]="0" 
+               (keydown.enter)="removeItem(chip)" 
+               (click)="removeItem(chip)">cancel</md-icon>
+    </td-chip>
   </template>
   <td-autocomplete #autocomplete 
                    [disabled]="readOnly" 

--- a/src/platform/chips/chips.component.html
+++ b/src/platform/chips/chips.component.html
@@ -12,6 +12,7 @@
   <td-autocomplete #autocomplete 
                    [disabled]="readOnly" 
                    [searchItems]="filteredItems"
+                   [placeholder]="placeholder"
                    (focus)="handleFocus()"
                    (blur)="handleBlur() && (matches = autocomplete.clear())"
                    (itemSelect)="(matches = addItem($event)) && autocomplete.clear()"></td-autocomplete>

--- a/src/platform/chips/chips.component.html
+++ b/src/platform/chips/chips.component.html
@@ -3,10 +3,10 @@
     <td-chip><span>{{chip}}</span><md-icon *ngIf="!readOnly" (click)="removeItem(chip)">cancel</md-icon></td-chip>
   </template>
   <td-autocomplete #autocomplete 
-                   [hidden]="readOnly" 
+                   [disabled]="readOnly" 
                    [searchItems]="filteredItems"
-                   (focus)="focused = $event"
-                   (blur)="onTouched() || (focused = $event) || (matches = autocomplete.clear())"
+                   (focus)="handleFocus()"
+                   (blur)="handleBlur() && (matches = autocomplete.clear())"
                    (itemSelect)="(matches = addItem($event)) && autocomplete.clear()"></td-autocomplete>
   <div class="md-input-underline"
        [class.md-disabled]="disabled">

--- a/src/platform/chips/chips.component.html
+++ b/src/platform/chips/chips.component.html
@@ -6,7 +6,7 @@
                    [hidden]="readOnly" 
                    [searchItems]="filteredItems"
                    (focus)="focused = $event"
-                   (blur)="(focused = $event) || (matches = autocomplete.clear())"
+                   (blur)="onTouched() || (focused = $event) || (matches = autocomplete.clear())"
                    (itemSelect)="(matches = addItem($event)) && autocomplete.clear()"></td-autocomplete>
   <div class="md-input-underline"
        [class.md-disabled]="disabled">

--- a/src/platform/chips/chips.component.html
+++ b/src/platform/chips/chips.component.html
@@ -4,7 +4,7 @@
   </template>
   <td-autocomplete #autocomplete 
                    [hidden]="readOnly" 
-                   [searchItems]="filteredSearchItems"
+                   [searchItems]="filteredItems"
                    (focus)="focused = $event"
                    (blur)="(focused = $event) || (matches = autocomplete.clear())"
                    (itemSelect)="(matches = addItem($event)) && autocomplete.clear()"></td-autocomplete>

--- a/src/platform/chips/chips.component.html
+++ b/src/platform/chips/chips.component.html
@@ -5,7 +5,8 @@
       <md-icon *ngIf="!readOnly"
                [tabIndex]="0" 
                (keydown.enter)="removeItem(chip)" 
-               (click)="removeItem(chip)">cancel</md-icon>
+               (click)="removeItem(chip)"
+               title="Delete">cancel</md-icon>
     </td-chip>
   </template>
   <td-autocomplete #autocomplete 

--- a/src/platform/chips/chips.component.scss
+++ b/src/platform/chips/chips.component.scss
@@ -15,13 +15,31 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
 :host {
   display: block;
   padding: 0px 5px 0px 5px;
-}
-
-td-chip {
-  md-icon {
+  .td-chip {
+    display: inline-block;;
+    background: md-color($md-grey, 300);;
+    color: rgba(0, 0, 0, 0.87);
+    cursor: default;
+    border-radius: 16px;
+    line-height: 32px;
+    margin: 8px 8px 0 0;
+    padding: 0 12px;
+    box-sizing: border-box;
+    max-width: 100%;
     position: relative;
-    top: 5px;
-    left: 5px;
+    md-icon {
+      position: relative;
+      top: 5px;
+      left: 5px;
+      height: 18px;
+      width: 18px;
+      font-size: 19px;
+      color: rgba(0, 0, 0, 0.23);
+      &:hover {
+        cursor: pointer;
+        color: rgba(0, 0, 0, 0.54);
+      }
+    }
   }
 }
 

--- a/src/platform/chips/chips.component.scss
+++ b/src/platform/chips/chips.component.scss
@@ -1,0 +1,76 @@
+@import '../core/styles/variables';
+@import '../core/styles/default-theme';
+
+// Underline colors.
+$md-input-underline-color: md-color($md-foreground, hint-text);
+$md-input-underline-color-accent: md-color($md-accent);
+$md-input-underline-color-warn: md-color($md-warn);
+$md-input-underline-disabled-color: md-color($md-foreground, hint-text);
+$md-input-underline-focused-color: md-color($md-primary);
+
+// Gradient for showing the dashed line when the input is disabled.
+$md-input-underline-disabled-background-image: linear-gradient(to right,
+        rgba(0, 0, 0, 0.26) 0%, rgba(0, 0, 0, 0.26) 33%, transparent 0%);
+
+:host {
+  display: block;
+  padding: 5px 5px 5px;
+}
+
+td-chip {
+  md-icon {
+    position: relative;
+    top: 5px;
+    left: 5px;
+  }
+}
+
+.md-input-underline {
+  position: relative;
+  height: 1px;
+  width: 100%;
+  margin-top: 4px;
+  border-top: 1px solid $md-input-underline-color;
+
+  &.md-disabled {
+    border-top: 0;
+    background-image: $md-input-underline-disabled-background-image;
+    background-position: 0;
+    background-size: 4px 1px;
+    background-repeat: repeat-x;
+  }
+
+  .md-input-ripple {
+    position: absolute;
+    height: 2px;
+    z-index: 1;
+    background-color: $md-input-underline-focused-color;
+    top: -1px;
+    width: 100%;
+    transform-origin: top;
+    opacity: 0;
+    transform: scaleY(0);
+    transition: transform $swift-ease-out-duration $swift-ease-out-timing-function,
+                opacity $swift-ease-out-duration $swift-ease-out-timing-function;
+    &.md-accent {
+      background-color: $md-input-underline-color-accent;
+    }
+    &.md-warn {
+      background-color: $md-input-underline-color-warn;
+      opacity: 1;
+      transform: scaleY(1);
+    }
+    &.md-focused {
+      opacity: 1;
+      transform: scaleY(1);
+    }
+  }
+}
+
+:host {
+  md-input {
+    .md-input-underline {
+      display: none;
+    }
+  }
+}

--- a/src/platform/chips/chips.component.scss
+++ b/src/platform/chips/chips.component.scss
@@ -87,6 +87,9 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
 
 :host {
   md-input {
+    input::-webkit-calendar-picker-indicator { // removes input arrow for datalist in chrome
+      display: none;
+    }
     .md-input-underline {
       display: none;
     }

--- a/src/platform/chips/chips.component.scss
+++ b/src/platform/chips/chips.component.scss
@@ -14,7 +14,7 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
 
 :host {
   display: block;
-  padding: 5px 5px 5px;
+  padding: 0px 5px 0px 5px;
 }
 
 td-chip {

--- a/src/platform/chips/chips.component.ts
+++ b/src/platform/chips/chips.component.ts
@@ -67,7 +67,7 @@ export class TdChipsComponent implements ControlValueAccessor {
   }
 
   addItem(value: string): boolean {
-    if (this._value.indexOf(value) > -1) {
+    if (value.trim() === '' || this._value.indexOf(value) > -1) {
       return false;
     }
     if (this.searchItems && this.requireMatch) {

--- a/src/platform/chips/chips.component.ts
+++ b/src/platform/chips/chips.component.ts
@@ -54,16 +54,12 @@ export class TdChipsComponent implements ControlValueAccessor {
   }
 
   get filteredSearchItems(): string[] {
+    if (!this._value) {
+      return [];
+    }
     return this.searchItems.filter((item: string) => {
       return this._value.indexOf(item) < 0;
     });
-  }
-
-  isEmpty(value: string): boolean {
-    if (value.length === 0) {
-      return true;
-    }
-    return false;
   }
 
   addItem(value: string): boolean {

--- a/src/platform/chips/chips.component.ts
+++ b/src/platform/chips/chips.component.ts
@@ -73,6 +73,12 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck {
   @Input('readOnly') readOnly: boolean = false;
 
   /**
+   * placeholder?: string
+   * Placeholder for the autocomplete input.
+   */
+  @Input('placeholder') placeholder: string;
+
+  /**
    * add?: function
    * Method to be executed when string is added as chip through the autocomplete.
    * Sends chip value as event.

--- a/src/platform/chips/chips.component.ts
+++ b/src/platform/chips/chips.component.ts
@@ -38,6 +38,7 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck {
   private _requireMatch: boolean = false;
 
   matches: boolean = true;
+  focused: boolean = false;
 
   @Input('items') items: string[] = [];
   @Input('requireMatch')
@@ -99,6 +100,17 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck {
     this._value.splice(index, 1);
     this.remove.emit(value);
     this.onChange(this._value);
+    return true;
+  }
+
+  handleFocus(): boolean {
+    this.focused = true;
+    return true;
+  }
+
+  handleBlur(): boolean {
+    this.focused = false;
+    this.onTouched();
     return true;
   }
 

--- a/src/platform/chips/chips.component.ts
+++ b/src/platform/chips/chips.component.ts
@@ -34,13 +34,30 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck {
    * Implemented as part of ControlValueAccessor.
    */
   private _value: any = [];
+
   private _length: number = 0;
   private _requireMatch: boolean = false;
 
+  /**
+   * Boolean value that specifies if the input is valid against the provieded list.
+   */
   matches: boolean = true;
+  /**
+   * Flag that is true when autocomplete is focused.
+   */
   focused: boolean = false;
 
+  /**
+   * items?: string[]
+   * Enables Autocompletion with the provided list of strings.
+   */
   @Input('items') items: string[] = [];
+
+  /**
+   * requireMatch?: boolean
+   * Validates input against the provided list before adding it to the model.
+   * If it doesnt exist, it cancels the event.
+   */
   @Input('requireMatch')
   set requireMatch(requireMatch: any) {
     this._requireMatch = requireMatch !== '' ? (requireMatch === 'true' || requireMatch === true) : true;
@@ -48,26 +65,48 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck {
   get requireMatch(): any {
     return this._requireMatch;
   }
+
+  /**
+   * readOnly?: boolean
+   * Disables the chip input and removal.
+   */
   @Input('readOnly') readOnly: boolean = false;
 
+  /**
+   * add?: function
+   * Method to be executed when item is added as chip through the autocomplete.
+   */
   @Output('add') add: EventEmitter<string> = new EventEmitter<string>();
+
+  /**
+   * add?: function
+   * Method to be executed when item is removed as chip with the "remove" button.
+   */
   @Output('remove') remove: EventEmitter<string> = new EventEmitter<string>();
 
-  get value(): any { return this._value; };
+  /**
+   * Implemented as part of ControlValueAccessor.
+   */
   @Input() set value(v: any) {
     if (v !== this._value) {
       this._value = v;
       this._length = this._value ? this._value.length : 0;
     }
   }
+  get value(): any { return this._value; };
 
   ngDoCheck(): void {
+    // Throw onChange event only if array changes size.
     if (this._value && this._value.length !== this._length) {
       this._length = this._value.length;
       this.onChange(this._value);
     }
   }
 
+  /**
+   * Returns a list of filtered items.
+   * Removes the ones that have been added as value.
+   */
   get filteredItems(): string[] {
     if (!this._value) {
       return [];
@@ -77,6 +116,10 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck {
     });
   }
 
+  /**
+   * Method that is executed when trying to create a new chip from the autocomplete.
+   * returns 'true' if successful, 'false' if it fails.
+   */
   addItem(value: string): boolean {
     if (value.trim() === '' || this._value.indexOf(value) > -1) {
       return false;
@@ -92,6 +135,10 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck {
     return true;
   }
 
+  /**
+   * Method that is executed when trying to remove a chip.
+   * returns 'true' if successful, 'false' if it fails.
+   */
   removeItem(value: string): boolean {
     let index: number = this._value.indexOf(value);
     if (index < 0) {
@@ -121,28 +168,15 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck {
     this.value = value;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   */
   registerOnChange(fn: any): void {
     this.onChange = fn;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   */
   registerOnTouched(fn: any): void {
     this.onTouched = fn;
   }
 
-  /**
-   * Implemented as part of ControlValueAccessor.
-   */
   onChange = (_: any) => noop;
-
-  /**
-   * Implemented as part of ControlValueAccessor.
-   */
   onTouched = () => noop;
 
 }

--- a/src/platform/chips/chips.component.ts
+++ b/src/platform/chips/chips.component.ts
@@ -74,13 +74,15 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck {
 
   /**
    * add?: function
-   * Method to be executed when item is added as chip through the autocomplete.
+   * Method to be executed when string is added as chip through the autocomplete.
+   * Sends chip value as event.
    */
   @Output('add') add: EventEmitter<string> = new EventEmitter<string>();
 
   /**
-   * add?: function
-   * Method to be executed when item is removed as chip with the "remove" button.
+   * remove?: function
+   * Method to be executed when string is removed as chip with the "remove" button.
+   * Sends chip value as event.
    */
   @Output('remove') remove: EventEmitter<string> = new EventEmitter<string>();
 

--- a/src/platform/chips/chips.component.ts
+++ b/src/platform/chips/chips.component.ts
@@ -1,0 +1,117 @@
+import { Component, Input, Output, forwardRef } from '@angular/core';
+import { EventEmitter } from '@angular/core';
+import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+
+const noop: () => void = () => {
+  // empty method
+};
+
+export const TD_CHIPS_CONTROL_VALUE_ACCESSOR: any = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => TdChipsComponent),
+  multi: true,
+};
+
+import { MdIcon } from '@angular2-material/icon';
+import { TdAutoCompleteComponent } from './autocomplete/autocomplete.component';
+import { TdChipComponent } from './chip.component';
+
+@Component({
+  directives: [
+    MdIcon,
+    TdAutoCompleteComponent,
+    TdChipComponent,
+  ],
+  providers: [ TD_CHIPS_CONTROL_VALUE_ACCESSOR ],
+  moduleId: module.id,
+  selector: 'td-chips',
+  styleUrls: [ 'chips.component.css' ],
+  templateUrl: 'chips.component.html',
+})
+export class TdChipsComponent implements ControlValueAccessor {
+
+  private _value: any = [];
+  /** Callback registered via registerOnTouched (ControlValueAccessor) */
+  private _onTouchedCallback: () => void = noop;
+  /** Callback registered via registerOnChange (ControlValueAccessor) */
+  private _onChangeCallback: (_: any) => void = noop;
+
+  matches: boolean = true;
+
+  @Input('searchItems') searchItems: string[] = [];
+  @Input('requireMatch') requireMatch: boolean = false;
+  @Input('readOnly') readOnly: boolean = false;
+
+  @Output('add') add: EventEmitter<string> = new EventEmitter<string>();
+  @Output('remove') remove: EventEmitter<string> = new EventEmitter<string>();
+
+  get value(): any { return this._value; };
+  @Input() set value(v: any) {
+    if (v !== this._value) {
+      this._value = v;
+      this._onChangeCallback(v);
+    }
+  }
+
+  get filteredSearchItems(): string[] {
+    return this.searchItems.filter((item: string) => {
+      return this._value.indexOf(item) < 0;
+    });
+  }
+
+  isEmpty(value: string): boolean {
+    if (value.length === 0) {
+      return true;
+    }
+    return false;
+  }
+
+  addItem(value: string): boolean {
+    if (this._value.indexOf(value) > -1) {
+      return false;
+    }
+    if (this.searchItems && this.requireMatch) {
+      if (this.searchItems.indexOf(value) < 0) {
+        return false;
+      }
+    }
+    this._value.push(value);
+    this.add.emit(value);
+    return true;
+  }
+
+  removeItem(value: string): boolean {
+    let index: number = this._value.indexOf(value);
+    if (index < 0) {
+      return false;
+    }
+    this._value.splice(index, 1);
+    this.remove.emit(value);
+    return true;
+  }
+
+  /**
+   * Implemented as part of ControlValueAccessor.
+   * TODO: internal
+   */
+  writeValue(value: any): void {
+    this._value = value;
+  }
+
+  /**
+   * Implemented as part of ControlValueAccessor.
+   * TODO: internal
+   */
+  registerOnChange(fn: any): void {
+    this._onChangeCallback = fn;
+  }
+
+  /**
+   * Implemented as part of ControlValueAccessor.
+   * TODO: internal
+   */
+  registerOnTouched(fn: any): void {
+    this._onTouchedCallback = fn;
+  }
+
+}

--- a/src/platform/chips/chips.component.ts
+++ b/src/platform/chips/chips.component.ts
@@ -38,7 +38,7 @@ export class TdChipsComponent implements ControlValueAccessor {
 
   matches: boolean = true;
 
-  @Input('searchItems') searchItems: string[] = [];
+  @Input('items') items: string[] = [];
   @Input('requireMatch') requireMatch: boolean = false;
   @Input('readOnly') readOnly: boolean = false;
 
@@ -53,11 +53,11 @@ export class TdChipsComponent implements ControlValueAccessor {
     }
   }
 
-  get filteredSearchItems(): string[] {
+  get filteredItems(): string[] {
     if (!this._value) {
       return [];
     }
-    return this.searchItems.filter((item: string) => {
+    return this.items.filter((item: string) => {
       return this._value.indexOf(item) < 0;
     });
   }
@@ -66,8 +66,8 @@ export class TdChipsComponent implements ControlValueAccessor {
     if (value.trim() === '' || this._value.indexOf(value) > -1) {
       return false;
     }
-    if (this.searchItems && this.requireMatch) {
-      if (this.searchItems.indexOf(value) < 0) {
+    if (this.items && this.requireMatch) {
+      if (this.items.indexOf(value) < 0) {
         return false;
       }
     }

--- a/src/platform/chips/index.ts
+++ b/src/platform/chips/index.ts
@@ -1,2 +1,1 @@
 export { TdChipsComponent } from './chips.component';
-export { TdAutoCompleteComponent } from './autocomplete/autocomplete.component';

--- a/src/platform/chips/index.ts
+++ b/src/platform/chips/index.ts
@@ -1,0 +1,2 @@
+export { TdChipsComponent } from './chips.component';
+export { TdAutoCompleteComponent } from './autocomplete/autocomplete.component';

--- a/src/platform/chips/package.json
+++ b/src/platform/chips/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@covalent/chips",
+  "version": "0.5.0",
+  "description": "Teradata UI Platform Chips Module",
+  "keywords": [
+    "angular",
+    "components",
+    "reusable",
+    "chips",
+    "list"
+  ],
+  "scripts": {
+  },
+  "engines": {
+    "node": ">4.4 < 5",
+    "npm": ">= 3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/teradata/covalent.git"
+  },
+  "bugs": {
+    "url": "https://github.com/teradata/covalent/issues"
+  },
+  "license": "MIT",
+  "author": "Teradata UX",
+  "contributors": [
+    "Kyle Ledbetter <kyle.ledbetter@teradata.com>",
+    "Richa Vyas <richa.vyas@teradata.com>",
+    "Ed Morales <eduardo.morales@teradata.com>",
+    "Jason Weaver <jason.weaver@teradata.com>",
+    "Jeremy Wilken <jeremy.wilken@teradata.com>"
+  ],
+  "dependencies": {
+    "@covalent/core": "0.5.0"
+  }
+}

--- a/src/system-config.ts
+++ b/src/system-config.ts
@@ -35,6 +35,7 @@ const barrels: string[] = [
   'platform/file-upload',
   'platform/markdown',
   'platform/http',
+  'platform/chips',
 
   // App specific barrels.
   'app',

--- a/src/system-config.ts
+++ b/src/system-config.ts
@@ -50,6 +50,7 @@ const barrels: string[] = [
   'app/components/components/pipes',
   'app/components/components/media',
   'app/components/components/http',
+  'app/components/components/chips',
   'app/components/components/markdown',
   'app/components/docs',
   'app/components/docs/overview',


### PR DESCRIPTION
## Description

First iteration of the Chips Module.

### What's included?

#### TdChipsComponent

Added <td-chips> component that generates a list of string as chips.
- Module docs and demo.
- Added package.json
- Added README.md
- [items] attribute to provide a search list for autocomplete.
- [readOnly] flag to disable edition (entering/removing chips)
- [requireMatch] flag to validate autocomplete input against search list.
- Basic `a11y` (tabbing between autocomplete and removal buttons, and enter to remove chip)

Usage:
```html
<td-chips [items]="items" [(ngModel)]="model" readOnly="readOnly" (add)="add($event)" (remove)="remove($event)" requireMatch>
</td-chips>
```
Properties:
![image](https://cloud.githubusercontent.com/assets/5846742/17758043/c7ad8f5e-64a0-11e6-982d-75aaf83bede3.png)

#### Test Steps

- [x] `ng serve`
- [x] go to http://localhost:4200/#/components/chips
- [x] Use demo and see documentation.
- [x] Try to use element following documentation anywhere in docs app.
- [x] :v: 

##### Screenshots or link to CodePen/Plunker/JSfiddle
![td-chips-demo1](https://cloud.githubusercontent.com/assets/5846742/17758049/d73837b2-64a0-11e6-9539-f6338c7ef848.gif)

