### PR TITLE
bugfix(animations): explicitly used window.setTimeout. (closes #225)

### DIFF
--- a/src/platform/core/common/animations/fade/fade.directive.ts
+++ b/src/platform/core/common/animations/fade/fade.directive.ts
@@ -101,7 +101,7 @@ export class TdFadeDirective {
      * before the previous one ends. The onComplete event is not executed.
      * e.g.hide event started before show event is completed.
      */
-    this._timeoutNumber = setTimeout(() => {
+    this._timeoutNumber = window.setTimeout(() => {
       setTimeout(() => {
         this._renderer.setElementStyle(this._element.nativeElement, 'display', 'none');
       }, 0);
@@ -138,7 +138,7 @@ export class TdFadeDirective {
      * before the previous one ends. The onComplete event is not executed.
      * e.g. hide event started before show event is completed.
      */
-    this._timeoutNumber = setTimeout(() => {
+    this._timeoutNumber = window.setTimeout(() => {
       this._renderer.setElementStyle(this._element.nativeElement, 'display', this._defaultDisplay);
       this.fadeIn.emit(undefined);
       animation.destroy();

--- a/src/platform/core/common/animations/toggle/toggle.directive.ts
+++ b/src/platform/core/common/animations/toggle/toggle.directive.ts
@@ -92,7 +92,7 @@ export class TdToggleDirective {
      * before the previous one ends. The onComplete event is not executed.
      * e.g. hide event started before show event is completed.
      */
-    this._timeoutNumber = setTimeout(() => {
+    this._timeoutNumber = window.setTimeout(() => {
       this._renderer.setElementStyle(this._element.nativeElement, 'display', 'none');
       this._hiddenState = this._state;
       animation.destroy();
@@ -153,7 +153,7 @@ export class TdToggleDirective {
        * before the previous one ends. The onComplete event is not executed.
        * e.g. hide event started before show event is completed.
        */
-      this._timeoutNumber = setTimeout(() => {
+      this._timeoutNumber = window.setTimeout(() => {
         this._renderer.setElementStyle(this._element.nativeElement, 'display', this._defaultDisplay);
         animation.destroy();
       }, this.duration);


### PR DESCRIPTION
## Description

Depending on the `tsconfig.json`, `setTimeout` could be either `window.setTimeout` or `NodeJS.setTimeout`.. to avoid this, we have to explicitly call it from `window`.
https://github.com/Teradata/covalent/issues/225