### PR TITLE
feature(docs): dialogs, toast & inline error patterns

### DIFF
--- a/src/app/components/components/directives/directives.component.html
+++ b/src/app/components/components/directives/directives.component.html
@@ -60,7 +60,7 @@
     <td-highlight lang="typescript">
         toggleDiv: boolean = true;
 
-        toggle(): any {{ '{' }}
+        toggle(): void {{ '{' }}
           this.toggleDiv = !this.toggleDiv;
         {{ '}' }}
     </td-highlight>
@@ -94,7 +94,7 @@
     <td-highlight lang="typescript">
         fadeDiv: boolean = true;
 
-        fade(): any {{ '{' }}
+        fade(): void {{ '{' }}
           this.fadeDiv = !this.fadeDiv;
         {{ '}' }}
     </td-highlight>

--- a/src/app/components/style-guide/dialogs/dialogs.component.html
+++ b/src/app/components/style-guide/dialogs/dialogs.component.html
@@ -9,11 +9,11 @@
     <p>Toasts &amp; Snackbars provide brief feedback about an operation through a message at the bottom of the screen. This information is transient and will go away momentarily.</p>
     <p>Inline errors are use in forms for validation, warnings and errors.</p>
     <div layout="row" class="push-top">
-      <a md-button class="md-whiteframe-z1" [routerLink]="['mock-data']" md-ripple flex>
-        <div class="inset">
+      <div class="md-whiteframe-z1" flex>
+        <div class="inset text-center">
           <h4><span class="tc-orange-800 md-title">Important:</span> we recommend using full-page forms for creation instead of dialogs.</h4>
         </div>
-      </a>
+      </div>
     </div>
   </md-card-content>
 </md-card>
@@ -29,6 +29,50 @@
     <p>Example for a confirmation on an action:</p>
     <button md-raised-button color="accent" (click)="openConfirm()">Delete an item</button>
   </md-card-content>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p>HTML:</p>
+    <td-highlight lang="html">
+      <![CDATA[
+        <button md-raised-button color="warn" (click)="openAlert()">View Sensitive Document</button>
+
+        <button md-raised-button color="accent" (click)="openConfirm()">Delete an item</button>
+      ]]>
+    </td-highlight>
+    <p>Typescript:</p>
+    <td-highlight lang="typescript">
+      <![CDATA[
+      import { TdDialogService } from '@covalent/core';
+      ...
+      constructor(private _dialogService: TdDialogService,
+                  private _viewContainerRef: ViewContainerRef) {
+      }
+      openAlert(): void {
+        this._dialogService.openAlert({
+          message: 'You don\'t have the required permissions to view this item! Contact an administrator!',
+          viewContainerRef: this._viewContainerRef,
+          title: '401 Permissions Error!',
+          closeButton: 'Dismiss',
+        });
+      }
+      openConfirm(): void {
+        this._dialogService.openConfirm({
+          message: 'Are you sure you want to delete this item? It\'s used on other items.',
+          viewContainerRef: this._viewContainerRef,
+          title: 'Confirm',
+          cancelButton: 'No, Cancel',
+          acceptButton: 'Yes, Delete',
+        }).afterClosed().subscribe((accept: boolean) => {
+          if (accept) {
+            // DO SOMETHING
+          } else {
+            // DO SOMETHING ELSE
+          }
+        });
+      }
+      ]]>
+    </td-highlight>
+  </md-card-content>
 </md-card>
 <md-card>
   <md-card-title>Toast (Snack Bar)</md-card-title>
@@ -37,6 +81,36 @@
   <md-card-content>
     <p>Example toast usage for a simple confirmation:</p>
     <button md-raised-button color="primary" (click)="showSnackBar()">Send Direct Message</button>
+  </md-card-content>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p>HTML:</p>
+    <td-highlight lang="html">
+      <![CDATA[
+        <button md-raised-button color="primary" (click)="showSnackBar()">Send Direct Message</button>
+      ]]>
+    </td-highlight>
+    <p>Typescript:</p>
+    <td-highlight lang="typescript">
+      <![CDATA[
+      import { MdSnackBar, MdSnackBarConfig, MdSnackBarRef } from '@angular/material';
+      ...
+      export class ToastsComponent {
+        _snackBarConfig: MdSnackBarConfig;
+        constructor(private _viewContainerRef: ViewContainerRef,
+                    private _snackBarService: MdSnackBar) {
+          this._snackBarConfig = new MdSnackBarConfig(_viewContainerRef);
+        }
+        showSnackBar(): void {
+          let snackBarRef: MdSnackBarRef<any> = this._snackBarService
+            .open('Direct message sent!', 'Dismiss', this._snackBarConfig);
+          setTimeout(() => {
+            snackBarRef.dismiss();
+          }, 3000);
+        }
+      }
+      ]]>
+    </td-highlight>
   </md-card-content>
 </md-card>
 <md-card>
@@ -47,31 +121,31 @@
     <form #myForm="ngForm">
       <div layout-gt-xs="row" layout-margin>
         <md-input #firstNameForm="ngModel" flex placeholder="Firstname" [(ngModel)]="first_name" name="first_name" required tdAutoTrim>
-          <md-hint [hidden]="firstNameForm.pristine || !firstNameForm.errors?.required" class="tc-red-600">This field is required</md-hint>
+          <md-hint [hidden]="firstNameForm.pristine || !firstNameForm.errors?.required" class="tc-red-600">Required</md-hint>
         </md-input>
         <md-input #lastNameForm="ngModel" flex placeholder="Lastname" [(ngModel)]="last_name" name="last_name" required tdAutoTrim>
-          <md-hint [hidden]="lastNameForm.pristine || !lastNameForm.errors?.required" class="tc-red-600">This field is required</md-hint>
+          <md-hint [hidden]="lastNameForm.pristine || !lastNameForm.errors?.required" class="tc-red-600">Required</md-hint>
         </md-input>
       </div>
       <div layout-gt-xs="row" layout-margin>
-        <md-input #adressEl #addressForm="ngModel" flex placeholder="Address" [(ngModel)]="adress" name="adress" required maxlength="50" tdAutoTrim>
-          <md-hint [hidden]="addressForm.pristine || !addressForm.errors?.required" class="tc-red-600">This field is required</md-hint>
+        <md-input #adressEl #addressForm="ngModel" flex="40" placeholder="Address" [(ngModel)]="adress" name="adress" required maxlength="50" tdAutoTrim>
+          <md-hint [hidden]="addressForm.pristine || !addressForm.errors?.required" class="tc-red-600">Required</md-hint>
           <md-hint align="end">{{adressEl.characterCount}} / 50</md-hint>
         </md-input>
-        <md-input flex placeholder="City" tdAutoTrim>
-          
-        </md-input>
-        <md-input #stateForm="ngModel" flex="10" placeholder="State" [(ngModel)]="state" name="state" pattern="[A-Z]{2}" maxlength="2" required tdAutoTrim>
+        <md-input flex="35" placeholder="City" tdAutoTrim></md-input>
+      </div>
+      <div layout-gt-xs="row" layout-margin>
+        <md-input #stateForm="ngModel" flex="20" placeholder="State" [(ngModel)]="state" name="state" pattern="[A-Z]{2}" maxlength="2" required tdAutoTrim>
           <md-hint [hidden]="stateForm.pristine" class="tc-red-600">
-            <span [hidden]="!stateForm.errors?.required">This field is required</span>
-            <span [hidden]="!stateForm.errors?.pattern">2 upper case required.</span>
+            <span [hidden]="!stateForm.errors?.required">Required</span>
+            <span [hidden]="!stateForm.errors?.pattern">2 letters</span>
           </md-hint>
           <md-hint align="end">e.g CA</md-hint>
         </md-input>
-        <md-input #zipForm="ngModel" flex="20" placeholder="Zip" [(ngModel)]="zip" name="zip" pattern="\d{5}" maxlength="5" required>
+        <md-input #zipForm="ngModel" flex="25" placeholder="Zip" [(ngModel)]="zip" name="zip" pattern="\d{5}" maxlength="5" required>
           <md-hint [hidden]="zipForm.pristine" class="tc-red-600">
-            <span [hidden]="!zipForm.errors?.required">This field is required</span>
-            <span [hidden]="!zipForm.errors?.pattern">This field required 5 digits</span>
+            <span [hidden]="!zipForm.errors?.required">Required</span>
+            <span [hidden]="!zipForm.errors?.pattern">5 digits pls</span>
           </md-hint>
           <md-hint align="end">e.g 92101</md-hint>
         </md-input>
@@ -79,7 +153,47 @@
     </form>
   </md-card-content>
   <md-divider></md-divider>
-  <md-card-actions>
+  <div class="inset">
     <button md-raised-button [disabled]="!myForm.valid">Submit Form</button>
-  </md-card-actions>
+  </div>
+  <md-divider></md-divider>
+  <md-card-content>
+    <td-highlight lang="html">
+      <![CDATA[
+        <form #myForm="ngForm">
+          <div layout-gt-xs="row" layout-margin>
+            <md-input #firstNameForm="ngModel" flex placeholder="Firstname" [(ngModel)]="first_name" name="first_name" required tdAutoTrim>
+              <md-hint [hidden]="firstNameForm.pristine || !firstNameForm.errors?.required" class="tc-red-600">Required</md-hint>
+            </md-input>
+            <md-input #lastNameForm="ngModel" flex placeholder="Lastname" [(ngModel)]="last_name" name="last_name" required tdAutoTrim>
+              <md-hint [hidden]="lastNameForm.pristine || !lastNameForm.errors?.required" class="tc-red-600">Required</md-hint>
+            </md-input>
+          </div>
+          <div layout-gt-xs="row" layout-margin>
+            <md-input #adressEl #addressForm="ngModel" flex="40" placeholder="Address" [(ngModel)]="adress" name="adress" required maxlength="50" tdAutoTrim>
+              <md-hint [hidden]="addressForm.pristine || !addressForm.errors?.required" class="tc-red-600">Required</md-hint>
+              <md-hint align="end">{{adressEl.characterCount}} / 50</md-hint>
+            </md-input>
+            <md-input flex="35" placeholder="City" tdAutoTrim></md-input>
+          </div>
+          <div layout-gt-xs="row" layout-margin>
+            <md-input #stateForm="ngModel" flex="20" placeholder="State" [(ngModel)]="state" name="state" pattern="[A-Z]{2}" maxlength="2" required tdAutoTrim>
+              <md-hint [hidden]="stateForm.pristine" class="tc-red-600">
+                <span [hidden]="!stateForm.errors?.required">Required</span>
+                <span [hidden]="!stateForm.errors?.pattern">2 letters</span>
+              </md-hint>
+              <md-hint align="end">e.g CA</md-hint>
+            </md-input>
+            <md-input #zipForm="ngModel" flex="25" placeholder="Zip" [(ngModel)]="zip" name="zip" pattern="\d{5}" maxlength="5" required>
+              <md-hint [hidden]="zipForm.pristine" class="tc-red-600">
+                <span [hidden]="!zipForm.errors?.required">Required</span>
+                <span [hidden]="!zipForm.errors?.pattern">5 digits pls</span>
+              </md-hint>
+              <md-hint align="end">e.g 92101</md-hint>
+            </md-input>
+          </div>
+        </form>
+      ]]>
+    </td-highlight>
+  </md-card-content>
 </md-card>

--- a/src/app/components/style-guide/dialogs/dialogs.component.html
+++ b/src/app/components/style-guide/dialogs/dialogs.component.html
@@ -44,21 +44,42 @@
   <md-card-subtitle>For forms and inputs use inline errors for contextual feedback:</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
-    <form #myForm>
+    <form #myForm="ngForm">
       <div layout-gt-xs="row" layout-margin>
-        <md-input flex placeholder="Firstname"></md-input>
-        <md-input flex placeholder="Lastname"></md-input>
+        <md-input #firstNameForm="ngModel" flex placeholder="Firstname" [(ngModel)]="first_name" name="first_name" required tdAutoTrim>
+          <md-hint [hidden]="firstNameForm.pristine || !firstNameForm.errors?.required" class="tc-red-600">This field is required</md-hint>
+        </md-input>
+        <md-input #lastNameForm="ngModel" flex placeholder="Lastname" [(ngModel)]="last_name" name="last_name" required tdAutoTrim>
+          <md-hint [hidden]="lastNameForm.pristine || !lastNameForm.errors?.required" class="tc-red-600">This field is required</md-hint>
+        </md-input>
       </div>
       <div layout-gt-xs="row" layout-margin>
-        <md-input flex placeholder="Address"></md-input>
-        <md-input flex placeholder="City"></md-input>
-        <md-input flex="10" placeholder="State"></md-input>
-        <md-input flex="20" placeholder="Zip"></md-input>
+        <md-input #adressEl #addressForm="ngModel" flex placeholder="Address" [(ngModel)]="adress" name="adress" required maxlength="50" tdAutoTrim>
+          <md-hint [hidden]="addressForm.pristine || !addressForm.errors?.required" class="tc-red-600">This field is required</md-hint>
+          <md-hint align="end">{{adressEl.characterCount}} / 50</md-hint>
+        </md-input>
+        <md-input flex placeholder="City" tdAutoTrim>
+          
+        </md-input>
+        <md-input #stateForm="ngModel" flex="10" placeholder="State" [(ngModel)]="state" name="state" pattern="[A-Z]{2}" maxlength="2" required tdAutoTrim>
+          <md-hint [hidden]="stateForm.pristine" class="tc-red-600">
+            <span [hidden]="!stateForm.errors?.required">This field is required</span>
+            <span [hidden]="!stateForm.errors?.pattern">2 upper case required.</span>
+          </md-hint>
+          <md-hint align="end">e.g CA</md-hint>
+        </md-input>
+        <md-input #zipForm="ngModel" flex="20" placeholder="Zip" [(ngModel)]="zip" name="zip" pattern="\d{5}" maxlength="5" required>
+          <md-hint [hidden]="zipForm.pristine" class="tc-red-600">
+            <span [hidden]="!zipForm.errors?.required">This field is required</span>
+            <span [hidden]="!zipForm.errors?.pattern">This field required 5 digits</span>
+          </md-hint>
+          <md-hint align="end">e.g 92101</md-hint>
+        </md-input>
       </div>
     </form>
   </md-card-content>
   <md-divider></md-divider>
   <md-card-actions>
-    <button md-raised-button>Submit Form</button>
+    <button md-raised-button [disabled]="!myForm.valid">Submit Form</button>
   </md-card-actions>
 </md-card>

--- a/src/app/components/style-guide/dialogs/dialogs.component.html
+++ b/src/app/components/style-guide/dialogs/dialogs.component.html
@@ -1,0 +1,64 @@
+<md-card>
+  <md-card-header>
+    <md-icon md-card-avatar>filter_none</md-icon>
+    <md-card-title class="md-display-1">Dialogs, Toasts and Inline Errors</md-card-title>
+  </md-card-header>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p>In Material Design, it's recommended to reserve dialogs to  inform users about a specific task and may contain critical information, such as a verbose/critical error, and alert or a confirmation of an action.</p>
+    <p>Toasts &amp; Snackbars provide brief feedback about an operation through a message at the bottom of the screen. This information is transient and will go away momentarily.</p>
+    <p>Inline errors are use in forms for validation, warnings and errors.</p>
+    <div layout="row" class="push-top">
+      <a md-button class="md-whiteframe-z1" [routerLink]="['mock-data']" md-ripple flex>
+        <div class="inset">
+          <h4><span class="tc-orange-800 md-title">Important:</span> we recommend using full-page forms for creation instead of dialogs.</h4>
+        </div>
+      </a>
+    </div>
+  </md-card-content>
+</md-card>
+<md-card>
+  <md-card-title>Dialog (Modal)</md-card-title>
+  <md-card-subtitle>A floating card that blocks underlying functions</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p>Example dialog usage:</p>
+    <p>Example for an API error or warning:</p>
+    <button md-raised-button color="warn" (click)="openAlert()">View Sensitive Document</button>
+    <md-divider class="push-top"></md-divider>
+    <p>Example for a confirmation on an action:</p>
+    <button md-raised-button color="accent" (click)="openConfirm()">Delete an item</button>
+  </md-card-content>
+</md-card>
+<md-card>
+  <md-card-title>Toast (Snack Bar)</md-card-title>
+  <md-card-subtitle>Brief, floating confirmation for an action taken.</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p>Example toast usage for a simple confirmation:</p>
+    <button md-raised-button color="primary" (click)="showSnackBar()">Send Direct Message</button>
+  </md-card-content>
+</md-card>
+<md-card>
+  <md-card-title>Inline Errors</md-card-title>
+  <md-card-subtitle>For forms and inputs use inline errors for contextual feedback:</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <form #myForm>
+      <div layout-gt-xs="row" layout-margin>
+        <md-input flex placeholder="Firstname"></md-input>
+        <md-input flex placeholder="Lastname"></md-input>
+      </div>
+      <div layout-gt-xs="row" layout-margin>
+        <md-input flex placeholder="Address"></md-input>
+        <md-input flex placeholder="City"></md-input>
+        <md-input flex="10" placeholder="State"></md-input>
+        <md-input flex="20" placeholder="Zip"></md-input>
+      </div>
+    </form>
+  </md-card-content>
+  <md-divider></md-divider>
+  <md-card-actions>
+    <button md-raised-button>Submit Form</button>
+  </md-card-actions>
+</md-card>

--- a/src/app/components/style-guide/dialogs/dialogs.component.ts
+++ b/src/app/components/style-guide/dialogs/dialogs.component.ts
@@ -17,7 +17,8 @@ export class DialogsToastsComponent {
     this._snackBarConfig = new MdSnackBarConfig(_viewContainerRef);
   }
   showSnackBar(): void {
-    let snackBarRef: MdSnackBarRef<any> = this._snackBarService.open('Direct message sent!', 'Dismiss', this._snackBarConfig);
+    let snackBarRef: MdSnackBarRef<any> = this._snackBarService
+      .open('Direct message sent!', 'Dismiss', this._snackBarConfig);
     setTimeout(() => {
       snackBarRef.dismiss();
     }, 3000);

--- a/src/app/components/style-guide/dialogs/dialogs.component.ts
+++ b/src/app/components/style-guide/dialogs/dialogs.component.ts
@@ -1,0 +1,70 @@
+import { Component, ViewContainerRef } from '@angular/core';
+
+import { TdDialogService } from '../../../../platform/core';
+
+import { MdSnackBar, MdSnackBarConfig, MdSnackBarRef} from '@angular/material';
+
+@Component({
+  selector: 'design-patterns-dialogs',
+  styleUrls: ['dialogs.component.scss'],
+  templateUrl: 'dialogs.component.html',
+})
+export class DialogsToastsComponent {
+  _snackBarConfig: MdSnackBarConfig;
+  constructor(private _dialogService: TdDialogService,
+              private _viewContainerRef: ViewContainerRef,
+              private _snackBarService: MdSnackBar) {
+    this._snackBarConfig = new MdSnackBarConfig(_viewContainerRef);
+  }
+  showSnackBar(): void {
+    let snackBarRef: MdSnackBarRef<any> = this._snackBarService.open('Direct message sent!', 'Dismiss', this._snackBarConfig);
+    setTimeout(() => {
+      snackBarRef.dismiss();
+    }, 3000);
+  }
+  openAlert(): void {
+    this._dialogService.openAlert({
+      message: 'You don\'t have the required permissions to view this item! Contact an administrator!',
+      viewContainerRef: this._viewContainerRef,
+      title: '401 Permissions Error!',
+      closeButton: 'Dismiss',
+    });
+  }
+  openConfirm(): void {
+    this._dialogService.openConfirm({
+      message: 'Are you sure you want to delete this item? It\'s used on other items.',
+      viewContainerRef: this._viewContainerRef,
+      title: 'Confirm',
+      cancelButton: 'No, Cancel',
+      acceptButton: 'Yes, Delete',
+    }).afterClosed().subscribe((accept: boolean) => {
+      if (accept) {
+        this.confirmDelete();
+      } else {
+        // DO SOMETHING ELSE
+      }
+    });
+  }
+  confirmDelete(): void {
+    let snackBarRef: MdSnackBarRef<any> = this._snackBarService.open('Item deleted!', 'Ok', this._snackBarConfig);
+    setTimeout(() => {
+      snackBarRef.dismiss();
+    }, 3000);
+  }
+  openPrompt(): void {
+    this._dialogService.openPrompt({
+      message: 'This is how simple it is to create a prompt with this wrapper service. Prompt something.',
+      viewContainerRef: this._viewContainerRef,
+      title: 'Prompt',
+      value: 'Prepopulated value',
+      cancelButton: 'Cancel',
+      acceptButton: 'Ok',
+    }).afterClosed().subscribe((newValue: string) => {
+      if (newValue) {
+        // DO SOMETHING
+      } else {
+        // DO SOMETHING ELSE
+      }
+    });
+  }
+}

--- a/src/app/components/style-guide/style-guide.component.html
+++ b/src/app/components/style-guide/style-guide.component.html
@@ -1,17 +1,31 @@
 <td-layout-nav-list #list logo="app/assets/icons/teradata.svg" title="Covalent">
   <md-nav-list list-items>
+    <h3 md-subheader>Style Guide</h3>
     <template let-item let-last="last" ngFor [ngForOf]="items">
-        <a md-list-item 
-           [routerLink]="[item.route]" 
-           [routerLinkActive]="['active']" 
-           [routerLinkActiveOptions]="{exact:true}" 
-           (click)="list.toggle()">
-          <md-icon md-list-avatar>{{item.icon}}</md-icon>
-          <h3 md-line> {{item.title}} </h3>
-          <p md-line> {{item.description}} </p>
-        </a>
-        <md-divider *ngIf="!last" md-inset></md-divider>
-      </template>
+      <a md-list-item 
+          [routerLink]="[item.route]" 
+          [routerLinkActive]="['active']" 
+          [routerLinkActiveOptions]="{exact:true}" 
+          (click)="list.toggle()">
+        <md-icon md-list-avatar>{{item.icon}}</md-icon>
+        <h3 md-line> {{item.title}} </h3>
+        <p md-line> {{item.description}} </p>
+      </a>
+      <md-divider *ngIf="!last" md-inset></md-divider>
+    </template>
+    <h3 md-subheader>Design Patterns</h3>
+    <template let-item let-last="last" ngFor [ngForOf]="patterns">
+      <a md-list-item 
+          [routerLink]="[item.route]" 
+          [routerLinkActive]="['active']" 
+          [routerLinkActiveOptions]="{exact:true}" 
+          (click)="list.toggle()">
+        <md-icon md-list-avatar>{{item.icon}}</md-icon>
+        <h3 md-line> {{item.title}} </h3>
+        <p md-line> {{item.description}} </p>
+      </a>
+      <md-divider *ngIf="!last" md-inset></md-divider>
+    </template>
   </md-nav-list>
   <div nav-toolbar-content layout="row" layout-align="center center" flex>
     <span>Teradata Style Guide</span>

--- a/src/app/components/style-guide/style-guide.component.ts
+++ b/src/app/components/style-guide/style-guide.component.ts
@@ -38,11 +38,6 @@ export class StyleGuideComponent {
     route: 'material-components',
     title: 'Material Components',
   }, {
-    description: 'Material Design card patterns',
-    icon: 'view_agenda',
-    route: 'cards',
-    title: 'Cards',
-  }, {
     description: 'Utility CSS classes',
     icon: 'build',
     route: 'utility-styles',
@@ -53,5 +48,15 @@ export class StyleGuideComponent {
     route: 'resources',
     title: 'Resources',
   }];
-
+  patterns: Object[] = [{
+    description: 'Material Design card patterns',
+    icon: 'view_agenda',
+    route: 'cards',
+    title: 'Card Patterns',
+  }, {
+    description: 'Dialog, toast & inline error patterns',
+    icon: 'filter_none',
+    route: 'dialogs',
+    title: 'Dialog Patterns',
+  },];
 }

--- a/src/app/components/style-guide/style-guide.component.ts
+++ b/src/app/components/style-guide/style-guide.component.ts
@@ -58,5 +58,5 @@ export class StyleGuideComponent {
     icon: 'filter_none',
     route: 'dialogs',
     title: 'Dialog Patterns',
-  },];
+  }];
 }

--- a/src/app/components/style-guide/style-guide.module.ts
+++ b/src/app/components/style-guide/style-guide.module.ts
@@ -10,6 +10,7 @@ import { IconographyComponent } from './iconography/iconography.component';
 import { ColorsComponent } from './colors/colors.component';
 import { MaterialComponentsComponent } from './material-components/material-components.component';
 import { CardsComponent } from './cards/cards.component';
+import { DialogsToastsComponent } from './dialogs/dialogs.component';
 import { UtilityStylesComponent } from './utility-styles/utility-styles.component';
 import { ResourcesComponent } from './resources/resources.component';
 
@@ -26,6 +27,7 @@ import { CovalentHighlightModule } from '../../../platform/highlight';
     ColorsComponent,
     MaterialComponentsComponent,
     CardsComponent,
+    DialogsToastsComponent,
     UtilityStylesComponent,
     ResourcesComponent,
   ],

--- a/src/app/components/style-guide/style-guide.routes.ts
+++ b/src/app/components/style-guide/style-guide.routes.ts
@@ -8,6 +8,7 @@ import { IconographyComponent } from './iconography/iconography.component';
 import { ColorsComponent } from './colors/colors.component';
 import { MaterialComponentsComponent } from './material-components/material-components.component';
 import { CardsComponent } from './cards/cards.component';
+import { DialogsToastsComponent } from './dialogs/dialogs.component';
 import { UtilityStylesComponent } from './utility-styles/utility-styles.component';
 import { ResourcesComponent } from './resources/resources.component';
 
@@ -33,6 +34,9 @@ const routes: Routes = [{
     }, {
       component: CardsComponent,
       path: 'cards',
+    }, {
+      component: DialogsToastsComponent,
+      path: 'dialogs',
     }, {
       component: UtilityStylesComponent,
       path: 'utility-styles',

--- a/src/platform/core/styles/_input.scss
+++ b/src/platform/core/styles/_input.scss
@@ -1,0 +1,18 @@
+@import '~@angular/material/core/theming/palette';
+@import '~@angular/material/core/theming/theming';
+
+// TODO properly wrap in mixin to apply theme like material2 components
+$foreground: $md-light-theme-foreground;
+$background: $md-light-theme-background;
+$warn: md-palette($md-red);
+
+md-input {
+    &.ng-invalid:not(.ng-pristine) {
+        label {
+            color: md-color($warn);
+        }
+        .md-input-underline {
+            border-top-color: md-color($warn);
+        }
+    }
+}

--- a/src/platform/core/styles/platform.scss
+++ b/src/platform/core/styles/platform.scss
@@ -8,6 +8,7 @@ $md-font-url: 'font/';
 @import "content";
 @import "divider";
 @import "icons";
+@import "input";
 @import "mixins";
 @import "navigation-drawer";
 @import "theme-functions";


### PR DESCRIPTION
## Description

Design patterns & code snippets on when & where to use dialogs, toasts & inline errors.

### What's included?

- Dialog patterns
- Toast/Snackbar patterns
- Inline form error patterns

#### Test Steps

- [x] ng serve
- [x] /style-guide/dialogs
- [x] click all the buttons and try the form
- [x] check out the input.scss code
- [x] npm run test

##### Screenshots or link to CodePen/Plunker/JSfiddle
![dialog-patterns](https://cloud.githubusercontent.com/assets/867883/19332067/5a275214-90ae-11e6-9298-dcfe43b25f95.gif)
