### PR TITLE
use enter event instead of search event so it works in IE and firefox

### DIFF
--- a/src/platform/search/search-input/search-input.component.html
+++ b/src/platform/search/search-input/search-input.component.html
@@ -5,7 +5,8 @@
             [placeholder]="placeholder"
             [formControl]="searchTermControl"
             (blur)="handleBlur()"
-            (search)="handleSearch($event)"
+            (search)="stopPropagation($event)"
+            (keyup.enter)="handleSearch($event)"
             flex>
   </md-input>
   <button md-icon-button 

--- a/src/platform/search/search-input/search-input.component.ts
+++ b/src/platform/search/search-input/search-input.component.ts
@@ -97,8 +97,12 @@ export class TdSearchInputComponent implements OnInit {
     this.onBlur.emit(undefined);
   }
 
-  handleSearch(event: Event): void {
+  stopPropagation(event: Event): void {
     event.stopPropagation();
+  }
+
+  handleSearch(event: Event): void {
+    this.stopPropagation(event);
     this.onSearch.emit(this.searchTermControl.value);
   }
 


### PR DESCRIPTION
## Description

Bugfix for `td-search-input` since `search` event does not work in FF and IE.

### What's included?

- Internally use `enter` event instead of `search` event

#### Test Steps

- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/search
- [ ] Test enter event to display `search` input in Safari, FF, Chrome and IE

#### Screenshots
![image](https://cloud.githubusercontent.com/assets/5846742/20843355/e45487b6-b86f-11e6-9761-2919f55729ee.png)

![image](https://cloud.githubusercontent.com/assets/5846742/20843409/187b372e-b870-11e6-960e-2c52412b08a1.png)

