### PR TITLE
feature(markdown): enhancements and code-health.

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -9,7 +9,7 @@
       "outDir": "dist",
       "assets": [
         "app/assets",
-        "platform/charts",
+        "platform",
         "favicon.ico"
       ],
       "index": "index.html",

--- a/src/app/components/components/components.component.html
+++ b/src/app/components/components/components.component.html
@@ -1,17 +1,31 @@
 <td-layout-nav-list #list logo="assets:teradata" toolbarTitle="Covalent">
   <md-nav-list list-items>
+    <h3 md-subheader>Core Components</h3>
     <template let-item let-last="last" ngFor [ngForOf]="items">
-        <a md-list-item 
-           [routerLink]="[item.route]" 
-           [routerLinkActive]="['active']" 
-           [routerLinkActiveOptions]="{exact:true}" 
-           (click)="list.toggle()">
-          <md-icon md-list-avatar>{{item.icon}}</md-icon>
-          <h3 md-line> {{item.title}} </h3>
-          <p md-line> {{item.description}} </p>
-        </a>
-        <md-divider *ngIf="!last" md-inset></md-divider>
-      </template>
+      <a md-list-item 
+          [routerLink]="[item.route]" 
+          [routerLinkActive]="['active']" 
+          [routerLinkActiveOptions]="{exact:true}" 
+          (click)="list.toggle()">
+        <md-icon md-list-avatar>{{item.icon}}</md-icon>
+        <h3 md-line> {{item.title}} </h3>
+        <p md-line> {{item.description}} </p>
+      </a>
+      <md-divider *ngIf="!last" md-inset></md-divider>
+    </template>
+    <h3 md-subheader>Optional Components</h3>
+    <template let-item let-last="last" ngFor [ngForOf]="optional">
+      <a md-list-item 
+          [routerLink]="[item.route]" 
+          [routerLinkActive]="['active']" 
+          [routerLinkActiveOptions]="{exact:true}" 
+          (click)="list.toggle()">
+        <md-icon md-list-avatar>{{item.icon}}</md-icon>
+        <h3 md-line> {{item.title}} </h3>
+        <p md-line> {{item.description}} </p>
+      </a>
+      <md-divider *ngIf="!last" md-inset></md-divider>
+    </template>
   </md-nav-list>
   <div nav-toolbar-content layout="row" layout-align="center center" flex>
     <span>Covalent Components &amp; Addons</span>

--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -59,25 +59,10 @@ export class ComponentsComponent {
     route: 'data-table',
     title: 'Data Table',
   }, {
-    description: 'Highlighting your code snippets',
-    icon: 'code',
-    route: 'syntax-highlighting',
-    title: 'Syntax Highlighting',
-  }, {
     description: 'JSON object tree with collapsible nodes',
     icon: 'format_indent_increase',
     route: 'json-formatter',
     title: 'JSON Formatter',
-  }, {
-    description: 'Parse markdown code',
-    icon: 'chrome_reader_mode',
-    route: 'markdown',
-    title: 'Markdown',
-  }, {
-    description: 'Responsive Charts',
-    icon: 'show_chart',
-    route: 'charts',
-    title: 'Charts',
   }, {
     description: 'Paging for lists and tables',
     icon: 'swap_horiz',
@@ -94,20 +79,10 @@ export class ComponentsComponent {
     route: 'search',
     title: 'Search',
   }, {
-    description: 'Build forms from a JS object',
-    icon: 'format_align_center',
-    route: 'dynamic-forms',
-    title: 'Dynamic Forms',
-  }, {
     description: 'Responsive service & directive',
     icon: 'devices',
     route: 'media',
     title: 'Media Queries',
-  }, {
-    description: 'Http wrappers and helpers',
-    icon: 'http',
-    route: 'http',
-    title: 'Http',
   }, {
     description: 'Core directives & utilities',
     icon: 'wb_iridescent',
@@ -120,4 +95,30 @@ export class ComponentsComponent {
     title: 'Pipes',
   }];
 
+  optional: Object[] = [{
+    description: 'Highlighting your code snippets',
+    icon: 'code',
+    route: 'syntax-highlighting',
+    title: 'Syntax Highlighting',
+  }, {
+    description: 'Parse markdown code',
+    icon: 'chrome_reader_mode',
+    route: 'markdown',
+    title: 'Markdown',
+  }, {
+    description: 'Responsive Charts',
+    icon: 'show_chart',
+    route: 'charts',
+    title: 'Charts',
+  }, {
+    description: 'Build forms from a JS object',
+    icon: 'format_align_center',
+    route: 'dynamic-forms',
+    title: 'Dynamic Forms',
+  }, {
+    description: 'Http wrappers and helpers',
+    icon: 'http',
+    route: 'http',
+    title: 'Http',
+  }];
 }

--- a/src/app/components/components/markdown/markdown.component.html
+++ b/src/app/components/components/markdown/markdown.component.html
@@ -3,9 +3,6 @@
   <md-card-subtitle>Parse markdown code</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
-    <md-card>
-      <md-card-content><h4>Imporant Note:</h4>You must wrap all markdown in <code>&lt;pre&gt;&lt;code&gt;&lt;/code&gt;&lt;/pre&gt;</code> and maintain whitespace.</md-card-content>
-    </md-card>
     <h3>Basic Markdown</h3>
     <td-markdown>
       # Heading (H1) 
@@ -200,21 +197,17 @@
           ]]>
       </td-highlight>
     <h3>Setup:</h3>
-    <p><code>showdown.js</code> needs to be added as vendor and referenced in `index.html`.</p>
-    <td-highlight lang="javascript">
-      module.exports = function(defaults) {{'{'}}
-        return new Angular2App(defaults, {{'{'}}
-          vendorNpmFiles: [
-            ...
-            'showdown/dist/showdown.js'
-          ]
-        });
-      };
+    <p><code>showdown.js</code> needs to be added as script in the `angular-cli.json` OR referenced in `index.html`.</p>
+    <p>`angular-cli.json` example:</p>
+    <td-highlight lang="json">
+      "scripts": [
+        "../node_modules/showdown/dist/showdown.js"
+      ]
     </td-highlight>
-    <p>Reference the script in the `index.html` file.</p>
+    <p>`index.html` example:</p>
     <td-highlight lang="html">
       <![CDATA[
-        <script src="vendor/showdown/dist/showdown.js"></script>
+        <script src="../node_modules/showdown/dist/showdown.js"></script>
       ]]>
     </td-highlight>
     <p>Then, import the [CovalentMarkdownModule] using the forRoot() method in your NgModule:</p>

--- a/src/app/components/components/markdown/markdown.component.html
+++ b/src/app/components/components/markdown/markdown.component.html
@@ -16,8 +16,8 @@
       * One
       * Two
       * Three
-          * A
-          * B
+          * 4 extra spaces for nested lists
+              * Another 4 spaces for a nested list
 
       Emphasis, aka italics, with *asterisks* or _underscores_.
 
@@ -39,8 +39,8 @@
           * One
           * Two
           * Three
-              * A
-              * B
+            * 4 extra spaces for nested lists
+                * Another 4 spaces for a nested list
 
           Emphasis, aka italics, with *asterisks* or _underscores_.
 
@@ -224,6 +224,6 @@
         export class MyModule {}
       ]]>
     </td-highlight>
+    <md-divider></md-divider>
   </md-card-content>
-  <md-divider></md-divider>
 </md-card>

--- a/src/app/components/components/markdown/markdown.component.html
+++ b/src/app/components/components/markdown/markdown.component.html
@@ -3,44 +3,31 @@
   <md-card-subtitle>Parse markdown code</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
-    <h3>Basic Markdown</h3>
-    <td-markdown>
-      # Heading (H1) 
-
-      ## Sub Heading (H2)
-
-      ### Steps (H3)
-
-      ###List Items
-
-      * One
-      * Two
-      * Three
-          * 4 extra spaces for nested lists
-              * Another 4 spaces for a nested list
-
-      Emphasis, aka italics, with *asterisks* or _underscores_.
-
-      Strong emphasis, aka bold, with **asterisks** or __underscores__.
-
-      Combined emphasis with **asterisks and _underscores_**.
-    </td-markdown>
-    <td-highlight lang="html">
-      <![CDATA[
+    With this component you can easily write inline markdown, or alternatively you can sanitize and load external markdown (.md) files.
+  </md-card-content>
+</md-card>
+<md-card>
+  <md-card-title>Basic example</md-card-title>
+  <md-card-subtitle>Headings, lists &amp; paragraphs</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <md-tab-group md-stretch-tabs>
+      <md-tab>
+        <template md-tab-label>Demo</template>
         <td-markdown>
           # Heading (H1) 
-                
+
           ## Sub Heading (H2)
 
           ### Steps (H3)
-              
+
           ###List Items
 
           * One
           * Two
           * Three
-            * 4 extra spaces for nested lists
-                * Another 4 spaces for a nested list
+              * 4 extra spaces for nested lists
+                  * Another 4 spaces for a nested list
 
           Emphasis, aka italics, with *asterisks* or _underscores_.
 
@@ -48,27 +35,48 @@
 
           Combined emphasis with **asterisks and _underscores_**.
         </td-markdown>
-      ]]>
-    </td-highlight>
-    <h3>Links &amp; Images</h3>
-    <p>There are two ways to create links. Inline & reference:</p>
-    <td-markdown>
-      [I'm an inline-style link](https://teradata.github.io/)
+      </md-tab>
+      <md-tab>
+        <template md-tab-label>Code</template>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-markdown>
+              # Heading (H1) 
+                    
+              ## Sub Heading (H2)
 
-      [I'm a reference-style link case does not matter][Teradata Github Landing]
+              ### Steps (H3)
+                  
+              ###List Items
 
-      [teradata github Landing]: https://teradata.github.io/
+              * One
+              * Two
+              * Three
+                * 4 extra spaces for nested lists
+                    * Another 4 spaces for a nested list
 
-      Inline image
-      ![alt text here](app/assets/icons/teradata.svg)
+              Emphasis, aka italics, with *asterisks* or _underscores_.
 
-      Reference-style image:
-      ![alt text][logo]
+              Strong emphasis, aka bold, with **asterisks** or __underscores__.
 
-      [logo]: app/assets/icons/teradata.svg "Teradata Labs"
-    </td-markdown>
-    <td-highlight lang="html">
-      <![CDATA[
+              Combined emphasis with **asterisks and _underscores_**.
+            </td-markdown>
+          ]]>
+        </td-highlight>
+      </md-tab>
+    </md-tab-group>
+  </md-card-content>
+</md-card>
+<md-card>
+  <md-card-title>Links &amp; Images</md-card-title>
+  <md-card-subtitle>There are two ways to create links, inline &amp; reference</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <md-tab-group md-stretch-tabs>
+      <md-tab>
+        <template md-tab-label>Demo</template>
+        <h3>Links &amp; Images</h3>
+        <p>There are two ways to create links. Inline & reference:</p>
         <td-markdown>
           [I'm an inline-style link](https://teradata.github.io/)
 
@@ -84,26 +92,43 @@
 
           [logo]: app/assets/icons/teradata.svg "Teradata Labs"
         </td-markdown>
-      ]]>
-    </td-highlight>
-    <h3>Inline Code &amp; Snippets</h3>
-    <p>Inline has `back-ticks` around it.</p>
-    <p>Blocks of code are either fenced by lines with three back-ticks <code>```</code>, or are indented with four spaces. </p>
-    <td-markdown>
-      `this is an inline code snippet`
+      </md-tab>
+      <md-tab>
+        <template md-tab-label>Code</template>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-markdown>
+              [I'm an inline-style link](https://teradata.github.io/)
 
-      ```javascript
-      var s = "JavaScript syntax highlighting";
-      alert(s);
-      ```
+              [I'm a reference-style link case does not matter][Teradata Github Landing]
 
-      ```python
-      s = "Python syntax highlighting"
-      print s
-      ```
-    </td-markdown>
-    <td-highlight lang="html">
-      <![CDATA[
+              [teradata github Landing]: https://teradata.github.io/
+
+              Inline image
+              ![alt text here](app/assets/icons/teradata.svg)
+
+              Reference-style image:
+              ![alt text][logo]
+
+              [logo]: app/assets/icons/teradata.svg "Teradata Labs"
+            </td-markdown>
+          ]]>
+        </td-highlight>
+      </md-tab>
+    </md-tab-group>
+  </md-card-content>
+</md-card>
+
+<md-card>
+  <md-card-title>Inline Code &amp; Snippets</md-card-title>
+  <md-card-subtitle>Code blocks</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <md-tab-group md-stretch-tabs>
+      <md-tab>
+        <template md-tab-label>Demo</template>
+        <p>Inline has `back-ticks` around it.</p>
+        <p>Blocks of code are either fenced by lines with three back-ticks <code>```</code>, or are indented with four spaces. </p>
         <td-markdown>
           `this is an inline code snippet`
 
@@ -117,19 +142,39 @@
           print s
           ```
         </td-markdown>
-      ]]>
-    </td-highlight>
-    <h3>Blockquotes</h3>
-    <td-markdown>
-      > Blockquotes are very handy in email to emulate reply text.
-      > This line is part of the same quote.
+      </md-tab>
+      <md-tab>
+        <template md-tab-label>Code</template>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-markdown>
+              `this is an inline code snippet`
 
-      Quote break.
+              ```javascript
+              var s = "JavaScript syntax highlighting";
+              alert(s);
+              ```
 
-      > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
-    </td-markdown>
-    <td-highlight lang="html">
-      <![CDATA[
+              ```python
+              s = "Python syntax highlighting"
+              print s
+              ```
+            </td-markdown>
+          ]]>
+        </td-highlight>
+      </md-tab>
+    </md-tab-group>
+  </md-card-content>
+</md-card>
+
+<md-card>
+  <md-card-title>Block Quotes &amp; Dividers</md-card-title>
+  <md-divider></md-divider>
+  <md-card-content>
+    <md-tab-group md-stretch-tabs>
+      <md-tab>
+        <template md-tab-label>Demo</template>
+        <h3>Blockquotes</h3>
         <td-markdown>
           > Blockquotes are very handy in email to emulate reply text.
           > This line is part of the same quote.
@@ -138,26 +183,7 @@
 
           > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
         </td-markdown>
-      ]]>
-    </td-highlight>
-    <h3>Dividers</h3>
-    <td-markdown>
-      Three or more...
-
-      ---
-
-      Hyphens
-
-      ***
-
-      Asterisks
-
-      ___
-
-      Underscores
-    </td-markdown>
-    <td-highlight lang="html">
-      <![CDATA[
+        <h3>Dividers</h3>
         <td-markdown>
           Three or more...
 
@@ -173,10 +199,46 @@
 
           Underscores
         </td-markdown>
-      ]]>
-    </td-highlight>
+      </md-tab>
+      <md-tab>
+        <template md-tab-label>Code</template>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-markdown>
+              > Blockquotes are very handy in email to emulate reply text.
+              > This line is part of the same quote.
+
+              Quote break.
+
+              > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
+            </td-markdown>
+          ]]>
+        </td-highlight>
+        
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-markdown>
+              Three or more...
+
+              ---
+
+              Hyphens
+
+              ***
+
+              Asterisks
+
+              ___
+
+              Underscores
+            </td-markdown>
+          ]]>
+        </td-highlight>
+      </md-tab>
+    </md-tab-group>
   </md-card-content>
 </md-card>
+
 <md-card>
   <md-card-content>
     <td-markdown [content]="content">

--- a/src/app/components/components/markdown/markdown.component.html
+++ b/src/app/components/components/markdown/markdown.component.html
@@ -178,52 +178,8 @@
   </md-card-content>
 </md-card>
 <md-card>
-  <md-card-title>TdMarkdownComponent</md-card-title>
-  <md-card-subtitle>How to use this component</md-card-subtitle>
-  <md-divider></md-divider>
   <md-card-content>
-    <h2><code><![CDATA[<td-markdown>]]></code></h2>
-    <p>Use <code><![CDATA[<td-markdown>]]></code> element to parse the markdown files</p>
-    <p>Wrap your code snippets in <code><![CDATA[<td-markdown>]]></code></p>
-    <h3>Example:</h3>
-    <p>HTML</p>
-      <td-highlight lang="html">
-        <![CDATA[
-          <td-markdown>
-            # Heading 
-            ## Sub Heading (H2)
-            ### Steps (H2)
-          </td-markdown>
-          ]]>
-      </td-highlight>
-    <h3>Setup:</h3>
-    <p><code>showdown.js</code> needs to be added as script in the `angular-cli.json` OR referenced in `index.html`.</p>
-    <p>`angular-cli.json` example:</p>
-    <td-highlight lang="json">
-      "scripts": [
-        "../node_modules/showdown/dist/showdown.js"
-      ]
-    </td-highlight>
-    <p>`index.html` example:</p>
-    <td-highlight lang="html">
-      <![CDATA[
-        <script src="../node_modules/showdown/dist/showdown.js"></script>
-      ]]>
-    </td-highlight>
-    <p>Then, import the [CovalentMarkdownModule] using the forRoot() method in your NgModule:</p>
-    <td-highlight lang="html">
-      <![CDATA[
-        import { CovalentMarkdownModule } from '@covalent/markdown';
-        @NgModule({
-          imports: [
-            CovalentMarkdownModule.forRoot(),
-            ...
-          ],
-          ...
-        })
-        export class MyModule {}
-      ]]>
-    </td-highlight>
-    <md-divider></md-divider>
+    <td-markdown [content]="content">
+    </td-markdown>
   </md-card-content>
 </md-card>

--- a/src/app/components/components/markdown/markdown.component.html
+++ b/src/app/components/components/markdown/markdown.component.html
@@ -9,46 +9,50 @@
     <h3>Basic Markdown</h3>
     <td-markdown>
       <pre><code>
-# Heading (H1) 
-      
-## Sub Heading (H2)
+        # Heading (H1) 
 
-### Steps (H3)
-    
-###List Items
+        ## Sub Heading (H2)
 
-* One
-* Two
-* Three
+        ### Steps (H3)
 
-Emphasis, aka italics, with *asterisks* or _underscores_.
+        ###List Items
 
-Strong emphasis, aka bold, with **asterisks** or __underscores__.
+        * One
+        * Two
+        * Three
+            * A
+            * B
 
-Combined emphasis with **asterisks and _underscores_**.
+        Emphasis, aka italics, with *asterisks* or _underscores_.
+
+        Strong emphasis, aka bold, with **asterisks** or __underscores__.
+
+        Combined emphasis with **asterisks and _underscores_**.
       </code></pre>
     </td-markdown>
     <td-highlight lang="html">
       <![CDATA[
         <td-markdown>
           <pre><code>
-    # Heading (H1) 
-          
-    ## Sub Heading (H2)
+            # Heading (H1) 
+                  
+            ## Sub Heading (H2)
 
-    ### Steps (H3)
-        
-    ###List Items
+            ### Steps (H3)
+                
+            ###List Items
 
-    * One
-    * Two
-    * Three
+            * One
+            * Two
+            * Three
+                * A
+                * B
 
-    Emphasis, aka italics, with *asterisks* or _underscores_.
+            Emphasis, aka italics, with *asterisks* or _underscores_.
 
-    Strong emphasis, aka bold, with **asterisks** or __underscores__.
+            Strong emphasis, aka bold, with **asterisks** or __underscores__.
 
-    Combined emphasis with **asterisks and _underscores_**.
+            Combined emphasis with **asterisks and _underscores_**.
           </code></pre>
         </td-markdown>
       ]]>
@@ -57,38 +61,38 @@ Combined emphasis with **asterisks and _underscores_**.
     <p>There are two ways to create links. Inline & reference:</p>
     <td-markdown>
       <pre><code>
-[I'm an inline-style link](https://teradata.github.io/)
+        [I'm an inline-style link](https://teradata.github.io/)
 
-[I'm a reference-style link case does not matter][Teradata Github Landing]
+        [I'm a reference-style link case does not matter][Teradata Github Landing]
 
-[teradata github Landing]: https://teradata.github.io/
+        [teradata github Landing]: https://teradata.github.io/
 
-Inline image
-![alt text here](app/assets/icons/teradata.svg)
+        Inline image
+        ![alt text here](app/assets/icons/teradata.svg)
 
-Reference-style image:
-![alt text][logo]
+        Reference-style image:
+        ![alt text][logo]
 
-[logo]: app/assets/icons/teradata.svg "Teradata Labs"
+        [logo]: app/assets/icons/teradata.svg "Teradata Labs"
       </code></pre>
     </td-markdown>
     <td-highlight lang="html">
       <![CDATA[
         <td-markdown>
           <pre><code>
-    [I'm an inline-style link](https://teradata.github.io/)
+            [I'm an inline-style link](https://teradata.github.io/)
 
-    [I'm a reference-style link case does not matter][Teradata Github Landing]
+            [I'm a reference-style link case does not matter][Teradata Github Landing]
 
-    [teradata github Landing]: https://teradata.github.io/
+            [teradata github Landing]: https://teradata.github.io/
 
-    Inline image
-    ![alt text here](app/assets/icons/teradata.svg)
+            Inline image
+            ![alt text here](app/assets/icons/teradata.svg)
 
-    Reference-style image:
-    ![alt text][logo]
+            Reference-style image:
+            ![alt text][logo]
 
-    [logo]: app/assets/icons/teradata.svg "Teradata Labs"
+            [logo]: app/assets/icons/teradata.svg "Teradata Labs"
           </code></pre>
         </td-markdown>
       ]]>
@@ -98,34 +102,34 @@ Reference-style image:
     <p>Blocks of code are either fenced by lines with three back-ticks <code>```</code>, or are indented with four spaces. </p>
     <td-markdown>
       <pre><code>
-`this is an inline code snippet`
+        `this is an inline code snippet`
 
-```javascript
-var s = "JavaScript syntax highlighting";
-alert(s);
-```
+        ```javascript
+        var s = "JavaScript syntax highlighting";
+        alert(s);
+        ```
 
-```python
-s = "Python syntax highlighting"
-print s
-```
+        ```python
+        s = "Python syntax highlighting"
+        print s
+        ```
       </code></pre>
     </td-markdown>
     <td-highlight lang="html">
       <![CDATA[
         <td-markdown>
           <pre><code>
-    `this is an inline code snippet`
+            `this is an inline code snippet`
 
-    ```javascript
-    var s = "JavaScript syntax highlighting";
-    alert(s);
-    ```
+            ```javascript
+            var s = "JavaScript syntax highlighting";
+            alert(s);
+            ```
 
-    ```python
-    s = "Python syntax highlighting"
-    print s
-    ```
+            ```python
+            s = "Python syntax highlighting"
+            print s
+            ```
           </code></pre>
         </td-markdown>
       ]]>
@@ -133,24 +137,24 @@ print s
     <h3>Blockquotes</h3>
     <td-markdown>
       <pre><code>
-> Blockquotes are very handy in email to emulate reply text.
-> This line is part of the same quote.
+        > Blockquotes are very handy in email to emulate reply text.
+        > This line is part of the same quote.
 
-Quote break.
+        Quote break.
 
-> This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
+        > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
       </code></pre>
     </td-markdown>
     <td-highlight lang="html">
       <![CDATA[
         <td-markdown>
           <pre><code>
-    > Blockquotes are very handy in email to emulate reply text.
-    > This line is part of the same quote.
+            > Blockquotes are very handy in email to emulate reply text.
+            > This line is part of the same quote.
 
-    Quote break.
+            Quote break.
 
-    > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
+            > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
           </code></pre>
         </td-markdown>
       ]]>
@@ -158,38 +162,38 @@ Quote break.
     <h3>Dividers</h3>
     <td-markdown>
       <pre><code>
-Three or more...
+        Three or more...
 
----
+        ---
 
-Hyphens
+        Hyphens
 
-***
+        ***
 
-Asterisks
+        Asterisks
 
-___
+        ___
 
-Underscores
+        Underscores
       </code></pre>
     </td-markdown>
     <td-highlight lang="html">
       <![CDATA[
         <td-markdown>
           <pre><code>
-    Three or more...
+            Three or more...
 
-    ---
+            ---
 
-    Hyphens
+            Hyphens
 
-    ***
+            ***
 
-    Asterisks
+            Asterisks
 
-    ___
+            ___
 
-    Underscores
+            Underscores
           </code></pre>
         </td-markdown>
       ]]>

--- a/src/app/components/components/markdown/markdown.component.html
+++ b/src/app/components/components/markdown/markdown.component.html
@@ -8,92 +8,84 @@
     </md-card>
     <h3>Basic Markdown</h3>
     <td-markdown>
-      <pre><code>
-        # Heading (H1) 
+      # Heading (H1) 
 
-        ## Sub Heading (H2)
+      ## Sub Heading (H2)
 
-        ### Steps (H3)
+      ### Steps (H3)
 
-        ###List Items
+      ###List Items
 
-        * One
-        * Two
-        * Three
-            * A
-            * B
+      * One
+      * Two
+      * Three
+          * A
+          * B
 
-        Emphasis, aka italics, with *asterisks* or _underscores_.
+      Emphasis, aka italics, with *asterisks* or _underscores_.
 
-        Strong emphasis, aka bold, with **asterisks** or __underscores__.
+      Strong emphasis, aka bold, with **asterisks** or __underscores__.
 
-        Combined emphasis with **asterisks and _underscores_**.
-      </code></pre>
+      Combined emphasis with **asterisks and _underscores_**.
     </td-markdown>
     <td-highlight lang="html">
       <![CDATA[
         <td-markdown>
-          <pre><code>
-            # Heading (H1) 
-                  
-            ## Sub Heading (H2)
-
-            ### Steps (H3)
+          # Heading (H1) 
                 
-            ###List Items
+          ## Sub Heading (H2)
 
-            * One
-            * Two
-            * Three
-                * A
-                * B
+          ### Steps (H3)
+              
+          ###List Items
 
-            Emphasis, aka italics, with *asterisks* or _underscores_.
+          * One
+          * Two
+          * Three
+              * A
+              * B
 
-            Strong emphasis, aka bold, with **asterisks** or __underscores__.
+          Emphasis, aka italics, with *asterisks* or _underscores_.
 
-            Combined emphasis with **asterisks and _underscores_**.
-          </code></pre>
+          Strong emphasis, aka bold, with **asterisks** or __underscores__.
+
+          Combined emphasis with **asterisks and _underscores_**.
         </td-markdown>
       ]]>
     </td-highlight>
     <h3>Links &amp; Images</h3>
     <p>There are two ways to create links. Inline & reference:</p>
     <td-markdown>
-      <pre><code>
-        [I'm an inline-style link](https://teradata.github.io/)
+      [I'm an inline-style link](https://teradata.github.io/)
 
-        [I'm a reference-style link case does not matter][Teradata Github Landing]
+      [I'm a reference-style link case does not matter][Teradata Github Landing]
 
-        [teradata github Landing]: https://teradata.github.io/
+      [teradata github Landing]: https://teradata.github.io/
 
-        Inline image
-        ![alt text here](app/assets/icons/teradata.svg)
+      Inline image
+      ![alt text here](app/assets/icons/teradata.svg)
 
-        Reference-style image:
-        ![alt text][logo]
+      Reference-style image:
+      ![alt text][logo]
 
-        [logo]: app/assets/icons/teradata.svg "Teradata Labs"
-      </code></pre>
+      [logo]: app/assets/icons/teradata.svg "Teradata Labs"
     </td-markdown>
     <td-highlight lang="html">
       <![CDATA[
         <td-markdown>
-          <pre><code>
-            [I'm an inline-style link](https://teradata.github.io/)
+          [I'm an inline-style link](https://teradata.github.io/)
 
-            [I'm a reference-style link case does not matter][Teradata Github Landing]
+          [I'm a reference-style link case does not matter][Teradata Github Landing]
 
-            [teradata github Landing]: https://teradata.github.io/
+          [teradata github Landing]: https://teradata.github.io/
 
-            Inline image
-            ![alt text here](app/assets/icons/teradata.svg)
+          Inline image
+          ![alt text here](app/assets/icons/teradata.svg)
 
-            Reference-style image:
-            ![alt text][logo]
+          Reference-style image:
+          ![alt text][logo]
 
-            [logo]: app/assets/icons/teradata.svg "Teradata Labs"
-          </code></pre>
+          [logo]: app/assets/icons/teradata.svg "Teradata Labs"
         </td-markdown>
       ]]>
     </td-highlight>
@@ -101,100 +93,88 @@
     <p>Inline has `back-ticks` around it.</p>
     <p>Blocks of code are either fenced by lines with three back-ticks <code>```</code>, or are indented with four spaces. </p>
     <td-markdown>
-      <pre><code>
-        `this is an inline code snippet`
+      `this is an inline code snippet`
 
-        ```javascript
-        var s = "JavaScript syntax highlighting";
-        alert(s);
-        ```
+      ```javascript
+      var s = "JavaScript syntax highlighting";
+      alert(s);
+      ```
 
-        ```python
-        s = "Python syntax highlighting"
-        print s
-        ```
-      </code></pre>
+      ```python
+      s = "Python syntax highlighting"
+      print s
+      ```
     </td-markdown>
     <td-highlight lang="html">
       <![CDATA[
         <td-markdown>
-          <pre><code>
-            `this is an inline code snippet`
+          `this is an inline code snippet`
 
-            ```javascript
-            var s = "JavaScript syntax highlighting";
-            alert(s);
-            ```
+          ```javascript
+          var s = "JavaScript syntax highlighting";
+          alert(s);
+          ```
 
-            ```python
-            s = "Python syntax highlighting"
-            print s
-            ```
-          </code></pre>
+          ```python
+          s = "Python syntax highlighting"
+          print s
+          ```
         </td-markdown>
       ]]>
     </td-highlight>
     <h3>Blockquotes</h3>
     <td-markdown>
-      <pre><code>
-        > Blockquotes are very handy in email to emulate reply text.
-        > This line is part of the same quote.
+      > Blockquotes are very handy in email to emulate reply text.
+      > This line is part of the same quote.
 
-        Quote break.
+      Quote break.
 
-        > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
-      </code></pre>
+      > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
     </td-markdown>
     <td-highlight lang="html">
       <![CDATA[
         <td-markdown>
-          <pre><code>
-            > Blockquotes are very handy in email to emulate reply text.
-            > This line is part of the same quote.
+          > Blockquotes are very handy in email to emulate reply text.
+          > This line is part of the same quote.
 
-            Quote break.
+          Quote break.
 
-            > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
-          </code></pre>
+          > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
         </td-markdown>
       ]]>
     </td-highlight>
     <h3>Dividers</h3>
     <td-markdown>
-      <pre><code>
-        Three or more...
+      Three or more...
 
-        ---
+      ---
 
-        Hyphens
+      Hyphens
 
-        ***
+      ***
 
-        Asterisks
+      Asterisks
 
-        ___
+      ___
 
-        Underscores
-      </code></pre>
+      Underscores
     </td-markdown>
     <td-highlight lang="html">
       <![CDATA[
         <td-markdown>
-          <pre><code>
-            Three or more...
+          Three or more...
 
-            ---
+          ---
 
-            Hyphens
+          Hyphens
 
-            ***
+          ***
 
-            Asterisks
+          Asterisks
 
-            ___
+          ___
 
-            Underscores
-          </code></pre>
+          Underscores
         </td-markdown>
       ]]>
     </td-highlight>
@@ -213,11 +193,9 @@
       <td-highlight lang="html">
         <![CDATA[
           <td-markdown>
-            <pre><code>
             # Heading 
             ## Sub Heading (H2)
             ### Steps (H2)
-            </code></pre>
           </td-markdown>
           ]]>
       </td-highlight>

--- a/src/app/components/components/markdown/markdown.component.ts
+++ b/src/app/components/components/markdown/markdown.component.ts
@@ -1,4 +1,5 @@
-import { Component, HostBinding } from '@angular/core';
+import { Component, HostBinding, OnInit } from '@angular/core';
+import { Http, Response } from '@angular/http';
 
 import { slideInDownAnimation } from '../../../app.animations';
 
@@ -8,9 +9,26 @@ import { slideInDownAnimation } from '../../../app.animations';
   templateUrl: './markdown.component.html',
   animations: [slideInDownAnimation],
 })
-export class MarkdownDemoComponent {
+export class MarkdownDemoComponent implements OnInit {
 
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
+
+  content: string;
+
+  constructor(private _http: Http) {}
+
+  ngOnInit(): void {
+    let errorString: string = 'Warning: Resource could not be loaded.';
+    this._http.get('platform/markdown/README.md').subscribe((res: Response) => {
+      try {
+        this.content = res.text();
+      } catch (e) {
+        this.content = errorString;
+      }
+    }, (error: Error) => {
+      this.content = errorString;
+    });
+  }
 
 }

--- a/src/platform/markdown/README.md
+++ b/src/platform/markdown/README.md
@@ -10,6 +10,12 @@ Methods:
 | --- | --- | --- |
 | `content` | `string` | Markdown format content to be parsed as html markup. Used to load data dynamically. e.g. Resource file.
 
+**Note:** This module uses the **DomSanitizer** ng2 service to ~sanitize~ the parsed `html` from the `showdown` lib to avoid **XSS** issues.
+
+By default, `--dev` build will log the following message in the console to let you know:
+
+`WARNING: sanitizing HTML stripped some content (see http://g.co/ng/security#xss).`
+
 ## Installation
 
 This component can be installed as npm package.

--- a/src/platform/markdown/README.md
+++ b/src/platform/markdown/README.md
@@ -1,8 +1,14 @@
-## Markdown : `<td-markdown>`
+## TdMarkdownComponent: td-markdown
 
 `<td-markdown>` is a directive for Github flavored Javascript Markdown to HTML converter. It is based on [showdown](https://github.com/showdownjs/showdown/) library.
 
-------
+## API Summary
+
+Methods:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `content` | `string` | Markdown format content to be parsed as html markup. Used to load data dynamically. e.g. Resource file.
 
 ## Installation
 

--- a/src/platform/markdown/README.md
+++ b/src/platform/markdown/README.md
@@ -1,34 +1,36 @@
-# Markdown : td-markdown
+## Markdown : `<td-markdown>`
 
-```<td-markdown>``` is a directive for Github flavored Javascript Markdown to HTML converter. It is based on Showdown Library (https://github.com/showdownjs/showdown/).
+`<td-markdown>` is a directive for Github flavored Javascript Markdown to HTML converter. It is based on [showdown](https://github.com/showdownjs/showdown/) library.
 
 ------
 
 ## Installation
 
-This component can be installed as npm package and can be included by importing from @covalent/markdown.
+This component can be installed as npm package.
+
+```npm
+npm i -save @covalent/markdown
+```
 
 ## Setup
 
-`showdown.js` needs to be added as vendor (installed as a `markdown` dependency).
+`showdown.js` needs to be added as script in the `angular-cli.json` OR referenced in `index.html` (installed as a `markdown` dependency).
 
-```typescript
-module.exports = function(defaults) {
-  return new Angular2App(defaults, {
-    vendorNpmFiles: [
-      ...
-      'showdown/dist/showdown.js'
-    ]
-  });
-};
+**angular-cli.json**:
+
+```json
+"scripts": [
+  "../node_modules/showdown/dist/showdown.js"
+]
 ```
-Reference the script in the `index.html` file.
+
+**index.html**:
 
 ```html
-<script src="vendor/showdown/dist/showdown.js"></script>
+<script src="../node_modules/showdown/dist/showdown.js"></script>
 ```
 
-Then, import the [CovalentMarkdownModule] using the forRoot() method in your NgModule:
+Then, import the **[CovalentMarkdownModule]** using the *forRoot()* method in your NgModule:
 
 ```typescript
 import { CovalentMarkdownModule } from '@covalent/markdown';
@@ -42,39 +44,21 @@ import { CovalentMarkdownModule } from '@covalent/markdown';
 export class MyModule {}
 ```
 
-Markdown has been tested successfully with:
+## Example
 
-  * Chrome 
-  * Firefox
-  * Safari
-
-## Extended documentation
-Check our [demo](https://teradata.github.io/covalent/#/components/markdown) for examples and a more in-depth documentation on usage.
-
-
-## Quick Example
+**Html:**
 
 ```html
 <td-markdown>
-  <pre><code>
-# Heading 
-## Sub Heading (H2)
-### Steps (H2)
-  </code></pre>
+  # Heading 
+  ## Sub Heading (H2)
+  ### Steps (H2)
 </td-markdown>
 ```
 
-### Output 
+**Output:**
 
-Above examples should output...
+# Heading 
+## Sub Heading (H2)
+### Steps (H2)
 
-    <h1 id="headingh1">Heading (H1)</h1>
-    <h2 id="subheadingh2">Sub Heading (H2)</h2>
-    <h3 id="stepsh3">Steps (H3)</h3>
-
- * **It also has support for GFM code block style & GFM takslists. Example:
- 
-   ```md
-    - [x] This task is done
-    - [ ] This is still pending
-   ```

--- a/src/platform/markdown/_markdown-theme.scss
+++ b/src/platform/markdown/_markdown-theme.scss
@@ -15,7 +15,7 @@
       color: md-color($foreground, secondary-text);
     }
     hr {
-      background-color: md-color($foreground, divider);
+      border-color: md-color($foreground, divider);
     }
     blockquote {
       color: md-color($foreground, secondary-text);

--- a/src/platform/markdown/markdown.component.html
+++ b/src/platform/markdown/markdown.component.html
@@ -1,5 +1,6 @@
-<div #markdown>
+<div #markdown *ngIf="!markup">
   <pre><code>
     <ng-content></ng-content>
   </code></pre>
 </div>
+<div [innerHTML]="markup"></div>

--- a/src/platform/markdown/markdown.component.html
+++ b/src/platform/markdown/markdown.component.html
@@ -1,3 +1,5 @@
 <div #markdown>
+  <pre><code>
     <ng-content></ng-content>
+  </code></pre>
 </div>

--- a/src/platform/markdown/markdown.component.html
+++ b/src/platform/markdown/markdown.component.html
@@ -1,6 +1,1 @@
-<div #markdown *ngIf="!markup">
-  <pre><code>
-    <ng-content></ng-content>
-  </code></pre>
-</div>
-<div [innerHTML]="markup"></div>
+<ng-content></ng-content>

--- a/src/platform/markdown/markdown.component.scss
+++ b/src/platform/markdown/markdown.component.scss
@@ -98,8 +98,8 @@
     margin: 15px 0;
     overflow: hidden;
     background: transparent;
-    border: 0;
-    border-bottom: 1px solid #ddd;
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
   }
 
   hr::before {
@@ -338,10 +338,7 @@
   }
 
   hr {
-    height: 1px;
-    padding: 0;
     margin: 16px 0;
-    border: 0 none;
   }
 
   ul,

--- a/src/platform/markdown/markdown.component.spec.ts
+++ b/src/platform/markdown/markdown.component.spec.ts
@@ -9,7 +9,7 @@ import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { CovalentMarkdownModule } from './';
 
-describe('Component: TdMarkdownComponent', () => {
+describe('Component: Markdown', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({

--- a/src/platform/markdown/markdown.component.spec.ts
+++ b/src/platform/markdown/markdown.component.spec.ts
@@ -1,0 +1,144 @@
+import {
+  TestBed,
+  inject,
+  async,
+  ComponentFixture,
+} from '@angular/core/testing';
+import 'hammerjs';
+import { Component } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { CovalentMarkdownModule } from './';
+
+describe('Component: TdMarkdownComponent', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CovalentMarkdownModule.forRoot(),
+      ],
+      declarations: [
+        TdMarkdownEmptyTestComponent,
+        TdMarkdownBasicTestComponent,
+        TdMarkdownContentTestComponent,
+      ],
+    });
+    TestBed.compileComponents();
+  }));
+
+  it('should render empty', async(inject([], () => {
+
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownEmptyTestComponent);
+    let component: TdMarkdownEmptyTestComponent = fixture.debugElement.componentInstance;
+    let element: HTMLElement = fixture.nativeElement;
+
+    expect(fixture.debugElement.query(By.css('td-markdown')).nativeElement.textContent.trim())
+    .toBe(``);
+    expect(fixture.debugElement.query(By.css('td-markdown div'))).toBeFalsy();
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('td-markdown div'))).toBeFalsy();
+      expect(fixture.debugElement.query(By.css('td-markdown')).nativeElement.textContent.trim()).toBe('');
+    });
+  })));
+
+  it('should render markup from static content', async(inject([], () => {
+
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownBasicTestComponent);
+    let component: TdMarkdownBasicTestComponent = fixture.debugElement.componentInstance;
+    let element: HTMLElement = fixture.nativeElement;
+
+    expect(fixture.debugElement.query(By.css('td-markdown')).nativeElement.textContent.trim())
+    .toBe(`
+      # title
+
+      * list item`.trim());
+    expect(fixture.debugElement.query(By.css('td-markdown div'))).toBeFalsy();
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('td-markdown div'))).toBeTruthy();
+      expect(element.querySelector('td-markdown div h1').textContent.trim()).toBe('title');
+      expect(element.querySelector('td-markdown div ul li').textContent.trim()).toBe('list item');
+    });
+  })));
+
+  it('should render markup from dynamic content', async(inject([], () => {
+
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownContentTestComponent);
+    let component: TdMarkdownContentTestComponent = fixture.debugElement.componentInstance;
+    component.content = `
+    # another title
+    
+    ## subtitle
+    
+    \`\`\`
+    pseudo code
+    \`\`\``;
+    let element: HTMLElement = fixture.nativeElement;
+
+    expect(fixture.debugElement.query(By.css('td-markdown')).nativeElement.textContent.trim())
+    .toBe('');
+    expect(fixture.debugElement.query(By.css('td-markdown div'))).toBeFalsy();
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('td-markdown div'))).toBeTruthy();
+      expect(element.querySelector('td-markdown div h1').textContent.trim()).toBe('another title');
+      expect(element.querySelector('td-markdown div h2').textContent.trim()).toBe('subtitle');
+      expect(element.querySelector('td-markdown div code').textContent.trim()).toBe('pseudo code');
+    });
+  })));
+
+  it('should render markup from dynamic content incorrectly', async(inject([], () => {
+
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownContentTestComponent);
+    let component: TdMarkdownContentTestComponent = fixture.debugElement.componentInstance;
+    component.content = `
+    # another title
+    
+      ## subtitle`;
+    let element: HTMLElement = fixture.nativeElement;
+
+    expect(fixture.debugElement.query(By.css('td-markdown')).nativeElement.textContent.trim())
+    .toBe('');
+    expect(fixture.debugElement.query(By.css('td-markdown div'))).toBeFalsy();
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('td-markdown div'))).toBeTruthy();
+      expect(element.querySelector('td-markdown div h1').textContent.trim()).toBe('another title');
+      expect(element.querySelector('td-markdown div h2')).toBeFalsy();
+      expect(element.querySelector('td-markdown div').textContent.trim()).toContain('## subtitle');
+    });
+  })));
+
+});
+
+@Component({
+  template: `
+    <td-markdown>
+    </td-markdown>`,
+})
+class TdMarkdownEmptyTestComponent {
+}
+
+@Component({
+  template: `
+    <td-markdown>
+      # title
+
+      * list item
+    </td-markdown>`,
+})
+class TdMarkdownBasicTestComponent {
+}
+
+@Component({
+  template: `
+    <td-markdown [content]="content">
+    </td-markdown>`,
+})
+class TdMarkdownContentTestComponent {
+  content: string;
+}

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -44,7 +44,7 @@ export class TdMarkdownComponent implements AfterViewInit {
       // Parse html string into actual HTML elements.
       let divElement: HTMLDivElement = this._elementFromString(this._render(markdown));
       // Clean container
-      this._elementRef.nativeElement.innerHTML = '';
+      this._renderer.setElementProperty(this._elementRef.nativeElement, 'innerHTML', '');
       // Project DIV element into container
       this._renderer.projectNodes(this._elementRef.nativeElement, [divElement]);
     }

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -63,17 +63,16 @@ export class TdMarkdownComponent implements AfterViewInit {
     let lines: string[] = markup.split('\n');
 
     // check how much indentation is used by the first actual markup line
-    let whiteSpacesInfront: number = 0;
-    for (let i: number = 0; i < lines.length; i++) {
-      let line: string = lines[i];
-      if (line.trim().length > 0) {
-        whiteSpacesInfront = line.match(/^\s*/)[0].length;
+    let firstLineWhitespace: string = '';
+    for (let line of lines) {
+      if (line && line.trim().length > 0) {
+        firstLineWhitespace = line.match(/^\s*/)[0];
         break;
       }
     }
 
     // Remove all indentation spaces so markup can be parsed correctly
-    let startingWhitespaceRegex: RegExp = new RegExp('^\\s{' + whiteSpacesInfront + '}');
+    let startingWhitespaceRegex: RegExp = new RegExp('^' + firstLineWhitespace);
     lines = lines.map(function(line: string): string {
       return line.replace(startingWhitespaceRegex, '');
     });

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
+import { Component, AfterViewInit, ViewChild, ElementRef, Input } from '@angular/core';
 
 declare var showdown: any;
 
@@ -9,14 +9,44 @@ declare var showdown: any;
 })
 export class TdMarkdownComponent implements AfterViewInit {
 
-  @ViewChild('markdown') content: ElementRef;
+  private _content: string;
 
-  ngAfterViewInit(): void {
-    let markup: string = this.content.nativeElement.innerText;
-    this.content.nativeElement.innerHTML = this.render(markup);
+  @ViewChild('markdown') container: ElementRef;
+
+  /**
+   * content?: string
+   * 
+   * Markdown format content to be parsed as html markup.
+   * Used to load data dynamically.
+   * 
+   * e.g. Resource file.
+   */
+  @Input('content')
+  set content(content: string) {
+    this._content = content;
+    this._loadContent();
   }
 
-  render(markup: string): string {
+  ngAfterViewInit(): void {
+    if (!this._content) {
+      this._loadStaticTemplate();
+    }
+  }
+
+  private _loadContent(): void {
+    if (this._content) {
+      this.container.nativeElement.innerHTML = this._render(this._content);
+    }
+  }
+
+  private _loadStaticTemplate(): void {
+    let markup: string = this.container.nativeElement.innerText;
+    if (markup && markup.trim().length > 0) {
+      this.container.nativeElement.innerHTML = this._render(markup);
+    }
+  }
+
+  private _render(markup: string): string {
     // Split markup by line characters
     let lines: string[] = markup.split('\n');
 
@@ -43,6 +73,7 @@ export class TdMarkdownComponent implements AfterViewInit {
     let converter: any = new showdown.Converter();
     converter.setOption('ghCodeBlocks', true);
     converter.setOption('tasklists', true);
+    converter.setOption('tables', true);
     let html: string = converter.makeHtml(codeToParse);
     return html;
   }

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -10,6 +10,7 @@ declare var showdown: any;
 export class TdMarkdownComponent implements AfterViewInit {
 
   private _content: string;
+  markup: string;
 
   @ViewChild('markdown') container: ElementRef;
 
@@ -24,25 +25,18 @@ export class TdMarkdownComponent implements AfterViewInit {
   @Input('content')
   set content(content: string) {
     this._content = content;
-    this._loadContent();
+    this._loadContent(this._content);
   }
 
   ngAfterViewInit(): void {
     if (!this._content) {
-      this._loadStaticTemplate();
+      this._loadContent(this.container.nativeElement.innerText);
     }
   }
 
-  private _loadContent(): void {
-    if (this._content) {
-      this.container.nativeElement.innerHTML = this._render(this._content);
-    }
-  }
-
-  private _loadStaticTemplate(): void {
-    let markup: string = this.container.nativeElement.innerText;
-    if (markup && markup.trim().length > 0) {
-      this.container.nativeElement.innerHTML = this._render(markup);
+  private _loadContent(markdown: string): void {
+    if (markdown && markdown.trim().length > 0) {
+      this.markup = this._render(markdown);
     }
   }
 

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -12,15 +12,38 @@ export class TdMarkdownComponent implements AfterViewInit {
   @ViewChild('markdown') content: ElementRef;
 
   ngAfterViewInit(): void {
-    let code: string = this.content.nativeElement.innerText;
-    this.content.nativeElement.innerHTML = this.render(code);
+    let markup: string = this.content.nativeElement.innerText;
+    this.content.nativeElement.innerHTML = this.render(markup);
   }
 
-  render(contents: string): string {
+  render(markup: string): string {
+    // Split markup by line characters
+    let lines: string[] = markup.split('\n');
+
+    // check how much indentation is used by the first actual markup line
+    let whiteSpacesInfront: number = 0;
+    for (let i: number = 0; i < lines.length; i++) {
+      let line: string = lines[i];
+      if (line.trim().length > 0) {
+        whiteSpacesInfront = line.match(/^\s*/)[0].length;
+        break;
+      }
+    }
+
+    // Remove all indentation spaces so markup can be parsed correctly
+    let startingWhitespaceRegex: RegExp = new RegExp('^\\s{' + whiteSpacesInfront + '}');
+    lines = lines.map(function(line: string): string {
+      return line.replace(startingWhitespaceRegex, '');
+    });
+
+    // Join lines again with line characters
+    let codeToParse: string =  lines.join('\n');
+
+    // Convert markup into html
     let converter: any = new showdown.Converter();
     converter.setOption('ghCodeBlocks', true);
     converter.setOption('tasklists', true);
-    let html: string = converter.makeHtml(contents);
+    let html: string = converter.makeHtml(codeToParse);
     return html;
   }
 


### PR DESCRIPTION
## Description

Major enhancements, initial unit tests and XSS protection.

### What's included?

- **feature(markdown):** Support space indentation set by the first markdown line.
- **feature(markdown):** No more need to add `<pre><code>`.
- **feature(markdown):** Added `[content]` input to `td-markdown` to load content dynamically.
- **bugfix(markdown):** Use `Renderer` to limit access to native DOM and `DomSanitizer` to prevent `XSS` issues. 
- **bugfix(markdown):** `<hr>` was not showing properly. 
- **code-health(markdown):** Added initial set of unit-tests.
- Updated `README.md` and demo.
- Load `README.md` as resource using `[content]` input in docs to avoid doc duplication.

#### Test Steps

- [x] `ng serve` or `ng serve --aot --prod`
- [x] Go to localhost:4200/#/components/markdown and see docs with loaded `README.md`
- [x] `npm run test`
- [x] `npm run lint`
- [x] `npm run build`

##### Screenshots or link to CodePen/Plunker/JSfiddle

![image](https://cloud.githubusercontent.com/assets/5846742/22173381/b72d40de-df75-11e6-9cfc-1aa113b72097.png)
