### PR TITLE
Changes to support multi-column sort.

### DIFF
--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -6,53 +6,22 @@
     <p>Basic Demo</p>
 
     <td-data-table
+      title="Search and pagination enabled"
       [data]="data"
       [columns]="columns"
       [pagination]="pagination"
       [pageSize]="pageSize"
       [rowSelection]="rowSelection"
-      [multiple]="multiple"
-      [sorting]="sorting"
-      [sortBy]="sortBy"
+      [multiSelect]="multiSelect"
+      [search]="search"
+      [initialSortColumn]="initialSortColumn"
       [sortOrder]="sortOrder"
-      search="true"
-      title="Search and pagination enabled"
       (sortChanged)="sortChanged($event)">
     </td-data-table>
 
   </md-card-content>
   <md-divider></md-divider>
   <md-card-actions>
-    <button md-button color="primary" (click)="toggleSorting()">
-      Toggle Sorting
-      ({{sorting ? 'ON' : 'OFF'}})
-    </button>
-
-    <button md-button color="primary" (click)="toggleSortBy()" [disabled]="!sorting">
-      Toggle SortBy
-      ({{sortBy}})
-    </button>
-
-    <button md-button color="primary" (click)="toggleSortOrder()" [disabled]="!sorting">
-      Toggle SortOrder
-      ({{sortOrder}})
-    </button>
-
-    <button md-button color="primary" (click)="toggleRowSelection()">
-      Toggle RowSelection
-      ({{rowSelection ? 'ON' : 'OFF'}})
-    </button>
-
-    <button md-button color="primary" (click)="toggleRowSelectionMultiple()" [disabled]="!rowSelection">
-      Toggle RowSelectionMultiple
-      ({{multiple ? 'ON' : 'OFF'}})
-    </button>
-
-    <button md-button color="primary" (click)="toggleTooltips()">
-      Toggle Tooltip
-      ({{areTooltipsOn() ? 'ON' : 'OFF'}})
-    </button>
-
     <button md-button color="primary" (click)="togglePagination()">
       Toggle Pagination
       ({{pagination ? 'ON' : 'OFF'}})
@@ -61,6 +30,26 @@
     <button md-button color="primary" (click)="togglePageSize()" [disabled]="!pagination">
       Change Page Size
       ({{pageSize}})
+    </button>
+
+    <button md-button color="primary" (click)="toggleRowSelection()">
+      Toggle RowSelection
+      ({{rowSelection ? 'ON' : 'OFF'}})
+    </button>
+
+    <button md-button color="primary" (click)="toggleRowMultiSelect()" [disabled]="!rowSelection">
+      Toggle RowMultiSelect
+      ({{multiSelect ? 'ON' : 'OFF'}})
+    </button>
+
+    <button md-button color="primary" (click)="toggleSortOrder()">
+      Toggle SortOrder
+      ({{sortOrder}})
+    </button>
+
+    <button md-button color="primary" (click)="toggleTooltips()">
+      Toggle Tooltip
+      ({{areTooltipsOn() ? 'ON' : 'OFF'}})
     </button>
   </md-card-actions>
 </md-card>
@@ -90,11 +79,13 @@
         <td-data-table
           [data]="data"
           [columns]="columns"
-          sortBy="age"
-          sortOrder="DESC"
           pagination="true"
           pageSize="5"
-          search="true">
+          rowSelection="true"          
+          multiSelect="false"          
+          search="true"
+          initialSortColumn="calories"
+          sortOrder="ASC">
         </td-data-table>
       ]]>
     </td-highlight>
@@ -104,15 +95,50 @@
         ...
         })
         export class Demo {
-          private data: any[] = [
-            { sku: '1452-2', item: 'Pork Chops', price: 32.11 },
-            { sku: '1421-0', item: 'Prime Rib', price: 41.15 },
+          columns: any[] = [
+            { name: 'name',  label: 'Dessert (100g serving)', tooltip: 'Common food name', sortable: true },
+            { name: 'type', label: 'Type', sortable: true },
+            { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT, sortable: true },
+            { name: 'fat', label: 'Fat (g)', numeric: true, format: DECIMAL_FORMAT },
+            { name: 'carbs', label: 'Carbs (g)', numeric: true, format: NUMBER_FORMAT },
+            { name: 'protein', label: 'Protein (g)', numeric: true, format: DECIMAL_FORMAT },
+            { name: 'sodium', label: 'Sodium (mg)', numeric: true, format: NUMBER_FORMAT },
+            { name: 'calcium', label: 'Calcium (%)', numeric: true, format: NUMBER_FORMAT },
+            { name: 'iron', label: 'Iron (%)', numeric: true, format: NUMBER_FORMAT },
           ];
-          private columns: any[] = [
-            { name: 'sku', label: 'SKU #', tooltip: 'Stock Keeping Unit' },
-            { name: 'item', label: 'Item name' },
-            { name: 'price', label 'Price (US$)', numeric: true, format: v => v.toFixed(2) },
-          ];
+
+          data: any[] = [
+              {
+                'name': 'Frozen yogurt',
+                'type': 'Ice cream',
+                'calories': { 'value': 159.0 },
+                'fat': { 'value': 6.0 },
+                'carbs': { 'value': 24.0 },
+                'protein': { 'value': 4.0 },
+                'sodium': { 'value': 87.0 },
+                'calcium': { 'value': 14.0 },
+                'iron': { 'value': 1.0 },
+              }, {
+                'name': 'Ice cream sandwich',
+                'type': 'Ice cream',
+                'calories': { 'value': 237.0 },
+                'fat': { 'value': 9.0 },
+                'carbs': { 'value': 37.0 },
+                'protein': { 'value': 4.3 },
+                'sodium': { 'value': 129.0 },
+                'calcium': { 'value': 8.0 },
+                'iron': { 'value': 1.0 },
+              }, {
+                'name': 'Eclair',
+                'type': 'Pastry',
+                'calories': { 'value':  262.0 },
+                'fat': { 'value': 16.0 },
+                'carbs': { 'value': 24.0 },
+                'protein': { 'value':  6.0 },
+                'sodium': { 'value': 337.0 },
+                'calcium': { 'value':  6.0 },
+                'iron': { 'value': 7.0 },
+              }];
         }
       ]]>
     </td-highlight>

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -13,6 +13,10 @@ const DECIMAL_FORMAT: any = (v: {value: number}) => v.value.toFixed(2);
 export class DataTableDemoComponent {
 
   dataTableAttrs: Object[] = [{
+    description: `If present will display a title before the table`,
+    name: 'title?',
+    type: 'string',
+  }, {
     description: `Rows of data to be displayed`,
     name: 'data',
     type: 'any[]',
@@ -20,10 +24,6 @@ export class DataTableDemoComponent {
     description: `List of columns to be displayed`,
     name: 'columns?',
     type: 'ITdDataTableColumn[]',
-  }, {
-    description: `If present will display a title before the table`,
-    name: 'title?',
-    type: 'string',
   }, {
     description: `Enables pagination`,
     name: 'pagination?',
@@ -33,35 +33,31 @@ export class DataTableDemoComponent {
     name: 'pageSize?',
     type: 'number',
   }, {
-    description: `Enables sorting by column`,
-    name: 'sorting?',
-    type: 'boolean',
-  }, {
-    description: `Name of the column to use for sorting`,
-    name: 'sortBy?',
-    type: 'string',
-  }, {
-    description: `Sorting order - ascending or descending`,
-    name: 'sortOrder?',
-    type: `'ASC' | 'DESC'`,
-  }, {
-    description: `Enables search`,
-    name: 'search?',
-    type: `boolean`,
-  }, {
     description: `Adds a checkbox column to allow user to select rows`,
     name: 'rowSelection?',
     type: 'boolean',
   }, {
     description: `Toggles between multiple or single row selection`,
-    name: 'multiple?',
+    name: 'multiSelect?',
     type: 'boolean',
+  }, {
+    description: `Enables search`,
+    name: 'search?',
+    type: 'boolean',
+  }, {
+    description: `Name of the column to use for initial sort`,
+    name: 'initialSortColumn?',
+    type: 'string',
+  }, {
+    description: `Sorting order - ascending or descending`,
+    name: 'sortOrder?',
+    type: `'ASC' | 'DESC'`,
   }];
 
   columns: any[] = [
-    { name: 'name',  label: 'Dessert (100g serving)' },
-    { name: 'type', label: 'Type' },
-    { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT },
+    { name: 'name',  label: 'Dessert (100g serving)', tooltip: 'Common food name', sortable: true },
+    { name: 'type', label: 'Type', sortable: true },
+    { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT, sortable: true },
     { name: 'fat', label: 'Fat (g)', numeric: true, format: DECIMAL_FORMAT },
     { name: 'carbs', label: 'Carbs (g)', numeric: true, format: NUMBER_FORMAT },
     { name: 'protein', label: 'Protein (g)', numeric: true, format: DECIMAL_FORMAT },
@@ -69,10 +65,6 @@ export class DataTableDemoComponent {
     { name: 'calcium', label: 'Calcium (%)', numeric: true, format: NUMBER_FORMAT },
     { name: 'iron', label: 'Iron (%)', numeric: true, format: NUMBER_FORMAT },
   ];
-
-  sorting: boolean = true;
-  pagination: boolean = true;
-  pageSize: number = 5;
 
   data: any[] = [
       {
@@ -168,32 +160,22 @@ export class DataTableDemoComponent {
       },
     ];
 
-  sortBy: string = 'name';
+  pagination: boolean = true;
+  pageSize: number = 5;
+  rowSelection: boolean = true;
+  multiSelect: boolean = false;
+  search: boolean = true;
+  initialSortColumn: string = 'calories';
   sortOrder: string = 'ASC';
 
-  rowSelection: boolean = false;
-  multiple: boolean = true;
+  currentSortColumn: string;
 
   toggleRowSelection(): void {
     this.rowSelection = !this.rowSelection;
   }
 
-  toggleRowSelectionMultiple(): void {
-    this.multiple = !this.multiple;
-  }
-
-  toggleSorting(): void {
-    this.sorting = !this.sorting;
-  }
-
-  toggleSortBy(): void {
-    const columns: any[] = this.columns.map((c: any) => c.name);
-    const idx: number = columns.indexOf(this.sortBy);
-    if (idx < columns.length - 1) {
-      this.sortBy = columns[idx + 1];
-    } else {
-      this.sortBy = columns[0];
-    }
+  toggleRowMultiSelect(): void {
+    this.multiSelect = !this.multiSelect;
   }
 
   toggleSortOrder(): void {
@@ -226,7 +208,7 @@ export class DataTableDemoComponent {
   sortChanged(changes: any): void {
     const { column, order }: any = changes;
 
-    this.sortBy = column.name;
+    this.currentSortColumn = column.name;
     this.sortOrder = order === TdDataTableSortingOrder.Ascending ? 'ASC' : 'DESC';
   }
 }

--- a/src/platform/data-table/README.md
+++ b/src/platform/data-table/README.md
@@ -4,21 +4,32 @@
 
 ## API Summary
 
-Properties:
+Table Properties:
 
 | Name | Type | Description |
 | --- | --- | --- |
+| `title?` | `string` | If defined, will display a title before the table
 | `data` | `any[]` | Rows of data to be displayed
 | `columns` | `ITdDataTableColumn[]` | List of columns to be displayed
-| `title?` | `string` | If present will display a title before the table
-| `pagination?` | `boolean` | Enables pagination
-| `pageSize?` | `number` | Number of rows per page, when omitted defaults to 10
-| `sorting?` | `boolean` | Enables sorting by column
-| `sortBy?` | `string` | Name of the column to use for sorting
-| `sortOrder?` | `'ASC' | 'DESC'` | Sorting order - ascending or descending
-| `search?` | `boolean` | Enables search
-| `rowSelection?` | `boolean` | Adds a checkbox column to allow user to select rows
-| `multiple?` | `boolean` | Toggles between multiple or single row selection
+| `pagination?` | `boolean` | Enables pagination, default false
+| `pageSize?` | `number` | Number of rows per page, default 10
+| `rowSelection?` | `boolean` | Adds a checkbox column to allow user to select rows, default false
+| `multiSelect?` | `boolean` | Toggles between multiple or single row selection, default true
+| `search?` | `boolean` | Enables search, default false
+| `initialSortColumn?` | `string` | Name of sortable column for initial ordering of table, default is first sortable column defined
+| `sortOrder?` | `'ASC'` | `'DESC'` | Initial sorting order - ascending or descending
+
+
+Column Properties
+
+| Name | Type | Description |
+|--- | --- | --- |
+| `name` | `string` | Field name in data row
+| `label` | `string` | Label to display in column header
+| `tooltip?` | `string` | Tooltip text to display on mouse hover
+| `numeric?` | `boolean` | Indicates if data to be displayed is numeric, data is formatted if sorting, default false
+| `format?` | `{ (value: any): any }` | Format to be applied to the column
+| `sortable?` | `boolean` | Indicates table is sortable by this column, default false
 
 ## Setup
 
@@ -33,7 +44,52 @@ import { CovalentDataTableModule } from '@covalent/chips';
   ],
   ...
 })
-export class MyModule {}
+export class MyModule {
+  columns: any[] = [
+    { name: 'name',  label: 'Dessert (100g serving)', tooltip: 'Common food name', sortable: true },
+    { name: 'type', label: 'Type', sortable: true },
+    { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT, sortable: true },
+    { name: 'fat', label: 'Fat (g)', numeric: true, format: DECIMAL_FORMAT },
+    { name: 'carbs', label: 'Carbs (g)', numeric: true, format: NUMBER_FORMAT },
+    { name: 'protein', label: 'Protein (g)', numeric: true, format: DECIMAL_FORMAT },
+    { name: 'sodium', label: 'Sodium (mg)', numeric: true, format: NUMBER_FORMAT },
+    { name: 'calcium', label: 'Calcium (%)', numeric: true, format: NUMBER_FORMAT },
+    { name: 'iron', label: 'Iron (%)', numeric: true, format: NUMBER_FORMAT },
+  ];
+
+  data: any[] = [
+      {
+        'name': 'Frozen yogurt',
+        'type': 'Ice cream',
+        'calories': { 'value': 159.0 },
+        'fat': { 'value': 6.0 },
+        'carbs': { 'value': 24.0 },
+        'protein': { 'value': 4.0 },
+        'sodium': { 'value': 87.0 },
+        'calcium': { 'value': 14.0 },
+        'iron': { 'value': 1.0 },
+      }, {
+        'name': 'Ice cream sandwich',
+        'type': 'Ice cream',
+        'calories': { 'value': 237.0 },
+        'fat': { 'value': 9.0 },
+        'carbs': { 'value': 37.0 },
+        'protein': { 'value': 4.3 },
+        'sodium': { 'value': 129.0 },
+        'calcium': { 'value': 8.0 },
+        'iron': { 'value': 1.0 },
+      }, {
+        'name': 'Eclair',
+        'type': 'Pastry',
+        'calories': { 'value':  262.0 },
+        'fat': { 'value': 16.0 },
+        'carbs': { 'value': 24.0 },
+        'protein': { 'value':  6.0 },
+        'sodium': { 'value': 337.0 },
+        'calcium': { 'value':  6.0 },
+        'iron': { 'value': 7.0 },
+      }];
+}
 ```
 
 ## Usage
@@ -44,10 +100,12 @@ Example for HTML usage:
 <td-data-table
   [data]="data"
   [columns]="columns"
-  sortBy="age"
-  sortOrder="DESC"
   pagination="true"
   pageSize="5"
-  search="true">
+  rowSelection="true"          
+  multiSelect="false"          
+  search="true"
+  initialSortColumn="calories"
+  sortOrder="ASC">
 </td-data-table>
  ```

--- a/src/platform/data-table/data-table.component.html
+++ b/src/platform/data-table/data-table.component.html
@@ -30,29 +30,31 @@
         </th>
         <th td-column 
             *ngFor="let column of columns" 
-            [class.md-clickable]="_sorting"
-            [class.md-active]="_sorting && column === _sortBy"
+            [class.md-clickable]="isSortColumn(column)"
+            [class.md-active]="isSortColumn(column)"
             [class.md-numeric]="column.numeric"
-            [class.md-asc]="(column === _sortBy && isAscending())"
-            [class.md-desc]="(column === _sortBy && isDescending())">
+            [class.md-asc]="(isCurrentSortColumn(column) && isAscending())"
+            [class.md-desc]="(isCurrentSortColumn(column) && isDescending())">
           <md-icon 
             class="md-sort-icon" 
-            *ngIf="_sorting && column.numeric"
-            [class.md-asc]="(!(column === _sortBy) || isAscending())"
-            [class.md-desc]="(column === _sortBy && isDescending())"
-            (click)="_sorting && setSorting(column)">
+            *ngIf="(isSortColumn(column) && column.numeric)"
+            [class.md-active]="(isCurrentSortColumn(column))"
+            [class.md-asc]="(isCurrentSortColumn(column) && isAscending())"
+            [class.md-desc]="(isCurrentSortColumn(column) && isDescending())"
+            (click)="setCurrentSortColumn(column)">
             arrow_upward
           </md-icon>
-          <span class="md-caption" (click)="_sorting && setSorting(column)">
+          <span class="md-caption" (click)="(isSortColumn(column) && setCurrentSortColumn(column))">
             <span *ngIf="column.tooltip" [md-tooltip]="column.tooltip">{{column.label}}</span>
             <span *ngIf="!column.tooltip">{{column.label}}</span>
           </span>
           <md-icon 
             class="md-sort-icon" 
-            *ngIf="_sorting && !column.numeric"
-            [class.md-asc]="(!(column === _sortBy) || isAscending())"
-            [class.md-desc]="(column === _sortBy && isDescending())"
-            (click)="_sorting && setSorting(column)">
+            *ngIf="(isSortColumn(column) && !column.numeric)"
+            [class.md-active]="(isCurrentSortColumn(column))"
+            [class.md-asc]="(isCurrentSortColumn(column) && isAscending())"
+            [class.md-desc]="(isCurrentSortColumn(column) && isDescending())"
+            (click)="setCurrentSortColumn(column)">
             arrow_upward
           </md-icon>
         </th>


### PR DESCRIPTION
## Description

Promoted sortable property from the table and only one column to column metadata to allow sorting on multiple columns. Enhanced docs to describe table and column properties.

### What's included?

- Modified core data table component.
- Updated sample data table component to utilizing new functionality.
- Updated README.md to document new functionality.

#### Test Steps

- Launch app, navigate to the data table sample page.
- Click on column headers and notice that only the first three columns are sortable.
- Click on column headers and confirm entire table is sorted by the current column values.

##### Screenshot

![datatablemulticolumnsort](https://cloud.githubusercontent.com/assets/546264/19698257/6e1de220-9aa3-11e6-95be-080dad007af9.gif)

