### PR TITLE
feature(deps): relaxed dependency limitations

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "finish-release": "bash scripts/finish-release"
   },
   "engines": {
-    "node": ">4.4 < 5",
+    "node": ">4.4 < 7",
     "npm": ">3"
   },
   "repository": {

--- a/src/platform/charts/package.json
+++ b/src/platform/charts/package.json
@@ -12,7 +12,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">4.4 < 5",
+    "node": ">4.4 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/chips/package.json
+++ b/src/platform/chips/package.json
@@ -12,7 +12,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">4.4 < 5",
+    "node": ">4.4 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/core/package.json
+++ b/src/platform/core/package.json
@@ -10,7 +10,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">4.4 < 5",
+    "node": ">4.4 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/data-table/package.json
+++ b/src/platform/data-table/package.json
@@ -11,7 +11,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">4.4 < 5",
+    "node": ">4.4 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/file-upload/package.json
+++ b/src/platform/file-upload/package.json
@@ -13,7 +13,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">4.4 < 5",
+    "node": ">4.4 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/highlight/package.json
+++ b/src/platform/highlight/package.json
@@ -12,7 +12,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">4.4 < 5",
+    "node": ">4.4 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/http/package.json
+++ b/src/platform/http/package.json
@@ -34,6 +34,7 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@covalent/core": "0.8.1"
+    "@angular/core": "^2.0.0",
+    "@angular/http": "^2.0.0"
   }
 }

--- a/src/platform/http/package.json
+++ b/src/platform/http/package.json
@@ -13,7 +13,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">4.4 < 5",
+    "node": ">4.4 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/json-formatter/package.json
+++ b/src/platform/json-formatter/package.json
@@ -13,7 +13,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">4.4 < 5",
+    "node": ">4.4 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/markdown/package.json
+++ b/src/platform/markdown/package.json
@@ -10,7 +10,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">4.4 < 5",
+    "node": ">4.4 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/paging/package.json
+++ b/src/platform/paging/package.json
@@ -13,7 +13,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">4.4 < 5",
+    "node": ">4.4 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/search/package.json
+++ b/src/platform/search/package.json
@@ -12,7 +12,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">4.4 < 5",
+    "node": ">4.4 < 7",
     "npm": ">= 3"
   },
   "repository": {


### PR DESCRIPTION
## Description

Removed `@covalent/core` as dependency from `http` module since this module in particular only needs `@angular/core` and `@angular/http`. https://github.com/Teradata/covalent/issues/123
Relaxed engine node dependency to be up `< 7` https://github.com/Teradata/covalent/issues/134