### PR TITLE
bump(npm): released patch @0.10.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="0.10.1"></a>
+# [0.10.1](https://github.com/Teradata/covalent/tree/v0.10.0) (2017-1-2)
+
+## Bug Fixes
+* **animations:** Depending on the tsconfig.json, setTimeout could be either window.setTimeout or NodeJS.setTimeout. ([1cd3e49c62a3cc8b03f3f153fc3bb554061e495e](https://github.com/Teradata/covalent/commit/1cd3e49c62a3cc8b03f3f153fc3bb554061e495e)), closes [#225](https://github.com/Teradata/covalent/issues/225)
+* **http:** `rxjs` upgrade caused concurrent request failure. ([31a60cd0e322f2ab9190325381c08b4872414caa](https://github.com/Teradata/covalent/commit/31a60cd0e322f2ab9190325381c08b4872414caa))
+
+
 <a name="0.10.0"></a>
 # [0.10.0 Bedlington Cummerbund](https://github.com/Teradata/covalent/tree/v0.10.0) (2016-12-30)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "covalent",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "description": "Teradata UI Platform built on Angular Material 2",
   "keywords": [

--- a/src/platform/charts/package.json
+++ b/src/platform/charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/charts",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Teradata UI Platform Charts Module",
   "keywords": [
     "angular",
@@ -33,7 +33,7 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@covalent/core": "0.10.0",
+    "@covalent/core": "0.10.1",
     "d3": "^4.2.1"
   }
 }

--- a/src/platform/core/package.json
+++ b/src/platform/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Teradata UI Platform built on Angular Material 2",
   "keywords": [
     "angular",

--- a/src/platform/dynamic-forms/package.json
+++ b/src/platform/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/dynamic-forms",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Teradata UI Platform Dynamic Forms Module",
   "keywords": [
     "angular",
@@ -33,6 +33,6 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@covalent/core": "0.10.0"
+    "@covalent/core": "0.10.1"
   }
 }

--- a/src/platform/highlight/package.json
+++ b/src/platform/highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/highlight",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Teradata UI Platform Highlight Module",
   "keywords": [
     "angular",
@@ -33,7 +33,7 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@covalent/core": "0.10.0",
+    "@covalent/core": "0.10.1",
     "highlight.js": "9.6.0"
   }
 }

--- a/src/platform/http/package.json
+++ b/src/platform/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/http",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Teradata UI Platform Http Helper Module",
   "keywords": [
     "angular",

--- a/src/platform/markdown/package.json
+++ b/src/platform/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/markdown",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Teradata UI Platform Markdown Module",
   "keywords": [
     "angular",
@@ -31,7 +31,7 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@covalent/core": "0.10.0",
+    "@covalent/core": "0.10.1",
     "showdown": "1.4.2"
   }
 }


### PR DESCRIPTION
## Description

- Updated changelog for 0.10.1
- Contains bugfixes:
  - Solved request concurrency issue. https://github.com/Teradata/covalent/pull/228
  - Explicitly used window.setTimeout. https://github.com/Teradata/covalent/pull/227