### PR TITLE
feature(http): improvements on http module. closes (#179)

### DIFF
--- a/src/app/components/components/http/http.component.html
+++ b/src/app/components/components/http/http.component.html
@@ -95,7 +95,7 @@
     <td-highlight lang="typescript">
       <![CDATA[
         import { Injectable } from '@angular/core';
-        import { Response, Http } from '@angular/http';
+        import { Response, Http, Headers } from '@angular/http';
         import { RESTService, HttpInterceptorService } from '@covalent/http';
 
         @Injectable()
@@ -105,6 +105,8 @@
             super(_http, {
               baseUrl: 'www.api.com',
               path: '/path/to/endpoint',
+              headers: new Headers(),
+              dynamicHeaders: () => new Headers(),
               transform: (res: Response): any => res.json(),
             });
           }

--- a/src/app/components/components/http/http.component.html
+++ b/src/app/components/components/http/http.component.html
@@ -39,7 +39,8 @@
 
           onRequest(requestOptions: RequestOptionsArgs): RequestOptionsArgs {
             ... // do something to requestOptions before a request
-            ... // if something is wrong, throw an error to execute onRequestError (if there is an onRequestError hook)
+            ... // if something is wrong, throw an error to execute 
+            ... // onRequestError (if there is an onRequestError hook)
             if (/*somethingWrong*/) {
               throw 'error message for subscription error callback';
             }
@@ -49,7 +50,8 @@
           onRequestError(requestOptions: RequestOptionsArgs): RequestOptionsArgs {
             ... // do something to try and recover from an error thrown `onRequest` 
             ... // and return the requestOptions needed for the request
-            ... // else return 'undefined' or throw an error to execute the error callback of the subscription
+            ... // else return 'undefined' or throw an error to execute the 
+            ... // error callback of the subscription
             if (cantRecover) {
               throw 'error message for subscription error callback'; // or return undefined;
             }

--- a/src/app/components/components/http/http.component.html
+++ b/src/app/components/components/http/http.component.html
@@ -7,8 +7,9 @@
     <p>Service provided with methods that wrap the ng2 [Http] service and provide an easier experience for interceptor implementation.</p>
     <p>To add a desired interceptor, it needs to implement the [IHttpInterceptor] interface.</p>
     <td-highlight lang="typescript">
-      export interface IHttpInterceptor {{'{'}}
+      export interface IHttpInterceptor {
         onRequest?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
+        onRequestError?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
         onResponse?: (response: Response) => Response;
         onResponseError?: (error: Response) => Response;
       }
@@ -35,7 +36,21 @@
         export class CustomInterceptor implements IHttpInterceptor {
 
           onRequest(requestOptions: RequestOptionsArgs): RequestOptionsArgs {
-            ... // do something to requestOptions
+            ... // do something to requestOptions before a request
+            ... // if something is wrong, throw an error to execute onRequestError (if there is an onRequestError hook)
+            if (/*somethingWrong*/) {
+              throw 'error message for subscription error callback';
+            }
+            return requestOptions;
+          }
+
+          onRequestError(requestOptions: RequestOptionsArgs): RequestOptionsArgs {
+            ... // do something to try and recover from an error thrown `onRequest` 
+            ... // and return the requestOptions needed for the request
+            ... // else return 'undefined' or throw an error to execute the error callback of the subscription
+            if (cantRecover) {
+              throw 'error message for subscription error callback'; // or return undefined;
+            }
             return requestOptions;
           }
 

--- a/src/app/components/components/http/http.component.html
+++ b/src/app/components/components/http/http.component.html
@@ -7,12 +7,14 @@
     <p>Service provided with methods that wrap the ng2 [Http] service and provide an easier experience for interceptor implementation.</p>
     <p>To add a desired interceptor, it needs to implement the [IHttpInterceptor] interface.</p>
     <td-highlight lang="typescript">
-      export interface IHttpInterceptor {
-        onRequest?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
-        onRequestError?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
-        onResponse?: (response: Response) => Response;
-        onResponseError?: (error: Response) => Response;
-      }
+      <![CDATA[
+        export interface IHttpInterceptor {
+          onRequest?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
+          onRequestError?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
+          onResponse?: (response: Response) => Response;
+          onResponseError?: (error: Response) => Response;
+        }
+      ]]>
     </td-highlight>
     <h3>Methods:</h3>
     <p>The [HttpInterceptorService] service has {{interceptorServiceMethods.length}} properties:</p>

--- a/src/app/components/components/http/http.component.ts
+++ b/src/app/components/components/http/http.component.ts
@@ -65,23 +65,23 @@ export class HttpDemoComponent {
   restServiceMethods: Object[] = [{
     description: `Creates a GET request to the generated endpoint URL.`,
     name: 'query',
-    type: 'function(query?: IRestQuery)',
+    type: 'function(query?: IRestQuery, transform?: IRestTransform)',
   }, {
     description: `Creates a GET request to the generated endpoint URL, adding the ID at the end.`,
     name: 'get',
-    type: 'function(id: string | number)',
+    type: 'function(id: string | number, transform?: IRestTransform)',
   }, {
     description: `Creates a POST request to the generated endpoint URL.`,
     name: 'create',
-    type: 'function(obj: T)',
+    type: 'function(obj: T, transform?: IRestTransform)',
   }, {
     description: `Creates a PATCH request to the generated endpoint URL, adding the ID at the end.`,
     name: 'update',
-    type: 'function(id: string | number, obj: T)',
+    type: 'function(id: string | number, obj: T, transform?: IRestTransform)',
   }, {
     description: `Creates a DELETE request to the generated endpoint URL, adding the ID at the end.`,
     name: 'delete',
-    type: 'function(id: string | number)',
+    type: 'function(id: string | number, transform?: IRestTransform)',
   }, {
     description: `Builds the endpoint URL with the configured properties and arguments passed in the method.`,
     name: 'buildUrl',

--- a/src/app/components/components/http/http.component.ts
+++ b/src/app/components/components/http/http.component.ts
@@ -1,27 +1,9 @@
-import { Component, Injectable } from '@angular/core';
-import { Headers, Response } from '@angular/http';
-
-import { RESTService, HttpInterceptorService } from '@covalent/http';
-
-@Injectable()
-export class DemoService extends RESTService<any> {
-
-  constructor(http: HttpInterceptorService) {
-    super(http, {
-      baseUrl: 'url',
-      path: 'path',
-      baseHeaders: new Headers({'authorization': 'token'}),
-      transform: (res: Response) => res.json(),
-    });
-  }
-
-}
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'http-demo',
   styleUrls: [ 'http.component.scss' ],
   templateUrl: 'http.component.html',
-  providers: [ DemoService ],
 })
 export class HttpDemoComponent {
 
@@ -87,17 +69,5 @@ export class HttpDemoComponent {
     name: 'buildUrl',
     type: 'function(id?: string | number, query?: IRestQuery)',
   }];
-
-  constructor(private demoService: DemoService) {
-    // Piece of code to test http requests using our internal products (need to put mock api in covalent soon)
-    /*
-    demoService.query(undefined, (res: Response) => {
-      let data: any[] = res.json();
-      return {total: apps.length, data: data};
-    }).subscribe((result: any) => {
-      console.log(result)
-    })
-    */
-  }
 
 }

--- a/src/app/components/components/http/http.component.ts
+++ b/src/app/components/components/http/http.component.ts
@@ -1,9 +1,27 @@
-import { Component } from '@angular/core';
+import { Component, Injectable } from '@angular/core';
+import { Headers, Response } from '@angular/http';
+
+import { RESTService, HttpInterceptorService } from '@covalent/http';
+
+@Injectable()
+export class DemoService extends RESTService<any> {
+
+  constructor(http: HttpInterceptorService) {
+    super(http, {
+      baseUrl: 'url',
+      path: 'path',
+      baseHeaders: new Headers({'authorization': 'token'}),
+      transform: (res: Response) => res.json(),
+    });
+  }
+
+}
 
 @Component({
   selector: 'http-demo',
   styleUrls: [ 'http.component.scss' ],
   templateUrl: 'http.component.html',
+  providers: [ DemoService ],
 })
 export class HttpDemoComponent {
 
@@ -69,5 +87,17 @@ export class HttpDemoComponent {
     name: 'buildUrl',
     type: 'function(id?: string | number, query?: IRestQuery)',
   }];
+
+  constructor(private demoService: DemoService) {
+    // Piece of code to test http requests using our internal products (need to put mock api in covalent soon)
+    /*
+    demoService.query(undefined, (res: Response) => {
+      let data: any[] = res.json();
+      return {total: apps.length, data: data};
+    }).subscribe((result: any) => {
+      console.log(result)
+    })
+    */
+  }
 
 }

--- a/src/platform/http/README.md
+++ b/src/platform/http/README.md
@@ -86,11 +86,11 @@ Methods:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `query` | `function(query?: IRestQuery)` | Creates a GET request to the generated endpoint URL.
-| `get` | `function(id: string | number)` | Creates a GET request to the generated endpoint URL, adding the ID at the end.
-| `create` | `function(obj: T)` | Creates a POST request to the generated endpoint URL.
-| `update` | `function(id: string | number, obj: T)` | Creates a PATCH request to the generated endpoint URL, adding the ID at the end.
-| `delete` | `function(id: string | number)` | Creates a DELETE request to the generated endpoint URL, adding the ID at the end.
+| `query` | `function(query?: IRestQuery, transform?: IRestTransform)` | Creates a GET request to the generated endpoint URL.
+| `get` | `function(id: string | number, transform?: IRestTransform)` | Creates a GET request to the generated endpoint URL, adding the ID at the end.
+| `create` | `function(obj: T, transform?: IRestTransform)` | Creates a POST request to the generated endpoint URL.
+| `update` | `function(id: string | number, obj: T, transform?: IRestTransform)` | Creates a PATCH request to the generated endpoint URL, adding the ID at the end.
+| `delete` | `function(id: string | number, transform?: IRestTransform)` | Creates a DELETE request to the generated endpoint URL, adding the ID at the end.
 | `buildUrl` | `function(id?: string | number, query?: IRestQuery)` | Builds the endpoint URL with the configured properties and arguments passed in the method.
 
 ## Usage
@@ -101,7 +101,7 @@ Example:
 
 ```typescript
 import { Injectable } from '@angular/core';
-import { Response, Http } from '@angular/http';
+import { Response, Http, Headers } from '@angular/http';
 import { RESTService, HttpInterceptorService } from '@covalent/http';
 
 @Injectable()
@@ -111,6 +111,8 @@ export class CustomRESTService extends RESTService<any> {
     super(_http, {
       baseUrl: 'www.api.com',
       path: '/path/to/endpoint',
+      headers: new Headers(),
+      dynamicHeaders: () => new Headers(),
       transform: (res: Response): any => res.json(),
     });
   }

--- a/src/platform/http/README.md
+++ b/src/platform/http/README.md
@@ -23,6 +23,7 @@ To add a desired interceptor, it needs to implement the [IHttpInterceptor] inter
 ```typescript
 export interface IHttpInterceptor {
   onRequest?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
+  onRequestError?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
   onResponse?: (response: Response) => Response;
   onResponseError?: (error: Response) => Response;
 }
@@ -40,8 +41,22 @@ import { IHttpInterceptor } from '@covalent/http';
 @Injectable()
 export class CustomInterceptor implements IHttpInterceptor {
 
-  onRequest(requestOptions: RequestOptionsArgs): RequestOptionsArgs {
-    ... // do something to requestOptions
+   onRequest(requestOptions: RequestOptionsArgs): RequestOptionsArgs {
+    ... // do something to requestOptions before a request
+    ... // if something is wrong, throw an error to execute onRequestError (if there is an onRequestError hook)
+    if (/*somethingWrong*/) {
+      throw 'error message for subscription error callback';
+    }
+    return requestOptions;
+  }
+
+  onRequestError(requestOptions: RequestOptionsArgs): RequestOptionsArgs {
+    ... // do something to try and recover from an error thrown `onRequest` 
+    ... // and return the requestOptions needed for the request
+    ... // else return 'undefined' or throw an error to execute the error callback of the subscription
+    if (cantRecover) {
+      throw 'error message for subscription error callback'; // or return undefined;
+    }
     return requestOptions;
   }
 

--- a/src/platform/http/http-interceptor.service.ts
+++ b/src/platform/http/http-interceptor.service.ts
@@ -6,6 +6,7 @@ import { Subscriber } from 'rxjs/Subscriber';
 
 export interface IHttpInterceptor {
   onRequest?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
+  onRequestError?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
   onResponse?: (response: Response) => Response;
   onResponseError?: (error: Response) => Response;
 }
@@ -22,31 +23,87 @@ export class HttpInterceptorService {
   }
 
   request(url: string | Request, options: RequestOptionsArgs = {}): Observable<Response> {
-    return this._setupRequest(this._http.request(url, this._requestResolve(options)));
+    let requestOptionsArgs: RequestOptionsArgs;
+    try {
+      requestOptionsArgs = this._requestResolve(options);
+    } catch (e) {
+      return new Observable<any>((subscriber: Subscriber<any>) => {
+        subscriber.error(e);
+      });
+    }
+    return this._setupRequest(this._http.request(url, requestOptionsArgs));
   }
 
   delete(url: string, options: RequestOptionsArgs = {}): Observable<Response> {
-    return this._setupRequest(this._http.delete(url, this._requestResolve(options)));
+    let requestOptionsArgs: RequestOptionsArgs;
+    try {
+      requestOptionsArgs = this._requestResolve(options);
+    } catch (e) {
+      return new Observable<any>((subscriber: Subscriber<any>) => {
+        subscriber.error(e);
+      });
+    }
+    return this._setupRequest(this._http.delete(url, requestOptionsArgs));
   }
 
   get(url: string, options: RequestOptionsArgs = {}): Observable<Response> {
-    return this._setupRequest(this._http.get(url, this._requestResolve(options)));
+    let requestOptionsArgs: RequestOptionsArgs;
+    try {
+      requestOptionsArgs = this._requestResolve(options);
+    } catch (e) {
+      return new Observable<any>((subscriber: Subscriber<any>) => {
+        subscriber.error(e);
+      });
+    }
+    return this._setupRequest(this._http.get(url, requestOptionsArgs));
   }
 
   head(url: string, options: RequestOptionsArgs = {}): Observable<Response> {
-    return this._setupRequest(this._http.head(url, this._requestResolve(options)));
+    let requestOptionsArgs: RequestOptionsArgs;
+    try {
+      requestOptionsArgs = this._requestResolve(options);
+    } catch (e) {
+      return new Observable<any>((subscriber: Subscriber<any>) => {
+        subscriber.error(e);
+      });
+    }
+    return this._setupRequest(this._http.head(url, requestOptionsArgs));
   }
 
   patch(url: string, data: any, options: RequestOptionsArgs = {}): Observable<Response> {
-    return this._setupRequest(this._http.patch(url, data, this._requestResolve(options)));
+    let requestOptionsArgs: RequestOptionsArgs;
+    try {
+      requestOptionsArgs = this._requestResolve(options);
+    } catch (e) {
+      return new Observable<any>((subscriber: Subscriber<any>) => {
+        subscriber.error(e);
+      });
+    }
+    return this._setupRequest(this._http.patch(url, data, requestOptionsArgs));
   }
 
   post(url: string, data: any, options: RequestOptionsArgs = {}): Observable<Response> {
-    return this._setupRequest(this._http.post(url, data, this._requestResolve(options)));
+    let requestOptionsArgs: RequestOptionsArgs;
+    try {
+      requestOptionsArgs = this._requestResolve(options);
+    } catch (e) {
+      return new Observable<any>((subscriber: Subscriber<any>) => {
+        subscriber.error(e);
+      });
+    }
+    return this._setupRequest(this._http.post(url, data, requestOptionsArgs));
   }
 
   put(url: string, data: any, options: RequestOptionsArgs = {}): Observable<Response> {
-    return this._setupRequest(this._http.put(url, data, this._requestResolve(options)));
+    let requestOptionsArgs: RequestOptionsArgs;
+    try {
+      requestOptionsArgs = this._requestResolve(options);
+    } catch (e) {
+      return new Observable<any>((subscriber: Subscriber<any>) => {
+        subscriber.error(e);
+      });
+    }
+    return this._setupRequest(this._http.put(url, data, requestOptionsArgs));
   }
 
   private _setupRequest(responseObservable: Observable<Response>): Observable<Response> {
@@ -65,7 +122,18 @@ export class HttpInterceptorService {
   private _requestResolve(requestOptions: RequestOptionsArgs): RequestOptionsArgs {
     this._requestInterceptors.forEach((interceptor: IHttpInterceptor) => {
       if (interceptor.onRequest) {
-        requestOptions = interceptor.onRequest(requestOptions);
+        try {
+          requestOptions = interceptor.onRequest(requestOptions);
+        } catch (e) {
+          if (interceptor.onRequestError) {
+            requestOptions = interceptor.onRequestError(requestOptions);
+            if (!requestOptions) {
+              throw e;
+            }
+          } else {
+            throw e;
+          }
+        }
       }
     });
     return requestOptions;

--- a/src/platform/http/http-rest.service.spec.ts
+++ b/src/platform/http/http-rest.service.spec.ts
@@ -136,7 +136,7 @@ describe('Service: RESTService', () => {
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         expect(connection.request.url)
-        .toBe('www.url.com/path/to/endpoint?firstParam=1&secondParam=value&thirdParam=false',
+        .toBe('www.url.com/path/to/endpoint?firstParam=1&second-Param=value&thirdParam=false',
               'url with query parameters didnt match the expected url');
         expect(connection.request.method).toBe(RequestMethod.Get, 'request didnt have GET method');
         connection.mockRespond(new Response(new ResponseOptions({
@@ -149,7 +149,7 @@ describe('Service: RESTService', () => {
       let complete: boolean = false;
       service.query({
         firstParam: 1,
-        secondParam: 'value',
+        'second-Param': 'value',
         thirdParam: false,
       }).subscribe((data: string) => {
         expect(data).toBe('success');

--- a/src/platform/http/http-rest.service.spec.ts
+++ b/src/platform/http/http-rest.service.spec.ts
@@ -397,4 +397,31 @@ describe('Service: RESTService', () => {
       expect(complete).toBe(true, 'on complete didnt execute with observables');
     })
   ));
+
+  it('expect to do a query succesfully with dynamicHeaders with observables',
+    async(inject([DynamicHeadersTestRESTService, MockBackend],
+                 (service: DynamicHeadersTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.headers.get('header')).toBe('value', 'request didnt have dynamicHeaders');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.query().subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    })
+  ));
 });

--- a/src/platform/http/http-rest.service.spec.ts
+++ b/src/platform/http/http-rest.service.spec.ts
@@ -251,7 +251,7 @@ describe('Service: RESTService', () => {
       let success: boolean = false;
       let error: boolean = false;
       let complete: boolean = false;
-      service.get('id-for-something').subscribe((data: any) => {
+      service.get('id-of-something').subscribe((data: any) => {
         expect(data.data).toBe('success');
         expect(data.transformFrom).toBe('service');
         success = true;
@@ -267,7 +267,7 @@ describe('Service: RESTService', () => {
       success = false;
       error = false;
       complete = false;
-      service.get('id-for-something', (res: Response) => {
+      service.get('id-of-something', (res: Response) => {
         return { data: res.json(), transformFrom: 'method'};
       }).subscribe((data: any) => {
         expect(data.data).toBe('success');
@@ -447,7 +447,7 @@ describe('Service: RESTService', () => {
       let success: boolean = false;
       let error: boolean = false;
       let complete: boolean = false;
-      service.update('id-for-something', {}).subscribe((data: any) => {
+      service.update('id-of-something', {}).subscribe((data: any) => {
         expect(data.data).toBe('success');
         expect(data.transformFrom).toBe('service');
         success = true;
@@ -463,7 +463,7 @@ describe('Service: RESTService', () => {
       success = false;
       error = false;
       complete = false;
-      service.update('id-for-something', {}, (res: Response) => {
+      service.update('id-of-something', {}, (res: Response) => {
         return { data: res.json(), transformFrom: 'method'};
       }).subscribe((data: any) => {
         expect(data.data).toBe('success');
@@ -544,7 +544,7 @@ describe('Service: RESTService', () => {
       let success: boolean = false;
       let error: boolean = false;
       let complete: boolean = false;
-      service.delete('id-for-something').subscribe((data: any) => {
+      service.delete('id-of-something').subscribe((data: any) => {
         expect(data.data).toBe('success');
         expect(data.transformFrom).toBe('service');
         success = true;
@@ -560,7 +560,7 @@ describe('Service: RESTService', () => {
       success = false;
       error = false;
       complete = false;
-      service.delete('id-for-something', (res: Response) => {
+      service.delete('id-of-something', (res: Response) => {
         return { data: res.json(), transformFrom: 'method'};
       }).subscribe((data: any) => {
         expect(data.data).toBe('success');

--- a/src/platform/http/http-rest.service.spec.ts
+++ b/src/platform/http/http-rest.service.spec.ts
@@ -370,4 +370,31 @@ describe('Service: RESTService', () => {
       expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
     })
   ));
+
+  it('expect to do a query succesfully with baseHeaders with observables',
+    async(inject([BaseHeadersTestRESTService, MockBackend],
+                 (service: BaseHeadersTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.headers.get('header')).toBe('value', 'request didnt have baseHeaders');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.query().subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    })
+  ));
 });

--- a/src/platform/http/http-rest.service.spec.ts
+++ b/src/platform/http/http-rest.service.spec.ts
@@ -1,0 +1,373 @@
+import {
+  TestBed,
+  inject,
+  async,
+} from '@angular/core/testing';
+import { Injector, Injectable } from '@angular/core';
+import { XHRBackend, Response, ResponseOptions, Headers, RequestMethod } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+import { MockBackend, MockConnection } from '@angular/http/testing';
+import { HttpModule, Http } from '@angular/http';
+import { RESTService } from './http-rest.service';
+import 'rxjs/Rx';
+
+@Injectable()
+export class BasicTestRESTService extends RESTService<any> {
+
+  constructor(http: Http) {
+    super(http, {
+      baseUrl: 'www.url.com',
+      path: 'path/to/endpoint',
+    });
+  }
+
+}
+
+@Injectable()
+export class BaseHeadersTestRESTService extends RESTService<any> {
+
+  constructor(http: Http) {
+    super(http, {
+      baseUrl: 'www.url.com',
+      path: 'path/to/endpoint',
+      baseHeaders: new Headers({'header': 'value'}),
+    });
+  }
+}
+
+@Injectable()
+export class DynamicHeadersTestRESTService extends RESTService<any> {
+
+  constructor(http: Http) {
+    super(http, {
+      baseUrl: 'www.url.com',
+      path: 'path/to/endpoint',
+      dynamicHeaders: () => {
+        return new Headers({'header': 'value'});
+      },
+    });
+  }
+}
+
+@Injectable()
+export class TransformTestRESTService extends RESTService<any> {
+
+  constructor(http: Http) {
+    super(http, {
+      baseUrl: 'www.url.com',
+      path: 'path/to/endpoint',
+      transform: (res: Response) => {
+        return { data: res.json(), message: 'service'};
+      },
+    });
+  }
+}
+
+describe('Service: RESTService', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpModule,
+      ],
+      providers: [
+        MockBackend, {
+          provide: XHRBackend,
+          useExisting: MockBackend,
+        },
+        BasicTestRESTService,
+        BaseHeadersTestRESTService,
+        DynamicHeadersTestRESTService,
+        TransformTestRESTService,
+      ],
+    });
+  }));
+
+  it('expect to do a query succesfully with observables',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.url).toBe('www.url.com/path/to/endpoint',  'url doesnt match expected url');
+        expect(connection.request.method).toBe(RequestMethod.Get, 'request didnt have GET method');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.query().subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    })
+  ));
+
+  it('expect to do a query failure with observables',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Error('error'));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.query().subscribe(() => {
+        success = true;
+      }, (err: Error) => {
+        expect(err.message).toBe('error');
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
+      expect(error).toBe(true, 'on error didnt execute with observables');
+      expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
+    })
+  ));
+
+  it('expect to do a query with parameters succesfully with observables',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.url)
+        .toBe('www.url.com/path/to/endpoint?firstParam=1&secondParam=value&thirdParam=false',
+              'url with query parameters didnt match the expected url');
+        expect(connection.request.method).toBe(RequestMethod.Get, 'request didnt have GET method');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.query({
+        firstParam: 1,
+        secondParam: 'value',
+        thirdParam: false,
+      }).subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    })
+  ));
+
+  it('expect to do a get succesfully with observables',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.url)
+        .toBe('www.url.com/path/to/endpoint/id-of-something',
+              'url with :id didnt match the expected url');
+        expect(connection.request.method).toBe(RequestMethod.Get, 'request didnt have GET method');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.get('id-of-something').subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    })
+  ));
+
+  it('expect to do a get failure with observables',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Error('error'));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.get('id-of-something').subscribe(() => {
+        success = true;
+      }, (err: Error) => {
+        expect(err.message).toBe('error');
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
+      expect(error).toBe(true, 'on error didnt execute with observables');
+      expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
+    })
+  ));
+
+  it('expect to do a create succesfully with observables',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.url)
+        .toBe('www.url.com/path/to/endpoint',
+              'url didnt match the expected url');
+        expect(connection.request.method).toBe(RequestMethod.Post, 'request didnt have POST method');
+        expect(connection.request.getBody()).toBe('data', 'request didnt have the body');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 201,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.create('data').subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    })
+  ));
+
+  it('expect to do a create failure with observables',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Error('error'));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.create({data: 'value'}).subscribe(() => {
+        success = true;
+      }, (err: Error) => {
+        expect(err.message).toBe('error');
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
+      expect(error).toBe(true, 'on error didnt execute with observables');
+      expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
+    })
+  ));
+
+  it('expect to do an update succesfully with observables',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.url)
+        .toBe('www.url.com/path/to/endpoint/id-of-something',
+              'url with :id didnt match the expected url');
+        expect(connection.request.method).toBe(RequestMethod.Patch, 'request didnt have PATCH method');
+        expect(connection.request.getBody()).toBe('data', 'request didnt have the body');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.update('id-of-something', 'data').subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    })
+  ));
+
+  it('expect to do a update failure with observables',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Error('error'));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.update('id-of-something', 'data').subscribe((data: string) => {
+        success = true;
+      }, (err: Error) => {
+        expect(err.message).toBe('error');
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
+      expect(error).toBe(true, 'on error didnt execute with observables');
+      expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
+    })
+  ));
+
+  it('expect to do a delete succesfully with observables',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.url)
+        .toBe('www.url.com/path/to/endpoint/id-of-something',
+              'url with :id didnt match the expected url');
+        expect(connection.request.method).toBe(RequestMethod.Delete, 'request didnt have DELETE method');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.delete('id-of-something').subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    })
+  ));
+
+  it('expect to do a delete failure with observables',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Error('error'));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.delete('id-of-something').subscribe((data: string) => {
+        success = true;
+      }, (err: Error) => {
+        expect(err.message).toBe('error');
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
+      expect(error).toBe(true, 'on error didnt execute with observables');
+      expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
+    })
+  ));
+});

--- a/src/platform/http/http-rest.service.spec.ts
+++ b/src/platform/http/http-rest.service.spec.ts
@@ -57,7 +57,7 @@ export class TransformTestRESTService extends RESTService<any> {
       baseUrl: 'www.url.com',
       path: 'path/to/endpoint',
       transform: (res: Response) => {
-        return { data: res.json(), message: 'service'};
+        return { data: res.json(), transformFrom: 'service'};
       },
     });
   }
@@ -107,6 +107,52 @@ describe('Service: RESTService', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
+    })
+  ));
+
+  it('expect to do a query and use the service transform() and then override it with a method transform()',
+    async(inject([TransformTestRESTService, MockBackend],
+                 (service: TransformTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.query().subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('service');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+      success = false;
+      error = false;
+      complete = false;
+      service.query(undefined, (res: Response) => {
+        return { data: res.json(), transformFrom: 'method'};
+      }).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('method');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
     })
   ));
 
@@ -194,6 +240,52 @@ describe('Service: RESTService', () => {
     })
   ));
 
+  it('expect to do a get and use the service transform() and then override it with a method transform()',
+    async(inject([TransformTestRESTService, MockBackend],
+                 (service: TransformTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.get('id-for-something').subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('service');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+      success = false;
+      error = false;
+      complete = false;
+      service.get('id-for-something', (res: Response) => {
+        return { data: res.json(), transformFrom: 'method'};
+      }).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('method');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+    })
+  ));
+
   it('expect to do a get failure with observables',
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
@@ -243,6 +335,52 @@ describe('Service: RESTService', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
+    })
+  ));
+
+  it('expect to do a create and use the service transform() and then override it with a method transform()',
+    async(inject([TransformTestRESTService, MockBackend],
+                 (service: TransformTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 201,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.create({}).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('service');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+      success = false;
+      error = false;
+      complete = false;
+      service.create({}, (res: Response) => {
+        return { data: res.json(), transformFrom: 'method'};
+      }).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('method');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
     })
   ));
 
@@ -298,6 +436,52 @@ describe('Service: RESTService', () => {
     })
   ));
 
+  it('expect to do an update and use the service transform() and then override it with a method transform()',
+    async(inject([TransformTestRESTService, MockBackend],
+                 (service: TransformTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.update('id-for-something', {}).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('service');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+      success = false;
+      error = false;
+      complete = false;
+      service.update('id-for-something', {}, (res: Response) => {
+        return { data: res.json(), transformFrom: 'method'};
+      }).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('method');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+    })
+  ));
+
   it('expect to do a update failure with observables',
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
@@ -346,6 +530,52 @@ describe('Service: RESTService', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
+    })
+  ));
+
+  it('expect to do a delete and use the service transform() and then override it with a method transform()',
+    async(inject([TransformTestRESTService, MockBackend],
+                 (service: TransformTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')}
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.delete('id-for-something').subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('service');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+      success = false;
+      error = false;
+      complete = false;
+      service.delete('id-for-something', (res: Response) => {
+        return { data: res.json(), transformFrom: 'method'};
+      }).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('method');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
     })
   ));
 

--- a/src/platform/http/http-rest.service.spec.ts
+++ b/src/platform/http/http-rest.service.spec.ts
@@ -3,9 +3,8 @@ import {
   inject,
   async,
 } from '@angular/core/testing';
-import { Injector, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { XHRBackend, Response, ResponseOptions, Headers, RequestMethod } from '@angular/http';
-import { Observable } from 'rxjs/Observable';
 import { MockBackend, MockConnection } from '@angular/http/testing';
 import { HttpModule, Http } from '@angular/http';
 import { RESTService } from './http-rest.service';
@@ -83,7 +82,7 @@ describe('Service: RESTService', () => {
     });
   }));
 
-  it('expect to do a query succesfully with observables',
+  it('expect to do a query succesfully',
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         expect(connection.request.url).toBe('www.url.com/path/to/endpoint',  'url doesnt match expected url');
@@ -156,7 +155,7 @@ describe('Service: RESTService', () => {
     })
   ));
 
-  it('expect to do a query failure with observables',
+  it('expect to do a query failure',
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockError(new Error('error'));
@@ -178,7 +177,7 @@ describe('Service: RESTService', () => {
     })
   ));
 
-  it('expect to do a query with parameters succesfully with observables',
+  it('expect to do a query with parameters succesfully',
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         expect(connection.request.url)
@@ -211,7 +210,7 @@ describe('Service: RESTService', () => {
     })
   ));
 
-  it('expect to do a get succesfully with observables',
+  it('expect to do a get succesfully',
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         expect(connection.request.url)
@@ -286,7 +285,7 @@ describe('Service: RESTService', () => {
     })
   ));
 
-  it('expect to do a get failure with observables',
+  it('expect to do a get failure',
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockError(new Error('error'));
@@ -308,7 +307,7 @@ describe('Service: RESTService', () => {
     })
   ));
 
-  it('expect to do a create succesfully with observables',
+  it('expect to do a create succesfully',
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         expect(connection.request.url)
@@ -384,7 +383,7 @@ describe('Service: RESTService', () => {
     })
   ));
 
-  it('expect to do a create failure with observables',
+  it('expect to do a create failure',
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockError(new Error('error'));
@@ -406,7 +405,7 @@ describe('Service: RESTService', () => {
     })
   ));
 
-  it('expect to do an update succesfully with observables',
+  it('expect to do an update succesfully',
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         expect(connection.request.url)
@@ -482,7 +481,7 @@ describe('Service: RESTService', () => {
     })
   ));
 
-  it('expect to do a update failure with observables',
+  it('expect to do a update failure',
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockError(new Error('error'));
@@ -579,7 +578,7 @@ describe('Service: RESTService', () => {
     })
   ));
 
-  it('expect to do a delete failure with observables',
+  it('expect to do a delete failure',
     async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockError(new Error('error'));
@@ -601,7 +600,7 @@ describe('Service: RESTService', () => {
     })
   ));
 
-  it('expect to do a query succesfully with baseHeaders with observables',
+  it('expect to do a query succesfully with baseHeaders',
     async(inject([BaseHeadersTestRESTService, MockBackend],
                  (service: BaseHeadersTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
@@ -628,7 +627,7 @@ describe('Service: RESTService', () => {
     })
   ));
 
-  it('expect to do a query succesfully with dynamicHeaders with observables',
+  it('expect to do a query succesfully with dynamicHeaders',
     async(inject([DynamicHeadersTestRESTService, MockBackend],
                  (service: DynamicHeadersTestRESTService, mockBackend: MockBackend) => {
       mockBackend.connections.subscribe((connection: MockConnection) => {

--- a/src/platform/http/http-rest.service.ts
+++ b/src/platform/http/http-rest.service.ts
@@ -47,10 +47,13 @@ export abstract class RESTService<T> {
     this.transform = config.transform ? config.transform : (response: Response): any => response.json();
   }
 
-  public query(query?: IRestQuery): Observable<Array<T>> {
+  public query(query?: IRestQuery, transform?: IRestTransform): Observable<any> {
     let request: Observable<Response> = this.http.get(this.buildUrl(undefined, query), this.buildRequestOptions());
     return request.map((res: Response) => {
-      return <Array<T>>this.transform(res);
+      if (transform) {
+        return transform(res);
+      }
+      return this.transform(res);
     }).catch((error: Response) => {
       return new Observable<any>((subscriber: Subscriber<any>) => {
         try {
@@ -62,10 +65,13 @@ export abstract class RESTService<T> {
     });
   }
 
-  public get(id: string | number): Observable<T> {
+  public get(id: string | number, transform?: IRestTransform): Observable<any> {
     let request: Observable<Response> = this.http.get(this.buildUrl(id), this.buildRequestOptions());
     return request.map((res: Response) => {
-      return <T>this.transform(res);
+      if (transform) {
+        return transform(res);
+      }
+      return this.transform(res);
     }).catch((error: Response) => {
       return new Observable<any>((subscriber: Subscriber<any>) => {
         try {
@@ -77,12 +83,15 @@ export abstract class RESTService<T> {
     });
   }
 
-  public create(obj: T): Observable<T> {
+  public create(obj: T, transform?: IRestTransform): Observable<any> {
     let requestOptions: RequestOptionsArgs = this.buildRequestOptions();
     let request: Observable<Response> = this.http.post(this.buildUrl(), obj, requestOptions);
     return request.map((res: Response) => {
       if (res.status === 201) {
-        return <T>this.transform(res);
+        if (transform) {
+          return transform(res);
+        }
+        return this.transform(res);
       } else {
         return res;
       }
@@ -97,12 +106,15 @@ export abstract class RESTService<T> {
     });
   }
 
-  public update(id: string | number, obj: T): Observable<T> {
+  public update(id: string | number, obj: T, transform?: IRestTransform): Observable<any> {
     let requestOptions: RequestOptionsArgs = this.buildRequestOptions();
     let request: Observable<Response> = this.http.patch(this.buildUrl(id), obj, requestOptions);
     return request.map((res: Response) => {
       if (res.status === 200) {
-        return <T>this.transform(res);
+        if (transform) {
+          return transform(res);
+        }
+        return this.transform(res);
       } else {
         return res;
       }
@@ -117,11 +129,14 @@ export abstract class RESTService<T> {
     });
   }
 
-  public delete(id: string | number): Observable<T> {
+  public delete(id: string | number, transform?: IRestTransform): Observable<any> {
     let request: Observable<Response> = this.http.delete(this.buildUrl(id), this.buildRequestOptions());
     return request.map((res: Response) => {
       if (res.status === 200) {
-        return <T>this.transform(res);
+        if (transform) {
+          return transform(res);
+        }
+        return this.transform(res);
       } else {
         return res;
       }


### PR DESCRIPTION
## Description

There is a need to be able to override the service `transform` in the RESTService at a method level. So now you can pass a specific `transform` callback that overrides the service level `transform` function.
https://github.com/Teradata/covalent/issues/179

### What's included?

- REST Methods now accept an extra optional parameter for method level `IRestTransform` callback to allow more flexibility on response transformations
- Added new `onRequestError` hook to the `IHttpInterceptor` interface and usage in `HttpInterceptorService` (upstreamed from AC)
- Added `code-health` unit test to `RESTService`
- Updated docs and README.md

#### Test Steps

There is no real way to test it without actually using it, so the `unit-tests` should check if the `RESTService` acts like it should on every scenario.

- [ ] `ng serve`
- [ ] See updated docs in `http` module
- [ ] `ng serve` to see test the `RESTService` with its `http-rest.service.spec.ts`
