### PR TITLE
bugfix(ts): changed `file.types` type to work with both ts 2.0 and 2.1. (closes #236)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,16 +51,16 @@
     "Ilsun Park <ilsun.park@teradata.com>"
   ],
   "dependencies": {
-    "@angular/common": "^2.4.1",
-    "@angular/compiler": "^2.4.1",
-    "@angular/core": "^2.4.1",
-    "@angular/forms": "^2.4.1",
-    "@angular/http": "^2.4.1",
+    "@angular/common": "^2.4.2",
+    "@angular/compiler": "^2.4.2",
+    "@angular/core": "^2.4.2",
+    "@angular/forms": "^2.4.2",
+    "@angular/http": "^2.4.2",
     "@angular/material": "2.0.0-beta.1",
-    "@angular/platform-browser": "^2.4.1",
-    "@angular/platform-browser-dynamic": "^2.4.1",
-    "@angular/platform-server": "^2.4.1",
-    "@angular/router": "^3.4.1",
+    "@angular/platform-browser": "^2.4.2",
+    "@angular/platform-browser-dynamic": "^2.4.2",
+    "@angular/platform-server": "^2.4.2",
+    "@angular/router": "^3.4.2",
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
     "highlight.js": "9.6.0",
@@ -70,7 +70,7 @@
     "d3": "^4.2.1"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "^2.4.1",
+    "@angular/compiler-cli": "^2.4.2",
     "@types/hammerjs": "^2.0.30",
     "@types/jasmine": "^2.2.31",
     "@types/node": "^6.0.34",
@@ -87,7 +87,7 @@
     "gulp-if": "2.0.1",
     "gulp-sass": "2.3.2",
     "gulp-sourcemaps": "1.6.0",
-    "gulp-typescript": "3.0.1",
+    "gulp-typescript": "3.1.4",
     "gulp-util": "3.0.7",
     "jasmine-core": "^2.4.1",
     "jasmine-spec-reporter": "2.5.0",
@@ -110,6 +110,6 @@
     "semver": "5.2.0",
     "ts-node": "1.2.1",
     "tslint": "^3.15.1",
-    "typescript": "2.0.10"
+    "typescript": "2.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@types/selenium-webdriver": "^2.52.0",
     "angular-cli": "1.0.0-beta.24",
     "awesome-typescript-loader": "^2.2.4",
-    "codelyzer": "~0.0.26",
+    "codelyzer": "2.0.0-beta.4",
     "coveralls": "^2.11.15",
     "ember-cli-inject-live-reload": "1.4.0",
     "glob": "^6.0.4",
@@ -109,7 +109,7 @@
     "sass-loader": "^4.0.2",
     "semver": "5.2.0",
     "ts-node": "1.2.1",
-    "tslint": "^3.15.1",
+    "tslint": "^4.1.1",
     "typescript": "2.1.4"
   }
 }

--- a/scripts/compile-ts.js
+++ b/scripts/compile-ts.js
@@ -25,7 +25,11 @@ var tsProject = ts.createProject({
       ],
       types: [
         "jasmine", "hammerjs", "rxjs"
-      ]
+      ],
+      noUnusedParameters: false,
+      noUnusedLocals: false,
+      allowUnreachableCode: false,
+      pretty: true
     });
 
 gulp.task('compile-ts', 'Build the UDA scripts', function() {

--- a/src/app/app.animations.ts
+++ b/src/app/app.animations.ts
@@ -6,7 +6,7 @@ export const fadeAnimation: AnimationEntryMetadata =
     state('*',
       style({
         opacity: 1,
-      })
+      }),
     ),
     transition(':enter', [
       style({
@@ -26,7 +26,7 @@ export const slideInLeftAnimation: AnimationEntryMetadata =
       style({
         opacity: 1,
         transform: 'translateX(0)',
-      })
+      }),
     ),
     transition(':enter', [
       style({
@@ -48,7 +48,7 @@ export const slideInDownAnimation: AnimationEntryMetadata =
       style({
         opacity: 1,
         transform: 'translateY(0)',
-      })
+      }),
     ),
     transition(':enter', [
       style({

--- a/src/platform/charts/charts.component.ts
+++ b/src/platform/charts/charts.component.ts
@@ -132,7 +132,7 @@ export class TdXAxisComponent {
       .attr('transform', 'translate(0,' + this._parent.height + ')')
       .call(d3.axisBottom(x)
             .tickSize(-this._parent.height)
-            .tickFormat('')
+            .tickFormat(''),
       );
     svg.append('text')
       .attr('display', this.show ? 'display' : 'none')

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -17,7 +17,7 @@ export const TD_DATA_TABLE_CONTROL_VALUE_ACCESSOR: any = {
 
 export enum TdDataTableSortingOrder {
   Ascending = <any>'ASC',
-  Descending = <any>'DESC'
+  Descending = <any>'DESC',
 };
 
 export interface ITdDataTableColumn {
@@ -225,7 +225,7 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
     for (let i: number = 0; i < this._templates.toArray().length; i++) {
       this._templateMap.set(
         this._templates.toArray()[i].tdDataTableTemplate,
-        this._templates.toArray()[i].templateRef
+        this._templates.toArray()[i].templateRef,
       );
     }
   }

--- a/src/platform/core/file/directives/file-drop.directive.spec.ts
+++ b/src/platform/core/file/directives/file-drop.directive.spec.ts
@@ -1,0 +1,233 @@
+import {
+  TestBed,
+  inject,
+  async,
+  ComponentFixture,
+} from '@angular/core/testing';
+import { Component, DebugElement } from '@angular/core';
+import { CovalentFileModule, TdFileDropDirective } from '../file.module';
+import { By } from '@angular/platform-browser';
+
+describe('Directive: FileDrop', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TdFileDropBasicTestComponent,
+      ],
+      imports: [
+        CovalentFileModule.forRoot(),
+      ],
+    });
+    TestBed.compileComponents();
+  }));
+
+  it('should add/remove class on dragenter and dragleave',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileDropBasicTestComponent);
+      let component: TdFileDropBasicTestComponent = fixture.debugElement.componentInstance;
+      component.multiple = false;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        let directive: DebugElement = fixture.debugElement.query(By.directive(TdFileDropDirective));
+        directive.triggerEventHandler('dragenter', new Event('dragenter'));
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(directive.classes['drop-zone']).toBeTruthy();
+          directive.triggerEventHandler('dragleave', new Event('dragleave'));
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(directive.classes['drop-zone']).toBeFalsy();
+          });
+        });
+      });
+  })));
+
+  it('should disable element and not add class on dragenter',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileDropBasicTestComponent);
+      let component: TdFileDropBasicTestComponent = fixture.debugElement.componentInstance;
+      component.disabled = true;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        let directive: DebugElement = fixture.debugElement.query(By.directive(TdFileDropDirective));
+        directive.triggerEventHandler('dragenter', new Event('dragenter'));
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(directive.classes['drop-zone']).toBeFalsy();
+        });
+      });
+  })));
+
+  it('should throw dragover event and add copy dropEffect for a single file',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileDropBasicTestComponent);
+      let component: TdFileDropBasicTestComponent = fixture.debugElement.componentInstance;
+      component.multiple = false;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        let directive: DebugElement = fixture.debugElement.query(By.directive(TdFileDropDirective));
+        let event: any = <DragEvent>new Event('dragover');
+        event.dataTransfer = {
+          dropEffect: 'none',
+          types: ['Files'],
+          items: ['file-name.txt'],
+        };
+        directive.triggerEventHandler('dragover', event);
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(event.dataTransfer.dropEffect).toBe('copy');
+        });
+      });
+  })));
+
+  it('should throw dragover event and not add copy dropEffect for a multiple file',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileDropBasicTestComponent);
+      let component: TdFileDropBasicTestComponent = fixture.debugElement.componentInstance;
+      component.multiple = false;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        let directive: DebugElement = fixture.debugElement.query(By.directive(TdFileDropDirective));
+        let event: any = <DragEvent>new Event('dragover');
+        event.dataTransfer = {
+          dropEffect: 'none',
+          types: ['Files'],
+          items: ['file-name.txt', 'file-name1.txt'],
+        };
+        directive.triggerEventHandler('dragover', event);
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(event.dataTransfer.dropEffect).toBe('none');
+        });
+      });
+  })));
+
+  it('should throw dragover event and add copy dropEffect for a multiple file',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileDropBasicTestComponent);
+      let component: TdFileDropBasicTestComponent = fixture.debugElement.componentInstance;
+      component.multiple = true;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        let directive: DebugElement = fixture.debugElement.query(By.directive(TdFileDropDirective));
+        let event: any = <DragEvent>new Event('dragover');
+        event.dataTransfer = {
+          dropEffect: 'none',
+          types: ['Files'],
+          items: ['file-name.txt', 'file-name1.txt'],
+        };
+        directive.triggerEventHandler('dragover', event);
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(event.dataTransfer.dropEffect).toBe('copy');
+        });
+      });
+  })));
+
+  it('should throw dragover event and not add copy dropEffect on disabled state',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileDropBasicTestComponent);
+      let component: TdFileDropBasicTestComponent = fixture.debugElement.componentInstance;
+      component.multiple = false;
+      component.disabled = true;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        let directive: DebugElement = fixture.debugElement.query(By.directive(TdFileDropDirective));
+        let event: any = <DragEvent>new Event('dragover');
+        event.dataTransfer = {
+          dropEffect: 'none',
+          types: ['Files'],
+          items: ['file-name.txt'],
+        };
+        directive.triggerEventHandler('dragover', event);
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(event.dataTransfer.dropEffect).toBe('none');
+        });
+      });
+  })));
+
+  it('should throw ondrop event for a single file',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileDropBasicTestComponent);
+      let component: TdFileDropBasicTestComponent = fixture.debugElement.componentInstance;
+      component.multiple = false;
+      expect(component.files).toBeFalsy();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        let directive: DebugElement = fixture.debugElement.query(By.directive(TdFileDropDirective));
+        let event: any = <DragEvent>new Event('drop');
+        event.dataTransfer = {
+          files: [{}],
+        };
+        directive.triggerEventHandler('drop', event);
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(component.files).toBeTruthy();
+        });
+      });
+  })));
+
+  it('should throw ondrop event for a multiple files',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileDropBasicTestComponent);
+      let component: TdFileDropBasicTestComponent = fixture.debugElement.componentInstance;
+      component.multiple = true;
+      expect(component.files).toBeFalsy();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        let directive: DebugElement = fixture.debugElement.query(By.directive(TdFileDropDirective));
+        let event: any = <DragEvent>new Event('drop');
+        event.dataTransfer = {
+          files: [{}, {}],
+        };
+        directive.triggerEventHandler('drop', event);
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect((<FileList>component.files).length).toBe(2);
+        });
+      });
+  })));
+
+  it('should not throw ondrop event for disabled state',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileDropBasicTestComponent);
+      let component: TdFileDropBasicTestComponent = fixture.debugElement.componentInstance;
+      component.disabled = true;
+      expect(component.files).toBeFalsy();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        let directive: DebugElement = fixture.debugElement.query(By.directive(TdFileDropDirective));
+        let event: any = <DragEvent>new Event('drop');
+        event.dataTransfer = {
+          files: [{}],
+        };
+        directive.triggerEventHandler('drop', event);
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(component.files).toBeFalsy();
+        });
+      });
+  })));
+
+});
+
+@Component({
+  selector: 'td-file-drop-basic-test',
+  template: `
+  <div tdFileDrop
+       [multiple]="multiple" 
+       [disabled]="disabled"
+       (fileDrop)="files = $event">
+  
+  </div>
+  `,
+})
+class TdFileDropBasicTestComponent {
+  multiple: boolean;
+  disabled: boolean;
+  files: FileList | File;
+}
+
+

--- a/src/platform/core/file/directives/file-drop.directive.spec.ts
+++ b/src/platform/core/file/directives/file-drop.directive.spec.ts
@@ -229,5 +229,3 @@ class TdFileDropBasicTestComponent {
   disabled: boolean;
   files: FileList | File;
 }
-
-

--- a/src/platform/core/file/directives/file-drop.directive.ts
+++ b/src/platform/core/file/directives/file-drop.directive.ts
@@ -116,10 +116,10 @@ export class TdFileDropDirective {
   /**
    * Validates if the transfer item types are 'Files'.
    */
-  private _typeCheck(types: DOMStringList): string {
+  private _typeCheck(types: string[] | DOMStringList): string {
     let dropEffect: string = 'none';
     if (types) {
-      if ((types.contains && types.contains('Files'))
+      if (((<any>types).contains && (<any>types).contains('Files'))
       || ((<any>types).indexOf && (<any>types).indexOf('Files') !== -1)) {
         dropEffect = 'copy';
       }

--- a/src/platform/core/file/directives/file-select.directive.spec.ts
+++ b/src/platform/core/file/directives/file-select.directive.spec.ts
@@ -1,0 +1,68 @@
+import {
+  TestBed,
+  inject,
+  async,
+  ComponentFixture,
+} from '@angular/core/testing';
+import { Component, DebugElement } from '@angular/core';
+import { CovalentFileModule, TdFileSelectDirective } from '../file.module';
+import { By } from '@angular/platform-browser';
+
+describe('Directive: FileSelect', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TdFileSelectBasicTestComponent,
+      ],
+      imports: [
+        CovalentFileModule.forRoot(),
+      ],
+    });
+    TestBed.compileComponents();
+  }));
+
+  it('should add multiple attr',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileSelectBasicTestComponent);
+      let component: TdFileSelectBasicTestComponent = fixture.debugElement.componentInstance;
+      component.multiple = true;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        let directive: DebugElement = fixture.debugElement.query(By.directive(TdFileSelectDirective));
+        expect((<any>directive.attributes).multiple).toBeDefined();
+      });
+  })));
+
+  it('should throw (fileSelect) event for a single file',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileSelectBasicTestComponent);
+      let component: TdFileSelectBasicTestComponent = fixture.debugElement.componentInstance;
+      component.multiple = false;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        let directive: DebugElement = fixture.debugElement.query(By.directive(TdFileSelectDirective));
+        directive.triggerEventHandler('change', {
+          target: directive.nativeElement,
+        });
+      });
+  })));
+
+});
+
+@Component({
+  selector: 'td-file-select-basic-test',
+  template: `
+  <input tdFileSelect
+         type="file"
+         [multiple]="multiple" 
+         (fileSelect)="files = $event">
+  `,
+})
+class TdFileSelectBasicTestComponent {
+  multiple: boolean;
+  disabled: boolean;
+  files: FileList | File;
+}
+
+

--- a/src/platform/core/file/directives/file-select.directive.spec.ts
+++ b/src/platform/core/file/directives/file-select.directive.spec.ts
@@ -64,5 +64,3 @@ class TdFileSelectBasicTestComponent {
   disabled: boolean;
   files: FileList | File;
 }
-
-

--- a/src/platform/core/file/file-upload.component.html
+++ b/src/platform/core/file/file-upload.component.html
@@ -1,6 +1,7 @@
 <div>
   <div *ngIf="!files">
     <button md-raised-button
+            class="td-file-browse"
             type="button"
             [color]="defaultColor" 
             [multiple]="multiple" 
@@ -23,7 +24,8 @@
            tdFileSelect>
   </div>
   <div *ngIf="files" layout="row">
-    <button #fileUpload 
+    <button #fileUpload
+            class="td-file-upload"
             md-raised-button
             type="button"
             [color]="activeColor"

--- a/src/platform/core/file/file-upload.component.spec.ts
+++ b/src/platform/core/file/file-upload.component.spec.ts
@@ -1,0 +1,118 @@
+import {
+  TestBed,
+  inject,
+  async,
+  ComponentFixture,
+} from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { CovalentFileModule, TdFileUploadComponent } from './file.module';
+import { By } from '@angular/platform-browser';
+
+describe('Component: FileUpload', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TdFileUploadBasicTestComponent,
+      ],
+      imports: [
+        CovalentFileModule.forRoot(),
+      ],
+    });
+    TestBed.compileComponents();
+  }));
+
+  it('should mimic file selection and then clear it',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileUploadBasicTestComponent);
+      let component: TdFileUploadBasicTestComponent = fixture.debugElement.componentInstance;
+      component.multiple = false;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(fixture.debugElement.query(By.css('.td-file-browse'))).toBeTruthy();
+        expect(fixture.debugElement.query(By.css('.td-file-upload'))).toBeFalsy();
+        fixture.debugElement.query(By.directive(TdFileUploadComponent)).componentInstance.files = [{}];
+        fixture.debugElement.query(By.css('.td-file-browse')).triggerEventHandler('click', new Event('click'));
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(fixture.debugElement.query(By.css('.td-file-browse'))).toBeFalsy();
+          expect(fixture.debugElement.query(By.css('.td-file-upload'))).toBeTruthy();
+          fixture.debugElement.query(By.css('.td-file-cancel')).triggerEventHandler('click', new Event('click'));
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(fixture.debugElement.query(By.css('.td-file-browse'))).toBeTruthy();
+            expect(fixture.debugElement.query(By.css('.td-file-upload'))).toBeFalsy();
+            expect(fixture.debugElement.query(By.directive(TdFileUploadComponent)).componentInstance.files)
+            .toBeUndefined();
+          });
+        });
+      });
+  })));
+
+  it('should mimic file selection and then clear it by disabling it',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileUploadBasicTestComponent);
+      let component: TdFileUploadBasicTestComponent = fixture.debugElement.componentInstance;
+      component.multiple = false;
+      component.disabled = false;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(fixture.debugElement.query(By.css('.td-file-browse'))).toBeTruthy();
+        expect(fixture.debugElement.query(By.css('.td-file-upload'))).toBeFalsy();
+        fixture.debugElement.query(By.directive(TdFileUploadComponent)).componentInstance.files = [{}];
+        fixture.debugElement.query(By.css('.td-file-browse')).triggerEventHandler('click', new Event('click'));
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(fixture.debugElement.query(By.css('.td-file-browse'))).toBeFalsy();
+          expect(fixture.debugElement.query(By.css('.td-file-upload'))).toBeTruthy();
+          component.disabled = true;
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(fixture.debugElement.query(By.css('.td-file-browse'))).toBeTruthy();
+            expect(fixture.debugElement.query(By.css('.td-file-upload'))).toBeFalsy();
+            expect(component.files).toBeUndefined();
+          });
+        });
+      });
+  })));
+
+  it('should mimic file selection and then upload it',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdFileUploadBasicTestComponent);
+      let component: TdFileUploadBasicTestComponent = fixture.debugElement.componentInstance;
+      component.multiple = false;
+      component.disabled = false;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(fixture.debugElement.query(By.css('.td-file-browse'))).toBeTruthy();
+        expect(fixture.debugElement.query(By.css('.td-file-upload'))).toBeFalsy();
+        fixture.debugElement.query(By.directive(TdFileUploadComponent)).componentInstance.files = [{}];
+        fixture.debugElement.query(By.css('.td-file-browse')).triggerEventHandler('click', new Event('click'));
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(fixture.debugElement.query(By.css('.td-file-browse'))).toBeFalsy();
+          expect(fixture.debugElement.query(By.css('.td-file-upload'))).toBeTruthy();
+          fixture.debugElement.query(By.css('.td-file-upload')).triggerEventHandler('click', new Event('click'));
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(component.files).toBeTruthy();
+          });
+        });
+      });
+  })));
+
+});
+
+@Component({
+  selector: 'td-file-upload-basic-test',
+  template: `
+  <td-file-upload [multiple]="multiple" [disabled]="disabled" (upload)="files = $event">
+  </td-file-upload>
+  `,
+})
+class TdFileUploadBasicTestComponent {
+  accept: string;
+  multiple: boolean;
+  disabled: boolean;
+  files: File | FileList;
+}

--- a/src/platform/core/file/file-upload.component.ts
+++ b/src/platform/core/file/file-upload.component.ts
@@ -2,7 +2,6 @@ import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from 
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
-
   selector: 'td-file-upload',
   styleUrls: ['./file-upload.component.scss'],
   templateUrl: './file-upload.component.html',

--- a/src/platform/core/loading/loading.component.ts
+++ b/src/platform/core/loading/loading.component.ts
@@ -4,12 +4,12 @@ import { Observable } from 'rxjs/Observable';
 
 export enum LoadingType {
   Circular = <any>'circular',
-  Linear = <any>'linear'
+  Linear = <any>'linear',
 }
 
 export enum LoadingMode {
   Determinate = <any>'determinate',
-  Indeterminate = <any>'indeterminate'
+  Indeterminate = <any>'indeterminate',
 }
 
 @Component({

--- a/src/platform/core/steps/step.component.ts
+++ b/src/platform/core/steps/step.component.ts
@@ -6,7 +6,7 @@ import { TemplatePortalDirective, TemplatePortal } from '@angular/material';
 export enum StepState {
   None = <any>'none',
   Required = <any>'required',
-  Complete = <any>'complete'
+  Complete = <any>'complete',
 }
 
 @Directive({

--- a/src/platform/core/steps/steps.component.ts
+++ b/src/platform/core/steps/steps.component.ts
@@ -12,7 +12,7 @@ export interface IStepChangeEvent {
 
 export enum StepMode {
   Vertical = <any>'vertical',
-  Horizontal = <any>'horizontal'
+  Horizontal = <any>'horizontal',
 }
 
 @Component({

--- a/src/platform/dynamic-forms/services/dynamic-forms.service.spec.ts
+++ b/src/platform/dynamic-forms/services/dynamic-forms.service.spec.ts
@@ -46,7 +46,7 @@ describe('Service: TdDynamicFormsService', () => {
         expect(false).toBeTruthy('normal@22-name_22 name should not be validated correctly');
       } catch (e) { /* */ }
 
-    })
+    }),
   ));
 
   it('expect to return components depending on type | element',
@@ -69,7 +69,7 @@ describe('Service: TdDynamicFormsService', () => {
       } catch (e) {
         expect(e).toBeTruthy();
       }
-    })
+    }),
   ));
 
   it('expect to return default flex depending on type | element',
@@ -92,7 +92,7 @@ describe('Service: TdDynamicFormsService', () => {
       } catch (e) {
         expect(e).toBeTruthy();
       }
-    })
+    }),
   ));
 
 });

--- a/src/platform/http/http-rest.service.spec.ts
+++ b/src/platform/http/http-rest.service.spec.ts
@@ -89,7 +89,7 @@ describe('Service: RESTService', () => {
         expect(connection.request.method).toBe(RequestMethod.Get, 'request didnt have GET method');
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -106,7 +106,7 @@ describe('Service: RESTService', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
-    })
+    }),
   ));
 
   it('expect to do a query and use the service transform() and then override it with a method transform()',
@@ -115,7 +115,7 @@ describe('Service: RESTService', () => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -152,7 +152,7 @@ describe('Service: RESTService', () => {
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
 
-    })
+    }),
   ));
 
   it('expect to do a query failure',
@@ -174,7 +174,7 @@ describe('Service: RESTService', () => {
       expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
       expect(error).toBe(true, 'on error didnt execute with observables');
       expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
-    })
+    }),
   ));
 
   it('expect to do a query with parameters succesfully',
@@ -186,7 +186,7 @@ describe('Service: RESTService', () => {
         expect(connection.request.method).toBe(RequestMethod.Get, 'request didnt have GET method');
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -207,7 +207,7 @@ describe('Service: RESTService', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
-    })
+    }),
   ));
 
   it('expect to do a get succesfully',
@@ -219,7 +219,7 @@ describe('Service: RESTService', () => {
         expect(connection.request.method).toBe(RequestMethod.Get, 'request didnt have GET method');
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -236,7 +236,7 @@ describe('Service: RESTService', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
-    })
+    }),
   ));
 
   it('expect to do a get and use the service transform() and then override it with a method transform()',
@@ -245,7 +245,7 @@ describe('Service: RESTService', () => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -282,7 +282,7 @@ describe('Service: RESTService', () => {
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
 
-    })
+    }),
   ));
 
   it('expect to do a get failure',
@@ -304,7 +304,7 @@ describe('Service: RESTService', () => {
       expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
       expect(error).toBe(true, 'on error didnt execute with observables');
       expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
-    })
+    }),
   ));
 
   it('expect to do a create succesfully',
@@ -317,7 +317,7 @@ describe('Service: RESTService', () => {
         expect(connection.request.getBody()).toBe('data', 'request didnt have the body');
         connection.mockRespond(new Response(new ResponseOptions({
             status: 201,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -334,7 +334,7 @@ describe('Service: RESTService', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
-    })
+    }),
   ));
 
   it('expect to do a create and use the service transform() and then override it with a method transform()',
@@ -343,7 +343,7 @@ describe('Service: RESTService', () => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockRespond(new Response(new ResponseOptions({
             status: 201,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -380,7 +380,7 @@ describe('Service: RESTService', () => {
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
 
-    })
+    }),
   ));
 
   it('expect to do a create failure',
@@ -402,7 +402,7 @@ describe('Service: RESTService', () => {
       expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
       expect(error).toBe(true, 'on error didnt execute with observables');
       expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
-    })
+    }),
   ));
 
   it('expect to do an update succesfully',
@@ -415,7 +415,7 @@ describe('Service: RESTService', () => {
         expect(connection.request.getBody()).toBe('data', 'request didnt have the body');
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -432,7 +432,7 @@ describe('Service: RESTService', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
-    })
+    }),
   ));
 
   it('expect to do an update and use the service transform() and then override it with a method transform()',
@@ -441,7 +441,7 @@ describe('Service: RESTService', () => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -478,7 +478,7 @@ describe('Service: RESTService', () => {
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
 
-    })
+    }),
   ));
 
   it('expect to do a update failure',
@@ -500,7 +500,7 @@ describe('Service: RESTService', () => {
       expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
       expect(error).toBe(true, 'on error didnt execute with observables');
       expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
-    })
+    }),
   ));
 
   it('expect to do a delete succesfully with observables',
@@ -512,7 +512,7 @@ describe('Service: RESTService', () => {
         expect(connection.request.method).toBe(RequestMethod.Delete, 'request didnt have DELETE method');
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -529,7 +529,7 @@ describe('Service: RESTService', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
-    })
+    }),
   ));
 
   it('expect to do a delete and use the service transform() and then override it with a method transform()',
@@ -538,7 +538,7 @@ describe('Service: RESTService', () => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -575,7 +575,7 @@ describe('Service: RESTService', () => {
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
 
-    })
+    }),
   ));
 
   it('expect to do a delete failure',
@@ -597,7 +597,7 @@ describe('Service: RESTService', () => {
       expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
       expect(error).toBe(true, 'on error didnt execute with observables');
       expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
-    })
+    }),
   ));
 
   it('expect to do a query succesfully with baseHeaders',
@@ -607,7 +607,7 @@ describe('Service: RESTService', () => {
         expect(connection.request.headers.get('header')).toBe('value', 'request didnt have baseHeaders');
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -624,7 +624,7 @@ describe('Service: RESTService', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
-    })
+    }),
   ));
 
   it('expect to do a query succesfully with dynamicHeaders',
@@ -634,7 +634,7 @@ describe('Service: RESTService', () => {
         expect(connection.request.headers.get('header')).toBe('value', 'request didnt have dynamicHeaders');
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -651,6 +651,6 @@ describe('Service: RESTService', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
-    })
+    }),
   ));
 });

--- a/src/platform/http/interceptors/http-interceptor.service.spec.ts
+++ b/src/platform/http/interceptors/http-interceptor.service.spec.ts
@@ -104,7 +104,7 @@ describe('Service: HttpInterceptor', () => {
         }
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
 
@@ -117,7 +117,7 @@ describe('Service: HttpInterceptor', () => {
       .map((res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBe('recovered', '/error/*/fromerror was not intercepted');
       });
-    })
+    }),
   ));
 
   it('expect to intercept only the route with `/error` and fail',
@@ -125,7 +125,7 @@ describe('Service: HttpInterceptor', () => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
 
@@ -135,7 +135,7 @@ describe('Service: HttpInterceptor', () => {
       }, (error: any) => {
         expect(error).toBe('error');
       });
-    })
+    }),
   ));
 
   it('expect to intercept all routes and add an `auth=test-auth` header',
@@ -144,7 +144,7 @@ describe('Service: HttpInterceptor', () => {
         expect(connection.request.headers.get('auth')).toBe('test-auth', 'didnt add `auth` header on all routes');
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
 
@@ -187,7 +187,7 @@ describe('Service: HttpInterceptor', () => {
       .map((res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBeTruthy();
       });
-    })
+    }),
   ));
 
   it('expect to intercept routes that contain `/url` in them and override responses body with `override`',
@@ -195,7 +195,7 @@ describe('Service: HttpInterceptor', () => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
 
@@ -238,7 +238,7 @@ describe('Service: HttpInterceptor', () => {
       .map((res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBe('success', 'intercepted url without `/url`');
       });
-    })
+    }),
   ));
 
 });
@@ -270,7 +270,7 @@ describe('Service: HttpInterceptor', () => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -291,7 +291,7 @@ describe('Service: HttpInterceptor', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
-    })
+    }),
   ));
 
   it('expect to do a post succesfully with observables',
@@ -299,7 +299,7 @@ describe('Service: HttpInterceptor', () => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -316,7 +316,7 @@ describe('Service: HttpInterceptor', () => {
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
-    })
+    }),
   ));
 
   it('expect to do a post failure with observables',
@@ -338,7 +338,7 @@ describe('Service: HttpInterceptor', () => {
       expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
       expect(error).toBe(true, 'on error didnt execute with observables');
       expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
-    })
+    }),
   ));
 
   it('expect to do a post succesfully with promises',
@@ -346,7 +346,7 @@ describe('Service: HttpInterceptor', () => {
       mockBackend.connections.subscribe((connection: MockConnection) => {
         connection.mockRespond(new Response(new ResponseOptions({
             status: 200,
-            body: JSON.stringify('success')}
+            body: JSON.stringify('success')},
         )));
       });
       let success: boolean = false;
@@ -361,7 +361,7 @@ describe('Service: HttpInterceptor', () => {
         expect(success).toBe(true, 'on success didnt execute with promises');
         expect(error).toBe(false, 'on error executed when it shouldnt have with promises');
       });
-    })
+    }),
   ));
 
   it('expect to do a post failure with promises',
@@ -381,6 +381,6 @@ describe('Service: HttpInterceptor', () => {
         expect(success).toBe(false, 'on success execute when it shouldnt have with promises');
         expect(error).toBe(true, 'on error didnt execute with promises');
       });
-    })
+    }),
   ));
 });

--- a/src/platform/http/interceptors/url-regexp-interceptor-matcher.class.spec.ts
+++ b/src/platform/http/interceptors/url-regexp-interceptor-matcher.class.spec.ts
@@ -10,138 +10,138 @@ describe('Http: URLRegExpInterceptorMatcher', () => {
   it('should match all URLs', () => {
     expect(matcher.matches(
       {url: 'www.google.com/path/1_1_-_1/ano111_ther/11-22?query=1&query=2'},
-      {interceptor: undefined, paths: ['**']}
+      {interceptor: undefined, paths: ['**']},
     )).toBeTruthy();
     expect(matcher.matches(
       {url: 'www.google.com/path/111/another/11-22'},
-      {interceptor: undefined, paths: ['**']}
+      {interceptor: undefined, paths: ['**']},
     )).toBeTruthy();
     expect(matcher.matches(
       {url: 'www.google.com/path'},
-      {interceptor: undefined, paths: ['**']}
+      {interceptor: undefined, paths: ['**']},
     )).toBeTruthy();
     expect(matcher.matches(
       {url: 'www.google.com?'},
-      {interceptor: undefined, paths: ['**']}
+      {interceptor: undefined, paths: ['**']},
     )).toBeTruthy();
     expect(matcher.matches(
       {url: 'www.google.com/path/1_1_-_1/?query=1&query=2'},
-      {interceptor: undefined, paths: ['**']}
+      {interceptor: undefined, paths: ['**']},
     )).toBeTruthy();
   });
 
   it('should match routes that contain with /apps or /sys', () => {
     expect(matcher.matches(
       {url: 'www.google.com/apps/1_1_-_1/ano111_ther/11-22?query=1&query=2'},
-      {interceptor: undefined, paths: ['/apps**', '/sys**']}
+      {interceptor: undefined, paths: ['/apps**', '/sys**']},
     )).toBeTruthy();
     expect(matcher.matches(
       {url: 'www.google.com/path/111/sys/11-22'},
-      {interceptor: undefined, paths: ['/apps**', '/sys**']}
+      {interceptor: undefined, paths: ['/apps**', '/sys**']},
     )).toBeTruthy();
     expect(matcher.matches(
       {url: 'www.google.com/apps'},
-      {interceptor: undefined, paths: ['/apps**', '/sys**']}
+      {interceptor: undefined, paths: ['/apps**', '/sys**']},
     )).toBeTruthy();
     expect(matcher.matches(
       {url: 'www.google.com?'},
-      {interceptor: undefined, paths: ['/apps**', '/sys**']}
+      {interceptor: undefined, paths: ['/apps**', '/sys**']},
     )).toBeFalsy();
     expect(matcher.matches(
       {url: 'www.google.com/path/1_1_-_1/?query=1&query=2'},
-      {interceptor: undefined, paths: ['/apps**', '/sys**']}
+      {interceptor: undefined, paths: ['/apps**', '/sys**']},
     )).toBeFalsy();
   });
 
   it('should match routes that end with /apps', () => {
     expect(matcher.matches(
       {url: 'www.google.com/apps/1_1_-_1/ano111_ther/11-22?query=1&query=2'},
-      {interceptor: undefined, paths: ['/apps']}
+      {interceptor: undefined, paths: ['/apps']},
     )).toBeFalsy();
     expect(matcher.matches(
       {url: 'www.google.com/path/111/sys/11-22'},
-      {interceptor: undefined, paths: ['/apps']}
+      {interceptor: undefined, paths: ['/apps']},
     )).toBeFalsy();
     expect(matcher.matches(
       {url: 'www.google.com/apps'},
-      {interceptor: undefined, paths: ['/apps']}
+      {interceptor: undefined, paths: ['/apps']},
     )).toBeTruthy();
     expect(matcher.matches(
       {url: 'www.google.com?'},
-      {interceptor: undefined, paths: ['/apps']}
+      {interceptor: undefined, paths: ['/apps']},
     )).toBeFalsy();
     expect(matcher.matches(
       {url: 'www.google.com/path/1_1_-_1/?query=1&query=2'},
-      {interceptor: undefined, paths: ['/apps']}
+      {interceptor: undefined, paths: ['/apps']},
     )).toBeFalsy();
   });
 
   it('should match routes that end with /apps/* (only with extra path)', () => {
     expect(matcher.matches(
       {url: 'www.google.com/apps/1_1_-_1/ano111_ther/11-22?query=1&query=2'},
-      {interceptor: undefined, paths: ['/apps/*']}
+      {interceptor: undefined, paths: ['/apps/*']},
     )).toBeFalsy();
     expect(matcher.matches(
       {url: 'www.google.com/path/111/apps/11-22'},
-      {interceptor: undefined, paths: ['/apps/*']}
+      {interceptor: undefined, paths: ['/apps/*']},
     )).toBeTruthy();
     expect(matcher.matches(
       {url: 'www.google.com/apps'},
-      {interceptor: undefined, paths: ['/apps/*']}
+      {interceptor: undefined, paths: ['/apps/*']},
     )).toBeFalsy();
     expect(matcher.matches(
       {url: 'www.google.com?'},
-      {interceptor: undefined, paths: ['/apps/*']}
+      {interceptor: undefined, paths: ['/apps/*']},
     )).toBeFalsy();
     expect(matcher.matches(
       {url: 'www.google.com/path/1_1_-_1/?query=1&query=2'},
-      {interceptor: undefined, paths: ['/apps/*']}
+      {interceptor: undefined, paths: ['/apps/*']},
     )).toBeFalsy();
   });
 
   it('should match routes that end with /apps/*/path (only one path in the middle)', () => {
     expect(matcher.matches(
       {url: 'www.google.com/apps/1_1_-_1/path?query=1&query=2'},
-      {interceptor: undefined, paths: ['/apps/*/path']}
+      {interceptor: undefined, paths: ['/apps/*/path']},
     )).toBeTruthy();
     expect(matcher.matches(
       {url: 'www.google.com/apps/111/path/11-22'},
-      {interceptor: undefined, paths: ['/apps/*/path']}
+      {interceptor: undefined, paths: ['/apps/*/path']},
     )).toBeFalsy();
     expect(matcher.matches(
       {url: 'www.google.com/apps'},
-      {interceptor: undefined, paths: ['/apps/*/path']}
+      {interceptor: undefined, paths: ['/apps/*/path']},
     )).toBeFalsy();
     expect(matcher.matches(
       {url: 'www.google.com?'},
-      {interceptor: undefined, paths: ['/apps/*/path']}
+      {interceptor: undefined, paths: ['/apps/*/path']},
     )).toBeFalsy();
     expect(matcher.matches(
       {url: 'www.google.com/path/1_1_-_1/?query=1&query=2'},
-      {interceptor: undefined, paths: ['/apps/*/path']}
+      {interceptor: undefined, paths: ['/apps/*/path']},
     )).toBeFalsy();
   });
 
   it('should match routes that end with /apps/**/path (any number of paths in the middle)', () => {
     expect(matcher.matches(
       {url: 'www.google.com/apps/1_1_-_1/path?query=1&query=2'},
-      {interceptor: undefined, paths: ['/apps/**/path']}
+      {interceptor: undefined, paths: ['/apps/**/path']},
     )).toBeTruthy();
     expect(matcher.matches(
       {url: 'www.google.com/apps/111/122/path'},
-      {interceptor: undefined, paths: ['/apps/**/path']}
+      {interceptor: undefined, paths: ['/apps/**/path']},
     )).toBeTruthy();
     expect(matcher.matches(
       {url: 'www.google.com/apps'},
-      {interceptor: undefined, paths: ['/apps/**/path']}
+      {interceptor: undefined, paths: ['/apps/**/path']},
     )).toBeFalsy();
     expect(matcher.matches(
       {url: 'www.google.com?'},
-      {interceptor: undefined, paths: ['/apps/**/path']}
+      {interceptor: undefined, paths: ['/apps/**/path']},
     )).toBeFalsy();
     expect(matcher.matches(
       {url: 'www.google.com/path/1_1_-_1/?query=1&query=2'},
-      {interceptor: undefined, paths: ['/apps/**/path']}
+      {interceptor: undefined, paths: ['/apps/**/path']},
     )).toBeFalsy();
   });
 });

--- a/src/platform/tsconfig-aot.json
+++ b/src/platform/tsconfig-aot.json
@@ -25,7 +25,11 @@
     ],
     "paths": {
       "@covalent/*": ["./*"]
-    }
+    },
+    "noUnusedParameters": false,
+    "noUnusedLocals": false,
+    "allowUnreachableCode": false,
+    "pretty": true
   },
   "include": [
     "../typings.d.ts",

--- a/src/test.ts
+++ b/src/test.ts
@@ -23,7 +23,7 @@ Promise.all([
   .then(([testing, testingBrowser]: any[]) => {
     testing.getTestBed().initTestEnvironment(
       testingBrowser.BrowserDynamicTestingModule,
-      testingBrowser.platformBrowserDynamicTesting()
+      testingBrowser.platformBrowserDynamicTesting(),
     );
   })
   // Then we find all the tests.

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -20,6 +20,10 @@
     ],
     "paths": {
       "@covalent/*": ["./platform/*"]
-    }
+    },
+    "noUnusedParameters": false,
+    "noUnusedLocals": false,
+    "allowUnreachableCode": false,
+    "pretty": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -27,7 +27,6 @@
     ],
     "jsdoc-format": true,
     "label-position": true,
-    "label-undefined": true,
     "max-line-length": [true, 120],
     "member-access": [
       false
@@ -58,7 +57,7 @@
     "no-arg": true,
     "no-bitwise": true,
     "no-conditional-assignment": true,
-    "no-consecutive-blank-lines": true,
+    "no-consecutive-blank-lines": [true],
     "no-console": [
       true, 
       "assert", 
@@ -82,10 +81,8 @@
       "warn"
     ],
     "no-construct": true,
-    "no-constructor-vars": false,
     "no-debugger": true,
     "no-default-export": true,
-    "no-duplicate-key": true,
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
@@ -103,9 +100,7 @@
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-unreachable": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "no-var-requires": true,
@@ -165,10 +160,6 @@
       }
     ],
     "use-isnan": true,
-    "use-strict": [
-      true,
-      "check-module"
-    ],
     "variable-name": [
       true,
       "ban-keywords",
@@ -185,30 +176,8 @@
       "check-type"
     ],
     // ANGULAR 2 Rules
-    "directive-selector-name": [
-      false, // Checked in PR's (kebab-case usage when used as component placeholder)
-      "camelCase"
-    ],
-    "component-selector-name": [
-      true,
-      "kebab-case"
-    ],
-    "directive-selector-type": [
-      false, // Checked in PR's (usage as element when used as placeholder for `ng-content`)
-      "attribute"
-    ],
-    "component-selector-type": [
-      true,
-      "element"
-    ],
-    "directive-selector-prefix": [
-      false,
-      "td"
-    ],
-    "component-selector-prefix": [ // This will be checked in PR's since we only want `td-` prefix for platform components, not docs not product components.
-      false,
-      "td"
-    ],
+    "directive-selector": [false, "attribute", "td", "camelCase"],
+    "component-selector": [false, "element", "td", "kebab-case"],
     "component-class-suffix": true,
     "directive-class-suffix": false, // Checked in PR's (different suffix for validators and so)
     "use-input-property-decorator": true,


### PR DESCRIPTION
## Description

- Upgraded to `@angular@2.4.2`
- Upgraded to `typescript@2.1.4`
- Upgraded to `tslint@4.1.1`
- Upgraded to `codylizer@2.0.0-beta.4` (angular2 linter)

There is an issue with the `File.types` property between typescript 2.0 and 2.1. https://github.com/Teradata/covalent/issues/236
https://github.com/Microsoft/TypeScript/issues/12069
https://github.com/angular/angular-cli/issues/3157

So for now we are gonna use both types so you can compile it in both cases.

#### Test Steps

- [x] use ts 2.0.10 and `npm i`
- [x] `ng serve` and see it work
- [x] use ts 2.1.4 and `npm i`
- [x] `ng serve` and see it work too
