### PR TITLE
bugfix(serve): "ng serve --aot" broken from test file (closes #267)

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -25,5 +25,8 @@
     "noUnusedLocals": false,
     "allowUnreachableCode": false,
     "pretty": true
-  }
+  },
+  "exclude": [
+    "**/*.spec.*"
+  ]
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -27,6 +27,6 @@
     "pretty": true
   },
   "exclude": [
-    "**/*.spec.ts"
+    "**/*.spec.*"
   ]
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -27,6 +27,6 @@
     "pretty": true
   },
   "exclude": [
-    "**/*.spec.*"
+    "**/*.spec.ts"
   ]
 }


### PR DESCRIPTION
## Description

Adding exclusion of spec test files when running ng serve --aot
See bug: https://github.com/Teradata/covalent/issues/267

### What's included?

- modified:   src/tsconfig.json

#### Test Steps

- [ ] checkout feature/bug217-ng-serve-aot-broken branch
- [ ] run ng serve --aot
- [ ] see that server starts up and can go to http://localhost:4200
