### PR TITLE
bugfix(router): backbutton isnt working correctly.

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { LocationStrategy, HashLocationStrategy } from '@angular/common';
 
 import { DocsAppComponent } from './app.component';
 import { HomeComponent } from './components/home/home.component';
@@ -38,7 +37,6 @@ import { CovalentChipsModule } from '../platform/chips';
   ], // modules needed to run this module
   providers: [
     appRoutingProviders,
-    { provide: LocationStrategy, useClass: HashLocationStrategy },
   ], // additional providers needed for this module
   entryComponents: [ TD_LOADING_ENTRY_COMPONENTS ],
   bootstrap: [ DocsAppComponent ],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,6 @@
 import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { LocationStrategy, HashLocationStrategy } from '@angular/common';
 
 import { DocsAppComponent } from './app.component';
 import { HomeComponent } from './components/home/home.component';
@@ -21,6 +23,7 @@ import { CovalentChipsModule } from '../platform/chips';
     HomeComponent,
   ], // directives, components, and pipes owned by this NgModule
   imports: [
+    BrowserModule,
     ComponentsModule,
     DocsModule,
     LayoutsModule,
@@ -35,6 +38,7 @@ import { CovalentChipsModule } from '../platform/chips';
   ], // modules needed to run this module
   providers: [
     appRoutingProviders,
+    { provide: LocationStrategy, useClass: HashLocationStrategy },
   ], // additional providers needed for this module
   entryComponents: [ TD_LOADING_ENTRY_COMPONENTS ],
   bootstrap: [ DocsAppComponent ],

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,4 +12,4 @@ export const appRoutingProviders: any[] = [
 
 ];
 
-export const appRoutes: any = RouterModule.forRoot(routes);
+export const appRoutes: any = RouterModule.forRoot(routes, { useHash: true });

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,4 +12,4 @@ export const appRoutingProviders: any[] = [
 
 ];
 
-export const appRoutes: any = RouterModule.forRoot(routes, { useHash: true });
+export const appRoutes: any = RouterModule.forRoot(routes);

--- a/src/app/components/components/components.routes.ts
+++ b/src/app/components/components/components.routes.ts
@@ -57,4 +57,4 @@ const routes: Routes = [{
   path: 'components',
 }];
 
-export const componentsRoutes: any = RouterModule.forRoot(routes, { useHash: true });
+export const componentsRoutes: any = RouterModule.forChild(routes);

--- a/src/app/components/docs/docs.routes.ts
+++ b/src/app/components/docs/docs.routes.ts
@@ -45,4 +45,4 @@ const routes: Routes = [{
   path: 'docs',
 }];
 
-export const docsRoutes: any = RouterModule.forRoot(routes, { useHash: true });
+export const docsRoutes: any = RouterModule.forChild(routes);

--- a/src/app/components/layouts/layouts.routes.ts
+++ b/src/app/components/layouts/layouts.routes.ts
@@ -29,4 +29,4 @@ const routes: Routes = [{
   path: 'layouts',
 }];
 
-export const layoutsRoutes: any = RouterModule.forRoot(routes, { useHash: true });
+export const layoutsRoutes: any = RouterModule.forChild(routes);

--- a/src/app/components/style-guide/style-guide.routes.ts
+++ b/src/app/components/style-guide/style-guide.routes.ts
@@ -41,4 +41,4 @@ const routes: Routes = [{
   path: 'style-guide',
 }];
 
-export const styleGuideRoutes: any = RouterModule.forRoot(routes, { useHash: true });
+export const styleGuideRoutes: any = RouterModule.forChild(routes);

--- a/src/platform/core/index.ts
+++ b/src/platform/core/index.ts
@@ -1,11 +1,9 @@
 import { Type } from '@angular/core';
 import { NgModule, ModuleWithProviders } from '@angular/core';
 
-import { BrowserModule } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { HttpModule, JsonpModule } from '@angular/http';
 import { FormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
 
 /**
  * ANGULAR2 MATERIAL MODULES
@@ -215,11 +213,9 @@ export { TdMediaToggleDirective } from './media/directives/media-toggle.directiv
 
 @NgModule({
   imports: [
-    BrowserModule,
     HttpModule,
     JsonpModule,
     FormsModule,
-    RouterModule,
     CommonModule,
     MaterialModule.forRoot(),
   ],
@@ -235,11 +231,9 @@ export { TdMediaToggleDirective } from './media/directives/media-toggle.directiv
     TdToggleDirective,
   ],
   exports: [
-    BrowserModule,
     HttpModule,
     JsonpModule,
     FormsModule,
-    RouterModule,
     CommonModule,
     MaterialModule,
 


### PR DESCRIPTION
## Description

bugfix(router): router in submodules was configured incorrectly using `forRoot()`, needed to use `forChild()` since `forRoot()` tries to replaces the routes at an application level, which it already exists.

### What's included?

- Backbutton fixed.
- Router in submodules configured correctly with `forChild()`.

#### Test Steps

- [x] `ng serve`
- [x] Navigate and use back button.