### PR TITLE
Added "building for production" and "ahead-of-time compilation" sections to deployment documentation

### DIFF
--- a/src/app/components/docs/deployment/deployment.component.html
+++ b/src/app/components/docs/deployment/deployment.component.html
@@ -35,9 +35,27 @@
     of pushing to <code>gh-pages</code>, since user and organization pages require this.</p>
 
     <h3>Creating a build</h3>
+    <p></p>
     <p>The build artifacts will be stored in the dist/ directory.</p>
    <td-highlight lang="html">
      ng build
+   </td-highlight>
+
+    <h3>Building for production</h3>
+    <p>Adding the <code>prod</code> flag to <code>ng build</code> will
+      set the build target and environment to production, which will optimize the build.</p>
+   <td-highlight lang="html">
+     ng build --prod
+   </td-highlight>
+
+    <h3>Ahead-of-time Compilation</h3>
+    <p>When building for production, add the <code>aot</code>
+      flag to enable the Ahead-Of-Time compiler where the browser will
+      download a pre-compiled (from TypeScript) version of your application.
+      Ahead-of-time compilation may require modifications to your code, but
+      will enable faster rendering, fewer asynchronous requests, smaller Angular framework size, and better security.</p>
+   <td-highlight lang="html">
+     ng build --prod --aot
    </td-highlight>
   </md-card-content>
   <md-divider></md-divider>


### PR DESCRIPTION
## Description

Clarified build process for production with the explanation below.

## Building for production

Adding the prod flag to ng build will set the build target and environment to production, which will optimize the build.

`ng build --prod`

## Ahead-of-time Compilation

When building for production, add the aot flag to enable the Ahead-Of-Time compiler where the browser will download a pre-compiled (from TypeScript) version of your application. Ahead-of-time compilation may require modifications to your code, but will enable faster rendering, fewer asynchronous requests, smaller Angular framework size, and better security.

`ng build --prod --aot`
