### PR TITLE
feature(deployment): `ghpages-deploy` npm command improvements

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -9,7 +9,7 @@
       "outDir": "dist",
       "assets": [
         "app/assets",
-        "app/platform/charts",
+        "platform/charts",
         "favicon.ico"
       ],
       "index": "index.html",

--- a/angular-cli.json
+++ b/angular-cli.json
@@ -9,6 +9,7 @@
       "outDir": "dist",
       "assets": [
         "app/assets",
+        "app/platform/charts",
         "favicon.ico"
       ],
       "index": "index.html",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "aot": "./node_modules/.bin/ngc -p src/platform/tsconfig-aot.json",
     "build": "bash scripts/build-release",
     "publish": "bash scripts/publish-release",
-    "ghpages-deploy": "ng build --base-href /covalent/ --aot -prod && bash scripts/ghpages-deploy",
+    "ghpages-deploy": "./node_modules/.bin/ng build --base-href /covalent/ --aot -prod && bash scripts/ghpages-deploy",
     "start-release": "bash scripts/start-release",
     "finish-release": "bash scripts/finish-release"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "aot": "./node_modules/.bin/ngc -p src/platform/tsconfig-aot.json",
     "build": "bash scripts/build-release",
     "publish": "bash scripts/publish-release",
-    "ghpages-deploy": "bash scripts/ghpages-deploy",
+    "ghpages-deploy": "ng build --base-href /covalent/ --aot -prod && bash scripts/ghpages-deploy",
     "start-release": "bash scripts/start-release",
     "finish-release": "bash scripts/finish-release"
   },

--- a/scripts/ghpages-deploy
+++ b/scripts/ghpages-deploy
@@ -1,10 +1,4 @@
 #!/bin/bash
-echo 'Checking out develop branch to base deployment from it.'
-git checkout develop
-
-echo 'Started building process.'
-ng build -prod
-
 git branch -f gh-pages
 git checkout gh-pages
 echo 'Created and Checked out gh-pages branch'
@@ -12,7 +6,6 @@ echo 'Created and Checked out gh-pages branch'
 git reset --hard origin/develop
 
 cp -r dist/* .
-sed -i '' 's:<base href=\"/\">:<base href=\"/covalent/\">:' index.html
 echo 'Copied dist/ directory into root dir and replaced <base href="/"> with <base href="/covalent/"> in index.html'
 
 echo 'Tracking files'

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -13,7 +13,7 @@ import { DocsAppComponent } from './app.component';
 describe('Component: App', () => {
 
   let generalResponses: Map<string, Response> = new Map<string, Response>();
-  generalResponses.set('/app/assets/icons/teradata.svg', new Response(new ResponseOptions({
+  generalResponses.set('app/assets/icons/teradata.svg', new Response(new ResponseOptions({
     status: 200, body: '<svg></svg>',
   })));
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -35,18 +35,18 @@ export class DocsAppComponent {
   constructor(private _iconRegistry: MdIconRegistry,
               private _domSanitizer: DomSanitizer) {
     this._iconRegistry.addSvgIconInNamespace('assets', 'teradata',
-      this._domSanitizer.bypassSecurityTrustResourceUrl('/app/assets/icons/teradata.svg'));
+      this._domSanitizer.bypassSecurityTrustResourceUrl('app/assets/icons/teradata.svg'));
     this._iconRegistry.addSvgIconInNamespace('assets', 'github',
-      this._domSanitizer.bypassSecurityTrustResourceUrl('/app/assets/icons/github.svg'));
+      this._domSanitizer.bypassSecurityTrustResourceUrl('app/assets/icons/github.svg'));
     this._iconRegistry.addSvgIconInNamespace('assets', 'covalent',
-      this._domSanitizer.bypassSecurityTrustResourceUrl('/app/assets/icons/covalent.svg'));
+      this._domSanitizer.bypassSecurityTrustResourceUrl('app/assets/icons/covalent.svg'));
     this._iconRegistry.addSvgIconInNamespace('assets', 'teradata-ux',
-      this._domSanitizer.bypassSecurityTrustResourceUrl('/app/assets/icons/teradata-ux.svg'));
+      this._domSanitizer.bypassSecurityTrustResourceUrl('app/assets/icons/teradata-ux.svg'));
     this._iconRegistry.addSvgIconInNamespace('assets', 'appcenter',
-      this._domSanitizer.bypassSecurityTrustResourceUrl('/app/assets/icons/appcenter.svg'));
+      this._domSanitizer.bypassSecurityTrustResourceUrl('app/assets/icons/appcenter.svg'));
     this._iconRegistry.addSvgIconInNamespace('assets', 'listener',
-      this._domSanitizer.bypassSecurityTrustResourceUrl('/app/assets/icons/listener.svg'));
+      this._domSanitizer.bypassSecurityTrustResourceUrl('app/assets/icons/listener.svg'));
     this._iconRegistry.addSvgIconInNamespace('assets', 'querygrid',
-      this._domSanitizer.bypassSecurityTrustResourceUrl('/app/assets/icons/querygrid.svg'));
+      this._domSanitizer.bypassSecurityTrustResourceUrl('app/assets/icons/querygrid.svg'));
   }
 }

--- a/src/app/components/docs/icons/icons.component.html
+++ b/src/app/components/docs/icons/icons.component.html
@@ -23,7 +23,7 @@
        constructor(private _iconRegistry: MdIconRegistry,
                    private _domSanitizer: DomSanitizer) {
          this._iconRegistry.addSvgIconInNamespace('assets', 'sun',
-           this._domSanitizer.bypassSecurityTrustResourceUrl('/app/assets/icons/sun.svg'));
+           this._domSanitizer.bypassSecurityTrustResourceUrl('app/assets/icons/sun.svg'));
        }
      ]]>
     </td-highlight>


### PR DESCRIPTION
## Description

Improved `ghpages-deploy` npm command to deploy it in `AoT`.

### What's included?

- Deploy `ghpages` in `AoT` compilation and `production` mode.
- Added `chart` data files into cli `assets`.
- Replaced base href with `--base-href` ng command.
- Use svg URL's relative path instead of absolute path.

#### Test Steps

- [ ] `npm run ghpages-deploy`

Note: if you have problems with the memory heap. Check the following `angular-cli` issue.
https://github.com/angular/angular-cli/issues/1652#issuecomment-261269197