### PR TITLE
feat(data-table): initial template support

### DIFF
--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -18,16 +18,17 @@
       search="true"
       title="Search and pagination enabled"
       (sortChanged)="sortChanged($event)">
+      <template tdTemplate="icons" let-value="value">
+        <md-icon>{{value}}</md-icon>
+      </template>
+      <template tdTemplate="comment" let-row="row" let-column="column">
+        <div layout="row" layout-align="start center" (click)="editCell(row, column)" flex>
+          <span flex>{{row[column]}}</span>
+          <md-icon>edit</md-icon>
+        </div>
+      </template>
     </td-data-table>
 
-    <template #nameTmpl let-value="value">
-      <a href="#">{{value}}</a>
-    </template>
-
-    <template #actionsTmpl let-row="row">
-      <button md-raised-button>Edit {{row['name']}}</button>
-    </template>
-    
   </md-card-content>
   <md-divider></md-divider>
   <md-card-actions>

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -20,6 +20,14 @@
       (sortChanged)="sortChanged($event)">
     </td-data-table>
 
+    <template #nameTmpl let-value="value">
+      <a href="#">{{value}}</a>
+    </template>
+
+    <template #actionsTmpl let-row="row">
+      <button md-raised-button>Edit {{row['name']}}</button>
+    </template>
+    
   </md-card-content>
   <md-divider></md-divider>
   <md-card-actions>

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit, ViewChild, TemplateRef } from '@angular/core';
+import { Component, OnInit, ViewContainerRef } from '@angular/core';
 
+import { TdDialogService } from '../../../../platform/core';
 import { TdDataTableSortingOrder } from '../../../../platform/data-table';
 
 const NUMBER_FORMAT: any = (v: {value: number}) => v.value;
@@ -11,9 +12,6 @@ const DECIMAL_FORMAT: any = (v: {value: number}) => v.value.toFixed(2);
   templateUrl: 'data-table.component.html',
 })
 export class DataTableDemoComponent implements OnInit {
-
-  @ViewChild('actionsTmpl') actionsTmpl: TemplateRef<any>;
-  @ViewChild('nameTmpl') nameTmpl: TemplateRef<any>;
 
   dataTableAttrs: Object[] = [{
     description: `Rows of data to be displayed`,
@@ -70,6 +68,7 @@ export class DataTableDemoComponent implements OnInit {
   data: any[] = [
       {
         'name': 'Frozen yogurt',
+        'icons': 'add',
         'type': 'Ice cream',
         'calories': { 'value': 159.0 },
         'fat': { 'value': 6.0 },
@@ -80,6 +79,7 @@ export class DataTableDemoComponent implements OnInit {
         'iron': { 'value': 1.0 },
       }, {
         'name': 'Ice cream sandwich',
+        'icons': 'cancel',
         'type': 'Ice cream',
         'calories': { 'value': 237.0 },
         'fat': { 'value': 9.0 },
@@ -90,6 +90,7 @@ export class DataTableDemoComponent implements OnInit {
         'iron': { 'value': 1.0 },
       }, {
         'name': 'Eclair',
+        'icons': 'person',
         'type': 'Pastry',
         'calories': { 'value':  262.0 },
         'fat': { 'value': 16.0 },
@@ -100,6 +101,7 @@ export class DataTableDemoComponent implements OnInit {
         'iron': { 'value': 7.0 },
       }, {
         'name': 'Cupcake',
+        'icons': 'person',
         'type': 'Pastry',
         'calories': { 'value':  305.0 },
         'fat': { 'value': 3.7 },
@@ -110,6 +112,7 @@ export class DataTableDemoComponent implements OnInit {
         'iron': { 'value': 8.0 },
       }, {
         'name': 'Jelly bean',
+        'icons': 'people',
         'type': 'Candy',
         'calories': { 'value':  375.0 },
         'fat': { 'value': 0.0 },
@@ -120,6 +123,7 @@ export class DataTableDemoComponent implements OnInit {
         'iron': { 'value': 0.0 },
       }, {
         'name': 'Lollipop',
+        'icons': 'people',
         'type': 'Candy',
         'calories': { 'value': 392.0 },
         'fat': { 'value': 0.2 },
@@ -130,6 +134,7 @@ export class DataTableDemoComponent implements OnInit {
         'iron': { 'value': 2.0 },
       }, {
         'name': 'Honeycomb',
+        'icons': 'add',
         'type': 'Other',
         'calories': { 'value': 408.0 },
         'fat': { 'value': 3.2 },
@@ -140,6 +145,7 @@ export class DataTableDemoComponent implements OnInit {
         'iron': { 'value': 45.0 },
       }, {
         'name': 'Donut',
+        'icons': 'timer',
         'type': 'Pastry',
         'calories': { 'value': 452.0 },
         'fat': { 'value': 25.0 },
@@ -150,6 +156,7 @@ export class DataTableDemoComponent implements OnInit {
         'iron': { 'value': 22.0 },
       }, {
         'name': 'KitKat',
+        'icons': 'timer',
         'type': 'Candy',
         'calories': { 'value': 518.0 },
         'fat': { 'value': 26.0 },
@@ -167,10 +174,26 @@ export class DataTableDemoComponent implements OnInit {
   rowSelection: boolean = false;
   multiple: boolean = true;
 
+  constructor(private _dialogService: TdDialogService,
+              private _viewContainerRef: ViewContainerRef) {}
+
+  editCell(row: any, column: string): void {
+    this._dialogService.openPrompt({
+      message: 'Edit this field?',
+      value: row[column],
+      viewContainerRef: this._viewContainerRef,
+    }).afterClosed().subscribe((value: string) => {
+      if (value) {
+        row[column] = value;
+      }
+    });
+  }
+
   ngOnInit(): void {
     this.columns = [
-      { name: 'name',  label: 'Dessert (100g serving)', template: this.nameTmpl },
+      { name: 'name',  label: 'Dessert (100g serving)' },
       { name: 'type', label: 'Type' },
+      { name: 'icons', label: 'Icon'},
       { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT },
       { name: 'fat', label: 'Fat (g)', numeric: true, format: DECIMAL_FORMAT },
       { name: 'carbs', label: 'Carbs (g)', numeric: true, format: NUMBER_FORMAT },
@@ -178,7 +201,7 @@ export class DataTableDemoComponent implements OnInit {
       { name: 'sodium', label: 'Sodium (mg)', numeric: true, format: NUMBER_FORMAT },
       { name: 'calcium', label: 'Calcium (%)', numeric: true, format: NUMBER_FORMAT },
       { name: 'iron', label: 'Iron (%)', numeric: true, format: NUMBER_FORMAT },
-      { name: 'actions', label: 'Actions', template: this.actionsTmpl },
+      { name: 'comment', label: 'Comment'},
     ];
   }
 

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, ViewChild, TemplateRef } from '@angular/core';
 
 import { TdDataTableSortingOrder } from '../../../../platform/data-table';
 
@@ -10,7 +10,10 @@ const DECIMAL_FORMAT: any = (v: {value: number}) => v.value.toFixed(2);
   styleUrls: ['data-table.component.scss'],
   templateUrl: 'data-table.component.html',
 })
-export class DataTableDemoComponent {
+export class DataTableDemoComponent implements OnInit {
+
+  @ViewChild('actionsTmpl') actionsTmpl: TemplateRef<any>;
+  @ViewChild('nameTmpl') nameTmpl: TemplateRef<any>;
 
   dataTableAttrs: Object[] = [{
     description: `Rows of data to be displayed`,
@@ -58,17 +61,7 @@ export class DataTableDemoComponent {
     type: 'boolean',
   }];
 
-  columns: any[] = [
-    { name: 'name',  label: 'Dessert (100g serving)' },
-    { name: 'type', label: 'Type' },
-    { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT },
-    { name: 'fat', label: 'Fat (g)', numeric: true, format: DECIMAL_FORMAT },
-    { name: 'carbs', label: 'Carbs (g)', numeric: true, format: NUMBER_FORMAT },
-    { name: 'protein', label: 'Protein (g)', numeric: true, format: DECIMAL_FORMAT },
-    { name: 'sodium', label: 'Sodium (mg)', numeric: true, format: NUMBER_FORMAT },
-    { name: 'calcium', label: 'Calcium (%)', numeric: true, format: NUMBER_FORMAT },
-    { name: 'iron', label: 'Iron (%)', numeric: true, format: NUMBER_FORMAT },
-  ];
+  columns: any[] = [];
 
   sorting: boolean = true;
   pagination: boolean = true;
@@ -173,6 +166,21 @@ export class DataTableDemoComponent {
 
   rowSelection: boolean = false;
   multiple: boolean = true;
+
+  ngOnInit(): void {
+    this.columns = [
+      { name: 'name',  label: 'Dessert (100g serving)', template: this.nameTmpl },
+      { name: 'type', label: 'Type' },
+      { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT },
+      { name: 'fat', label: 'Fat (g)', numeric: true, format: DECIMAL_FORMAT },
+      { name: 'carbs', label: 'Carbs (g)', numeric: true, format: NUMBER_FORMAT },
+      { name: 'protein', label: 'Protein (g)', numeric: true, format: DECIMAL_FORMAT },
+      { name: 'sodium', label: 'Sodium (mg)', numeric: true, format: NUMBER_FORMAT },
+      { name: 'calcium', label: 'Calcium (%)', numeric: true, format: NUMBER_FORMAT },
+      { name: 'iron', label: 'Iron (%)', numeric: true, format: NUMBER_FORMAT },
+      { name: 'actions', label: 'Actions', template: this.actionsTmpl },
+    ];
+  }
 
   toggleRowSelection(): void {
     this.rowSelection = !this.rowSelection;

--- a/src/platform/data-table/data-table.component.html
+++ b/src/platform/data-table/data-table.component.html
@@ -71,7 +71,12 @@
         <td td-cell
             [class.md-numeric]="column.numeric"
             *ngFor="let column of columns">
-          <span class="md-body-1">{{ row[column.name] }}</span>
+          <span class="md-body-1" *ngIf="!column.template">{{ row[column.name] }}</span>
+          <template
+            *ngIf="column.template"
+            [ngTemplateOutlet]="column.template"
+            [ngOutletContext]="{ value: row[column.name], row: row, column: column }">
+          </template>
         </td>
       </tr>
     </tbody>

--- a/src/platform/data-table/data-table.component.html
+++ b/src/platform/data-table/data-table.component.html
@@ -71,10 +71,10 @@
         <td td-cell
             [class.md-numeric]="column.numeric"
             *ngFor="let column of columns">
-          <span class="md-body-1" *ngIf="!column.template">{{ row[column.name] }}</span>
+          <span class="md-body-1" *ngIf="!getTemplateRef(column.name)">{{ row[column.name] }}</span>
           <template
-            *ngIf="column.template"
-            [ngTemplateOutlet]="column.template"
+            *ngIf="getTemplateRef(column.name)"
+            [ngTemplateOutlet]="getTemplateRef(column.name)"
             [ngOutletContext]="{ value: row[column.name], row: row, column: column }">
           </template>
         </td>

--- a/src/platform/data-table/data-table.component.ts
+++ b/src/platform/data-table/data-table.component.ts
@@ -16,6 +16,7 @@ export interface ITdDataTableColumn {
   tooltip?: string;
   numeric?: boolean;
   format?: { (value: any): any };
+  template?: any;
 };
 
 export interface ITdDataTableSortEvent {

--- a/src/platform/data-table/data-table.component.ts
+++ b/src/platform/data-table/data-table.component.ts
@@ -1,10 +1,12 @@
-import { Component, OnInit, Input, Output,
-         EventEmitter, ViewChildren, QueryList, Renderer } from '@angular/core';
+import { Component, OnInit, Input, Output, ContentChildren, TemplateRef,
+         EventEmitter, ViewChildren, QueryList, Renderer, AfterContentInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { MdInput } from '@angular/material';
 import 'rxjs/add/operator/debounceTime';
 
 import * as _ from 'lodash';
+
+import { TdTemplateDirective } from './directives/template.directive';
 
 export enum TdDataTableSortingOrder {
   Ascending, Descending
@@ -16,7 +18,6 @@ export interface ITdDataTableColumn {
   tooltip?: string;
   numeric?: boolean;
   format?: { (value: any): any };
-  template?: any;
 };
 
 export interface ITdDataTableSortEvent {
@@ -29,7 +30,7 @@ export interface ITdDataTableSortEvent {
   styleUrls: [ 'data-table.component.scss' ],
   templateUrl: 'data-table.component.html',
 })
-export class TdDataTableComponent implements OnInit {
+export class TdDataTableComponent implements OnInit, AfterContentInit {
 
   /** internal attributes */
   private _data: any[];
@@ -57,6 +58,8 @@ export class TdDataTableComponent implements OnInit {
   private _searchTerm: string = '';
   private _searchTermControl: FormControl = new FormControl();
 
+  private _templateMap: Map<string, TemplateRef<any>> = new Map<string, TemplateRef<any>>();
+  @ContentChildren(TdTemplateDirective) private _templates: QueryList<TdTemplateDirective>;
   @ViewChildren(MdInput) _searchTermInput: QueryList<MdInput>;
 
   /** events */
@@ -186,6 +189,18 @@ export class TdDataTableComponent implements OnInit {
     this.preprocessData();
     this._initialized = true;
     this.filterData();
+  }
+
+  ngAfterContentInit(): void {
+    for (let i: number = 0; i < this._templates.toArray().length; i++) {
+      this._templateMap.set(
+        this._templates.toArray()[i].tdTemplate,
+        this._templates.toArray()[i].templateRef);
+    }
+  }
+
+  getTemplateRef(name: string): TemplateRef<any> {
+    return this._templateMap.get(name);
   }
 
   areAllSelected(): boolean {

--- a/src/platform/data-table/data-table.module.ts
+++ b/src/platform/data-table/data-table.module.ts
@@ -5,6 +5,7 @@ import { CommonModule } from '@angular/common';
 import { MaterialModule } from '@angular/material';
 
 import { TdDataTableComponent } from './data-table.component';
+import { TdTemplateDirective } from './directives/template.directive';
 
 import { TdDataTableTableDirective } from './directives/table.directive';
 import { TdDataTableHeadDirective } from './directives/head.directive';
@@ -15,6 +16,7 @@ import { TdDataTableCellDirective } from './directives/cell.directive';
 
 export const TD_DATA_TABLE_DIRECTIVES: Type<any>[] = [
   TdDataTableComponent,
+  TdTemplateDirective,
 
   TdDataTableTableDirective,
   TdDataTableHeadDirective,

--- a/src/platform/data-table/directives/template.directive.ts
+++ b/src/platform/data-table/directives/template.directive.ts
@@ -1,0 +1,11 @@
+import { Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
+import { TemplatePortalDirective } from '@angular/material';
+
+@Directive({selector: '[tdTemplate]template'})
+export class TdTemplateDirective extends TemplatePortalDirective {
+
+  @Input() tdTemplate: string;
+  constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
+    super(templateRef, viewContainerRef);
+  }
+}


### PR DESCRIPTION
## Description

This adds initial support for templates within `data-table`. Here's how it works:
### Add a `<template>` to your component's HTML:

```
<template #nameTmpl let-value="value">
   <a href="#">{{value}}</a>
</template>
```

or 

```
<template #actionsTmpl let-row="row">
  <button md-raised-button>Edit {{row['name']}}</button>
</template>
```
### Add a `ViewChild` with the `TemplateRef` to the component:

```
  @ViewChild('actionsTmpl') actionsTmpl: TemplateRef<any>;
  @ViewChild('nameTmpl') nameTmpl: TemplateRef<any>;
```
### Reference the templates using the new `template` field in your `columns` collection:

```
  ngOnInit(): void {
    this.columns = [
      { name: 'name',  label: 'Dessert (100g serving)', template: this.nameTmpl },
      { name: 'type', label: 'Type' },
      { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT },
      { name: 'fat', label: 'Fat (g)', numeric: true, format: DECIMAL_FORMAT },
      { name: 'carbs', label: 'Carbs (g)', numeric: true, format: NUMBER_FORMAT },
      { name: 'protein', label: 'Protein (g)', numeric: true, format: DECIMAL_FORMAT },
      { name: 'sodium', label: 'Sodium (mg)', numeric: true, format: NUMBER_FORMAT },
      { name: 'calcium', label: 'Calcium (%)', numeric: true, format: NUMBER_FORMAT },
      { name: 'iron', label: 'Iron (%)', numeric: true, format: NUMBER_FORMAT },
      { name: 'actions', label: 'Actions', template: this.actionsTmpl },
    ];
  }
```
### What's included?
- Initial support for using templates within `data-table`
#### Test Steps
##### Screenshots or link to CodePen/Plunker/JSfiddle

![https://cl.ly/3t2r3U0F170u/Image%202016-10-28%20at%2012.22.29%20AM.png](https://cl.ly/3t2r3U0F170u/Image%202016-10-28%20at%2012.22.29%20AM.png)
![https://cl.ly/270i2C0T2x2E/Image%202016-10-28%20at%2012.22.49%20AM.png](https://cl.ly/270i2C0T2x2E/Image%202016-10-28%20at%2012.22.49%20AM.png)
