### PR TITLE
bugfix(docs): theme styles duplication

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,18 +1,4 @@
-@import "theme";
 // You can add global styles to this file that will cascade like normal CSS
-
-// Active icon color in list nav
-md-nav-list {
-    [md-list-item].active {
-        md-icon[md-list-avatar] {
-            background-color: md-color($accent);
-            color: md-color($accent, default-contrast)
-        }
-        md-icon[md-list-icon] {
-            color: md-color($accent);
-        }
-    }
-}
 
 // Href line height wasn't right for md-icon-button
 a[md-icon-button] {

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -52,3 +52,16 @@ $theme: md-light-theme($primary, $accent, $warn);
     @include angular-material-theme($blue-grey-deep-orange);
     @include covalent-theme($blue-grey-deep-orange);
 }
+
+// Active icon color in list nav
+md-nav-list {
+    [md-list-item].active {
+        md-icon[md-list-avatar] {
+            background-color: md-color($accent);
+            color: md-color($accent, default-contrast)
+        }
+        md-icon[md-list-icon] {
+            color: md-color($accent);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Since `theme.scss` was included in the `angular-cli.json` and as part of an `import` in the `styles.scss`, the file was actually getting included twice. This meant duplicated `css` rules and a bigger file.

#### Test Steps

- [x] `ng serve` with out the fix and check `styles` kb size. (`559kb`)
![image](https://cloud.githubusercontent.com/assets/5846742/21778007/58057874-d656-11e6-887d-9b47ad46b1d2.png)
- [x] `ng serve` with the fix and check `styles` kb size. (`473kb`)
![image](https://cloud.githubusercontent.com/assets/5846742/21777992/4dcec7ac-d656-11e6-9e1b-1bebd701ef5a.png)
