### PR TITLE
changed covalent data instructions in the documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
 language: node_js
-
 node_js:
-  - "5.4"
-
+- '5.4'
 addons:
-  firefox: "latest"
-
+  firefox: latest
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
 install:
-  - npm install
-  - ./node_modules/.bin/ng build
-
+- npm install
+- "./node_modules/.bin/ng build"
 script:
-  - ./node_modules/.bin/tslint -c ./tslint.json ./src/**/*.ts -e ./src/**/typings.d.ts
-  - ./node_modules/.bin/karma start ./config/karma.travis.conf.js
+- "./node_modules/.bin/tslint -c ./tslint.json ./src/**/*.ts -e ./src/**/typings.d.ts"
+- "./node_modules/.bin/karma start ./config/karma.travis.conf.js"
+notifications:
+  slack:
+    secure: pkXQL5AZiSBh1yWjilrcA7KbcJjC4xxjhd0SAwogJCQgyEf/i8/CfR1ZXiZYsIBJT6HTI7UMdJzwP6TiY/zih6Mq8PqUg38NUsvGyznILkbksMQJieWrg1r+1ideplPJFX7qdXwrOcxvSVoEFIGha26X0Fglq3kXSBHpPR9U0lDCoUxLUO35txQ/iji85Na4hjQnmtBEQkqaJogA0hRdcSLIKxwScgSrb4UU2PXEaIS9Zpr2SOG/RTOMkrrSMOD7bgocZbhAbk3c5shPZNj51gpEN+692Qxp4kQ/nfT10Hu5ATLaFCM5v04+w0D3ZJLA46LpU47qP0ALy6O9d16pGUcxJGbWaMZpV53vV9jIl9y2ahaqN1h1J9BcLIOzJvaQy92km8F7a3l7cN8gWSUZjs5Hd+gPFQH9Flcydmq26e8Maa1tQDF5R3GIdaCw4qkuJYbl4ToE59wtiPQ6M7xVKqNK4Qypu1YNsKOoLG/tZRFvp4771vgWcR5Lu/DqJJ9SAB0jsdrOXpe+0DmdrLBwhoZv2D9FTce+clDHIJ7ObPEc/UKw8rtWAA5iCPCEJ0sPl+WZwOS3ZFp4QmMC+5mzffMUiX6HBnzxiyOZvYGJD/jTy1yA1Cmt4RJYrOPM73csI1ELs5tj4tvqBNJQ8daIenfkg7u42IJfByDGIsJz8to=

--- a/src/app/components/docs/mock-data/mock-data.component.html
+++ b/src/app/components/docs/mock-data/mock-data.component.html
@@ -5,13 +5,10 @@
   <md-card-content>
      <p><a href="https://github.com/Teradata/covalent-quickstart">Covalent Quickstart</a> includes the ultimate prototyping tool, a localhost Mock API!</p>
      <p>With the mock API server, you can develop against realistic API service endpoints, and model the mock data closely to your production data!</p>
-     <p>Important: You'll need to open a new tab or window to run the API server if you're already running ng serve:</p>
-      <td-highlight lang="html">
-        cd mock-api/
-      </td-highlight>
-      <p>Pick your OS flavor ( .osx, .linux or .exe)</p>
-      <td-highlight lang="html">
-        ./covalent-data.osx 
+     <p>The mock api server is called <a href="https://github.com/Teradata/covalent-data">Covalent Data</a> and is available as an <a href="https://www.npmjs.com/package/@covalent/data">npm package</a>.</p>
+     <p>Covalent Quickstart integrates Covalent Data in its installation, so no additional steps are required to use it. In the covalent quickstart directory, simply run:</p>
+      <td-highlight>
+        npm run start-api
       </td-highlight>
       <p>You should see the server running starting with:</p>
       <td-highlight lang="html">
@@ -22,6 +19,10 @@
         INFO[0000] ######## This software is covered under the MIT license.  ######## 
         INFO[0000] ########                                                  ######## 
         INFO[0000] ##################################################################
+      </td-highlight>
+      <p>The server is running as a background process so it's still possible to use the terminal for other commands.  To stop covalent data, type:</p>
+      <td-highlight>
+        npm run stop-api
       </td-highlight>
       <md-divider></md-divider>
       <h3>Customizing Mock Data Schema</h3>
@@ -66,6 +67,7 @@
           ...
         ]]>
       </td-highlight>
+      <p>The Covalent Data Mock API Server actually stores data in memory, so it's possible to add, update, and delete records. All changes made will be erased once Covalent Data is stopped. See the Covalent Data repo for more information.</p>
   </md-card-content>
   <md-divider></md-divider>
   <md-card-actions>


### PR DESCRIPTION
## Description

The documentation for mock-api in Covalent Quickstart now has instructions for the npm version of Covalent Data.

### What's included?

- updates to `/src/app/components/docs/mock-data.component.html`

#### Test Steps

- [x] `ng serve`
- [x] go to the [mock data](http://localhost:4200/#/docs/mock-data) portion of the docs
- [x] read! (it's FUN... damental)

##### Screenshots or link to CodePen/Plunker/JSfiddle
<img width="825" alt="screen shot 2016-09-23 at 8 04 44 pm" src="https://cloud.githubusercontent.com/assets/6831837/18805003/0624760e-81c9-11e6-87e3-fcaf40b8e236.png">
