### PR TITLE
upgrade(angular-cli): upgrade to beta.25-5 and fix ng lint usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 - npm i process-nextick-args util-deprecate buffer-shims
 - npm install
 script:
-- npm run tslint
+- npm run lint
 - npm run test
 after_script:
 - npm run coveralls

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -11,7 +11,7 @@ Execute `npm run start-release -- [version]` to start the automatic release proc
   1. Creating a `release/v[version]` branch using `git flow release`.
   2. Bumping its version to [version] release and commiting bumped version files.
   3. Publishing `release/v[version]` branch into repository. 
-  4. Executes `npm run tslint` and `npm run test`.
+  4. Executes `npm run lint` and `npm run test`.
 
 The release is published in case there is a need for any additional tests, version fixes or bug fixes. This can be added before it is actually released.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "e2e": "protractor",
     "e2e-test": "protractor ./protractor.conf.js",
-    "tslint": "tslint -c ./tslint.json \"./src/**/*.ts\" -e \"./src/**/typings.d.ts\" -e \"./src/environments/**\"",
+    "lint": "tslint -c ./tslint.json \"./src/**/*.ts\" -e \"./src/**/typings.d.ts\" -e \"./src/environments/**\"",
     "postinstall": "webdriver-manager update",
     "webdriver-update": "bash ./node_modules/.bin/webdriver-manager update",
     "test": "ng test --code-coverage --single-run",
@@ -75,7 +75,7 @@
     "@types/jasmine": "^2.2.31",
     "@types/node": "^6.0.34",
     "@types/selenium-webdriver": "^2.52.0",
-    "angular-cli": "1.0.0-beta.24",
+    "angular-cli": "1.0.0-beta.25.5",
     "awesome-typescript-loader": "^2.2.4",
     "codelyzer": "2.0.0-beta.4",
     "coveralls": "^2.11.15",

--- a/scripts/start-release
+++ b/scripts/start-release
@@ -16,8 +16,8 @@ git commit -a -m "Version bump"
 echo "Publishing release v$version"
 git flow release publish v$version
 
-echo "Executed tslint test"
-npm run tslint
+echo "Executed lint test"
+npm run lint
 
 echo "Executed unit tests"
 npm run test


### PR DESCRIPTION
## Description

Upgrade to use latest `angular-cli` in covalent docs.
https://github.com/angular/angular-cli/blob/master/CHANGELOG.md#bug-fixes

#### Test Steps

- [x] `rm -rf node_modules tmp dist deploy` and `npm i`
- [x] `ng serve` and `ng serve --aot --prod`
- [x] `ng build` and `ng build --aot --prod`
- [x] `ng lint` or `npm run lint` (same thing now)
- [x] `npm run test` (which runs `ng test --code-coverage --single-run`)