### PR TITLE
fix(data-table): format columns correctly when displaying them. closes(#187)

### DIFF
--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -25,7 +25,7 @@
                 <button md-button [class.md-accent]="!row['comments']">{{row['comments'] || 'Add Comment'}}</button>
               </td>
               <td td-data-table-cell *ngFor="let column of columns" [numeric]="column.numeric">
-                {{row[column.name]}}
+                {{column.format ? column.format(row[column.name]) : row[column.name]}}
               </td>
             </tr>
           </table>
@@ -51,7 +51,7 @@
                   <button md-button [class.md-accent]="!row['comments']">{ {row['comments'] || 'Add Comment'}}</button>
                 </td>
                 <td td-data-table-cell *ngFor="let column of columns" [numeric]="column.numeric">
-                  { {row[column.name]}}
+                  { {column.format ? column.format(row[column.name]) : row[column.name]}}
                 </td>
               </tr>
             </table>

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -5,8 +5,8 @@ import { TdDataTableSortingOrder, TdDataTableService,
 import { IPageChangeEvent } from '../../../../platform/paging';
 import { TdDialogService } from '../../../../platform/core';
 
-const NUMBER_FORMAT: any = (v: number) => v;
-const DECIMAL_FORMAT: any = (v: number) => v.toFixed(2);
+const NUMBER_FORMAT: (v: any) => any = (v: number) => v;
+const DECIMAL_FORMAT: (v: any) => any = (v: number) => v.toFixed(2);
 
 @Component({
   selector: 'data-table-demo',

--- a/src/platform/data-table/data-table.component.html
+++ b/src/platform/data-table/data-table.component.html
@@ -32,7 +32,7 @@
       <td td-data-table-cell
           [numeric]="column.numeric"
           *ngFor="let column of columns">
-        <span class="md-body-1" *ngIf="!getTemplateRef(column.name)">{{row[column.name]}}</span>
+        <span class="md-body-1" *ngIf="!getTemplateRef(column.name)">{{column.format ? column.format(row[column.name]) : row[column.name]}}</span>
         <template
           *ngIf="getTemplateRef(column.name)"
           [ngTemplateOutlet]="getTemplateRef(column.name)"

--- a/src/platform/data-table/data-table.component.html
+++ b/src/platform/data-table/data-table.component.html
@@ -17,8 +17,7 @@
         [sortable]="_sortable"
         [sortOrder]="_sortOrder"
         (sortChange)="handleSort(column)">
-        <span *ngIf="column.tooltip" [md-tooltip]="column.tooltip">{{column.label}}</span>
-        <span *ngIf="!column.tooltip">{{column.label}}</span>
+        <span [md-tooltip]="column.tooltip">{{column.label}}</span>
     </th>
     <tr td-data-table-row
         [class.md-selected]="_selectable && isRowSelected(row)"

--- a/src/platform/data-table/data-table.component.ts
+++ b/src/platform/data-table/data-table.component.ts
@@ -25,7 +25,7 @@ export interface ITdDataTableColumn {
   label: string;
   tooltip?: string;
   numeric?: boolean;
-  format?: { (value: any): any };
+  format?: (value: any) => any;
 };
 
 export interface ITdDataTableSelectEvent {

--- a/src/platform/data-table/data-table.component.ts
+++ b/src/platform/data-table/data-table.component.ts
@@ -104,22 +104,19 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
       return this._columns;
     }
 
-    if (!this._data) {
-      return [];
-    }
-
-    this._columns = [];
-    // if columns is undefined, use key in [data] rows as name and label for column headers.
-    if (this._data.length > 0) {
+    if (this.hasData) {
+      this._columns = [];
+      // if columns is undefined, use key in [data] rows as name and label for column headers.
       let row: any = this._data[0];
       Object.keys(row).forEach((k: string) => {
         if (!this._columns.find((c: any) => c.name === k)) {
           this._columns.push({ name: k, label: k });
         }
       });
+      return this._columns;
+    } else {
+      return [];
     }
-
-    return this._columns;
   }
 
   /**
@@ -186,7 +183,7 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
   }
 
   get hasData(): boolean {
-    return this._data.length > 0;
+    return this._data && this._data.length > 0;
   }
 
   /**

--- a/src/platform/data-table/data-table.component.ts
+++ b/src/platform/data-table/data-table.component.ts
@@ -235,7 +235,6 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    */
   refresh(): void {
     this.clearModel();
-    this._preprocessData();
   }
 
   /**
@@ -335,15 +334,5 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
 
   onChange = (_: any) => noop;
   onTouched = () => noop;
-
-  private _preprocessData(): void {
-    let data: Object[] = JSON.parse(JSON.stringify(this._data));
-    this._data = data.map((row: any) => {
-      this.columns.filter((c: any) => c.format).forEach((c: any) => {
-        row[c.name] = c.format(row[c.name]);
-      });
-      return row;
-    });
-  }
 
 }


### PR DESCRIPTION
## Description

Switched the way we format the column values in the `data-table` component to be on display, so the underlying data is not modified nor copied.
https://github.com/Teradata/covalent/issues/187

#### Test Steps

- [x] `ng serve`
- [x] Go to http://localhost:4200/#/components/data-table
- [x] Play around with column formats in the demos.

##### Screenshots or link to CodePen/Plunker/JSfiddle

![image](https://cloud.githubusercontent.com/assets/5846742/21122249/de84c422-c085-11e6-9324-90b1f85981d2.png)
