### PR TITLE
feature(loading): added mode to loading directive + service.

### DIFF
--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -24,13 +24,13 @@
       </template>
       <p>Linear Type</p>
       <template tdLoading="test2.indeterminate" loadingType="linear">
-      <div layout="column" flex>
-        <md-input placeholder="Name" maxLength="20" [(ngModel)]="demo2.name">
-        </md-input>
-        <md-input placeholder="Description" maxLength="100" [(ngModel)]="demo2.desc">
-        </md-input>
-      </div>
-    </template>
+        <div layout="column" flex>
+          <md-input placeholder="Name" maxLength="20" [(ngModel)]="demo2.name">
+          </md-input>
+          <md-input placeholder="Description" maxLength="100" [(ngModel)]="demo2.desc">
+          </md-input>
+        </div>
+      </template>
     </div>
     <div *ngIf="determinate">
       <h3>Determinate Mode</h3>

--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -3,16 +3,27 @@
   <md-card-subtitle>Circular or linear progress loader</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
-    <p>Replace Loading Registered: {{replaceRegistered}} times</p>
-    <p>Circular Loading</p>
-    <div *tdLoading="'test'" loadingType="circular" layout="column" flex>
-      <md-input placeholder="Name" maxLength="20" [(ngModel)]="demo.name">
-      </md-input>
-      <md-input placeholder="Description" maxLength="100" [(ngModel)]="demo.desc">
-      </md-input>
+    <div layout="row" layout-align="start center" flex>
+      <md-button-toggle-group name="mode" [(ngModel)]="determinate" (click)="modeChange()">
+        <md-button-toggle md-tooltip="Determinate" [value]="0"><md-icon>timer_off</md-icon></md-button-toggle>
+        <md-button-toggle md-tooltip="Indeterminate" [value]="1"><md-icon>timer</md-icon></md-button-toggle>
+      </md-button-toggle-group>
+      <span flex="5"></span>
+      <span>Loading Registered: {{replaceRegistered}} times</span>
     </div>
-    <p>Linear Loading</p>
-    <template tdLoading="test2" loadingType="linear">
+    <div *ngIf="!determinate">
+      <h3>Indeterminate Mode</h3>
+      <p>Circular Type</p>
+      <template tdLoading="test.indeterminate">
+        <div layout="column" flex>
+          <md-input placeholder="Name" maxLength="20" [(ngModel)]="demo.name">
+          </md-input>
+          <md-input placeholder="Description" maxLength="100" [(ngModel)]="demo.desc">
+          </md-input>
+        </div>
+      </template>
+      <p>Linear Type</p>
+      <template tdLoading="test2.indeterminate" loadingType="linear">
       <div layout="column" flex>
         <md-input placeholder="Name" maxLength="20" [(ngModel)]="demo2.name">
         </md-input>
@@ -20,13 +31,35 @@
         </md-input>
       </div>
     </template>
+    </div>
+    <div *ngIf="determinate">
+      <h3>Determinate Mode</h3>
+      <p>Circular Type</p>
+      <template tdLoading="test.determinate" loadingMode="determinate">
+        <div layout="column" flex>
+          <md-input placeholder="Name" maxLength="20" [(ngModel)]="demo.name">
+          </md-input>
+          <md-input placeholder="Description" maxLength="100" [(ngModel)]="demo.desc">
+          </md-input>
+        </div>
+      </template>
+      <p>Linear Type</p>
+      <template tdLoading="test2.determinate" loadingType="linear" loadingMode="determinate">
+        <div layout="column" flex>
+          <md-input placeholder="Name" maxLength="20" [(ngModel)]="demo2.name">
+          </md-input>
+          <md-input placeholder="Description" maxLength="100" [(ngModel)]="demo2.desc">
+          </md-input>
+        </div>
+      </template>
+    </div>
   </md-card-content>
   <md-divider></md-divider>
   <md-card-actions>
-    <button md-button color="primary" (click)="registerCircleLoadingOverlay()">3 Second Circle Loading Overlay</button>
-    <button md-button color="primary" (click)="registerLinearLoadingOverlay()">3 Second Linear Loading Overlay</button>
-    <button md-button color="primary" (click)="registerLoadingReplace()">Register Loading Replace</button>
-    <button md-button color="primary" (click)="resolveLoadingReplace()">Resolve Loading Replace</button>
+    <button md-button color="primary" (click)="registerCircleLoadingMain()">3 Second Circle Loading Main</button>
+    <button md-button color="primary" (click)="registerLinearLoadingMain()">3 Second Linear Loading Main</button>
+    <button md-button color="primary" (click)="registerLoadingDirective()">Register Loading Directive</button>
+    <button md-button color="primary" (click)="resolveLoadingDirective()">Resolve Loading Directive</button>
   </md-card-actions>
 </md-card>
 <md-card>
@@ -62,7 +95,7 @@
     <p>HTML <![CDATA[<template>]]> syntax</p>
     <td-highlight lang="html">
       <![CDATA[
-        <template tdLoading="stringName" loadingType="circular|linear">
+        <template tdLoading="stringName" loadingType="circular|linear" loadingMode="ciruclar|linear">
           ...
         </template>
       ]]>
@@ -84,6 +117,10 @@
 
           resolveLoading(): void {
             this._loadingService.resolve('stringName');
+          }
+
+          changeValue(value: number): void { // Usage only enabled on [LoadingMode.Determinate] mode.
+            this._loadingService.setValue('stringName', value);
           }
         }
       ]]>
@@ -120,6 +157,7 @@
       interface ILoadingOptions {{'{'}}
         name: string;
         type?: LoadingType;
+        mode?: LoadingMode;
       }
     </td-highlight>
     <h3>Methods:</h3>
@@ -138,13 +176,14 @@
     <td-highlight lang="typescript">
       <![CDATA[
         import { ViewContainerRef } from '@angular/core';
-        import { TdLoadingService, ILoadingOptions, LoadingType } from '@covalent/core';
+        import { TdLoadingService, ILoadingOptions, LoadingType, LoadingMode } from '@covalent/core';
         ...
         export class Demo {
           constructor(private _loadingService: TdLoadingService, viewContainerRef: ViewContainerRef) {
             let options: ILoadingOptions = {
               name: 'stringName',
               type: LoadingType.Circular,
+              mode: LoadingMode.Indeterminate,
             };
             this._loadingService.createOverlayComponent(options, viewContainerRef);
           }

--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -54,7 +54,7 @@
     <p>HTML (*) syntax:</p>
     <td-highlight lang="html">
       <![CDATA[
-        <div *tdLoading="'stringName'" loadingType="circular|linear">
+        <div *tdLoading="'stringName'">
           ...
         </div>
       ]]>

--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -5,8 +5,8 @@
   <md-card-content>
     <div layout="row" layout-align="start center" flex>
       <md-button-toggle-group name="mode" [(ngModel)]="determinate" (click)="modeChange()">
-        <md-button-toggle md-tooltip="Determinate" [value]="0"><md-icon>timer_off</md-icon></md-button-toggle>
-        <md-button-toggle md-tooltip="Indeterminate" [value]="1"><md-icon>timer</md-icon></md-button-toggle>
+        <md-button-toggle md-tooltip="Indeterminate" [value]="0"><md-icon>timer_off</md-icon></md-button-toggle>
+        <md-button-toggle md-tooltip="Determinate" [value]="1"><md-icon>timer</md-icon></md-button-toggle>
       </md-button-toggle-group>
       <span flex="5"></span>
       <span>Loading Registered: {{replaceRegistered}} times</span>

--- a/src/app/components/components/loading/loading.component.ts
+++ b/src/app/components/components/loading/loading.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewContainerRef, AfterViewInit } from '@angular/core';
 
-import { TdLoadingService, ILoadingOptions, LoadingType } from '../../../../platform/core';
+import { TdLoadingService, ILoadingOptions, LoadingType, LoadingMode } from '../../../../platform/core';
 
 @Component({
   moduleId: module.id,
@@ -10,9 +10,14 @@ import { TdLoadingService, ILoadingOptions, LoadingType } from '../../../../plat
 })
 export class LoadingDemoComponent implements AfterViewInit {
 
+  private _intervalForDirective: number;
+  private _intervalForMain: number;
+
   demo: {name?: string, description?: string} = {};
   demo2: {name?: string, description?: string} = {};
   replaceRegistered: number = 0;
+  determinate: boolean = false;
+
 
   loadingAttrs: Object[] = [{
     description: 'Name reference of the loading mask, used to register/resolve requests to the mask.',
@@ -22,6 +27,11 @@ export class LoadingDemoComponent implements AfterViewInit {
     description: 'Sets the type of loading mask depending on value. Defaults to [LoadingType.Circular | "circular"]',
     name: 'loadingType?',
     type: 'LoadingType or ["linear" | "circular"]',
+  }, {
+    description: `Sets the mode of loading mask depending on value.
+                  Defaults to [LoadingMode.Indeterminate | "indeterminate"].`,
+    name: 'loadingMode?',
+    type: 'LoadingMode or ["determinate" | "indeterminate"]',
   }];
 
   loadingServiceMethods: Object[] = [{
@@ -35,6 +45,11 @@ export class LoadingDemoComponent implements AfterViewInit {
     name: 'resolve',
     type: 'function(name: string, resolves: number = 1)',
   }, {
+    description: `Set value on a loading mask referenced by the name parameter. 
+                  Usage only available if its mode is 'determinate'.`,
+    name: 'setValue',
+    type: 'function(name: string, value: number)',
+  }, {
     description: `Creates a fullscreen loading mask and attaches it to the viewContainerRef.
                   Only displayed when the mask has a request registered on it.`,
     name: 'createOverlayComponent',
@@ -44,46 +59,117 @@ export class LoadingDemoComponent implements AfterViewInit {
   constructor(viewContainer: ViewContainerRef,
               private _loadingService: TdLoadingService) {
     let options: ILoadingOptions = {
-      name: 'test.overlay',
+      name: 'test.overlay.determinate',
       type: LoadingType.Circular,
+      mode: LoadingMode.Determinate,
     };
     this._loadingService.createOverlayComponent(options, viewContainer);
     let options2: ILoadingOptions = {
-      name: 'test.overlay2',
+      name: 'test2.overlay.determinate',
       type: LoadingType.Linear,
+      mode: LoadingMode.Determinate,
     };
+    this._loadingService.createOverlayComponent(options2, viewContainer);
+    options.name = 'test.overlay.indeterminate';
+    options.mode = LoadingMode.Indeterminate;
+    this._loadingService.createOverlayComponent(options, viewContainer);
+    options2.name = 'test2.overlay.indeterminate';
+    options2.mode = LoadingMode.Indeterminate;
     this._loadingService.createOverlayComponent(options2, viewContainer);
   }
 
   ngAfterViewInit(): void {
-    this.registerLoadingReplace();
+    this.registerLoadingDirective();
   }
 
-  registerCircleLoadingOverlay(): void {
-    this._loadingService.register('test.overlay');
-    setTimeout(() => {
-      this._loadingService.resolve('test.overlay');
-    }, 3000);
+  modeChange(): void {
+    while (this.replaceRegistered > 0) {
+      this.resolveLoadingDirective();
+    }
+    clearInterval(this._intervalForDirective);
   }
 
-  registerLinearLoadingOverlay(): void {
-    this._loadingService.register('test.overlay2');
-    setTimeout(() => {
-      this._loadingService.resolve('test.overlay2');
-    }, 3000);
+  registerCircleLoadingMain(): void {
+    if (this.determinate) {
+      this._loadingService.register('test.overlay.determinate');
+      this.mockValuesForLoadingMain(LoadingType.Circular);
+      setTimeout(() => {
+        this._loadingService.resolve('test.overlay.determinate');
+      }, 3000);
+    } else {
+      this._loadingService.register('test.overlay.indeterminate');
+      setTimeout(() => {
+        this._loadingService.resolve('test.overlay.indeterminate');
+      }, 3000);
+    }
   }
 
-  registerLoadingReplace(): void {
-    this._loadingService.register('test');
-    this._loadingService.register('test2');
+  registerLinearLoadingMain(): void {
+    if (this.determinate) {
+      this._loadingService.register('test2.overlay.determinate');
+      this.mockValuesForLoadingMain(LoadingType.Linear);
+      setTimeout(() => {
+        this._loadingService.resolve('test2.overlay.determinate');
+      }, 3000);
+    } else {
+      this._loadingService.register('test2.overlay.indeterminate');
+      setTimeout(() => {
+        this._loadingService.resolve('test2.overlay.indeterminate');
+      }, 3000);
+    }
+  }
+
+  registerLoadingDirective(): void {
+    clearInterval(this._intervalForDirective);
+    if (this.determinate) {
+      this._loadingService.register('test.determinate');
+      this._loadingService.register('test2.determinate');
+      this.mockValuesForLoadingDirective();
+    } else {
+      this._loadingService.register('test.indeterminate');
+      this._loadingService.register('test2.indeterminate');
+    }
     this.replaceRegistered++;
   }
 
-  resolveLoadingReplace(): void {
+  resolveLoadingDirective(): void {
+    clearInterval(this._intervalForDirective);
     if (this.replaceRegistered > 0) {
       this.replaceRegistered--;
     }
-    this._loadingService.resolve('test');
-    this._loadingService.resolve('test2');
+    if (this.determinate) {
+      this._loadingService.resolve('test.determinate');
+      this._loadingService.resolve('test2.determinate');
+    } else {
+      this._loadingService.resolve('test.indeterminate');
+      this._loadingService.resolve('test2.indeterminate');
+    }
+  }
+
+  mockValuesForLoadingDirective(): void {
+    let value: number = 0;
+    this._intervalForDirective = setInterval(() => {
+      this._loadingService.setValue('test.determinate', value);
+      this._loadingService.setValue('test2.determinate', value);
+      value = value + 10;
+      if (value > 100) {
+        clearInterval(this._intervalForDirective);
+      }
+    }, 250);
+  }
+
+  mockValuesForLoadingMain(loadingType: LoadingType): void {
+    let value: number = 0;
+    this._intervalForMain = setInterval(() => {
+      if (loadingType === LoadingType.Circular) {
+        this._loadingService.setValue('test.overlay.determinate', value);
+      } else {
+        this._loadingService.setValue('test2.overlay.determinate', value);
+      }
+      value = value + 10;
+      if (value > 100) {
+        clearInterval(this._intervalForMain);
+      }
+    }, 250);
   }
 }

--- a/src/app/components/components/loading/loading.component.ts
+++ b/src/app/components/components/loading/loading.component.ts
@@ -18,7 +18,6 @@ export class LoadingDemoComponent implements AfterViewInit {
   replaceRegistered: number = 0;
   determinate: boolean = false;
 
-
   loadingAttrs: Object[] = [{
     description: 'Name reference of the loading mask, used to register/resolve requests to the mask.',
     name: 'tdLoading',

--- a/src/platform/core/index.ts
+++ b/src/platform/core/index.ts
@@ -151,7 +151,7 @@ export const TD_LOADING_ENTRY_COMPONENTS: Type<any>[] = [
   TdLoadingComponent,
 ];
 
-export { LoadingType } from './loading/loading.component';
+export { LoadingType, LoadingMode } from './loading/loading.component';
 export { TdLoadingService, ILoadingOptions } from './loading/services/loading.service';
 
 // Expansion

--- a/src/platform/core/loading/directives/loading.directive.ts
+++ b/src/platform/core/loading/directives/loading.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, Input, OnInit, OnDestroy } from '@angular/core';
 import { ViewContainerRef, TemplateRef } from '@angular/core';
 
-import { LoadingType } from '../loading.component';
+import { LoadingType, LoadingMode } from '../loading.component';
 import { TdLoadingService, ILoadingOptions } from '../services/loading.service';
 
 @Directive({
@@ -10,6 +10,7 @@ import { TdLoadingService, ILoadingOptions } from '../services/loading.service';
 export class TdLoadingDirective implements OnInit, OnDestroy {
 
   private _type: LoadingType;
+  private _mode: LoadingMode;
   private _name: string;
 
   /**
@@ -38,6 +39,23 @@ export class TdLoadingDirective implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * LoadingMode?: LoadingMode or ['determinate' | 'indeterminate']
+   * Sets the mode of loading mask depending on value.
+   * Defaults to [LoadingMode.Indeterminate | 'indeterminate'].
+   */
+  @Input('loadingMode')
+  set mode(mode: LoadingMode) {
+    switch (mode) {
+      case LoadingMode.Determinate:
+        this._mode = LoadingMode.Determinate;
+        break;
+      default:
+        this._mode = LoadingMode.Indeterminate;
+        break;
+    }
+  }
+
   constructor(private _viewContainer: ViewContainerRef,
               private _templateRef: TemplateRef<Object>,
               private _loadingService: TdLoadingService) {}
@@ -62,6 +80,7 @@ export class TdLoadingDirective implements OnInit, OnDestroy {
     let options: ILoadingOptions = {
       name: this._name,
       type: this._type,
+      mode: this._mode,
     };
     this._loadingService.createReplaceComponent(options, this._viewContainer, this._templateRef);
   }

--- a/src/platform/core/loading/loading.component.html
+++ b/src/platform/core/loading/loading.component.html
@@ -8,14 +8,16 @@
      layout-align="center center"
      layout-padding
      flex>
-    <md-progress-circle *ngIf="isCircular()" 
-                        [mode]="mode" 
+    <md-progress-circle *ngIf="isCircular() && reset" 
+                        [mode]="mode"
+                        [value]="value" 
                         color="primary" 
                         [style.height]="getCircleDiameter()"
                         [style.width]="getCircleDiameter()">
     </md-progress-circle>
-    <md-progress-bar *ngIf="isLinear()" 
-                     mode="indeterminate" 
+    <md-progress-bar *ngIf="isLinear() && reset" 
+                     [mode]="mode"
+                     [value]="value"
                      color="primary">
     </md-progress-bar>
 </div>

--- a/src/platform/core/loading/loading.component.ts
+++ b/src/platform/core/loading/loading.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { Input } from '@angular/core';
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 

--- a/src/platform/core/loading/services/loading.service.ts
+++ b/src/platform/core/loading/services/loading.service.ts
@@ -177,7 +177,7 @@ export class TdLoadingService {
     if (!this._context[name] || options.overlay) {
       this._context[name] = {};
     } else {
-      throw 'Name duplication: Loading Component name conflict.';
+      throw `Name duplication: Loading  Component name conflict with ${name}.`;
     }
     this._context[name].loadingRef = this._componentFactoryResolver
     .resolveComponentFactory(TdLoadingComponent).create(this._injector);

--- a/src/platform/core/loading/services/loading.service.ts
+++ b/src/platform/core/loading/services/loading.service.ts
@@ -4,11 +4,12 @@ import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
-import { TdLoadingComponent, LoadingType } from '../loading.component';
+import { TdLoadingComponent, LoadingType, LoadingMode } from '../loading.component';
 
 export interface ILoadingOptions {
   name: string;
   type?: LoadingType;
+  mode?: LoadingMode;
 }
 
 interface IInternalLoadingOptions extends ILoadingOptions {
@@ -166,6 +167,26 @@ export class TdLoadingService {
   }
 
   /**
+   * params:
+   * - name: string
+   * - value: number
+   * returns: true if successful
+   * 
+   * Set value on a loading mask referenced by the name parameter.
+   * Usage only available if its mode is 'determinate'.
+   */
+  public setValue(name: string, value: number): boolean {
+    if (this._loadingSources[name]) {
+      let instance: TdLoadingComponent = this._context[name].loadingRef.instance;
+      if (instance.mode === LoadingMode.Determinate) {
+        instance.value = value;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Creates a generic [TdLoadingComponent] and its context. 
    * Returns a promise that resolves to a [ILoadingRef] with the created [ComponentRef] and its referenced [Observable].
    */
@@ -200,6 +221,9 @@ export class TdLoadingService {
     }
     if (options.height !== undefined) {
       instance.height = options.height;
+    }
+    if (options.mode !== undefined) {
+      instance.mode = options.mode;
     }
   }
 

--- a/src/platform/core/loading/services/loading.service.ts
+++ b/src/platform/core/loading/services/loading.service.ts
@@ -173,12 +173,12 @@ export class TdLoadingService {
    * returns: true if successful
    * 
    * Set value on a loading mask referenced by the name parameter.
-   * Usage only available if its mode is 'determinate'.
+   * Usage only available if its mode is 'determinate' and if loading is showing.
    */
   public setValue(name: string, value: number): boolean {
     if (this._loadingSources[name]) {
       let instance: TdLoadingComponent = this._context[name].loadingRef.instance;
-      if (instance.mode === LoadingMode.Determinate) {
+      if (instance.mode === LoadingMode.Determinate && !instance.animation) {
         instance.value = value;
         return true;
       }


### PR DESCRIPTION
## Description

Added `mode` to loading component so it can be created with either `LoadingMode.Determinate` or `LoadingMode.Indeterminate`.
https://github.com/Teradata/covalent/issues/80

### What's included?

- Added enum for `LoadingMode.Determinate` and `LoadingMode.Indeterminate`.
- Added `loadingMode` input to `TdLoadingDirective` which accepts either `LoadingMode` or `'determinate'|'indeterminate'`.
- Added `setValue(name: string, value: number): boolean` method to `TdLoadingService` which is only successful if loading is set to `LoadingMode.Determinate` or `'determinate'`.
- Added `reset` flag in `TdLoadingComponent` so its refreshed before removing it from DOM. (else the animation going from the previous value to 0 would happen when the component is reattached again)
- Kept `protractor` hack intact so it does not timeout when loading mask is used on `'indeterminate'` mode. (`md-progress-circle` setInterval() usage affects protractor since it does not let it sync)
- Updated `docs`/`demos` with `mode` usage.

#### Test Steps

- [x] `ng serve`
- [x] Go to http://localhost:4200/#/components/loading
- [x] Play with demo and see how it works
- [x] :watch: 

##### Screenshots or link to CodePen/Plunker/JSfiddle
![loading-det-indet1](https://cloud.githubusercontent.com/assets/5846742/18610906/0a3cca2e-7cde-11e6-8683-6c4683721a4b.gif)
