### PR TITLE
added min/max/number-required validators

### DIFF
--- a/src/app/components/components/directives/directives.component.html
+++ b/src/app/components/components/directives/directives.component.html
@@ -41,7 +41,11 @@
     <p>Click on this to open a div:</p>
     <button md-raised-button color="accent" (click)="toggle()">Toggle</button>
     <div [tdToggle]="toggleDiv" [hidden]>
-      Reveal or hide with a toggle click!
+      <md-card>
+        <md-card-title>Toggle Card</md-card-title>
+        <md-card-content>Reveal or hide with a toggle click!</md-card-content>
+        <md-card-actions><button md-raised-button color="primary" (click)="toggle()">Toggle Out</button></md-card-actions>
+      </md-card>
     </div>
     <p>HTML:</p>
     <td-highlight lang="html">
@@ -49,6 +53,40 @@
           <button md-raised-button color="accent" (click)="toggle()">Toggle</button>
           <div [tdToggle]="toggleDiv" [hidden]>
             Reveal or hide with a toggle click!
+          </div>
+        ]]>
+    </td-highlight>
+    <p>TypeScript:</p>
+    <td-highlight lang="typescript">
+        toggleDiv: boolean = true;
+
+        toggle(): any {{ '{' }}
+          this.toggleDiv = !this.toggleDiv;
+        {{ '}' }}
+    </td-highlight>
+  </md-card-content>
+</md-card>
+
+<md-card>
+  <md-card-title>Fade directive</md-card-title>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p class="md-body-1">Use <code>[tdFade]="variable"</code> on an element to fade it in and out.</p>
+    <p>Click on this to open a div:</p>
+    <button md-raised-button color="accent" (click)="fade()">Fade</button>
+    <div [tdFade]="fadeDiv" [hidden]>
+      <md-card>
+        <md-card-title>Fade Card</md-card-title>
+        <md-card-content>Fade in or out with a click!</md-card-content>
+        <md-card-actions><button md-raised-button color="primary" (click)="fade()">Fade Out</button></md-card-actions>
+      </md-card>
+    </div>
+    <p>HTML:</p>
+    <td-highlight lang="html">
+        <![CDATA[
+          <button md-raised-button color="accent" (click)="fade()">Toggle</button>
+          <div [tdFade]="fadeDiv" [hidden]>
+            This one fades in and out!
           </div>
         ]]>
     </td-highlight>

--- a/src/app/components/components/directives/directives.component.html
+++ b/src/app/components/components/directives/directives.component.html
@@ -92,10 +92,10 @@
     </td-highlight>
     <p>TypeScript:</p>
     <td-highlight lang="typescript">
-        toggleDiv: boolean = true;
+        fadeDiv: boolean = true;
 
-        toggle(): any {{ '{' }}
-          this.toggleDiv = !this.toggleDiv;
+        fade(): any {{ '{' }}
+          this.fadeDiv = !this.fadeDiv;
         {{ '}' }}
     </td-highlight>
   </md-card-content>

--- a/src/app/components/components/directives/directives.component.html
+++ b/src/app/components/components/directives/directives.component.html
@@ -62,3 +62,29 @@
     </td-highlight>
   </md-card-content>
 </md-card>
+
+<md-card>
+  <md-card-title>Min/Max/Number Validators</md-card-title>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p class="md-body-1">We've added min/max/number-required validations since ng2 doesnt support them at the moment.</p>
+    <p>Supported:</p>
+    <ul>
+      <li><code>TdMinValidator</code> for selector: <code>[min][formControlName]</code>,<code>[min][formControl]</code>,<code>[min][ngModel]</code></li>
+      <li><code>TdMaxValidator</code> for selector: <code>[max][formControlName]</code>,<code>[max][formControl]</code>,<code>[max][ngModel]</code></li>
+      <li><code>TdNumberRequiredValidator</code> for selector: <code>[type=number][required][formControlName]</code>,<code>[type=number][required][formControl]</code>,<code>[type=number][required][ngModel]</code></li>
+    </ul>
+    <p>Example enter lower than 5 or higher than 10:</p>
+    <div layout="row">
+      <md-input flex="20" placeholder="CPUs" #el="ngModel" type="number" [(ngModel)]="val" min="5" max="10" required></md-input>
+    </div>
+    <p>Errors:</p>
+    <code>{{el?.errors | json}}</code>
+    <p>HTML:</p>
+    <td-highlight lang="html">
+        <![CDATA[
+          <md-input placeholder="CPUs" #el="ngModel" type="number" [(ngModel)]="val" min="5" max="10" required></md-input>
+        ]]>
+    </td-highlight>
+  </md-card-content>
+</md-card>

--- a/src/app/components/components/directives/directives.component.ts
+++ b/src/app/components/components/directives/directives.component.ts
@@ -8,8 +8,12 @@ import { Component } from '@angular/core';
 export class DirectivesComponent {
 
   toggleDiv: boolean = true;
+  fadeDiv: boolean = true;
 
   toggle(): void {
     this.toggleDiv = !this.toggleDiv;
+  }
+  fade(): void {
+    this.fadeDiv = !this.fadeDiv;
   }
 }

--- a/src/platform/core/index.ts
+++ b/src/platform/core/index.ts
@@ -114,12 +114,28 @@ export { TdPromptDialogComponent } from './dialogs/prompt-dialog/prompt-dialog.c
 /**
  * DIRECTIVES
  */
-
 import { TdToggleDirective } from './directives/toggle/toggle.directive';
 import { TdFadeDirective } from './directives/fade/fade.directive';
 
 export { TdToggleDirective } from './directives/toggle/toggle.directive';
 export { TdFadeDirective } from './directives/fade/fade.directive';
+
+/**
+ * VALIDATORS
+ */
+import { TdMinValidator } from './validators/min.validator';
+import { TdMaxValidator } from './validators/max.validator';
+import { TdNumberRequiredValidator } from './validators/number-required.validator';
+
+export const TD_VALIDATORS: Type<any>[] = [
+  TdMinValidator,
+  TdMaxValidator,
+  TdNumberRequiredValidator,
+];
+
+export { TdMinValidator } from './validators/min.validator';
+export { TdMaxValidator } from './validators/max.validator';
+export { TdNumberRequiredValidator } from './validators/number-required.validator';
 
 /**
  * PIPES
@@ -175,6 +191,7 @@ export { TdMediaToggleDirective } from './media/directives/media-toggle.directiv
     TD_DIALOG_DIRECTIVES,
     TdFadeDirective,
     TdToggleDirective,
+    TD_VALIDATORS,
   ],
   exports: [
     HttpModule,
@@ -193,6 +210,7 @@ export { TdMediaToggleDirective } from './media/directives/media-toggle.directiv
     TD_DIALOG_DIRECTIVES,
     TdFadeDirective,
     TdToggleDirective,
+    TD_VALIDATORS,
   ],
   entryComponents: [ TD_DIALOG_ENTRY_COMPONENTS ],
 })

--- a/src/platform/core/validators/max.validator.ts
+++ b/src/platform/core/validators/max.validator.ts
@@ -1,0 +1,40 @@
+import { Directive, Input, forwardRef } from '@angular/core';
+import { NG_VALIDATORS, Validator, Validators, AbstractControl, ValidatorFn } from '@angular/forms';
+
+import { TdNumberRequiredValidator } from './number-required.validator';
+
+export const MAX_VALIDATOR: any = {
+  provide: NG_VALIDATORS,
+  useExisting: forwardRef(() => TdMaxValidator),
+  multi: true,
+};
+
+@Directive({
+  selector: '[max][formControlName],[max][formControl],[max][ngModel]',
+  providers: [ MAX_VALIDATOR ],
+})
+export class TdMaxValidator implements Validator {
+
+  private _validator: ValidatorFn;
+
+  @Input('max')
+  set max(max: number) {
+    this._validator = TdMaxValidator.validate(max);
+  }
+
+  static validate(maxValue: any): ValidatorFn {
+    return (c: AbstractControl): {[key: string]: any} => {
+      if (!!Validators.required(c) || !!TdNumberRequiredValidator.validate(c) || (!maxValue && maxValue !== 0)) {
+        return undefined;
+      }
+      let v: number = c.value;
+      return v > maxValue ?
+        { max: {maxValue: maxValue, actualValue: v} } :
+        undefined;
+    };
+  };
+
+  validate(c: AbstractControl): {[key: string]: any} {
+    return this._validator(c);
+  };
+}

--- a/src/platform/core/validators/min.validator.ts
+++ b/src/platform/core/validators/min.validator.ts
@@ -1,0 +1,40 @@
+import { Directive, Input, forwardRef } from '@angular/core';
+import { NG_VALIDATORS, Validator, Validators, AbstractControl, ValidatorFn } from '@angular/forms';
+
+import { TdNumberRequiredValidator } from './number-required.validator';
+
+export const MIN_VALIDATOR: any = {
+  provide: NG_VALIDATORS,
+  useExisting: forwardRef(() => TdMinValidator),
+  multi: true,
+};
+
+@Directive({
+  selector: '[min][formControlName],[min][formControl],[min][ngModel]',
+  providers: [ MIN_VALIDATOR ],
+})
+export class TdMinValidator implements Validator {
+
+  private _validator: ValidatorFn;
+
+  @Input('min')
+  set min(min: number) {
+    this._validator = TdMinValidator.validate(min);
+  }
+
+  static validate(minValue: any): ValidatorFn {
+    return (c: AbstractControl): {[key: string]: any} => {
+      if (!!Validators.required(c) || !!TdNumberRequiredValidator.validate(c) || (!minValue && minValue !== 0)) {
+        return undefined;
+      }
+      let v: number = c.value;
+      return v < minValue ?
+        { min: {minValue: minValue, actualValue: v} } :
+        undefined;
+    };
+  };
+
+  validate(c: AbstractControl): {[key: string]: any} {
+    return this._validator(c);
+  };
+}

--- a/src/platform/core/validators/number-required.validator.ts
+++ b/src/platform/core/validators/number-required.validator.ts
@@ -1,0 +1,27 @@
+import { Directive, forwardRef } from '@angular/core';
+import { NG_VALIDATORS, Validator, AbstractControl } from '@angular/forms';
+
+export const NUMBER_INPUT_REQUIRED_VALIDATOR: any = {
+  provide: NG_VALIDATORS,
+  useExisting: forwardRef(() => TdNumberRequiredValidator),
+  multi: true,
+};
+
+@Directive({
+  selector: `[type=number][required][formControlName],
+             [type=number][required][formControl],
+             [type=number][required][ngModel]`,
+  providers: [ NUMBER_INPUT_REQUIRED_VALIDATOR ],
+})
+export class TdNumberRequiredValidator implements Validator {
+
+  static validate(c: AbstractControl): {[key: string]: any} {
+    return (Number.isNaN(c.value)) ?
+        { required: true } :
+        undefined;
+  }
+
+  validate(c: AbstractControl): {[key: string]: any} {
+    return TdNumberRequiredValidator.validate(c);
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -202,7 +202,7 @@
       "element"
     ],
     "directive-selector-prefix": [
-      true,
+      false,
       "td"
     ],
     "component-selector-prefix": [ // This will be checked in PR's since we only want `td-` prefix for platform components, not docs not product components.


### PR DESCRIPTION
## Description

Added `min`/`max`/`number-required` validations since ng2 doesnt support them at the moment.

### What's included?

- `TdMinValidator` for selector: `[min][formControlName],[min][formControl],[min][ngModel]`.
- `TdMaxValidator` for selector: `[max][formControlName],[max][formControl],[max][ngModel]`.
- `TdNumberRequiredValidator` for selector: `[type=number][required][formControlName],[type=number][required][formControl],[type=number][required][ngModel]`

#### Test Steps

- [x] use 
```
<md-input #el="ngModel" type="number" [(ngModel)]="val" min="5" max="550" required></md-input>
{{el?.errors | json}}
```
- [x] See errors depending on validation.
