### PR TITLE
feature(theming): create covalent-theme for components

### DIFF
--- a/src/app/components/docs/theme/theme.component.html
+++ b/src/app/components/docs/theme/theme.component.html
@@ -54,23 +54,23 @@
   </md-card-content>
   <md-divider></md-divider>
   <md-card-content>
-    <h3 class="md-title"><span class="tc-light-blue-700">Light Blue Primary</span> / <span class="tc-orange-700">Orange Accent</span></h3>
+    <h3 class="md-title"><span class="tc-blue-700">Blue Primary</span> / <span class="tc-orange-700">Orange Accent</span></h3>
     <div layout-gt-xs="row" layout-margin>
       <div flex-gt-xs="50" class="pad-top-sm">
         <td-highlight lang="scss">
-          .light-blue-orange {{ '{' }}
-              $primary2: md-palette($md-light-blue);
+          .blue-orange {{ '{' }}
+              $primary2: md-palette($md-blue, 700);
               $accent2:  md-palette($md-orange, 800);
               $warn2:    md-palette($md-red, 600);
 
-              $light-blue-orange: md-light-theme($primary2, $accent2, $warn2);
+              $blue-orange: md-light-theme($primary2, $accent2, $warn2);
 
-              @include angular-material-theme($light-blue-orange);   
+              @include angular-material-theme($blue-orange);   
           {{ '}' }}
         </td-highlight>
       </div>
       <div flex-gt-xs="50">
-        <md-card class="top-toolbar light-blue-orange">
+        <md-card class="top-toolbar blue-orange">
           <md-toolbar color="primary">
             <md-toolbar-row>
               <span></span>

--- a/src/app/components/style-guide/colors/colors.component.html
+++ b/src/app/components/style-guide/colors/colors.component.html
@@ -50,9 +50,9 @@
           <h3 md-line>Orange 700</h3>
         </md-grid-tile-footer>
      </md-grid-tile>
-     <md-grid-tile class="bgc-orange-500">
+     <md-grid-tile class="bgc-orange-800">
        <md-grid-tile-footer>
-          <h3 md-line>Orange 500</h3>
+          <h3 md-line>Orange 800</h3>
         </md-grid-tile-footer>
      </md-grid-tile>
      <md-grid-tile class="bgc-orange-900">
@@ -88,33 +88,24 @@
             <span>Hue: 700</span>
           </md-toolbar-row>
         </md-toolbar>
-        <md-toolbar class="bgc-blue-500 tc-white push-top">
-          <span>Hue: 500</span>
-        </md-toolbar>
-        <md-toolbar class="bgc-blue-900 tc-white push-bottom">
-          <span>Hue: 900</span>
-        </md-toolbar>
-        <md-toolbar class="bgc-orange-700 tc-white">
+        <md-toolbar class="bgc-orange-800 tc-white push-top">
           <span>Accent</span>
           <md-toolbar-row>
-            <span>Hue: 700</span>
+            <span>Hue: 800</span>
           </md-toolbar-row>
         </md-toolbar>
       </div>
       <div flex-gt-xs="50">
-        <md-card class="top-toolbar">
-          <md-toolbar class="bgc-blue-700 tc-white">
+        <md-card class="top-toolbar blue-orange">
+          <md-toolbar color="primary" class="relative">
             <md-toolbar-row>
               <span></span>
             </md-toolbar-row>
             <md-toolbar-row>
               <span>App Usage</span>
             </md-toolbar-row>
-          </md-toolbar>
-          <md-toolbar class="bgc-blue-500 tc-white push-bottom relative">
-            <span>Subtoolbar</span>
-            <button md-fab class="md-fab md-fab-position-bottom-right bgc-orange-700">
-              <md-icon class="md-24">add</md-icon>
+            <button md-fab class="md-fab md-fab-position-bottom-right">
+              <md-icon>add</md-icon>
             </button>
           </md-toolbar>
           <md-card-content>
@@ -133,19 +124,13 @@
     <h3 class="md-title"><span class="tc-orange-700">Orange Primary</span> / <span class="tc-light-blue-700">Light Blue Accent</span></h3>
     <div layout-gt-xs="row" layout-margin>
       <div flex-gt-xs="50" class="pad-top-sm">
-        <md-toolbar class="bgc-orange-700 tc-white">
+        <md-toolbar class="bgc-orange-800 tc-white">
           <span>Primary</span>
           <md-toolbar-row>
-            <span>Hue: 700</span>
+            <span>Hue: 800</span>
           </md-toolbar-row>
         </md-toolbar>
-        <md-toolbar class="bgc-orange-500 tc-white push-top">
-          <span>Hue: 500</span>
-        </md-toolbar>
-        <md-toolbar class="bgc-orange-900 tc-white push-bottom">
-          <span>Hue: 900</span>
-        </md-toolbar>
-        <md-toolbar class="bgc-light-blue-700 tc-white">
+        <md-toolbar class="bgc-light-blue-700 tc-white push-top">
           <span>Accent</span>
           <md-toolbar-row>
             <span>Hue: 700</span>
@@ -154,22 +139,19 @@
       </div>
       <div flex-gt-xs="50">
         <md-card class="top-toolbar">
-          <md-toolbar class="bgc-orange-700 tc-white">
+          <md-toolbar color="primary" class="relative">
             <md-toolbar-row>
               <span></span>
             </md-toolbar-row>
             <md-toolbar-row>
               <span>App Usage</span>
             </md-toolbar-row>
-          </md-toolbar>
-          <md-toolbar class="bgc-orange-500 tc-white push-bottom relative">
-            <span>Subtoolbar</span>
-            <button md-fab class="md-fab md-fab-position-bottom-right bgc-light-blue-700">
-              <md-icon class="md-24">add</md-icon>
+            <button md-fab class="md-fab md-fab-position-bottom-right">
+              <md-icon>add</md-icon>
             </button>
           </md-toolbar>
           <md-card-content>
-            <h3 class="md-title tc-orange-600">View title</h3>
+            <h3 class="md-title tc-orange-800">View title</h3>
             <p>
               When using a primary color in your palette, this color should be the most widely used across all screens and components.
             </p>
@@ -190,13 +172,7 @@
             <span>Hue: 700</span>
           </md-toolbar-row>
         </md-toolbar>
-        <md-toolbar class="bgc-blue-grey-500 tc-white push-top">
-          <span>Hue: 500</span>
-        </md-toolbar>
-        <md-toolbar class="bgc-blue-grey-900 tc-white push-bottom">
-          <span>Hue: 900</span>
-        </md-toolbar>
-        <md-toolbar class="bgc-deep-orange-700 tc-white">
+        <md-toolbar class="bgc-deep-orange-700 tc-white push-top">
           <span>Accent</span>
           <md-toolbar-row>
             <span>Hue: 700</span>
@@ -204,23 +180,20 @@
         </md-toolbar>
       </div>
       <div flex-gt-xs="50">
-        <md-card class="top-toolbar">
-          <md-toolbar class="bgc-blue-grey-700 tc-white">
+        <md-card class="top-toolbar blue-grey-deep-orange">
+          <md-toolbar color="primary" class="relative">
             <md-toolbar-row>
               <span></span>
             </md-toolbar-row>
             <md-toolbar-row>
               <span>App Usage</span>
             </md-toolbar-row>
-          </md-toolbar>
-          <md-toolbar class="bgc-blue-grey-500 tc-white push-bottom relative">
-            <span>Subtoolbar</span>
-            <button md-fab class="md-fab md-fab-position-bottom-right bgc-deep-orange-700">
-              <md-icon class="md-24">add</md-icon>
+            <button md-fab class="md-fab md-fab-position-bottom-right">
+              <md-icon>add</md-icon>
             </button>
           </md-toolbar>
           <md-card-content>
-            <h3 class="md-title tc-blue-grey-600">View title</h3>
+            <h3 class="md-title tc-blue-grey-700">View title</h3>
             <p>
               When using a primary color in your palette, this color should be the most widely used across all screens and components.
             </p>

--- a/src/platform/charts/_charts-theme.scss
+++ b/src/platform/charts/_charts-theme.scss
@@ -1,29 +1,28 @@
-@import '../../../node_modules/@angular/material/core/theming/palette';
 @import '../../../node_modules/@angular/material/core/theming/theming';
 
-// TODO properly wrap in mixin to apply theme like material2 components
-$foreground: $md-light-theme-foreground;
-$background: $md-light-theme-background;
-
-:host /deep/ {
-  text {
-    fill: md-color($foreground, secondary-text);
-  }
-  p {
-    color: md-color($foreground, secondary-text);
-  }
-  .grid {
-    line {
+@mixin td-charts-theme($theme) {
+  $foreground: map-get($theme, foreground);
+  td-charts {
+    text {
+      fill: md-color($foreground, secondary-text);
+    }
+    p {
+      color: md-color($foreground, secondary-text);
+    }
+    .grid {
+      line {
+        stroke: md-color($foreground, divider);
+      }
+    }
+    .ticks {
+      line,
+      path {
+        stroke: md-color($foreground, divider);
+      }
+    }
+    .domain {
       stroke: md-color($foreground, divider);
     }
-  }
-  .ticks {
-    line,
-    path {
-      stroke: md-color($foreground, divider);
-    }
-  }
-  .domain {
-    stroke: md-color($foreground, divider);
   }
 }
+

--- a/src/platform/charts/charts.component.scss
+++ b/src/platform/charts/charts.component.scss
@@ -1,4 +1,3 @@
-@import 'charts-theme';
 :host {
   display: block;
 }

--- a/src/platform/chips/_chips-theme.scss
+++ b/src/platform/chips/_chips-theme.scss
@@ -1,0 +1,35 @@
+@import '../../../node_modules/@angular/material/core/theming/theming';
+
+@mixin td-chips-theme($theme) {
+  $primary: map-get($theme, primary);
+  $accent: map-get($theme, accent);
+  $warn: map-get($theme, warn);
+  $background: map-get($theme, background);
+  $foreground: map-get($theme, foreground);
+  // chip
+  .td-chip {
+    background: md-color($background, status-bar);
+    color: md-color($foreground, text);
+    md-icon {
+      color: md-color($foreground, hint-text);
+      &:hover {
+        color: md-color($foreground, icon);
+      }
+    }
+  }
+  // chips
+  td-chips {
+    .md-input-underline {
+      border-top: 1px solid md-color($foreground, hint-text);
+      .md-input-ripple {
+        background-color: md-color($primary);
+        &.md-accent {
+          background-color: md-color($accent);
+        }
+        &.md-warn {
+          background-color: md-color($warn);
+        }
+      }
+    }
+  }
+}

--- a/src/platform/chips/chips.component.scss
+++ b/src/platform/chips/chips.component.scss
@@ -1,12 +1,4 @@
-@import '../core/styles/variables';
-@import '../core/styles/default-theme';
-
-// Underline colors.
-$md-input-underline-color: md-color($md-foreground, hint-text);
-$md-input-underline-color-accent: md-color($md-accent);
-$md-input-underline-color-warn: md-color($md-warn);
-$md-input-underline-disabled-color: md-color($md-foreground, hint-text);
-$md-input-underline-focused-color: md-color($md-primary);
+@import '../../../node_modules/@angular/material/core/style/variables';
 
 // Gradient for showing the dashed line when the input is disabled.
 $md-input-underline-disabled-background-image: linear-gradient(to right,
@@ -16,9 +8,7 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
   display: block;
   padding: 0px 5px 0px 5px;
   /deep/ .td-chip {
-    display: inline-block;;
-    background: md-color($md-grey, 300);;
-    color: rgba(0, 0, 0, 0.87);
+    display: inline-block;
     cursor: default;
     border-radius: 16px;
     line-height: 32px;
@@ -34,10 +24,8 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
       height: 18px;
       width: 18px;
       font-size: 19px;
-      color: rgba(0, 0, 0, 0.23);
       &:hover {
         cursor: pointer;
-        color: rgba(0, 0, 0, 0.54);
       }
     }
   }
@@ -48,7 +36,6 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
   height: 1px;
   width: 100%;
   margin-top: 4px;
-  border-top: 1px solid $md-input-underline-color;
 
   &.md-disabled {
     border-top: 0;
@@ -62,7 +49,6 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
     position: absolute;
     height: 2px;
     z-index: 1;
-    background-color: $md-input-underline-focused-color;
     top: -1px;
     width: 100%;
     transform-origin: top;
@@ -70,11 +56,7 @@ $md-input-underline-disabled-background-image: linear-gradient(to right,
     transform: scaleY(0);
     transition: transform $swift-ease-out-duration $swift-ease-out-timing-function,
                 opacity $swift-ease-out-duration $swift-ease-out-timing-function;
-    &.md-accent {
-      background-color: $md-input-underline-color-accent;
-    }
     &.md-warn {
-      background-color: $md-input-underline-color-warn;
       opacity: 1;
       transform: scaleY(1);
     }

--- a/src/platform/core/expansion-panel/_expansion-panel-theme.scss
+++ b/src/platform/core/expansion-panel/_expansion-panel-theme.scss
@@ -1,0 +1,33 @@
+@import '../../../../node_modules/@angular/material/core/theming/theming';
+
+@mixin td-expansion-panel-theme($theme) {
+  $accent: map-get($theme, accent);
+  $warn: map-get($theme, warn);
+  $foreground: map-get($theme, foreground);
+  $background: map-get($theme, background);
+  // panel
+  td-expansion-panel {
+    background-color: md-color($background, card);
+    .md-disabled {
+      &, & * {
+        color: md-color($foreground, disabled);
+      }
+    }
+    md-nav-list {
+      padding: 0;
+    }
+    md-icon {
+      color: md-color($foreground, icon);
+    }
+    .td-expansion-primary,
+    .td-expansion-secondary {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-right: 5px;
+    }
+    .td-expansion-secondary {
+      color: md-color($foreground, secondary-text);
+    }
+  }
+}

--- a/src/platform/core/expansion-panel/expansion-panel.component.scss
+++ b/src/platform/core/expansion-panel/expansion-panel.component.scss
@@ -1,6 +1,5 @@
 @import '../styles/variables';
-@import '../styles/default-theme';
-@import '../styles/shadows';
+@import '../../../../node_modules/@angular/material/core/style/elevation';
 
 :host /deep/ {
   md-nav-list {
@@ -15,9 +14,8 @@
   }
 }
 :host {
-  background-color: #fff;
   display: block;
-  box-shadow: $whiteframe-shadow-1dp;
+  @include md-elevation(1);
   
   .panel {
     transition: 1s all ease;
@@ -45,16 +43,8 @@
     padding-top: 0;
   }
 }
-.md-disabled {
-  &, & * {
-    color: md-color($md-grey, 500);
-  }
-}
 md-nav-list {
   padding: 0;
-}
-md-icon {
-  color: md-color($md-grey, 500);
 }
 .td-expansion-primary,
 .td-expansion-secondary {
@@ -62,7 +52,4 @@ md-icon {
   overflow: hidden;
   text-overflow: ellipsis;
   margin-right: 5px;
-}
-.td-expansion-secondary {
-  color: md-color($md-grey, 700);
 }

--- a/src/platform/core/layout/_layout-theme.scss
+++ b/src/platform/core/layout/_layout-theme.scss
@@ -1,0 +1,8 @@
+@import '../../../../node_modules/@angular/material/core/theming/theming';
+
+@mixin td-layout-theme($theme) {
+  $background: map-get($theme, background);
+  md-sidenav-layout {
+    background-color: md-color($background, status-bar);
+  }
+}

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.html
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.html
@@ -1,18 +1,16 @@
-<div class="md-content" layout="column" layout-fill>
-  <md-sidenav-layout class="td-layout-manage-list md-content" flex layout="row" layout-fill>
-    <md-sidenav opened align="start" mode="side" layout="column" layout-fill class="md-sidenav-left md-whiteframe-z1">
-      <div flex class="md-content list">
-        <ng-content select="[list-items]"></ng-content>
-      </div>
-    </md-sidenav>
-    <div layout="column" layout-fill class="md-content content">
-      <md-toolbar class="md-whiteframe-z1">
-        <button md-button (click)="toggle()" md-icon-button hide-gt-xs><md-icon class="md-24">arrow_back</md-icon></button>
-        <ng-content select="[toolbar-buttons]"></ng-content>
-      </md-toolbar>
-      <div class="md-content" flex>
-        <ng-content></ng-content>
-      </div>
+<md-sidenav-layout fullscreen class="td-layout-manage-list md-content" flex layout="row">
+  <md-sidenav opened align="start" mode="side" layout="column" layout-fill class="md-sidenav-left md-whiteframe-z1">
+    <div flex class="md-content list">
+      <ng-content select="[list-items]"></ng-content>
     </div>
-  </md-sidenav-layout>
-</div>
+  </md-sidenav>
+  <div layout="column" layout-fill class="md-content content">
+    <md-toolbar class="md-whiteframe-z1">
+      <button md-button (click)="toggle()" md-icon-button hide-gt-xs><md-icon class="md-24">arrow_back</md-icon></button>
+      <ng-content select="[toolbar-buttons]"></ng-content>
+    </md-toolbar>
+    <div class="md-content" flex>
+      <ng-content></ng-content>
+    </div>
+  </div>
+</md-sidenav-layout>

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.scss
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.scss
@@ -5,6 +5,8 @@
   height: 100%;
   position: relative;
   display: flex;
+  flex: 1;
+  flex-direction: column;
   z-index: 0;
   overflow: hidden;
 }
@@ -13,6 +15,7 @@
     font-size: 14px;
   }
   md-sidenav-layout.td-layout-manage-list {
+    top: 64px;
     & > .md-sidenav-content {
       margin-left: 0 !important;
     }
@@ -50,7 +53,6 @@
   }
 }
 .list {
-    background-color: #fff;
     text-align: start;
 }
 .content {

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
@@ -1,27 +1,23 @@
-<div layout="column" layout-fill>
-  <div class="md-content" flex layout-fill>
-    <md-sidenav-layout class="td-layout-nav-list" layout="row" layout-fill>
-      <md-sidenav opened align="start" mode="side" layout="column" layout-fill class="md-sidenav-left md-whiteframe-z1" flex-gt-xs="none">
-        <md-toolbar color="primary" class="md-whiteframe-z1">
-          <button md-button (click)="menuClick()" md-icon-button><md-icon class="md-24">menu</md-icon></button>
-          <md-icon *ngIf="icon">{{icon}}</md-icon>
-          <md-icon *ngIf="logo" class="md-icon-logo" svgSrc="{{logo}}"></md-icon>
-          <span>{{toolbarTitle}}</span>
-          <ng-content select="[list-toolbar-content]"></ng-content>
-        </md-toolbar>
-        <div flex class="list md-content">
-          <ng-content select="[list-items]"></ng-content>
-        </div>
-      </md-sidenav>
-      <div layout="column" layout-fill class="md-content content">
-        <md-toolbar color="primary" class="md-whiteframe-z1">
-          <button md-button (click)="toggle()" md-icon-button hide-gt-xs><md-icon class="md-24">arrow_back</md-icon></button>
-          <ng-content select="[nav-toolbar-content]"></ng-content>
-        </md-toolbar>
-        <div class="md-content" flex>
-          <ng-content></ng-content>
-        </div>
-      </div>
-    </md-sidenav-layout>
+<md-sidenav-layout fullscreen class="td-layout-nav-list" layout="row" flex>
+  <md-sidenav opened align="start" mode="side" layout="column" layout-fill class="md-sidenav-left md-whiteframe-z1" flex-gt-xs="none">
+    <md-toolbar color="primary" class="md-whiteframe-z1">
+      <button md-button (click)="menuClick()" md-icon-button><md-icon class="md-24">menu</md-icon></button>
+      <md-icon *ngIf="icon">{{icon}}</md-icon>
+      <md-icon *ngIf="logo" class="md-icon-logo" svgSrc="{{logo}}"></md-icon>
+      <span>{{toolbarTitle}}</span>
+      <ng-content select="[list-toolbar-content]"></ng-content>
+    </md-toolbar>
+    <div flex class="list md-content">
+      <ng-content select="[list-items]"></ng-content>
+    </div>
+  </md-sidenav>
+  <div layout="column" layout-fill class="md-content content">
+    <md-toolbar color="primary" class="md-whiteframe-z1">
+      <button md-button (click)="toggle()" md-icon-button hide-gt-xs><md-icon class="md-24">arrow_back</md-icon></button>
+      <ng-content select="[nav-toolbar-content]"></ng-content>
+    </md-toolbar>
+    <div class="md-content" flex>
+      <ng-content></ng-content>
+    </div>
   </div>
-</div>
+</md-sidenav-layout>

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.scss
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.scss
@@ -1,15 +1,16 @@
-@import '../../styles/variables';
-@import '../../styles/mixins';
-@import '../../styles/shadows';
-@import '../../styles/default-theme';
-
-@mixin toolbar-theme($palette) {
-  color: md-color($palette, default-contrast);
+:host {
+    display: flex;
+    margin: 0;
+    width: 100%;
+    min-height: 100%;
+    height: 100%;
+    overflow: hidden;
 }
 :host /deep/ {
   md-sidenav-layout.td-layout-nav-list {
     & > .md-sidenav-content {
       margin-left: 0 !important;
+      flex-grow: 1;
     }
   }
   @media (min-width: 600px) {
@@ -32,7 +33,6 @@
       & > .md-sidenav-content {
         margin-left: 0 !important;
         display: flex;
-        flex-grow: 1;
       }
     }
   }
@@ -52,22 +52,9 @@
     }
   }
 }
-md-toolbar {
-  box-shadow: $md-shadow-bottom-z-1;
-  z-index: 1;
-  &.md-primary {
-    @include toolbar-theme($md-primary);
-  }
-}
 .md-sidenav-left {
     z-index: 1;
 }
 .list {
-    background-color: #fff;
     text-align: start;
-    
-}
-.content {
-    // overflow: hidden;
-    // padding-bottom: 65px;
 }

--- a/src/platform/core/layout/layout-nav/layout-nav.component.html
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.html
@@ -6,7 +6,7 @@
     <span>{{toolbarTitle}}</span>
     <ng-content select="[toolbar-content]"></ng-content>
   </md-toolbar>
-  <div flex class="content md-content">
+  <div flex layout="column" class="content md-content">
     <ng-content></ng-content>
   </div>
 </div>

--- a/src/platform/core/layout/layout-nav/layout-nav.component.scss
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.scss
@@ -1,1 +1,8 @@
-
+:host {
+    display: flex;
+    margin: 0;
+    width: 100%;
+    min-height: 100%;
+    height: 100%;
+    overflow: hidden;
+}

--- a/src/platform/core/layout/layout.component.scss
+++ b/src/platform/core/layout/layout.component.scss
@@ -1,8 +1,14 @@
-@import '../styles/variables';
-@import '../styles/shadows';
+@import '../../../../node_modules/@angular/material/core/style/elevation';
 
-
+:host {
+  display: flex;
+  margin: 0;
+  width: 100%;
+  min-height: 100%;
+  height: 100%;
+  overflow: hidden;
+}
 /deep/ md-toolbar {
-  box-shadow: $md-shadow-bottom-z-1;
+  @include md-elevation(1);
   z-index: 1;
 }

--- a/src/platform/core/loading/_loading-theme.scss
+++ b/src/platform/core/loading/_loading-theme.scss
@@ -1,0 +1,10 @@
+@import '../../../../node_modules/@angular/material/core/theming/theming';
+
+@mixin td-loading-theme($theme) {
+  $background: map-get($theme, background);
+  .td-loading {
+    &.td-overlay {
+      background: rgba(md-color($background, dialog), 0.9);
+    }
+  }
+}

--- a/src/platform/core/loading/loading.component.scss
+++ b/src/platform/core/loading/loading.component.scss
@@ -6,7 +6,6 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(255, 255, 255, 0.9);
     z-index: 1000;
     md-progress-bar {
       position: fixed;

--- a/src/platform/core/steps/_steps-theme.scss
+++ b/src/platform/core/steps/_steps-theme.scss
@@ -1,0 +1,49 @@
+@import '../../../../node_modules/@angular/material/core/theming/theming';
+
+@mixin td-steps-theme($theme) {
+  $accent: map-get($theme, accent);
+  $warn: map-get($theme, warn);
+  $foreground: map-get($theme, foreground);
+  $background: map-get($theme, background);
+  // steps
+  .td-horizontal-line {
+    border-bottom-color: md-color($foreground, divider);
+  }
+  .td-vertical-line {
+    border-left-color: md-color($foreground, divider);
+  }
+  // header
+  .td-step-header {
+    .md-caption {
+      color: md-color($foreground, secondary-text);
+    }
+    .md-disabled {
+      &, & * {
+        color: md-color($foreground, disabled);
+      }
+    }
+    .md-warn {
+      &, & * {
+        color: md-color($warn);
+      }
+    }
+    .md-complete {
+      color: md-color($accent);
+    }
+  }
+  .td-circle {
+    color: md-color($background, card);
+    &.md-active {
+      background-color: md-color($accent);
+    }
+    &.md-inactive {
+      background-color: md-color($foreground, disabled);
+    }
+    & md-icon {
+      fill: md-color($foreground, text);
+    }
+  }
+  .td-triangle {
+    color: md-color($warn);
+  }
+}

--- a/src/platform/core/steps/step-header/step-header.component.scss
+++ b/src/platform/core/steps/step-header/step-header.component.scss
@@ -1,12 +1,3 @@
-@import '../../../../../node_modules/@angular/material/core/theming/palette';
-@import '../../../../../node_modules/@angular/material/core/theming/theming';
-
-// TODO properly wrap in mixin to apply theme like material2 components
-$foreground: $md-light-theme-foreground;
-$background: $md-light-theme-background;
-$accent: md-palette($md-blue);
-$warn: md-palette($md-red);
-
 $step-circle: 24px;
 
 :host /deep/ {
@@ -36,22 +27,6 @@ $step-circle: 24px;
     margin-right: 8px;
   }
 }
-.md-caption {
-  color: md-color($foreground, secondary-text);
-}
-.md-disabled {
-  &, & * {
-    color: md-color($foreground, disabled);
-  }
-}
-.md-warn {
-  &, & * {
-    color: md-color($warn);
-  }
-}
-.md-complete {
-  color: md-color($accent);
-}
 md-icon {
   &.md-warn {
     font-size: $step-circle;
@@ -72,23 +47,14 @@ md-icon {
   width: $step-circle;
   line-height: $step-circle;
   border-radius: 99%;
-  color: #ffffff;
   text-align: center;
   flex: none;
-  &.md-active {
-    background-color: md-color($accent);
-  }
-  &.md-inactive {
-    background-color: md-color($foreground, disabled);
-  }
   & md-icon {
-    fill: #ffffff;
     margin-top: 2px;
     font-weight: bold;
   }
 }
 .td-triangle {
-  color: md-color($warn);
   & > md-icon {
     font-size: 27px;
   }

--- a/src/platform/core/steps/steps.component.scss
+++ b/src/platform/core/steps/steps.component.scss
@@ -1,10 +1,4 @@
-@import '../../../../node_modules/@angular/material/core/theming/palette';
-@import '../../../../node_modules/@angular/material/core/theming/theming';
 @import '../../../../node_modules/@angular/material/core/style/elevation';
-
-// TODO properly wrap in mixin to apply theme like material2 components
-$foreground: $md-light-theme-foreground;
-$background: $md-light-theme-background;
 
 .td-line-wrapper,
 .td-step {
@@ -19,7 +13,6 @@ $background: $md-light-theme-background;
 .td-horizontal-line {
   border-bottom-width: 1px;
   border-bottom-style: solid;
-  border-bottom-color: md-color($foreground, divider);
   height: 1px;
   position: relative;
   top: 36px;
@@ -35,7 +28,6 @@ $background: $md-light-theme-background;
   top: -16px;
   border-left-width: 1px;
   border-left-style: solid;
-  border-left-color: md-color($foreground, divider);
 }
 
 .td-steps-header {

--- a/src/platform/core/styles/_content.scss
+++ b/src/platform/core/styles/_content.scss
@@ -1,6 +1,3 @@
-@import 'variables';
-@import 'default-theme';
-
 // Overall app layout height
 md-sidenav-layout {
   & > md-content,
@@ -28,19 +25,11 @@ md-content,
     overflow-x: auto;
     overflow-y: hidden;
   }
-  &[md-scroll-xy] {
-  }
-
   // For iOS allow disabling of momentum scrolling
   // @see issue #2640.
-
   &.autoScroll {
     -webkit-overflow-scrolling: auto;
   }
-
-  // Theme
-  color: md-color($md-foreground, text);
-  background-color: md-color($md-background, 200);
 }
 
 

--- a/src/platform/core/styles/theming/_all-theme.scss
+++ b/src/platform/core/styles/theming/_all-theme.scss
@@ -4,6 +4,7 @@
 @import '../../loading/loading-theme';
 @import '../../../chips/chips-theme';
 @import '../../../file-upload/file-upload-theme';
+@import '../../../json-formatter/json-formatter-theme';
 @import '../../../paging/paging-bar-theme';
 
 // Create a covalent theme
@@ -12,6 +13,7 @@
   @include td-expansion-panel-theme($theme);
   @include td-chips-theme($theme);
   @include td-file-upload-theme($theme);
+  @include td-json-formatter-theme($theme);
   @include td-paging-bar-theme($theme);
   @include td-loading-theme($theme);
 }

--- a/src/platform/core/styles/theming/_all-theme.scss
+++ b/src/platform/core/styles/theming/_all-theme.scss
@@ -1,11 +1,13 @@
 // Import all covalent components
 @import '../../steps/steps-theme';
+@import '../../expansion-panel/expansion-panel-theme';
 @import '../../../file-upload/file-upload-theme';
 @import '../../../paging/paging-bar-theme';
 
 // Create a covalent theme
 @mixin covalent-theme($theme) {
   @include td-steps-theme($theme);
+  @include td-expansion-panel-theme($theme);
   @include td-file-upload-theme($theme);
   @include td-paging-bar-theme($theme);
 }

--- a/src/platform/core/styles/theming/_all-theme.scss
+++ b/src/platform/core/styles/theming/_all-theme.scss
@@ -1,4 +1,5 @@
 // Import all covalent components
+@import '../../layout/layout-theme';
 @import '../../steps/steps-theme';
 @import '../../expansion-panel/expansion-panel-theme';
 @import '../../loading/loading-theme';
@@ -7,9 +8,11 @@
 @import '../../../json-formatter/json-formatter-theme';
 @import '../../../paging/paging-bar-theme';
 @import '../../../markdown/markdown-theme';
+@import '../../../charts/charts-theme';
 
 // Create a covalent theme
 @mixin covalent-theme($theme) {
+  @include td-layout-theme($theme);
   @include td-steps-theme($theme);
   @include td-expansion-panel-theme($theme);
   @include td-chips-theme($theme);
@@ -18,4 +21,5 @@
   @include td-paging-bar-theme($theme);
   @include td-loading-theme($theme);
   @include td-markdown-theme($theme);
+  @include td-charts-theme($theme);
 }

--- a/src/platform/core/styles/theming/_all-theme.scss
+++ b/src/platform/core/styles/theming/_all-theme.scss
@@ -1,6 +1,7 @@
 // Import all covalent components
 @import '../../steps/steps-theme';
 @import '../../expansion-panel/expansion-panel-theme';
+@import '../../../chips/chips-theme';
 @import '../../../file-upload/file-upload-theme';
 @import '../../../paging/paging-bar-theme';
 
@@ -8,6 +9,7 @@
 @mixin covalent-theme($theme) {
   @include td-steps-theme($theme);
   @include td-expansion-panel-theme($theme);
+  @include td-chips-theme($theme);
   @include td-file-upload-theme($theme);
   @include td-paging-bar-theme($theme);
 }

--- a/src/platform/core/styles/theming/_all-theme.scss
+++ b/src/platform/core/styles/theming/_all-theme.scss
@@ -1,9 +1,11 @@
 // Import all covalent components
+@import '../../steps/steps-theme';
 @import '../../../file-upload/file-upload-theme';
 @import '../../../paging/paging-bar-theme';
 
 // Create a covalent theme
 @mixin covalent-theme($theme) {
+  @include td-steps-theme($theme);
   @include td-file-upload-theme($theme);
   @include td-paging-bar-theme($theme);
 }

--- a/src/platform/core/styles/theming/_all-theme.scss
+++ b/src/platform/core/styles/theming/_all-theme.scss
@@ -1,0 +1,6 @@
+//@import '../../../data-table/data-table-theme';
+
+// Create a theme.
+@mixin covalent-theme($theme) {
+  //@include td-data-table-theme($theme);
+}

--- a/src/platform/core/styles/theming/_all-theme.scss
+++ b/src/platform/core/styles/theming/_all-theme.scss
@@ -1,6 +1,9 @@
+// Import all covalent components
+@import '../../../file-upload/file-upload-theme';
 @import '../../../paging/paging-bar-theme';
 
-// Create a theme.
+// Create a covalent theme
 @mixin covalent-theme($theme) {
+  @include td-file-upload-theme($theme);
   @include td-paging-bar-theme($theme);
 }

--- a/src/platform/core/styles/theming/_all-theme.scss
+++ b/src/platform/core/styles/theming/_all-theme.scss
@@ -1,6 +1,7 @@
 // Import all covalent components
 @import '../../steps/steps-theme';
 @import '../../expansion-panel/expansion-panel-theme';
+@import '../../loading/loading-theme';
 @import '../../../chips/chips-theme';
 @import '../../../file-upload/file-upload-theme';
 @import '../../../paging/paging-bar-theme';
@@ -12,4 +13,5 @@
   @include td-chips-theme($theme);
   @include td-file-upload-theme($theme);
   @include td-paging-bar-theme($theme);
+  @include td-loading-theme($theme);
 }

--- a/src/platform/core/styles/theming/_all-theme.scss
+++ b/src/platform/core/styles/theming/_all-theme.scss
@@ -6,6 +6,7 @@
 @import '../../../file-upload/file-upload-theme';
 @import '../../../json-formatter/json-formatter-theme';
 @import '../../../paging/paging-bar-theme';
+@import '../../../markdown/markdown-theme';
 
 // Create a covalent theme
 @mixin covalent-theme($theme) {
@@ -16,4 +17,5 @@
   @include td-json-formatter-theme($theme);
   @include td-paging-bar-theme($theme);
   @include td-loading-theme($theme);
+  @include td-markdown-theme($theme);
 }

--- a/src/platform/core/styles/theming/_all-theme.scss
+++ b/src/platform/core/styles/theming/_all-theme.scss
@@ -1,6 +1,6 @@
-//@import '../../../data-table/data-table-theme';
+@import '../../../paging/paging-bar-theme';
 
 // Create a theme.
 @mixin covalent-theme($theme) {
-  //@include td-data-table-theme($theme);
+  @include td-paging-bar-theme($theme);
 }

--- a/src/platform/file-upload/_file-upload-theme.scss
+++ b/src/platform/file-upload/_file-upload-theme.scss
@@ -1,0 +1,11 @@
+@import '../../../node_modules/@angular/material/core/theming/theming';
+
+@mixin td-file-upload-theme($theme) {
+  $background: map-get($theme, background);
+
+  .td-file-cancel {
+    md-icon {
+      background-color: md-color($background, background);
+    }
+  }
+}

--- a/src/platform/file-upload/file-upload.component.scss
+++ b/src/platform/file-upload/file-upload.component.scss
@@ -1,5 +1,5 @@
-@import "../core/styles/variables";
-@import "../core/styles/elevation";
+@import '../../../node_modules/@angular/material/core/style/variables';
+@import '../../../node_modules/@angular/material/core/style/elevation';
 
 button {
   padding-left: 0;
@@ -27,7 +27,6 @@ input.md-file-upload-input {
   top: 24px;
   left: -12px;
   md-icon {
-    background-color: white;
     border-radius: 12px;
   }
 }

--- a/src/platform/highlight/highlight.component.scss
+++ b/src/platform/highlight/highlight.component.scss
@@ -1,5 +1,5 @@
 @import '../core/styles/variables';
-@import '../core/styles/default-theme';
+@import '../../../node_modules/@angular/material/core/theming/theming';
 
 $code-font: Menlo, Monaco, "Andale Mono", "lucida console", "Courier New", monospace;
 

--- a/src/platform/json-formatter/_json-formatter-theme.scss
+++ b/src/platform/json-formatter/_json-formatter-theme.scss
@@ -1,0 +1,43 @@
+@import '../../../node_modules/@angular/material/core/theming/theming';
+
+@mixin td-json-formatter-theme($theme) {
+  $primary: map-get($theme, primary);
+  $accent: map-get($theme, accent);
+  $warn: map-get($theme, warn);
+  $foreground: map-get($theme, foreground);
+  $background: map-get($theme, background);
+  .td-json-formatter-wrapper {
+    .td-key {
+      &.td-key-node {
+        &:focus,
+        &:hover {
+          background-color: md-color($background, hover);
+        }
+      }
+    }
+    .key {
+      color: md-color($primary);
+    }
+    .value {
+      .string {
+        color: md-color($warn);
+      }
+      .number { 
+        color: md-color($accent);
+      }
+      .boolean { 
+        color: md-color($accent);
+      }
+      .null,
+      .undefined { 
+        color: md-color($foreground, disabled-text);
+      }
+      .function { 
+        color: md-color($primary);
+      }
+      .date { 
+        color: md-color($foreground, text);
+      }
+    }
+  }
+}

--- a/src/platform/json-formatter/json-formatter.component.scss
+++ b/src/platform/json-formatter/json-formatter.component.scss
@@ -1,6 +1,3 @@
-@import '../core/styles/variables';
-@import '../core/styles/default-theme';
-
 :host {
   display: block;
 }
@@ -9,10 +6,6 @@
   padding-bottom: 2px;
   .td-key {
     &.td-key-node {
-      &:focus,
-      &:hover {
-        background-color: rgba(158,158,158,0.1);
-      }
       &:hover {
         cursor: pointer;
       }
@@ -27,9 +20,6 @@
       }
     }
   }
-  .key {
-    color: md-color($md-primary);
-  }
   .value {
     margin-left: 5px;
     .td-empty {
@@ -37,26 +27,9 @@
       text-decoration: line-through;
     }
     .string {
-      color: md-color($md-warn);
       word-break: break-word;
     }
-    .number { 
-      color: md-color($md-accent);
-    }
-    .boolean { 
-      color: md-color($md-accent);
-    }
-    .null { 
-      color: gray; 
-    }
-    .undefined { 
-      color: gray; 
-    }
-    .function { 
-      color: md-color($md-primary);
-    }
     .date { 
-      color: black;
       word-break: break-word;
     }
   }

--- a/src/platform/markdown/_markdown-theme.scss
+++ b/src/platform/markdown/_markdown-theme.scss
@@ -1,0 +1,53 @@
+@import '../../../node_modules/@angular/material/core/theming/theming';
+
+@mixin td-markdown-theme($theme) {
+  $accent: map-get($theme, accent);
+  $foreground: map-get($theme, foreground);
+  $background: map-get($theme, background);
+  td-markdown {
+    a {
+      color: md-color($accent);
+    }
+    h1, h2 {
+      border-bottom-color: md-color($foreground, divider);
+    }
+    h3,h4,h5,h6 {
+      color: md-color($foreground, secondary-text);
+    }
+    hr {
+      background-color: md-color($foreground, divider);
+    }
+    blockquote {
+      color: md-color($foreground, secondary-text);
+      border-left-color: md-color($foreground, divider);
+    }
+    table {
+      th,
+      td {
+        border-color: md-color($foreground, dividers);
+      }
+      tr {
+        border-top-color: md-color($foreground, dividers);
+        &:nth-child(2n) {
+          background-color: md-color($foreground, dividers);
+        }
+      }
+    }
+    img {
+      background-color: md-color($background, card);
+    }
+    code {
+      background-color: md-color($background, hover);
+    }
+    .highlight pre,
+    pre {
+      background-color: md-color($background, app-bar);
+    }
+    kbd {
+      color: md-color($foreground, secondary-text);
+      background-color: md-color($background, app-bar);
+      border-color: md-color($foreground, divider);
+      border-bottom-color: md-color($foreground, disabled);
+    }
+  }
+}

--- a/src/platform/markdown/markdown.component.scss
+++ b/src/platform/markdown/markdown.component.scss
@@ -85,7 +85,6 @@
   }
 
   a {
-    color: #4078c0;
     text-decoration: none;
   }
 
@@ -274,7 +273,8 @@
     padding-bottom: 0.3em;
     font-size: 2.25em;
     line-height: 1.2;
-    border-bottom: 1px solid #eee;
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
   }
 
   h1 .anchor {
@@ -285,7 +285,8 @@
     padding-bottom: 0.3em;
     font-size: 1.75em;
     line-height: 1.225;
-    border-bottom: 1px solid #eee;
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
   }
 
   h2 .anchor {
@@ -319,7 +320,6 @@
 
   h6 {
     font-size: 1em;
-    color: #777;
   }
 
   h6 .anchor {
@@ -338,10 +338,9 @@
   }
 
   hr {
-    height: 4px;
+    height: 1px;
     padding: 0;
     margin: 16px 0;
-    background-color: #e7e7e7;
     border: 0 none;
   }
 
@@ -381,8 +380,8 @@
 
   blockquote {
     padding: 0 15px;
-    color: #777;
-    border-left: 4px solid #ddd;
+    border-left-width: 4px;
+    border-left-style: solid;
   }
 
   blockquote>:first-child {
@@ -408,22 +407,18 @@
   table th,
   table td {
     padding: 6px 13px;
-    border: 1px solid #ddd;
+    border-width: 1px;
+    border-style: solid;
   }
 
  table tr {
-  background-color: #fff;
-  border-top: 1px solid #ccc;
-}
-
- table tr:nth-child(2n) {
-  background-color: #f8f8f8;
+  border-top-width: 1px;
+  border-top-style: solid;
 }
 
  img {
   max-width: 100%;
   box-sizing: content-box;
-  background-color: #fff;
 }
 
  code {
@@ -432,7 +427,6 @@
   padding-bottom: 0.2em;
   margin: 0;
   font-size: 85%;
-  background-color: rgba(0,0,0,0.04);
   border-radius: 3px;
 }
 
@@ -456,13 +450,12 @@
 }
 
  .highlight pre,
- pre {
-  padding: 16px;
-  overflow: auto;
-  font-size: 85%;
-  line-height: 1.45;
-  background-color: #f7f7f7;
-  border-radius: 3px;
+  pre {
+    padding: 16px;
+    overflow: auto;
+    font-size: 85%;
+    line-height: 1.45;
+    border-radius: 3px;
 }
 
  .highlight pre {
@@ -496,13 +489,10 @@
   padding: 3px 5px;
   font-size: 11px;
   line-height: 10px;
-  color: #555;
   vertical-align: middle;
-  background-color: #fcfcfc;
-  border: solid 1px #ccc;
-  border-bottom-color: #bbb;
+  border-style: solid;
+  border-width: 1px;
   border-radius: 3px;
-  box-shadow: inset 0 -1px 0 #bbb;
 }
 
  .pl-c {
@@ -609,7 +599,6 @@
   padding: 3px 5px;
   font: 11px Consolas, "Liberation Mono", Menlo, Courier, monospace;
   line-height: 10px;
-  color: #555;
   vertical-align: middle;
   background-color: #fcfcfc;
   border: solid 1px #ccc;

--- a/src/platform/paging/_paging-bar-theme.scss
+++ b/src/platform/paging/_paging-bar-theme.scss
@@ -1,9 +1,13 @@
-@import '../../../node_modules/@angular/material/core/theming/palette';
 @import '../../../node_modules/@angular/material/core/theming/theming';
 
-// TODO properly wrap in mixin to apply theme like material2 components
-$foreground: $md-light-theme-foreground;
+@mixin td-paging-bar-theme($theme) {
+  $primary: map-get($theme, primary);
+  $accent: map-get($theme, accent);
+  $warn: map-get($theme, warn);
+  $background: map-get($theme, background);
+  $foreground: map-get($theme, foreground);
 
-:host {
-  color: md-color($foreground, secondary-text);
+  td-paging-bar {
+    color: md-color($foreground, secondary-text);
+  }
 }

--- a/src/platform/paging/paging-bar.component.scss
+++ b/src/platform/paging/paging-bar.component.scss
@@ -1,5 +1,3 @@
-@import 'paging-bar-theme';
-
 :host {
   display: block;
   [layout="row"] > * {

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -1,4 +1,5 @@
 @import '~@angular/material/core/theming/all-theme';
+@import './platform/core/styles/theming/all-theme';
 // Plus imports for other components in your app.
 
 // Include the base styles for Angular Material core. We include this here so that you only
@@ -21,23 +22,4 @@ $theme: md-light-theme($primary, $accent, $warn);
 // Alternatively, you can import and @include the theme mixins for each component
 // that you are using.
 @include angular-material-theme($theme);
-
-.light-blue-orange {
-    $primary2: md-palette($md-light-blue);
-    $accent2:  md-palette($md-orange, 800);
-    $warn2:    md-palette($md-red, 600);
-
-    $light-blue-orange: md-light-theme($primary2, $accent2, $warn2);
-
-    @include angular-material-theme($light-blue-orange);   
-}
-
-.blue-grey-deep-orange {
-    $primary3: md-palette($md-blue-grey);
-    $accent3:  md-palette($md-deep-orange);
-    $warn3:    md-palette($md-red, 600);
-
-    $blue-grey-deep-orange: md-light-theme($primary3, $accent3, $warn3);
-
-    @include angular-material-theme($blue-grey-deep-orange);   
-}
+@include covalent-theme($theme);

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -23,3 +23,24 @@ $theme: md-light-theme($primary, $accent, $warn);
 // that you are using.
 @include angular-material-theme($theme);
 @include covalent-theme($theme);
+
+// Custom theme examples
+.blue-orange {
+    $primary2: md-palette($md-blue, 700);
+    $accent2:  md-palette($md-orange, 800);
+    $warn2:    md-palette($md-red, 600);
+
+    $blue-orange: md-light-theme($primary2, $accent2, $warn2);
+
+    @include angular-material-theme($blue-orange);   
+}
+
+.blue-grey-deep-orange {
+    $primary3: md-palette($md-blue-grey, 700);
+    $accent3:  md-palette($md-deep-orange);
+    $warn3:    md-palette($md-red, 600);
+
+    $blue-grey-deep-orange: md-light-theme($primary3, $accent3, $warn3);
+
+    @include angular-material-theme($blue-grey-deep-orange);   
+}

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -16,7 +16,7 @@ $accent:  md-palette($md-light-blue, 600, A100, A400);
 $warn:    md-palette($md-red, 600);
 
 // Create the theme object (a Sass map containing all of the palettes).
-$theme: md-dark-theme($primary, $accent, $warn);
+$theme: md-light-theme($primary, $accent, $warn);
 
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -16,7 +16,7 @@ $accent:  md-palette($md-light-blue, 600, A100, A400);
 $warn:    md-palette($md-red, 600);
 
 // Create the theme object (a Sass map containing all of the palettes).
-$theme: md-light-theme($primary, $accent, $warn);
+$theme: md-dark-theme($primary, $accent, $warn);
 
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component


### PR DESCRIPTION
## Description

Create covalent-theme following material2 guildelines https://github.com/angular/material2/blob/master/docs/theming-your-components.md

### What's included?

- covalent-theme
- paging-bar theme
- next component theme

#### Test Steps

- [x] ng serve
- [x] view all covalent components to verify themes working
- [x] test different primary/warn/accent colors in /src/theme.scss
- [x] test light and dark theme by changing /src/theme.scss `$theme: md-light-theme($primary, $accent, $warn);` to `$theme: md-dark-theme($primary, $accent, $warn);`
- [x] ng test

##### Screenshots or link to CodePen/Plunker/JSfiddle

Paging bar:
![image](https://cloud.githubusercontent.com/assets/867883/20071989/40589e2c-a4ec-11e6-9e4e-a30b4fd4ec39.png)
