### PR TITLE
bugfix(stepper): Conditional margin for stepper templates

### DIFF
--- a/src/platform/core/steps/step-body/step-body.component.html
+++ b/src/platform/core/steps/step-body/step-body.component.html
@@ -1,15 +1,15 @@
 <div layout="row" flex>
   <ng-content></ng-content>
   <div flex>
-    <div [tdToggle]="!active">
-      <div class="td-step-content">
+    <div class="td-step-content-wrapper" [tdToggle]="!active">
+      <div #contentRef [class.td-step-content]="contentRef.children.length || contentRef.textContent.trim()">
         <ng-content select="[td-step-body-content]"></ng-content>
       </div>
-      <div layout="row" class="td-step-actions">
+      <div #actionsRef layout="row" [class.td-step-actions]="actionsRef.children.length || actionsRef.textContent.trim()">
         <ng-content select="[td-step-body-actions]"></ng-content>
       </div>
     </div>
-    <div [tdToggle]="active || !isComplete()" class="td-step-summary">
+    <div #summaryRef [tdToggle]="active || !isComplete()" [class.td-step-summary]="summaryRef.children.length || summaryRef.textContent.trim()">
       <ng-content select="[td-step-body-summary]"></ng-content>
     </div>
   </div>

--- a/src/platform/core/steps/step-body/step-body.component.scss
+++ b/src/platform/core/steps/step-body/step-body.component.scss
@@ -1,15 +1,7 @@
 @import '../../styles/variables';
-@import '../../styles/default-theme';
 
 .td-step-content,
 .td-step-summary,
 .td-step-actions {
-  padding-top: $padding;
-  padding-left: $padding;
-  display: block;
-}
-
-.td-step-summary,
-.td-step-content-wrapper {
-  margin-bottom: $margin;
+  margin: $margin;
 }

--- a/src/platform/core/steps/step-body/step-body.component.scss
+++ b/src/platform/core/steps/step-body/step-body.component.scss
@@ -10,6 +10,6 @@
 }
 
 .td-step-summary,
-.td-step-actions {
+.td-step-content-wrapper {
   margin-bottom: $margin;
 }


### PR DESCRIPTION
## Description

Removing margin and padding from step templates when they are empty or not used.
https://github.com/Teradata/covalent/issues/130 

#### Test Steps

- [x] `ng serve`
- [x] Check step template margins when any of them (content, actions or summary) are ignored.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![image](https://cloud.githubusercontent.com/assets/5846742/20017965/256bf98a-a283-11e6-8da2-75cae39a894d.png)
