### PR TITLE
feat: initial support to templates in label/sublabel for expansion-panel

### DIFF
--- a/src/app/components/components/expansion-panel/expansion-panel.component.html
+++ b/src/app/components/components/expansion-panel/expansion-panel.component.html
@@ -62,15 +62,81 @@
       </td-expansion-panel>
       <td-expansion-panel label="Label goes here" sublabel="sublabel goes here" [disabled]="disabled">
         <template td-expansion-panel-label>
-          Label (template)
+          <md-icon>star</md-icon> Custom Label (template)
         </template>
         <template td-expansion-panel-sublabel>
-          Sublabel (template)
+          <md-icon>list</md-icon> Custom Sublabel (template)
         </template>
-        <div>no md-padding class</div>
-        <div>Phase 2</div>
-        <div>Phase 3</div>
-        <div>Phase 4</div>
+        <div class="md-padding">
+          <h3 class="md-subhead">md-padding class</h3>
+          <div>Phase 1</div>
+          <div>Phase 2</div>
+          <div>Phase 3</div>
+        </div>
+      </td-expansion-panel>
+    </div>
+  </div>
+  <p>The entire panel header can be replaced as well:</p>
+  <div layout-gt-xs="row" layout-align-gt-xs="center start">
+    <div flex-gt-xs="90">
+      <td-expansion-panel [disabled]="disabled">
+        <template td-expansion-panel-header>
+          <md-toolbar color="accent">
+            <span>Custom td-expansion-panel-header</span>
+          </md-toolbar>
+        </template>
+        <td-expansion-summary>
+          <div class="md-padding">
+            <div flex layout-gt-xs="row" layout-align="start center">
+              <span flex="30" class="md-subhead">Owner</span>
+              <span flex="5" hide-xs><md-icon class="tc-grey-500">chevron_right</md-icon></span>
+              <span flex>John Jameson</span>
+            </div>
+            <div flex layout-gt-xs="row" layout-align="start center">
+              <span flex="30" class="md-subhead">API Key</span>
+              <span flex="5" hide-xs><md-icon class="tc-grey-500">chevron_right</md-icon></span>
+              <span flex>1141e8e8-8d24-4956-93c2</span>
+            </div>
+            <div flex layout-gt-xs="row" layout-align="start center">
+              <span flex="30" class="md-subhead">Last Updated</span>
+              <span flex="5" hide-xs><md-icon class="tc-grey-500">chevron_right</md-icon></span>
+              <span flex>Wed, July 6, 2016 11:13 AM</span>
+            </div>
+          </div>
+        </td-expansion-summary>
+        <md-list>
+          <h3 md-subheader>Metadata</h3>
+          <md-list-item>
+              <md-icon md-list-avatar>account_box</md-icon>
+              <h4 md-line>John Jameson</h4>
+              <p md-line>Owner</p>
+          </md-list-item>
+          <md-divider md-inset></md-divider>
+          <md-list-item>
+              <md-icon md-list-avatar>description</md-icon>
+              <h4 md-line>An item description</h4>
+              <p md-line>Description</p>
+          </md-list-item>
+          <md-divider md-inset></md-divider>
+          <md-list-item>
+              <md-icon md-list-avatar>vpn_key</md-icon>
+              <h4 md-line>1141e8e8-8d24-4956-93c2</h4>
+              <p md-line>API Key</p>
+          </md-list-item>
+          <md-divider></md-divider>
+          <h3 md-subheader>Dates</h3>
+          <md-list-item>
+              <md-icon md-list-avatar>access_time</md-icon>
+              <h4 md-line>Wed, July 6, 2016 11:13 AM</h4>
+              <p md-line>Last Updated</p>
+          </md-list-item>
+          <md-divider md-inset></md-divider>
+          <md-list-item>
+              <md-icon md-list-avatar>today</md-icon>
+              <h4 md-line>Wed, July 4, 2016 09:11 AM</h4>
+              <p md-line>Created</p>
+          </md-list-item>
+        </md-list>
       </td-expansion-panel>
     </div>
   </div>

--- a/src/app/components/components/expansion-panel/expansion-panel.component.html
+++ b/src/app/components/components/expansion-panel/expansion-panel.component.html
@@ -61,6 +61,12 @@
         </div>
       </td-expansion-panel>
       <td-expansion-panel label="Label goes here" sublabel="sublabel goes here" [disabled]="disabled">
+        <template td-expansion-panel-label>
+          Label (template)
+        </template>
+        <template td-expansion-panel-sublabel>
+          Sublabel (template)
+        </template>
         <div>no md-padding class</div>
         <div>Phase 2</div>
         <div>Phase 3</div>
@@ -120,39 +126,20 @@
       </template>
     </md-list>
     <h3>Example:</h3>
-    <p>HTML: Editing</p>
+    <p>HTML:</p>
     <td-highlight lang="html">
       <![CDATA[
-        <td-expansion-panel label="Google" sublabel="1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA">
+        <td-expansion-panel label="label" sublabel="sublabel" expand="true|false" disabled="true|false" (expanded)="expandedEvent()" (collapsed)="collapsedEvent()">
+          <template td-expansion-panel-label>
+            ... add label content (if not used, falls back to [label] input)
+          </template>
+          <template td-expansion-panel-sublabel>
+            ... add sublabel content (if not used, falls back to [sublabel] input)
+          </template>
           <td-expansion-summary>
-            <md-list>
-              <md-list-item>
-                <md-icon md-list-avatar>pin_drop</md-icon>
-                <h3 md-line>Google</h3>
-                <h4 md-line>Headquarters</h4>
-                <p md-line>
-                  1600 Amphitheatre Pkwy<br/>Mountain View, CA 94043, USA
-                </p>
-              </md-list-item>
-            </md-list>
+            ... add summary that will be shown when expansion-panel is "collapsed".
           </td-expansion-summary>
-          <form class="md-padding">
-            ...
-          </form>
-        </td-expansion-panel>
-      ]]>
-    </td-highlight>
-    <p>HTML: Creation Flows</p>
-    <td-highlight lang="html">
-      <![CDATA[
-        <td-expansion-panel label="Label" sublabel="Sublabel" [expand]="expand" [disabled]="disabled" (expanded)="expandedEvent()" (collapsed)="collapsedEvent()">
-          <div class="md-padding">
-            <h3 class="md-subhead">md-padding class</h3>
-            <div>Demo 1</div>
-            <div>Demo 2</div>
-            <div>Demo 3</div>
-            <div>Demo 4</div>
-          </div>
+          ... add content that will be shown when the step is "expanded"
         </td-expansion-panel>
       ]]>
     </td-highlight>
@@ -162,9 +149,6 @@
         ...
         })
         export class Demo {
-
-          expand: boolean = false;
-          disabled: boolean = false;
           
           expandedEvent(): void {
             ...

--- a/src/app/components/components/expansion-panel/expansion-panel.component.html
+++ b/src/app/components/components/expansion-panel/expansion-panel.component.html
@@ -62,10 +62,12 @@
       </td-expansion-panel>
       <td-expansion-panel label="Label goes here" sublabel="sublabel goes here" [disabled]="disabled">
         <template td-expansion-panel-label>
-          <md-icon>star</md-icon> Custom Label (template)
+          <md-icon>star</md-icon>
+          <span>Custom Label (template)</span>
         </template>
         <template td-expansion-panel-sublabel>
-          <md-icon>list</md-icon> Custom Sublabel (template)
+          <md-icon>list</md-icon>
+          <span>Custom Sublabel (template)</span>
         </template>
         <div class="md-padding">
           <h3 class="md-subhead">md-padding class</h3>

--- a/src/app/components/components/expansion-panel/expansion-panel.component.html
+++ b/src/app/components/components/expansion-panel/expansion-panel.component.html
@@ -198,6 +198,9 @@
     <td-highlight lang="html">
       <![CDATA[
         <td-expansion-panel label="label" sublabel="sublabel" expand="true|false" disabled="true|false" (expanded)="expandedEvent()" (collapsed)="collapsedEvent()">
+          <template td-expansion-panel-header>
+            ... add header content (overrides label and sublabel)
+          </template>
           <template td-expansion-panel-label>
             ... add label content (if not used, falls back to [label] input)
           </template>

--- a/src/app/components/components/expansion-panel/expansion-panel.component.ts
+++ b/src/app/components/components/expansion-panel/expansion-panel.component.ts
@@ -32,6 +32,21 @@ export class ExpansionPanelDemoComponent {
     description: 'Event emitted when [TdExpansionPanelComponent] is collapsed.',
     name: 'collapsed?',
     type: 'function()',
+  }, {
+    description: `Toggle active state of [TdExpansionPanelComponent]. Retuns "true" if successful, else "false".
+                  Can be accessed by referencing element in local variable.`,
+    name: 'toggle',
+    type: 'function()',
+  }, {
+    description: `Opens [TdExpansionPanelComponent]. Retuns "true" if successful, else "false".
+                  Can be accessed by referencing element in local variable.`,
+    name: 'open',
+    type: 'function()',
+  }, {
+    description: `Closes [TdExpansionPanelComponent]. Retuns "true" if successful, else "false".
+                  Can be accessed by referencing element in local variable.`,
+    name: 'close',
+    type: 'function()',
   }];
 
   expandCollapseExpansion1Msg: string = 'No expanded/collapsed detected yet';

--- a/src/platform/core/expansion-panel/_expansion-panel-theme.scss
+++ b/src/platform/core/expansion-panel/_expansion-panel-theme.scss
@@ -25,6 +25,9 @@
       overflow: hidden;
       text-overflow: ellipsis;
       margin-right: 5px;
+      &, & * {
+        vertical-align: middle;
+      }
     }
     .td-expansion-secondary {
       color: md-color($foreground, secondary-text);

--- a/src/platform/core/expansion-panel/_expansion-panel-theme.scss
+++ b/src/platform/core/expansion-panel/_expansion-panel-theme.scss
@@ -16,7 +16,7 @@
     md-nav-list {
       padding: 0;
     }
-    md-icon {
+    md-icon.td-expand-icon {
       color: md-color($foreground, icon);
     }
     .td-expansion-primary,

--- a/src/platform/core/expansion-panel/expansion-panel.component.html
+++ b/src/platform/core/expansion-panel/expansion-panel.component.html
@@ -19,7 +19,7 @@
         </div>
         <div class="md-body-1 td-expansion-secondary">
           <template [portalHost]="expansionPanelSublabel"></template>
-          <template>{{sublabel}}</template>
+          <template [ngIf]="!expansionPanelSublabel">{{sublabel}}</template>
         </div>
         <span flex></span>
         <md-icon class="td-expand-icon" *ngIf="!expand && !disabled">keyboard_arrow_down</md-icon>

--- a/src/platform/core/expansion-panel/expansion-panel.component.html
+++ b/src/platform/core/expansion-panel/expansion-panel.component.html
@@ -10,11 +10,17 @@
            layout="row" 
            layout-align="start center" 
            flex>
-        <div class="md-subhead td-expansion-primary" flex-gt-xs="33">{{label || 'Click to expand '}}</div>
-        <div class="md-body-1 td-expansion-secondary">{{sublabel}}</div>
+        <div class="md-subhead td-expansion-primary" flex-gt-xs="33">
+          <template [portalHost]="expansionPanelLabel"></template>
+          <template [ngIf]="!expansionPanelLabel">{{label || 'Click to expand '}}</template>
+        </div>
+        <div class="md-body-1 td-expansion-secondary">
+          <template [portalHost]="expansionPanelSublabel"></template>
+          <template [ngIf]="!expansionPanelSublabel">{{sublabel}}</template>
+        </div>
         <span flex></span>
-        <md-icon *ngIf="!expand && !disabled">keyboard_arrow_down</md-icon>
-        <md-icon *ngIf="expand">keyboard_arrow_up</md-icon>
+        <md-icon class="td-expand-icon" *ngIf="!expand && !disabled">keyboard_arrow_down</md-icon>
+        <md-icon class="td-expand-icon" *ngIf="expand">keyboard_arrow_up</md-icon>
       </div>
     </a>
   </md-nav-list>

--- a/src/platform/core/expansion-panel/expansion-panel.component.html
+++ b/src/platform/core/expansion-panel/expansion-panel.component.html
@@ -5,8 +5,11 @@
        (keydown.enter)="clickEvent()"
        (click)="clickEvent()"
        [class.md-interaction-disabled]="disabled"
+       [class.md-tall]="expansionPanelHeader"
        md-list-item>
+      <template [portalHost]="expansionPanelHeader"></template>
       <div [class.md-disabled]="disabled"
+           *ngIf="!expansionPanelHeader"
            layout="row" 
            layout-align="start center" 
            flex>
@@ -16,7 +19,7 @@
         </div>
         <div class="md-body-1 td-expansion-secondary">
           <template [portalHost]="expansionPanelSublabel"></template>
-          <template [ngIf]="!expansionPanelSublabel">{{sublabel}}</template>
+          <template>{{sublabel}}</template>
         </div>
         <span flex></span>
         <md-icon class="td-expand-icon" *ngIf="!expand && !disabled">keyboard_arrow_down</md-icon>

--- a/src/platform/core/expansion-panel/expansion-panel.component.scss
+++ b/src/platform/core/expansion-panel/expansion-panel.component.scss
@@ -3,13 +3,20 @@
 
 :host /deep/ {
   md-nav-list {
-    [md-list-item]:active,
-    [md-list-item]:focus {
-      outline: none;
-    }
-    [md-list-item].md-interaction-disabled .md-list-item {
-      background: none !important;
-      cursor: auto;
+    [md-list-item] {
+      &:active,
+      &:focus {
+        outline: none;
+      }
+      &.md-interaction-disabled .md-list-item {
+        background: none !important;
+        cursor: auto;
+      }
+      &.md-tall .md-list-item {
+        height: auto;
+        padding-left: 0;
+        padding-right: 0;
+      }
     }
   }
 }

--- a/src/platform/core/expansion-panel/expansion-panel.component.ts
+++ b/src/platform/core/expansion-panel/expansion-panel.component.ts
@@ -3,6 +3,15 @@ import { EventEmitter } from '@angular/core';
 import { TemplatePortalDirective } from '@angular/material';
 
 @Directive({
+  selector: '[td-expansion-panel-header]template',
+})
+export class TdExpansionPanelHeaderDirective extends TemplatePortalDirective {
+  constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
+    super(templateRef, viewContainerRef);
+  }
+}
+
+@Directive({
   selector: '[td-expansion-panel-label]template',
 })
 export class TdExpansionPanelLabelDirective extends TemplatePortalDirective {
@@ -36,6 +45,7 @@ export class TdExpansionPanelComponent {
   private _expand: boolean = false;
   private _disabled: boolean = false;
 
+  @ContentChild(TdExpansionPanelHeaderDirective) expansionPanelHeader: TdExpansionPanelHeaderDirective;
   @ContentChild(TdExpansionPanelLabelDirective) expansionPanelLabel: TdExpansionPanelLabelDirective;
   @ContentChild(TdExpansionPanelSublabelDirective) expansionPanelSublabel: TdExpansionPanelSublabelDirective;
 

--- a/src/platform/core/expansion-panel/expansion-panel.component.ts
+++ b/src/platform/core/expansion-panel/expansion-panel.component.ts
@@ -1,5 +1,24 @@
-import { Component, Input, Output } from '@angular/core';
+import { Component, Directive, Input, Output, TemplateRef, ViewContainerRef, ContentChild } from '@angular/core';
 import { EventEmitter } from '@angular/core';
+import { TemplatePortalDirective } from '@angular/material';
+
+@Directive({
+  selector: '[td-expansion-panel-label]template',
+})
+export class TdExpansionPanelLabelDirective extends TemplatePortalDirective {
+  constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
+    super(templateRef, viewContainerRef);
+  }
+}
+
+@Directive({
+  selector: '[td-expansion-panel-sublabel]template',
+})
+export class TdExpansionPanelSublabelDirective extends TemplatePortalDirective {
+  constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
+    super(templateRef, viewContainerRef);
+  }
+}
 
 @Component({
   selector: 'td-expansion-summary',
@@ -16,6 +35,9 @@ export class TdExpansionPanelComponent {
 
   private _expand: boolean = false;
   private _disabled: boolean = false;
+
+  @ContentChild(TdExpansionPanelLabelDirective) expansionPanelLabel: TdExpansionPanelLabelDirective;
+  @ContentChild(TdExpansionPanelSublabelDirective) expansionPanelSublabel: TdExpansionPanelSublabelDirective;
 
   /**
    * label?: string

--- a/src/platform/core/expansion-panel/expansion-panel.component.ts
+++ b/src/platform/core/expansion-panel/expansion-panel.component.ts
@@ -133,7 +133,6 @@ export class TdExpansionPanelComponent {
     return this._setExpand(false);
   }
 
-
   /**
    * Method to change expand state internally and emit the [onExpanded] event if 'true' or [onCollapsed]
    * event if 'false'. (Blocked if [disabled] is 'true')

--- a/src/platform/core/expansion-panel/expansion-panel.component.ts
+++ b/src/platform/core/expansion-panel/expansion-panel.component.ts
@@ -100,12 +100,37 @@ export class TdExpansionPanelComponent {
   };
 
   /**
+   * Toggle expand state of [TdExpansionPanelComponent]
+   * retuns 'true' if successful, else 'false'.
+   */
+  toggle(): boolean {
+    return this._setExpand(!this._expand);
+  }
+
+  /**
+   * Opens [TdExpansionPanelComponent]
+   * retuns 'true' if successful, else 'false'.
+   */
+  open(): boolean {
+    return this._setExpand(true);
+  }
+
+  /**
+   * Closes [TdExpansionPanelComponent]
+   * retuns 'true' if successful, else 'false'.
+   */
+  close(): boolean {
+    return this._setExpand(false);
+  }
+
+
+  /**
    * Method to change expand state internally and emit the [onExpanded] event if 'true' or [onCollapsed]
    * event if 'false'. (Blocked if [disabled] is 'true')
    */
-  private _setExpand(newExpand: boolean): void {
+  private _setExpand(newExpand: boolean): boolean {
     if (this._disabled) {
-      return;
+      return false;
     }
     if (this._expand !== newExpand) {
       this._expand = newExpand;
@@ -114,7 +139,9 @@ export class TdExpansionPanelComponent {
       } else {
         this._onCollapsed();
       }
+      return true;
     }
+    return false;
   };
 
   private _onExpanded(): void {

--- a/src/platform/core/index.ts
+++ b/src/platform/core/index.ts
@@ -70,15 +70,17 @@ export { LoadingType, LoadingMode } from './loading/loading.component';
 export { TdLoadingService, ILoadingOptions } from './loading/services/loading.service';
 
 // Expansion
-export { TdExpansionPanelComponent } from './expansion-panel/expansion-panel.component';
-
-import { TdExpansionPanelComponent,
+import { TdExpansionPanelComponent, TdExpansionPanelLabelDirective, TdExpansionPanelSublabelDirective,
          TdExpansionPanelSummaryComponent } from './expansion-panel/expansion-panel.component';
 
 export const TD_EXPANSION_DIRECTIVES: Type<any>[] = [
   TdExpansionPanelComponent,
+  TdExpansionPanelLabelDirective,
+  TdExpansionPanelSublabelDirective,
   TdExpansionPanelSummaryComponent,
 ];
+
+export { TdExpansionPanelComponent } from './expansion-panel/expansion-panel.component';
 
 // Dialogs
 

--- a/src/platform/core/index.ts
+++ b/src/platform/core/index.ts
@@ -70,11 +70,13 @@ export { LoadingType, LoadingMode } from './loading/loading.component';
 export { TdLoadingService, ILoadingOptions } from './loading/services/loading.service';
 
 // Expansion
-import { TdExpansionPanelComponent, TdExpansionPanelLabelDirective, TdExpansionPanelSublabelDirective,
-         TdExpansionPanelSummaryComponent } from './expansion-panel/expansion-panel.component';
+import { TdExpansionPanelComponent, TdExpansionPanelHeaderDirective, TdExpansionPanelLabelDirective,
+         TdExpansionPanelSublabelDirective, TdExpansionPanelSummaryComponent }
+         from './expansion-panel/expansion-panel.component';
 
 export const TD_EXPANSION_DIRECTIVES: Type<any>[] = [
   TdExpansionPanelComponent,
+  TdExpansionPanelHeaderDirective,
   TdExpansionPanelLabelDirective,
   TdExpansionPanelSublabelDirective,
   TdExpansionPanelSummaryComponent,


### PR DESCRIPTION
## Description

Initial support for label/sublabel templates (fallback to inputs) + updated docs

```html
<td-expansion-panel label="label" sublabel="sublabel" expand="true|false" disabled="true|false" (expanded)="expandedEvent()" (collapsed)="collapsedEvent()">
          <template td-expansion-panel-label>
            ... add label content (if not used, falls back to [label] input)
          </template>
          <template td-expansion-panel-sublabel>
            ... add sublabel content (if not used, falls back to [sublabel] input)
          </template>
          <td-expansion-summary>
            ... add summary that will be shown when expansion-panel is "collapsed".
          </td-expansion-summary>
          ... add content that will be shown when the step is "expanded"
        </td-expansion-panel>
```

#### Test Steps

- [x] `ng serve`
- [x] Go to http://localhost:4200/#/components/expansion-panel
- [x] Play with demo

##### Screenshots or link to CodePen/Plunker/JSfiddle
![image](https://cloud.githubusercontent.com/assets/5846742/20448734/5c5c8398-ad9a-11e6-91e5-9b3e694976d8.png)
