### PR TITLE
bump(npm): released patch @0.10.2.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="0.10.2"></a>
+# [0.10.2](https://github.com/Teradata/covalent/tree/v0.10.0) (2017-1-3)
+
+## Bug Fixes
+* **http:** `interceptors` instead of `inteceptors` typo in `HttpConfig`. closes [#233](https://github.com/Teradata/covalent/issues/233)
+
+
 <a name="0.10.1"></a>
 # [0.10.1](https://github.com/Teradata/covalent/tree/v0.10.0) (2017-1-2)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "covalent",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "description": "Teradata UI Platform built on Angular Material 2",
   "keywords": [

--- a/src/platform/charts/package.json
+++ b/src/platform/charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/charts",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Teradata UI Platform Charts Module",
   "keywords": [
     "angular",
@@ -33,7 +33,7 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@covalent/core": "0.10.1",
+    "@covalent/core": "0.10.2",
     "d3": "^4.2.1"
   }
 }

--- a/src/platform/core/package.json
+++ b/src/platform/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/core",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Teradata UI Platform built on Angular Material 2",
   "keywords": [
     "angular",

--- a/src/platform/dynamic-forms/package.json
+++ b/src/platform/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/dynamic-forms",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Teradata UI Platform Dynamic Forms Module",
   "keywords": [
     "angular",
@@ -33,6 +33,6 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@covalent/core": "0.10.1"
+    "@covalent/core": "0.10.2"
   }
 }

--- a/src/platform/highlight/package.json
+++ b/src/platform/highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/highlight",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Teradata UI Platform Highlight Module",
   "keywords": [
     "angular",
@@ -33,7 +33,7 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@covalent/core": "0.10.1",
+    "@covalent/core": "0.10.2",
     "highlight.js": "9.6.0"
   }
 }

--- a/src/platform/http/http.module.ts
+++ b/src/platform/http/http.module.ts
@@ -6,10 +6,10 @@ import { URLRegExpInterceptorMatcher } from './interceptors/url-regexp-intercept
 
 export const HTTP_CONFIG: OpaqueToken = new OpaqueToken('HTTP_CONFIG');
 
-export type HttpConfig = {inteceptors: IHttpInterceptorConfig[]};
+export type HttpConfig = {interceptors: IHttpInterceptorConfig[]};
 
 export function httpFactory(http: Http, injector: Injector, config: HttpConfig): HttpInterceptorService {
-  return new HttpInterceptorService(http, injector, new URLRegExpInterceptorMatcher(), config.inteceptors);
+  return new HttpInterceptorService(http, injector, new URLRegExpInterceptorMatcher(), config.interceptors);
 }
 
 @NgModule({
@@ -18,7 +18,7 @@ export function httpFactory(http: Http, injector: Injector, config: HttpConfig):
   ],
 })
 export class CovalentHttpModule {
-  static forRoot(config: HttpConfig = {inteceptors: []}): ModuleWithProviders {
+  static forRoot(config: HttpConfig = {interceptors: []}): ModuleWithProviders {
     return {
       ngModule: CovalentHttpModule,
       providers: [{

--- a/src/platform/http/interceptors/http-interceptor.service.spec.ts
+++ b/src/platform/http/interceptors/http-interceptor.service.spec.ts
@@ -60,7 +60,7 @@ export class RequestRecoveryInterceptor {
 describe('Service: HttpInterceptor', () => {
 
   let config: HttpConfig = {
-    inteceptors: [{
+    interceptors: [{
       interceptor: ResponseOverrideInterceptor, paths: ['/url**'],
     }, {
       interceptor: RequestAuthInterceptor, paths: ['**'],

--- a/src/platform/http/package.json
+++ b/src/platform/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/http",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Teradata UI Platform Http Helper Module",
   "keywords": [
     "angular",

--- a/src/platform/markdown/package.json
+++ b/src/platform/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/markdown",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Teradata UI Platform Markdown Module",
   "keywords": [
     "angular",
@@ -31,7 +31,7 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@covalent/core": "0.10.1",
+    "@covalent/core": "0.10.2",
     "showdown": "1.4.2"
   }
 }


### PR DESCRIPTION
## Description

- Updated changelog for 0.10.2
- Contains bugfixes:
  - `inteceptors` typo fix in `HttpConfig`. https://github.com/Teradata/covalent/issues/233