### PR TITLE
feat: initial data table template support

### DIFF
--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -107,6 +107,12 @@
         <td-data-table
           [data]="basicData"
           [columns]="columns">
+          <template tdDataTableTemplate="type" let-value="value" let-row="row" let-column="column">
+            <div layout="row">
+              <span flex>{{value}}</span>
+              <md-icon>star</md-icon>
+            </div>
+          </template>
         </td-data-table>
       </md-tab>
       <md-tab>
@@ -117,6 +123,12 @@
             <td-data-table
               [data]="basicData"
               [columns]="columns">
+              <template tdDataTableTemplate="type" let-value="value" let-row="row" let-column="column">
+                <div layout="row">
+                  <span flex>{{value}}</span> // or <span flex>{{row[column]}}</span>
+                  <md-icon>star</md-icon>
+                </div>
+              </template>
             </td-data-table>
           ]]>
         </td-highlight>
@@ -334,6 +346,7 @@
     <h2><code><![CDATA[<td-data-table>]]></code></h2>
     <p>Use <code><![CDATA[<td-data-table>]]></code> element to generate a table.</p>
     <p>Pass an array of javascript objects with the information to be displayed on the table to the [data] attribute.</p>
+    <p>Use [tdDataTableTemplate] directive for template support which gives context access to [value], [row] and [column].</p>
     <h3>Properties:</h3>
     <p>The <code><![CDATA[<td-data-table>]]></code> component has {{dataTableAttrs.length}} properties:</p>
     <md-list>

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -125,7 +125,7 @@
               [columns]="columns">
               <template tdDataTableTemplate="type" let-value="value" let-row="row" let-column="column">
                 <div layout="row">
-                  <span flex>{{value}}</span> // or <span flex>{{row[column]}}</span>
+                  <span flex>{ {value}}</span> // or <span flex>{ {row[column]}}</span>
                   <md-icon>star</md-icon>
                 </div>
               </template>

--- a/src/platform/data-table/README.md
+++ b/src/platform/data-table/README.md
@@ -2,6 +2,8 @@
 
 `td-data-table` element generates a data driven table layout sorting events.
 
+Use [tdDataTableTemplate] directive for template support which gives context access to [value], [row] and [column].
+
 ## API Summary
 
 Properties:
@@ -49,5 +51,11 @@ Example for HTML usage:
   [sortOrder]="'ASC'|'DESC'"
   (sortChange)="sortEvent($event)"
   (rowSelect)="selectEvent($event)">
+  <template tdDataTableTemplate="columnName" let-value="value" let-row="row" let-column="column">
+    <div layout="row">
+      <span flex>{{value}}</span> // or <span flex>{{row[column]}}</span>
+      <md-icon>star</md-icon>
+    </div>
+  </template>
 </td-data-table>
  ```

--- a/src/platform/data-table/data-table.component.html
+++ b/src/platform/data-table/data-table.component.html
@@ -32,7 +32,12 @@
       <td td-data-table-cell
           [numeric]="column.numeric"
           *ngFor="let column of columns">
-        <span class="md-body-1">{{row[column.name]}}</span>
+        <span class="md-body-1" *ngIf="!getTemplateRef(column.name)">{{row[column.name]}}</span>
+        <template
+          *ngIf="getTemplateRef(column.name)"
+          [ngTemplateOutlet]="getTemplateRef(column.name)"
+          [ngOutletContext]="{ value: row[column.name], row: row, column: column.name }">
+        </template>
       </td>
     </tr>
   </table>

--- a/src/platform/data-table/data-table.component.ts
+++ b/src/platform/data-table/data-table.component.ts
@@ -1,7 +1,9 @@
-import { Component, Input, Output, EventEmitter, forwardRef } from '@angular/core';
+import { Component, Input, Output, EventEmitter, forwardRef,
+         ContentChildren, TemplateRef, AfterContentInit, QueryList } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 
 import { ITdDataTableSortChangeEvent } from './data-table-column/data-table-column.component';
+import { TdDataTableTemplateDirective } from './directives/data-table-template.directive';
 
 const noop: any = () => {
   // empty method
@@ -37,7 +39,7 @@ export interface ITdDataTableSelectEvent {
   styleUrls: [ 'data-table.component.scss' ],
   templateUrl: 'data-table.component.html',
 })
-export class TdDataTableComponent implements ControlValueAccessor {
+export class TdDataTableComponent implements ControlValueAccessor, AfterContentInit {
 
   /**
    * Implemented as part of ControlValueAccessor.
@@ -56,6 +58,10 @@ export class TdDataTableComponent implements ControlValueAccessor {
   private _sortable: boolean = false;
   private _sortBy: ITdDataTableColumn;
   private _sortOrder: TdDataTableSortingOrder = TdDataTableSortingOrder.Ascending;
+
+  /** template fetching support */
+  private _templateMap: Map<string, TemplateRef<any>> = new Map<string, TemplateRef<any>>();
+  @ContentChildren(TdDataTableTemplateDirective) private _templates: QueryList<TdDataTableTemplateDirective>;
 
   /**
    * Implemented as part of ControlValueAccessor.
@@ -197,6 +203,24 @@ export class TdDataTableComponent implements ControlValueAccessor {
    * Emits an [ITdDataTableSelectEvent] implemented object.
    */
   @Output('rowSelect') onRowSelect: EventEmitter<ITdDataTableSelectEvent> = new EventEmitter<ITdDataTableSelectEvent>();
+
+  /**
+   * Loads templates and sets them in a map for faster access.
+   */
+  ngAfterContentInit(): void {
+    for (let i: number = 0; i < this._templates.toArray().length; i++) {
+      this._templateMap.set(
+        this._templates.toArray()[i].tdDataTableTemplate,
+        this._templates.toArray()[i].templateRef);
+    }
+   }
+
+  /**
+   * Getter method for template references
+   */
+   getTemplateRef(name: string): TemplateRef<any> {
+     return this._templateMap.get(name);
+   }
 
   /**
    * Clears model (ngModel) of component by removing all values in array.

--- a/src/platform/data-table/data-table.component.ts
+++ b/src/platform/data-table/data-table.component.ts
@@ -211,7 +211,8 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
     for (let i: number = 0; i < this._templates.toArray().length; i++) {
       this._templateMap.set(
         this._templates.toArray()[i].tdDataTableTemplate,
-        this._templates.toArray()[i].templateRef);
+        this._templates.toArray()[i].templateRef
+      );
     }
    }
 

--- a/src/platform/data-table/data-table.module.ts
+++ b/src/platform/data-table/data-table.module.ts
@@ -9,9 +9,11 @@ import { TdDataTableCellComponent } from './data-table-cell/data-table-cell.comp
 import { TdDataTableRowComponent } from './data-table-row/data-table-row.component';
 import { TdDataTableTableComponent } from './data-table-table/data-table-table.component';
 import { TdDataTableService } from './services/data-table.service';
+import { TdDataTableTemplateDirective } from './directives/data-table-template.directive';
 
 export const TD_DATA_TABLE_DIRECTIVES: Type<any>[] = [
   TdDataTableComponent,
+  TdDataTableTemplateDirective,
 
   TdDataTableColumnComponent,
   TdDataTableCellComponent,

--- a/src/platform/data-table/directives/data-table-template.directive.ts
+++ b/src/platform/data-table/directives/data-table-template.directive.ts
@@ -1,0 +1,11 @@
+import { Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
+import { TemplatePortalDirective } from '@angular/material';
+
+@Directive({selector: '[tdDataTableTemplate]template'})
+export class TdDataTableTemplateDirective extends TemplatePortalDirective {
+
+  @Input() tdDataTableTemplate: string;
+  constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
+    super(templateRef, viewContainerRef);
+  }
+}


### PR DESCRIPTION
## Description

Reopened the PR for template support with up-to-date `data-table`.
https://github.com/Teradata/covalent/pull/125

### What's included?

- Updated docs and demo.
- `tdDataTableTemplateDirective` for template support with access to value, row and column.

Usage:
```html
<td-data-table
          [data]="basicData"
          [columns]="columns">
          <template tdDataTableTemplate="type" let-value="value" let-row="row" let-column="column">
            <div layout="row">
              <span flex>{{value}}</span>
              <md-icon>star</md-icon>
            </div>
          </template>
        </td-data-table>
```


#### Test Steps

- [x] `ng serve`
- [x] Go to http://localhost:4200/#/components/data-table
- [x] See second demo with template cell support

##### Screenshots or link to CodePen/Plunker/JSfiddle
![image](https://cloud.githubusercontent.com/assets/5846742/20447276/d4f73ff8-ad92-11e6-8244-914c1fb5a102.png)
