### PR TITLE
fix(code-health): fix to run unit tests in chrome 55 and travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required  
+dist: trusty
 language: node_js
 node_js:
 - '5.4'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -47,7 +47,7 @@ module.exports = function (config) {
     singleRun: false
   };
   if (process.env.TRAVIS) {
-    configuration.browsers = ['Chrome_travis_ci'];
+    configuration.browsers = ['Firefox'];//['Chrome_travis_ci'];
   }
   config.set(configuration);
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -47,7 +47,7 @@ module.exports = function (config) {
     singleRun: false
   };
   if (process.env.TRAVIS) {
-    configuration.browsers = ['Firefox'];//['Chrome_travis_ci'];
+    configuration.browsers = ['Chrome_travis_ci'];
   }
   config.set(configuration);
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,16 +35,19 @@ module.exports = function (config) {
       config: './angular-cli.json',
       environment: 'dev'
     },
+    mime: {
+      'text/x-typescript': ['ts','tsx']
+    },
     reporters: ['progress', 'karma-remap-istanbul'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Firefox'],
+    browsers: ['Chrome'],
     singleRun: false
   };
   if (process.env.TRAVIS) {
-    //configuration.browsers = ['Chrome_travis_ci'];
+    configuration.browsers = ['Chrome_travis_ci'];
   }
   config.set(configuration);
 };


### PR DESCRIPTION
## Description

Bug fix to address https://github.com/angular/angular-cli/issues/2125
Unit tests not running in Chrome 55 

Bugfix for travis failing in Chrome
http://blog.500tech.com/setting-up-travis-ci-to-run-tests-on-latest-google-chrome-version/

#### Test Steps
- [x] upgrade to chrome 55
- [x] `ng test`
