### PR TITLE
hotfix(resources): urls for downloads

### DIFF
--- a/src/app/components/style-guide/resources/resources.component.html
+++ b/src/app/components/style-guide/resources/resources.component.html
@@ -17,7 +17,7 @@
   <md-divider></md-divider>
   <md-card-content>
     <p>Create static mockups that are identical to the Covalent layouts and Angular-Material components!</p>
-    <a md-ripple md-tooltip="Download" tooltip-position="below" md-button color="primary" href="https://dribbble.com/shots/2846624-Covalent-Material-Design-Sketch-Template-Free-download/attachments/585808">
+    <a md-ripple md-tooltip="Download" target="_blank" tooltip-position="below" md-button color="primary" href="https://dribbble.com/shots/2846624-Covalent-Material-Design-Sketch-Template-Free-download">
       <img width="100%" class="md-whiteframe-z1" src="https://d13yacurqjgara.cloudfront.net/users/13496/screenshots/2846624/covalent-sketch-template.gif">
     </a>
     <md-divider></md-divider>
@@ -25,11 +25,11 @@
       <md-list>
       <md-list-item>
         <h3 md-line>4 Covalent Layouts</h3>
-        <p md-line>nav view, manage list, card over & nav list</p>
+        <p md-line>nav view, manage list, card over &amp; nav list</p>
       </md-list-item>
       <md-list-item>
         <h3 md-line>4 responsive formats</h3>
-        <p md-line>desktop, tablet landscape, table portrait & mobile</p>
+        <p md-line>desktop, tablet landscape, table portrait &amp; mobile</p>
       </md-list-item>
       <md-list-item>
         <h3 md-line>All Core Material Design Components</h3>
@@ -37,18 +37,18 @@
       </md-list-item>
       <md-list-item>
         <h3 md-line>Material Design Patterns</h3>
-        <p md-line>tons of cards, lists, settings & forms</p>
+        <p md-line>tons of cards, lists, settings &amp; forms</p>
       </md-list-item>
       <md-list-item>
-        <h3 md-line>Material Design Typography & Iconography</h3>
-        <p md-line>Sketch shared text styles & SVG icons</p>
+        <h3 md-line>Material Design Typography &amp; Iconography</h3>
+        <p md-line>Sketch shared text styles &amp; SVG icons</p>
       </md-list-item>
     </md-list>
     </td-expansion-panel>
   </md-card-content>
   <md-divider></md-divider>
     <md-card-actions>
-      <a md-button color="accent" href="https://dribbble.com/shots/2846624-Covalent-Material-Design-Sketch-Template-Free-download/attachments/585808">
+      <a md-button color="accent" target="_blank" href="https://dribbble.com/shots/2846624-Covalent-Material-Design-Sketch-Template-Free-download">
       Download Sketch Template
       </a>
   </md-card-actions>
@@ -62,7 +62,7 @@
   <md-divider></md-divider>
   <md-card-content>
     <p>Prototype interactive UX flows that perfectly complement the Sketch template and production Covalent code.</p>
-    <a md-ripple md-tooltip="Download" tooltip-position="below" md-button color="primary" href="https://dribbble.com/shots/2963271-FREE-Official-Teradata-Covalent-Library-for-Axure-RP/attachments/616446">
+    <a md-ripple md-tooltip="Download" target="_blank" tooltip-position="below" md-button color="primary" href="https://dribbble.com/shots/2963271-FREE-Download-Official-Teradata-Covalent-Library-for-Axure-RP">
       <img width="100%" class="md-whiteframe-z1" src="https://d13yacurqjgara.cloudfront.net/users/815033/screenshots/2963271/attachments/616441/covalen-axure-library-1.1alpha.gif">
     </a>
     <md-divider></md-divider>
@@ -70,7 +70,7 @@
       <md-list>
       <md-list-item>
         <h3 md-line>4 Covalent Layouts</h3>
-        <p md-line>nav view, manage list, card over & nav list</p>
+        <p md-line>nav view, manage list, card over &amp; nav list</p>
       </md-list-item>
       <md-list-item>
         <h3 md-line>Interactive Prototype Elements</h3>
@@ -97,7 +97,7 @@
   </md-card-content>
   <md-divider></md-divider>
     <md-card-actions>
-      <a md-button color="accent" href="https://dribbble.com/shots/2963271-FREE-Official-Teradata-Covalent-Library-for-Axure-RP/attachments/616446">
+      <a md-button color="accent" target="_blank" href="https://dribbble.com/shots/2963271-FREE-Download-Official-Teradata-Covalent-Library-for-Axure-RP">
       Download Axure Library
       </a>
       <a md-button color="primary" href="http://gxkfh3.axshare.com/">


### PR DESCRIPTION
## Description

Fix URLS since dribbble attachment link urls change when files are updated

### What's included?

- Axure link fix
- Sketch link update

#### Test Steps

- [x] ng serve & /style-guide/resources
- [x] click sketch template link
- [x] click axure library link

