### PR TITLE
Feature/loading polish

### DIFF
--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -38,9 +38,9 @@
     <p>Simply add the <code>tdLoading</code> attibute with a "name" value to the element you want to mask.</p>
     <p>Dont forget to add the asterisk syntax before the <code>tdLoading</code> directive if its not used in a <code><![CDATA[<template>]]></code> element.</p>
     <p>More info on the asterisk (*) syntax <a target="_blank" href="https://angular.io/docs/ts/latest/guide/template-syntax.html#!#star-template">here</a></p>
-    <p>Note: when used on load, should be registered in [TdLoadingService] after 'AfterViewInit#ngAfterViewInit()' component hook cycle.</p>
+    <p>Note: when used on page load, <code>tdLoading</code> should be registered in [TdLoadingService] after 'AfterViewInit#ngAfterViewInit()' component hook cycle.</p>
     <h3>Properties:</h3>
-    <p>The <code>tdLoading</code> component has {{loadingAttrs.length}} properties:</p>
+    <p>The <code>tdLoading</code> directive has {{loadingAttrs.length}} properties:</p>
     <md-list>
       <template let-attr let-last="attr" ngFor [ngForOf]="loadingAttrs">
         <a md-list-item layout-align="row">
@@ -50,7 +50,7 @@
         <md-divider *ngIf="!last"></md-divider>
       </template>
     </md-list>
-    <h3>Example:</h3>
+    <h3>Example(after setup):</h3>
     <p>HTML (*) syntax:</p>
     <td-highlight lang="html">
       <![CDATA[
@@ -70,11 +70,8 @@
     <p>Typescript:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { TdLoadingDirective, TdLoadingService, TD_LOADING_ENTRY_COMPONENTS } from '@covalent/core';
+        import { TdLoadingService } from '@covalent/core';
         ...
-          directives: [ TdLoadingDirective ],
-          providers: [ TdLoadingService ],
-          precompile: [ TD_LOADING_ENTRY_COMPONENTS ],
         })
         export class Demo {
           constructor(private _loadingService: TdLoadingService) {
@@ -89,6 +86,23 @@
             this._loadingService.resolve('stringName');
           }
         }
+      ]]>
+    </td-highlight>
+    <h3>Setup:</h3>
+    <p>Import the [CovalentCoreModule] using the <code>forRoot()</code> method and set [TD_LOADING_ENTRY_COMPONENTS] as 'entryComponents' in your NgModule:</p>
+    <td-highlight lang="typescript">
+      <![CDATA[
+        import { CovalentCoreModule, TD_LOADING_ENTRY_COMPONENTS } from '../platform/core';
+
+        @NgModule({
+          imports: [
+            CovalentCoreModule.forRoot(),
+            ...
+          ],
+          entryComponents: [ TD_LOADING_ENTRY_COMPONENTS ],
+          ...
+        })
+        export class MyModule {}
       ]]>
     </td-highlight>
   </md-card-content>
@@ -119,16 +133,13 @@
         <md-divider *ngIf="!last"></md-divider>
       </template>
     </md-list>
-    <h3>Example:</h3>
+    <h3>Example(after setup):</h3>
     <p>Typescript:</p>
     <td-highlight lang="typescript">
       <![CDATA[
         import { ViewContainerRef } from '@angular/core';
-        import { TdLoadingService, ILoadingOptions, LoadingType, TD_LOADING_ENTRY_COMPONENTS } from '@covalent/core';
+        import { TdLoadingService, ILoadingOptions, LoadingType } from '@covalent/core';
         ...
-          providers: [ TdLoadingService ],
-          precompile: [ TD_LOADING_ENTRY_COMPONENTS ],
-        })
         export class Demo {
           constructor(private _loadingService: TdLoadingService, viewContainerRef: ViewContainerRef) {
             let options: ILoadingOptions = {

--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -92,7 +92,7 @@
     <p>Import the [CovalentCoreModule] using the <code>forRoot()</code> method and set [TD_LOADING_ENTRY_COMPONENTS] as 'entryComponents' in your NgModule:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { CovalentCoreModule, TD_LOADING_ENTRY_COMPONENTS } from '../platform/core';
+        import { CovalentCoreModule, TD_LOADING_ENTRY_COMPONENTS } from '@covalent/core';
 
         @NgModule({
           imports: [

--- a/src/app/components/components/loading/loading.component.ts
+++ b/src/app/components/components/loading/loading.component.ts
@@ -1,9 +1,8 @@
-import { Component, ViewContainerRef, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { Component, ViewContainerRef, AfterViewInit } from '@angular/core';
 
 import { TdLoadingService, ILoadingOptions, LoadingType } from '../../../../platform/core';
 
 @Component({
-  providers: [TdLoadingService], // TODOBUG Remove when we upstream fixes from AC
   moduleId: module.id,
   selector: 'loading-demo',
   styleUrls: [ 'loading.component.css' ],
@@ -43,7 +42,6 @@ export class LoadingDemoComponent implements AfterViewInit {
   }];
 
   constructor(viewContainer: ViewContainerRef,
-              private _changeDetectorRef: ChangeDetectorRef,
               private _loadingService: TdLoadingService) {
     let options: ILoadingOptions = {
       name: 'test.overlay',
@@ -59,7 +57,6 @@ export class LoadingDemoComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
     this.registerLoadingReplace();
-    this._changeDetectorRef.detectChanges();
   }
 
   registerCircleLoadingOverlay(): void {

--- a/src/platform/core/index.ts
+++ b/src/platform/core/index.ts
@@ -155,7 +155,6 @@ export const TD_LOADING_ENTRY_COMPONENTS: Type<any>[] = [
 
 export { LoadingType } from './loading/loading.component';
 export { TdLoadingService, ILoadingOptions } from './loading/services/loading.service';
-export { TdLoadingDirective } from './loading/directives/loading.directive'
 
 // Expansion
 export { TdExpansionPanelComponent } from './expansion-panel/expansion-panel.component';

--- a/src/platform/core/loading/loading.component.html
+++ b/src/platform/core/loading/loading.component.html
@@ -9,7 +9,7 @@
      layout-padding
      flex>
     <md-progress-circle *ngIf="isCircular()" 
-                        mode="indeterminate" 
+                        [mode]="mode" 
                         color="primary" 
                         [style.height]="getCircleDiameter()"
                         [style.width]="getCircleDiameter()">

--- a/src/platform/core/loading/loading.component.ts
+++ b/src/platform/core/loading/loading.component.ts
@@ -18,18 +18,17 @@ export class TdLoadingComponent {
 
   private _animationIn: Subject<any> = new Subject<any>();
   private _animationOut: Subject<any> = new Subject<any>();
-  private _animation: boolean = true;
   private _overlay: boolean = false;
 
   /**
    * Flag for animation
    */
-  set animation(animation: boolean) {
-    this._animation = animation;
-  }
-  get animation(): boolean {
-    return this._animation;
-  }
+  animation: boolean = false;
+
+  /**
+   * Flag for mode
+   */
+  mode: string = 'indeterminate';
 
   /**
    * overlay: boolean
@@ -92,7 +91,8 @@ export class TdLoadingComponent {
    * Starts in animation and returns an observable for completition event.
    */
   startInAnimation(): Observable<any> {
-    this._animation = false;
+    this.animation = false;
+    this.mode = 'indeterminate';
     return this._animationIn.asObservable();
   }
 
@@ -100,7 +100,11 @@ export class TdLoadingComponent {
    * Starts out animation and returns an observable for completition event.
    */
   startOutAnimation(): Observable<any> {
-    this._animation = true;
+    this.animation = true;
+    /* need to switch back and forth from determinate/indeterminate so the setInterval()
+    * inside md-progress-circle stops and protractor doesnt timeout waiting to sync.
+    */
+    this.mode = 'determinate';
     return this._animationOut.asObservable();
   }
 }

--- a/src/platform/core/loading/services/loading.service.ts
+++ b/src/platform/core/loading/services/loading.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ComponentFactoryResolver, NgZone } from '@angular/core';
+import { Injectable, ComponentFactoryResolver } from '@angular/core';
 import { Injector, ComponentRef, ViewContainerRef, TemplateRef } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
@@ -33,8 +33,7 @@ export class TdLoadingService {
   private _loadingObservables: {[key: string]: Observable<any>} = {};
 
   constructor(private _componentFactoryResolver: ComponentFactoryResolver,
-              private _injector: Injector,
-              private _ngZone: NgZone) {
+              private _injector: Injector) {
   }
 
   /**
@@ -58,19 +57,13 @@ export class TdLoadingService {
       let instance: TdLoadingComponent = loadingRef.ref.instance;
       if (registered > 0 && !loading) {
         loading = true;
-        this._ngZone.runOutsideAngular(() => {
-          viewContainerRef.insert(loadingRef.ref.hostView, 0);
-          instance.startInAnimation();
-          this._ngZone.run(noop);
-        });
+        viewContainerRef.insert(loadingRef.ref.hostView, 0);
+        instance.startInAnimation();
       } else if (registered <= 0 && loading) {
         loading = false;
-        this._ngZone.runOutsideAngular(() => {
-          let subs: Subscription = instance.startOutAnimation().subscribe(() => {
-            subs.unsubscribe();
-            viewContainerRef.detach(viewContainerRef.indexOf(loadingRef.ref.hostView));
-            this._ngZone.run(noop);
-          });
+        let subs: Subscription = instance.startOutAnimation().subscribe(() => {
+          subs.unsubscribe();
+          viewContainerRef.detach(viewContainerRef.indexOf(loadingRef.ref.hostView));
         });
       }
     });
@@ -101,24 +94,18 @@ export class TdLoadingService {
       let instance: TdLoadingComponent = loadingRef.ref.instance;
       if (registered > 0 && !loading) {
         loading = true;
-        this._ngZone.runOutsideAngular(() => {
-          let index: number = viewContainerRef.indexOf(loadingRef.ref.hostView);
-          if (index < 0) {
-            viewContainerRef.clear();
-            viewContainerRef.insert(loadingRef.ref.hostView, 0);
-          }
-          instance.startInAnimation();
-          this._ngZone.run(noop);
-        });
+        let index: number = viewContainerRef.indexOf(loadingRef.ref.hostView);
+        if (index < 0) {
+          viewContainerRef.clear();
+          viewContainerRef.insert(loadingRef.ref.hostView, 0);
+        }
+        instance.startInAnimation();
       } else if (registered <= 0 && loading) {
         loading = false;
-        this._ngZone.runOutsideAngular(() => {
-          let subs: Subscription = instance.startOutAnimation().subscribe(() => {
-            subs.unsubscribe();
-            viewContainerRef.createEmbeddedView(templateRef);
-            viewContainerRef.detach(viewContainerRef.indexOf(loadingRef.ref.hostView));
-            this._ngZone.run(noop);
-          });
+        let subs: Subscription = instance.startOutAnimation().subscribe(() => {
+          subs.unsubscribe();
+          viewContainerRef.createEmbeddedView(templateRef);
+          viewContainerRef.detach(viewContainerRef.indexOf(loadingRef.ref.hostView));
         });
       }
     });

--- a/src/platform/core/loading/services/loading.service.ts
+++ b/src/platform/core/loading/services/loading.service.ts
@@ -6,10 +6,6 @@ import { Subscription } from 'rxjs/Subscription';
 
 import { TdLoadingComponent, LoadingType } from '../loading.component';
 
-const noop: () => void = () => {
-  // empty function
-};
-
 export interface ILoadingOptions {
   name: string;
   type?: LoadingType;

--- a/src/platform/core/loading/services/loading.service.ts
+++ b/src/platform/core/loading/services/loading.service.ts
@@ -91,7 +91,8 @@ export class TdLoadingService {
   public createReplaceComponent(options: ILoadingOptions, viewContainerRef: ViewContainerRef,
                                 templateRef: TemplateRef<Object>): void {
     let nativeElement: HTMLElement = <HTMLElement>templateRef.elementRef.nativeElement;
-    (<IInternalLoadingOptions>options).height = nativeElement.nextElementSibling.scrollHeight;
+    (<IInternalLoadingOptions>options).height = nativeElement.nextElementSibling ?
+      nativeElement.nextElementSibling.scrollHeight : undefined;
     (<IInternalLoadingOptions>options).overlay = false;
     let loadingRef: ILoadingRef = this._createComponent(options);
     let loading: boolean = false;
@@ -190,13 +191,13 @@ export class TdLoadingService {
     if (!name) {
       throw 'Name is required for Loading Component.';
     }
-    if (!this._context[name]) {
+    if (!this._context[name] || options.overlay) {
       this._context[name] = {};
     } else {
       throw 'Name duplication: Loading Component name conflict.';
     }
     this._context[name].loadingRef = this._componentFactoryResolver
-      .resolveComponentFactory(TdLoadingComponent).create(this._injector);
+    .resolveComponentFactory(TdLoadingComponent).create(this._injector);
     this._context[name].times = 0;
     this._mapOptions(options, this._context[name].loadingRef.instance);
     let compRef: ILoadingRef = {


### PR DESCRIPTION
## Description

Updated`tdLoading` with bug fixes + polishing + docs with `ngModule` usage.
https://github.com/Teradata/covalent/issues/65

### What's included?

- Updated docs with `ngModule` usage.
- Fixed bug with `protractor` + `md-progress-circle` by switching between `indeterminate`/`determinate` (`protractor` times out since `md-progress-circle` uses `setInterval` on `indeterminate`)
- Allow to override overlay loading components.
- Fixed bug when parent was template. (sibling undefined).
- Removed `ngZone` from `tdLoading` code.
- Removed `ChangeDetectorRef` and providers from demo.

#### Test Steps

- [x] `ng serve`
- [x] Go to http://localhost:4200/#/components/loading and see docs
- [x] :boom: 