### PR TITLE
feat(upgrade-deps): material.11-3 and ng@2.3.0

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,6 +8,7 @@ module.exports = function (config) {
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
+      require('karma-firefox-launcher'),
       require('karma-remap-istanbul'),
       require('angular-cli/plugins/karma')
     ],
@@ -39,11 +40,11 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['Firefox'],
     singleRun: false
   };
   if (process.env.TRAVIS) {
-    configuration.browsers = ['Chrome_travis_ci'];
+    //configuration.browsers = ['Chrome_travis_ci'];
   }
   config.set(configuration);
 };

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@angular/core": "^2.3.0",
     "@angular/forms": "^2.3.0",
     "@angular/http": "^2.3.0",
-    "@angular/material": "2.0.0-alpha.11-2",
+    "@angular/material": "2.0.0-alpha.11-3",
     "@angular/platform-browser": "^2.3.0",
     "@angular/platform-browser-dynamic": "^2.3.0",
     "@angular/platform-server": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -49,26 +49,26 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@angular/common": "^2.2.1",
-    "@angular/compiler": "^2.2.1",
-    "@angular/core": "^2.2.1",
-    "@angular/forms": "^2.2.1",
-    "@angular/http": "^2.2.1",
-    "@angular/material": "2.0.0-alpha.10",
-    "@angular/platform-browser": "^2.2.1",
-    "@angular/platform-browser-dynamic": "^2.2.1",
-    "@angular/platform-server": "^2.2.1",
-    "@angular/router": "^3.2.1",
+    "@angular/common": "^2.3.0",
+    "@angular/compiler": "^2.3.0",
+    "@angular/core": "^2.3.0",
+    "@angular/forms": "^2.3.0",
+    "@angular/http": "^2.3.0",
+    "@angular/material": "2.0.0-alpha.11-2",
+    "@angular/platform-browser": "^2.3.0",
+    "@angular/platform-browser-dynamic": "^2.3.0",
+    "@angular/platform-server": "^2.3.0",
+    "@angular/router": "^3.3.0",
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
     "highlight.js": "9.6.0",
-    "rxjs": "5.0.0-beta.12",
+    "rxjs": "5.0.0-rc.4",
     "showdown": "1.4.2",
-    "zone.js": "^0.6.25",
+    "zone.js": "^0.7.2",
     "d3": "^4.2.1"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "^2.2.1",
+    "@angular/compiler-cli": "^2.3.0",
     "@types/hammerjs": "^2.0.30",
     "@types/jasmine": "^2.2.31",
     "@types/node": "^6.0.34",
@@ -107,6 +107,6 @@
     "semver": "5.2.0",
     "ts-node": "1.2.1",
     "tslint": "^3.15.1",
-    "typescript": "2.0.2"
+    "typescript": "2.0.10"
   }
 }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -3,8 +3,4 @@
 // :host /deep/ lets you travel down the Shadow DOM tree to change web component styles
 :host /deep/ {
 
-    // md-divider has a bug in angular-material that doesn't apply color
-    md-divider {
-        border-top-color: rgba(black, 0.12);
-    }
 }

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -6,7 +6,7 @@
     <h3 class="md-title">Custom Data Table</h3>
     <h4 class="md-subhead">with custom headings, columns, and inline editing</h4>
     <md-divider></md-divider>
-    <md-tab-group>
+    <md-tab-group md-stretch-tabs>
       <md-tab>
         <template md-tab-label>Demo</template>
           <div class="md-table-container">
@@ -98,7 +98,7 @@
   <md-card-content>
     <h3 class="md-title">Basic Data Table</h3>
     <md-divider></md-divider>
-    <md-tab-group>
+    <md-tab-group md-stretch-tabs>
       <md-tab>
         <template md-tab-label>Demo</template>
         <td-data-table
@@ -197,7 +197,7 @@
     <h3 class="md-title">Data Table with components</h3>
     <h4 class="md-subhead">Paging Bar / Search Box / Sortable components</h4>
     <md-divider></md-divider>
-    <md-tab-group>
+    <md-tab-group md-stretch-tabs>
       <md-tab>
         <template md-tab-label>Demo</template>
         <div layout="row" layout-align="start center" class="pad-left-sm pad-right-sm" [class.md-selected-title]="selectedRows.length && selectable">

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -61,7 +61,6 @@
         <td-highlight lang="typescript">
           <![CDATA[
             import { ITdDataTableColumn } from '@covalent/data-table';
-            import { ViewContainerRef } from '@angular/core';
             import { TdDialogService } from '@covalent/core';
             ...
             })
@@ -76,14 +75,12 @@
                 { name: 'price', label 'Price (US$)', numeric: true, format: v => v.toFixed(2) },
               ];
 
-              constructor(private _dialogService: TdDialogService,
-                          private _viewContainerRef: ViewContainerRef) {}
+              constructor(private _dialogService: TdDialogService) {}
 
               openPrompt(row: any, name: string): void {
                 this._dialogService.openPrompt({
                   message: 'Enter comment?',
                   value: row[name],
-                  viewContainerRef: this._viewContainerRef,
                 }).afterClosed().subscribe((value: any) => {
                   if (value !== undefined) {
                     row[name] = value;

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewContainerRef } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 
 import { TdDataTableSortingOrder, TdDataTableService,
          ITdDataTableSortChangeEvent, ITdDataTableColumn } from '../../../../platform/data-table';
@@ -256,14 +256,12 @@ export class DataTableDemoComponent implements OnInit {
   sortOrder: TdDataTableSortingOrder = TdDataTableSortingOrder.Descending;
 
   constructor(private _dataTableService: TdDataTableService,
-              private _dialogService: TdDialogService,
-              private _viewContainerRef: ViewContainerRef) {}
+              private _dialogService: TdDialogService) {}
 
   openPrompt(row: any, name: string): void {
     this._dialogService.openPrompt({
       message: 'Enter comment?',
       value: row[name],
-      viewContainerRef: this._viewContainerRef,
     }).afterClosed().subscribe((value: any) => {
       if (value !== undefined) {
         row[name] = value;

--- a/src/app/components/components/material-components/material-components.component.html
+++ b/src/app/components/components/material-components/material-components.component.html
@@ -1213,21 +1213,15 @@
     <md-divider class="push-top push-bottom"></md-divider>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { Component, ViewContainerRef } from '@angular/core';
-        import { MdSnackBar, MdSnackBarConfig, MdSnackBarRef } from '@angular/material';
+        import { Component } from '@angular/core';
+        import { MdSnackBar } from '@angular/material';
         ...
-        ...
-        private _snackBarConfig: MdSnackBarConfig;
-        
-        constructor(private _snackBarService: MdSnackBar, viewContainerRef: ViewContainerRef) {
-          this._snackBarConfig = new MdSnackBarConfig(viewContainerRef);
+        ...        
+        constructor(private _snackBarService: MdSnackBar) {
         }
 
         showSnackBar(): void {
-          let snackBarRef: MdSnackBarRef<any> = this._snackBarService.open('Message', 'Action', this._snackBarConfig);
-          setTimeout(() => {
-            snackBarRef.dismiss();
-          }, 3000);
+          let snackBarRef: MdSnackBarRef<any> = this._snackBarService.open('Message', 'Action', { duration: 3000 });
         }
         ]]>
       </td-highlight>
@@ -1242,27 +1236,21 @@
     <md-divider class="push-top push-bottom"></md-divider>
     <td-highlight lang="typescript">
       <![CDATA[
-          import { Component, ViewContainerRef } from '@angular/core';
-          import { MdDialog, MdDialogConfig, MdDialogRef } from '@angular/material';
+          import { Component } from '@angular/core';
+          import { MdDialog, MdDialogRef } from '@angular/material';
           import { CustomAlertDialogComponent, CustomConfirmDialogComponent } from 'path/to/customdialogs'
           ...
-          ...
-          private _dialogConfig: MdDialogConfig;
-
-          constructor(private _dialogService: MdDialog,
-                      viewContainerRef: ViewContainerRef) {
-            this._dialogConfig = new MdDialogConfig();
-            this._dialogConfig.viewContainerRef = viewContainerRef;
+          constructor(private _dialogService: MdDialog) {
           }
 
           showAlertDialog(): void {
             let dialogRef: MdDialogRef<CustomAlertDialogComponent> =
-            this._dialogService.open(CustomAlertDialogComponent, this._dialogConfig);
+            this._dialogService.open(CustomAlertDialogComponent);
           }
 
           showConfirmDialog(): void {
             let dialogRef: MdDialogRef<CustomConfirmDialogComponent> =
-            this._dialogService.open(CustomConfirmDialogComponent, this._dialogConfig);
+            this._dialogService.open(CustomConfirmDialogComponent);
             dialogRef.afterClosed().subscribe((data: boolean) => {
               if (data) {
                 // clicked yes

--- a/src/app/components/components/material-components/material-components.component.html
+++ b/src/app/components/components/material-components/material-components.component.html
@@ -852,7 +852,7 @@
   <md-card-title>Tabs</md-card-title>
   <md-divider></md-divider>
   <md-card-content>
-    <md-tab-group>
+    <md-tab-group md-stretch-tabs>
       <md-tab>
         <template md-tab-label>One</template>
         <h3 class="md-title">First tab content</h3>
@@ -867,7 +867,7 @@
     <md-divider></md-divider>
     <td-highlight lang="html">
       <![CDATA[
-        <md-tab-group>
+        <md-tab-group md-stretch-tabs>
           <md-tab>
             <template md-tab-label>First tab content</template>
             <h1>First content</h1>
@@ -982,7 +982,7 @@
 </md-card>
 <md-card>
   <md-card-title>Grid list with images and headers or footers</md-card-title>
-  <md-tab-group>
+  <md-tab-group md-stretch-tabs>
     <md-tab>
       <template md-tab-label>Headers</template>
       <md-grid-list cols="3" rowHeight="200px">

--- a/src/app/components/components/material-components/material-components.component.ts
+++ b/src/app/components/components/material-components/material-components.component.ts
@@ -1,6 +1,5 @@
-import { Component, ViewContainerRef } from '@angular/core';
-import { MdSnackBar, MdSnackBarConfig, MdDialog, MdSnackBarRef,
-        MdDialogConfig, MdDialogRef } from '@angular/material';
+import { Component } from '@angular/core';
+import { MdSnackBar, MdDialog, MdDialogRef } from '@angular/material';
 
 import { TdAlertDialogComponent } from '../../../../platform/core';
 import { TdConfirmDialogComponent } from '../../../../platform/core';
@@ -106,47 +105,32 @@ export class MaterialComponentsComponent {
     lockHouse: false,
   };
 
-  _snackBarConfig: MdSnackBarConfig;
-  _dialogConfig: MdDialogConfig;
-
   constructor(private _snackBarService: MdSnackBar,
-              private _dialogService: MdDialog,
-              viewContainerRef: ViewContainerRef) {
-    this._snackBarConfig = new MdSnackBarConfig();
-    this._snackBarConfig.viewContainerRef = viewContainerRef;
-    this._dialogConfig = new MdDialogConfig();
-    this._dialogConfig.viewContainerRef = viewContainerRef;
+              private _dialogService: MdDialog) {
   }
 
   showSnackBar(): void {
-    let snackBarRef: MdSnackBarRef<any> = this._snackBarService.open('Message', 'Action', this._snackBarConfig);
-    setTimeout(() => {
-      snackBarRef.dismiss();
-    }, 3000);
+    this._snackBarService.open('Message', 'Action', { duration: 3000 });
   }
 
   showAlertDialog(): void {
     let dialogRef: MdDialogRef<TdAlertDialogComponent> =
-    this._dialogService.open(TdAlertDialogComponent, this._dialogConfig);
+    this._dialogService.open(TdAlertDialogComponent);
     dialogRef.componentInstance.title = 'Alert Title';
     dialogRef.componentInstance.message = 'This is an alert dialog with a custom message.';
   }
 
   showConfirmDialog(): void {
     let dialogRef: MdDialogRef<TdConfirmDialogComponent> =
-    this._dialogService.open(TdConfirmDialogComponent, this._dialogConfig);
+    this._dialogService.open(TdConfirmDialogComponent);
     dialogRef.componentInstance.title = 'Confirmation Title';
     dialogRef.componentInstance.message = 'This is a confirmation dialog. Like what you see in covalent?';
     dialogRef.afterClosed().subscribe((data: any) => {
-      let snackBarRef: MdSnackBarRef<any>;
       if (data) {
-        snackBarRef = this._snackBarService.open('You clicked Yes :D', 'Ok', this._snackBarConfig);
+        this._snackBarService.open('You clicked Yes :D', 'Ok', { duration: 3000 });
       } else {
-        snackBarRef = this._snackBarService.open('You clicked No :(', 'Ok', this._snackBarConfig);
+        this._snackBarService.open('You clicked No :(', 'Ok', { duration: 3000 });
       }
-      setTimeout(() => {
-        snackBarRef.dismiss();
-      }, 3000);
     });
   }
 }

--- a/src/app/components/style-guide/colors/colors.component.html
+++ b/src/app/components/style-guide/colors/colors.component.html
@@ -209,7 +209,7 @@
 <md-card>
   <md-card-title>CSS Background Colors</md-card-title>
   <md-divider></md-divider>
-  <md-tab-group>
+  <md-tab-group md-stretch-tabs>
     <md-tab label="Default Colors">
       <md-card-content>
         <p>To manually color a background, use our simple bgc utility class:</p>

--- a/src/app/components/style-guide/dialogs/dialogs.component.html
+++ b/src/app/components/style-guide/dialogs/dialogs.component.html
@@ -44,13 +44,11 @@
       <![CDATA[
       import { TdDialogService } from '@covalent/core';
       ...
-      constructor(private _dialogService: TdDialogService,
-                  private _viewContainerRef: ViewContainerRef) {
+      constructor(private _dialogService: TdDialogService) {
       }
       openAlert(): void {
         this._dialogService.openAlert({
           message: 'You don\'t have the required permissions to view this item! Contact an administrator!',
-          viewContainerRef: this._viewContainerRef,
           title: '401 Permissions Error!',
           closeButton: 'Dismiss',
         });
@@ -58,7 +56,6 @@
       openConfirm(): void {
         this._dialogService.openConfirm({
           message: 'Are you sure you want to delete this item? It\'s used on other items.',
-          viewContainerRef: this._viewContainerRef,
           title: 'Confirm',
           cancelButton: 'No, Cancel',
           acceptButton: 'Yes, Delete',
@@ -93,20 +90,13 @@
     <p>Typescript:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-      import { MdSnackBar, MdSnackBarConfig, MdSnackBarRef } from '@angular/material';
+      import { MdSnackBar } from '@angular/material';
       ...
       export class ToastsComponent {
-        _snackBarConfig: MdSnackBarConfig;
-        constructor(private _viewContainerRef: ViewContainerRef,
-                    private _snackBarService: MdSnackBar) {
-          this._snackBarConfig = new MdSnackBarConfig(_viewContainerRef);
+        constructor(private _snackBarService: MdSnackBar) {
         }
         showSnackBar(): void {
-          let snackBarRef: MdSnackBarRef<any> = this._snackBarService
-            .open('Direct message sent!', 'Dismiss', this._snackBarConfig);
-          setTimeout(() => {
-            snackBarRef.dismiss();
-          }, 3000);
+          this._snackBarService.open('Direct message sent!', 'Dismiss', { duration: 3000 });
         }
       }
       ]]>

--- a/src/app/components/style-guide/dialogs/dialogs.component.ts
+++ b/src/app/components/style-guide/dialogs/dialogs.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 
 import { TdDialogService } from '../../../../platform/core';
 
-import { MdSnackBar, MdSnackBarRef } from '@angular/material';
+import { MdSnackBar } from '@angular/material';
 
 @Component({
   selector: 'design-patterns-dialogs',
@@ -15,11 +15,8 @@ export class DialogsToastsComponent {
               private _snackBarService: MdSnackBar) {}
 
   showSnackBar(): void {
-    let snackBarRef: MdSnackBarRef<any> = this._snackBarService
-      .open('Direct message sent!', 'Dismiss');
-    setTimeout(() => {
-      snackBarRef.dismiss();
-    }, 3000);
+    this._snackBarService
+      .open('Direct message sent!', 'Dismiss', { duration: 3000 });
   }
   openAlert(): void {
     this._dialogService.openAlert({
@@ -44,10 +41,7 @@ export class DialogsToastsComponent {
     });
   }
   confirmDelete(): void {
-    let snackBarRef: MdSnackBarRef<any> = this._snackBarService.open('Item deleted!', 'Ok');
-    setTimeout(() => {
-      snackBarRef.dismiss();
-    }, 3000);
+    this._snackBarService.open('Item deleted!', 'Ok', { duration: 3000 });
   }
   openPrompt(): void {
     this._dialogService.openPrompt({

--- a/src/app/components/style-guide/iconography/iconography.component.html
+++ b/src/app/components/style-guide/iconography/iconography.component.html
@@ -33,7 +33,7 @@
 <md-card>
   <md-card-title>CSS Icon (Font or SVG) Colors</md-card-title>
   <md-divider></md-divider>
-  <md-tab-group>
+  <md-tab-group md-stretch-tabs>
     <md-tab label="Default Colors">
       <md-card-content>
         <p>To manually color a fill or font color (depending if you're using a font icon or SVV icon), use our simple tc utility class:</p>

--- a/src/app/components/style-guide/typography/typography.component.html
+++ b/src/app/components/style-guide/typography/typography.component.html
@@ -116,7 +116,7 @@
 <md-card>
   <md-card-title>CSS Font Colors</md-card-title>
   <md-divider></md-divider>
-  <md-tab-group>
+  <md-tab-group md-stretch-tabs>
     <md-tab label="Default Colors">
       <md-card-content>
         <p>To manually color a font color, use our simple tc utility class:</p>

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.scss
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.scss
@@ -15,7 +15,6 @@
     font-size: 14px;
   }
   md-sidenav-layout.td-layout-manage-list {
-    top: 64px;
     & > .md-sidenav-content {
       margin-left: 0 !important;
     }

--- a/src/platform/http/http-rest.service.ts
+++ b/src/platform/http/http-rest.service.ts
@@ -49,9 +49,9 @@ export abstract class RESTService<T> {
 
   public query(query?: IRestQuery): Observable<Array<T>> {
     let request: Observable<Response> = this.http.get(this.buildUrl(undefined, query), this.buildRequestOptions());
-    return request.map<Array<T>>((res: Response) => {
+    return request.map((res: Response) => {
       return <Array<T>>this.transform(res);
-    }).catch<any>((error: Response) => {
+    }).catch((error: Response) => {
       return new Observable<any>((subscriber: Subscriber<any>) => {
         try {
           subscriber.error(this.transform(error));
@@ -64,9 +64,9 @@ export abstract class RESTService<T> {
 
   public get(id: string | number): Observable<T> {
     let request: Observable<Response> = this.http.get(this.buildUrl(id), this.buildRequestOptions());
-    return request.map<T>((res: Response) => {
+    return request.map((res: Response) => {
       return <T>this.transform(res);
-    }).catch<any>((error: Response) => {
+    }).catch((error: Response) => {
       return new Observable<any>((subscriber: Subscriber<any>) => {
         try {
           subscriber.error(this.transform(error));
@@ -86,7 +86,7 @@ export abstract class RESTService<T> {
       } else {
         return res;
       }
-    }).catch<any>((error: Response) => {
+    }).catch((error: Response) => {
       return new Observable<any>((subscriber: Subscriber<any>) => {
         try {
           subscriber.error(this.transform(error));
@@ -100,13 +100,13 @@ export abstract class RESTService<T> {
   public update(id: string | number, obj: T): Observable<T> {
     let requestOptions: RequestOptionsArgs = this.buildRequestOptions();
     let request: Observable<Response> = this.http.patch(this.buildUrl(id), obj, requestOptions);
-    return request.map<T>((res: Response) => {
+    return request.map((res: Response) => {
       if (res.status === 200) {
-        return this.transform(res);
+        return <T>this.transform(res);
       } else {
         return res;
       }
-    }).catch<any>((error: Response) => {
+    }).catch((error: Response) => {
       return new Observable<any>((subscriber: Subscriber<any>) => {
         try {
           subscriber.error(this.transform(error));
@@ -117,15 +117,15 @@ export abstract class RESTService<T> {
     });
   }
 
-  public delete(id: string | number): Observable<any> {
+  public delete(id: string | number): Observable<T> {
     let request: Observable<Response> = this.http.delete(this.buildUrl(id), this.buildRequestOptions());
     return request.map((res: Response) => {
       if (res.status === 200) {
-        return this.transform(res);
+        return <T>this.transform(res);
       } else {
         return res;
       }
-    }).catch<any>((error: Response) => {
+    }).catch((error: Response) => {
       return new Observable<any>((subscriber: Subscriber<any>) => {
         try {
           subscriber.error(this.transform(error));

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -18,8 +18,3 @@ md-nav-list {
 a[md-icon-button] {
     line-height: 36px;
 }
-
-// Stretch tab labels until there is an attribute for it
-.md-tab-label {
-    flex-grow: 1;
-}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "baseUrl": ".",
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
@@ -16,6 +17,9 @@
     ],
     "types": [
       "jasmine", "hammerjs"
-    ]
+    ],
+    "paths": {
+      "@covalent/*": ["./platform/*"]
+    }
   }
 }


### PR DESCRIPTION
## Description

Upgrade dependencies for latest angular and material. (11-2 and 2.3.0)
https://github.com/angular/material2/blob/master/CHANGELOG.md#200-alpha11-polyester-golem-2016-12-08
https://github.com/angular/angular/blob/master/CHANGELOG.md#230-2016-12-07

### What's included?

- `@angular@2.3.0`
- `@angular/material@2.0.0-alpha.11-3`
- `rxjs@5.0.0-rc.4`
- `zone.js@0.7.2`
- Fix `.map` generics in `http` module for `rxjs@5.0.0-rc.4`
- Remove top `64px` from manage-list content since its not needed anymore.
- Remove `viewContainterRef` from all places where is not needed and use new duration in `SnackBar`.
- Remove `md-divider` scss override since its fixed now.
- Remove scss override for stretching tabs and favor `md-stretch-tabs` attr
- Update tsconfig.json to use @covalent/* internally between modules

#### Test Steps

- [x] `npm i`
- [x] `ng serve`
- [x] Play around with docs and see everything working the same