### PR TITLE
update(nav-list): remove non-spec box-shadow

### DIFF
--- a/src/app/components/layouts/manage-list/manage-list.component.html
+++ b/src/app/components/layouts/manage-list/manage-list.component.html
@@ -1,5 +1,8 @@
 <td-layout-nav logo="app/assets/icons/teradata.svg" toolbarTitle="Covalent">
   <td-layout-manage-list #list>
+    <md-toolbar list-items>
+      <span>Section Title</span>
+    </md-toolbar>
     <md-nav-list list-items>
       <a md-list-item (click)="list.toggle()">
         <md-icon>folder</md-icon>
@@ -19,6 +22,7 @@
       </a>
     </md-nav-list>
     <div toolbar-buttons layout="row" layout-align="start center" flex>
+      <span>Page Title</span>
       <span flex></span>
       <button md-button class="md-icon-button"><md-icon class="md-24">view_module</md-icon></button>
       <button md-button class="md-icon-button"><md-icon class="md-24">sort</md-icon></button>
@@ -103,6 +107,12 @@
                   </md-list-item>
                   <md-divider></md-divider>
                   <md-list-item>
+                    <h3 md-line><code><![CDATA[<md-toolbar list-items>]]></code></h3>
+                    <h3 md-line><code><![CDATA[<span>Optional Title</span>]]></code></h3>
+                    <p md-line>Optional list toolbar w/ title</p>
+                  </md-list-item>
+                  <md-divider></md-divider>
+                  <md-list-item>
                     <h3 md-line><code><![CDATA[<md-nav-list list-items>]]></code></h3>
                     <p md-line>The list items wrapper with optional <code>dense</code> attribute </p>
                   </md-list-item>
@@ -122,8 +132,8 @@
                   </md-list-item>
                   <md-divider></md-divider>
                   <md-list-item>
-                    <h3 md-line><code><![CDATA[<span>Title</span>]]></code></h3>
-                    <p md-line>Optional toolbar title</p>
+                    <h3 md-line><code><![CDATA[<span>Optional Subtitle</span>]]></code></h3>
+                    <p md-line>Optional subtitle</p>
                   </md-list-item>
                   <md-divider></md-divider>
                   <md-list-item>
@@ -153,6 +163,9 @@
                   </md-nav-list>
                   <td-layout-nav toolbarTitle="Toolbar Title" logo="path/to/toolbar-logo.svg">
                     <td-layout-manage-list #list>
+                      <md-toolbar list-items>
+                        <span>Optional Title</span>
+                      </md-toolbar>
                       <md-nav-list list-items>
                         <template let-item let-last="last" ngFor [ngForOf]="items">
                             <a md-list-item [routerLink]="[item.route]">
@@ -162,7 +175,7 @@
                         </template>
                       </md-nav-list>
                       <div toolbar-buttons layout="row" layout-align="start center" flex>
-                        <span>Optional Toolbar Title</span>
+                        <span>Optional Subtitle</span>
                         <span flex></span>
                         <button md-button class="md-icon-button"><md-icon class="md-24">more_vert</md-icon></button>
                       </div>

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.scss
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.scss
@@ -43,6 +43,9 @@
           visibility: visible;
           transform: translate3d(0, 0, 0);
         }
+        &.md-sidenav-opened {
+          box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2);
+        }
       }
       & > .md-sidenav-content {
         display: flex;

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.scss
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.scss
@@ -45,7 +45,10 @@
           visibility: visible;
           transform: translate3d(0, 0, 0);
         }
-        &.md-sidenav-opened {
+        &.md-sidenav-opened,
+        &.md-sidenav-opening,
+        &.md-sidenav-closed,
+        &.md-sidenav-closing {
           box-shadow: none;
         }
       }

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.scss
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.scss
@@ -12,6 +12,22 @@
       margin-left: 0 !important;
       flex-grow: 1;
     }
+    /* Ensure the left sidenav is a flex column & 100% height */
+    & > md-sidenav {
+        & > focus-trap {
+        &, & > div {
+          min-height: 100%;
+          height: 100%;
+          box-sizing: border-box;
+          display: -webkit-box;
+          display: -webkit-flex;
+          display: -moz-box;
+          display: -ms-flexbox;
+          display: flex;
+          flex-direction: column;
+        }
+      }
+    }
   }
   @media (min-width: 600px) {
     md-sidenav-layout.td-layout-nav-list {
@@ -28,6 +44,9 @@
         &.md-sidenav-closing {
           visibility: visible;
           transform: translate3d(0, 0, 0);
+        }
+        &.md-sidenav-opened {
+          box-shadow: none;
         }
       }
       & > .md-sidenav-content {


### PR DESCRIPTION
The left sidenav list is suppose to scroll while the left top toolbar sticks, and there's suppose to be no box shadow

### What's included?

- updated nav-list
- updated manage-list
- updated manage-list docs

#### Test Steps

- [x] ng-serve
- [x] view any layout w/ nav-list
- [x] view manage-list docs
- [x] test scrolling in left nav on all browsers

##### Screenshots or link to CodePen/Plunker/JSfiddle

![image](https://cloud.githubusercontent.com/assets/867883/21363461/51c71bba-c6b2-11e6-80f7-fef776cb5fa6.png)
![image](https://cloud.githubusercontent.com/assets/867883/21364371/2aa9b07a-c6b6-11e6-900c-cafe087de772.png)

