### PR TITLE
fix(charts): line charts wouldn’t render with empty data set

### DIFF
--- a/src/platform/charts/chart-line/chart-line.component.ts
+++ b/src/platform/charts/chart-line/chart-line.component.ts
@@ -112,7 +112,13 @@ export class TdChartLineComponent extends ChartComponent {
 
     line.append('text')
       .datum((d: any) => { return {id: d.id, value: d.values[d.values.length - 1]}; })
-      .attr('transform', (d: any) => { return 'translate(' + x(d.value.xValue) + ',' + y(d.value.yValue) + ')'; })
+      .attr('transform', (d: any) => {
+        if (!d.value) {
+          return undefined;
+        } else {
+          return 'translate(' + x(d.value.xValue) + ',' + y(d.value.yValue) + ')';
+        }
+      })
       .attr('x', 3)
       .attr('dy', '0.35em')
       .style('font', '10px sans-serif')


### PR DESCRIPTION
## Description

The line chart wouldn’t render at all if an empty array is used on the [data] attribute, the following error would be thrown:

`TypeError: Cannot read property 'xValue' of undefined`

I narrowed it down to the translation of the data, where it was assumed that the value would be defined at all times, which isn’t the case if data is an empty array.

This fix solves the problem.

### What's included?

- Fix for line chart with empty data sets

#### Test Steps

- [ ] open `src/app/components/components/charts.component.html`
- [ ] change the first `<td-chart-line`, replacing `dataSrc="..."` by `[data]="[]"`
- [ ] visit the charts component page

##### Screenshots or link to CodePen/Plunker/JSfiddle

The error is the following:

![Error for empty line charts](https://cl.ly/1T3h3r1c0i1D/Image%202016-11-08%20at%203.11.29%20PM.png)