### PR TITLE
Fix all trailing whitespace lint errors

### DIFF
--- a/src/platform/charts/abstract-chart.component.ts
+++ b/src/platform/charts/abstract-chart.component.ts
@@ -1,7 +1,7 @@
 import { OnInit } from '@angular/core';
 import { TdChartsComponent } from './charts.component';
 
-/* tslint:disable-next-line */ 
+/* tslint:disable-next-line */
 let d3: any = require('d3');
 
 export interface IChartData {

--- a/src/platform/core/common/animations/collapse/collapse.animation.ts
+++ b/src/platform/core/common/animations/collapse/collapse.animation.ts
@@ -2,12 +2,12 @@ import { trigger, state, style, transition, animate, AnimationEntryMetadata } fr
 
 /**
  * Function TdCollapseAnimation
- * 
+ *
  * params:
  * * duration: Duration of animation in miliseconds. Defaults to 150 ms.
- * 
+ *
  * Returns an [AnimationEntryMetadata] object with states for a collapse/expand animation.
- * 
+ *
  * usage: [@tdCollapse]="true|false"
  */
 export function TdCollapseAnimation(duration: number = 150): AnimationEntryMetadata {

--- a/src/platform/core/common/animations/fade/fadeInOut.animation.ts
+++ b/src/platform/core/common/animations/fade/fadeInOut.animation.ts
@@ -2,12 +2,12 @@ import { trigger, state, style, transition, animate, AnimationEntryMetadata } fr
 
 /**
  * Function TdFadeInOutAnimation
- * 
+ *
  * params:
  * * duration: Duration of animation in miliseconds. Defaults to 150 ms.
- * 
+ *
  * Returns an [AnimationEntryMetadata] object with states for a fading animation.
- * 
+ *
  * usage: [@tdFadeInOut]="true|false"
  */
 export function TdFadeInOutAnimation(duration: number = 150): AnimationEntryMetadata {

--- a/src/platform/core/common/pipes/bytes/bytes.pipe.ts
+++ b/src/platform/core/common/pipes/bytes/bytes.pipe.ts
@@ -5,7 +5,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 
 export class TdBytesPipe implements PipeTransform {
-  /* `bytes` needs to be `any` or TypeScript complains 
+  /* `bytes` needs to be `any` or TypeScript complains
   Tried both `number` and `number | string` */
   transform(bytes: any, precision: number = 2): string {
     if (bytes === 0) {

--- a/src/platform/core/common/services/router.service.spec.ts
+++ b/src/platform/core/common/services/router.service.spec.ts
@@ -41,7 +41,7 @@ describe('Service: RouterPath', () => {
     (router: Router, routerPathService: RouterPathService) => {
         const fixture: ComponentFixture<FakeComponent> = TestBed.createComponent(FakeComponent);
 
-        // navigate to /foo then navigate to / 
+        // navigate to /foo then navigate to /
         // which will set previous route to /foo
         router.navigate(['/foo']);
         fixture.detectChanges();

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Renderer, ElementRef, HostBinding } from '@angular/core';
 
 @Component({
-  /* tslint:disable-next-line */ 
+  /* tslint:disable-next-line */
   selector: 'td[td-data-table-cell]',
   styleUrls: ['./data-table-cell.component.scss' ],
   templateUrl: './data-table-cell.component.html',

--- a/src/platform/core/data-table/data-table-column/data-table-column.component.ts
+++ b/src/platform/core/data-table/data-table-column/data-table-column.component.ts
@@ -8,7 +8,7 @@ export interface ITdDataTableSortChangeEvent {
 }
 
 @Component({
-  /* tslint:disable-next-line */ 
+  /* tslint:disable-next-line */
   selector: 'th[td-data-table-column]',
   styleUrls: ['./data-table-column.component.scss' ],
   templateUrl: './data-table-column.component.html',

--- a/src/platform/core/data-table/data-table-row/data-table-row.component.ts
+++ b/src/platform/core/data-table/data-table-row/data-table-row.component.ts
@@ -1,7 +1,7 @@
 import { Component, Renderer, ElementRef } from '@angular/core';
 
 @Component({
-  /* tslint:disable-next-line */ 
+  /* tslint:disable-next-line */
   selector: 'tr[td-data-table-row]',
   styleUrls: ['./data-table-row.component.scss' ],
   templateUrl: './data-table-row.component.html',

--- a/src/platform/core/data-table/data-table-table/data-table-table.component.ts
+++ b/src/platform/core/data-table/data-table-table/data-table-table.component.ts
@@ -1,7 +1,7 @@
 import { Component, Renderer, ElementRef } from '@angular/core';
 
 @Component({
-  /* tslint:disable-next-line */ 
+  /* tslint:disable-next-line */
   selector: 'table[td-data-table]',
   styleUrls: ['./data-table-table.component.scss' ],
   templateUrl: './data-table-table.component.html',

--- a/src/platform/core/data-table/services/data-table.service.ts
+++ b/src/platform/core/data-table/services/data-table.service.ts
@@ -10,7 +10,7 @@ export class TdDataTableService {
    * - data: any[]
    * - searchTerm: string
    * - ignoreCase: boolean = false
-   * 
+   *
    * Searches [data] parameter for [searchTerm] matches and returns a new array with them.
    */
   filterData(data: any[], searchTerm: string, ignoreCase: boolean = false): any[] {
@@ -33,7 +33,7 @@ export class TdDataTableService {
    * - data: any[]
    * - sortBy: string
    * - sortOrder: TdDataTableSortingOrder = TdDataTableSortingOrder.Ascending
-   * 
+   *
    * Sorts [data] parameter by [sortBy] and [sortOrder] and returns the sorted data.
    */
   sortData(data: any[], sortBy: string, sortOrder: TdDataTableSortingOrder = TdDataTableSortingOrder.Ascending): any[] {
@@ -62,7 +62,7 @@ export class TdDataTableService {
    * - data: any[]
    * - fromRow: number
    * - toRow: : number
-   * 
+   *
    * Returns a section of the [data] parameter starting from [fromRow] and ending in [toRow].
    */
   pageData(data: any[], fromRow: number, toRow: number): any[] {

--- a/src/platform/core/dialogs/services/dialog.service.ts
+++ b/src/platform/core/dialogs/services/dialog.service.ts
@@ -56,7 +56,7 @@ export class TdDialogService {
    * @deprecated since 0.9
    */
   public setDefaultViewContainerRef(viewContainerRef: ViewContainerRef): void {
-    /* tslint:disable-next-line */ 
+    /* tslint:disable-next-line */
     console.warn('setDefaultViewContainerRef is deprecated. ViewContainerRef is no longer required.');
   }
 

--- a/src/platform/core/file/services/file.service.ts
+++ b/src/platform/core/file/services/file.service.ts
@@ -30,13 +30,13 @@ export class TdFileService {
 
   /**
    * params:
-   * - options: IUploadOptions { 
-   *     url: string, 
+   * - options: IUploadOptions {
+   *     url: string,
    *     method: 'post' | 'put',
    *     file: File,
    *     headers?: {[key: string]: string}
    * }
-   * 
+   *
    * Uses underlying [XMLHttpRequest] to upload a file to a url.
    * Will be depricated when angular2 fixes [Http] to allow [FormData] as body.
    */

--- a/src/platform/core/json-formatter/json-formatter.component.spec.ts
+++ b/src/platform/core/json-formatter/json-formatter.component.spec.ts
@@ -69,7 +69,7 @@ describe('Component: JsonFormatter', () => {
         dateProperty: new Date(),
         numberProperty: 1,
         functionProperty: function(): void {/* */},
-        /* tslint:disable-next-line */ 
+        /* tslint:disable-next-line */
         nullProperty: null,
         undefinedProperty: undefined,
         arrayProperty: [],
@@ -111,7 +111,7 @@ describe('Component: JsonFormatter', () => {
         fixture.detectChanges();
         expect(fixture.debugElement.query(By.css('.td-key-node'))).toBeTruthy();
         expect(fixture.debugElement.queryAll(By.css('.td-key-leaf')).length).toBe(6);
-        /* tslint:disable-next-line */ 
+        /* tslint:disable-next-line */
         expect(fixture.debugElement.query(By.css('.td-object-children')).styles['display']).toBe('none');
       });
   })));
@@ -125,13 +125,13 @@ describe('Component: JsonFormatter', () => {
       fixture.whenStable().then(() => {
         fixture.detectChanges();
         expect(fixture.debugElement.query(By.css('.td-key-node'))).toBeTruthy();
-        /* tslint:disable-next-line */ 
+        /* tslint:disable-next-line */
         expect(fixture.debugElement.query(By.css('.td-object-children')).styles['display']).toBe('none');
         fixture.debugElement.query(By.css('.td-key-node')).triggerEventHandler('click', new Event('click'));
         fixture.detectChanges();
         fixture.whenStable().then(() => {
           fixture.detectChanges();
-          /* tslint:disable-next-line */ 
+          /* tslint:disable-next-line */
           expect(fixture.debugElement.query(By.css('.td-object-children')).styles['display']).toBeNull();
         });
       });
@@ -146,7 +146,7 @@ describe('Component: JsonFormatter', () => {
       fixture.detectChanges();
       fixture.whenStable().then(() => {
         fixture.detectChanges();
-        /* tslint:disable-next-line */ 
+        /* tslint:disable-next-line */
         expect(fixture.debugElement.query(By.css('.td-object-children')).styles['display']).toBeNull();
       });
   })));
@@ -159,7 +159,7 @@ describe('Component: JsonFormatter', () => {
       fixture.detectChanges();
       fixture.whenStable().then(() => {
         fixture.detectChanges();
-        /* tslint:disable-next-line */ 
+        /* tslint:disable-next-line */
         expect(fixture.debugElement.query(By.css('.string')).nativeElement.textContent.trim()).toBe('"test"');
         component.data.property = 'test2';
         fixture.detectChanges();

--- a/src/platform/core/loading/directives/loading.directive.ts
+++ b/src/platform/core/loading/directives/loading.directive.ts
@@ -25,7 +25,7 @@ export class TdLoadingDirective implements OnInit, OnDestroy {
 
   /**
    * @deprecated in 1.0.0-beta.1
-   * 
+   *
    * Please use the `tdLoadingType` method.
    */
   @Input('loadingType')
@@ -53,7 +53,7 @@ export class TdLoadingDirective implements OnInit, OnDestroy {
 
   /**
    * @deprecated in 1.0.0-beta.1
-   * 
+   *
    * Please use the `tdLoadingMode` method.
    */
   @Input('loadingMode')

--- a/src/platform/core/loading/services/loading.factory.ts
+++ b/src/platform/core/loading/services/loading.factory.ts
@@ -34,7 +34,7 @@ export class TdLoadingFactory {
   /**
    * Uses material `Overlay` services to create a DOM element and attach the loading component
    * into it. Leveraging the state and configuration from it.
-   * 
+   *
    * Saves a reference in context to be called when registering/resolving the loading element.
    */
   public createFullScreenComponent(options: ITdLoadingConfig): ILoadingRef {
@@ -66,9 +66,9 @@ export class TdLoadingFactory {
 
   /**
    * Creates a loading component dynamically and attaches it into the given viewContainerRef.
-   * Leverages TemplatePortals from material to inject the template inside of it so it fits 
+   * Leverages TemplatePortals from material to inject the template inside of it so it fits
    * perfecly when overlaying it.
-   * 
+   *
    * Saves a reference in context to be called when registering/resolving the loading element.
    */
   public createOverlayComponent(options: ITdLoadingConfig, viewContainerRef: ViewContainerRef,
@@ -96,7 +96,7 @@ export class TdLoadingFactory {
   /**
    * Creates a loading component dynamically and attaches it into the given viewContainerRef.
    * Replaces the template with the loading component depending if it was registered or resolved.
-   * 
+   *
    * Saves a reference in context to be called when registering/resolving the loading element.
    */
   public createReplaceComponent(options: ITdLoadingConfig, viewContainerRef: ViewContainerRef,

--- a/src/platform/core/loading/services/loading.service.ts
+++ b/src/platform/core/loading/services/loading.service.ts
@@ -75,7 +75,7 @@ export class TdLoadingService {
    *
    * Creates an replace loading mask and attaches it to the viewContainerRef.
    * Replaces the templateRef with the mask when a request is registered on it.
-   * 
+   *
    * NOTE: @internal usage only.
    */
   createComponent(config: ITdLoadingDirectiveConfig, viewContainerRef: ViewContainerRef,
@@ -107,7 +107,7 @@ export class TdLoadingService {
 
   /**
    * @deprecated in 1.0.0-beta.1
-   * 
+   *
    * Please use the `create()` method.
    */
   public createOverlayComponent(config: ITdLoadingConfig, viewContainerRef: ViewContainerRef): void {
@@ -119,7 +119,7 @@ export class TdLoadingService {
   /**
    * params:
    * - name: string
-   * 
+   *
    * Removes `loading` component from service context.
    */
   public removeComponent(name: string): void {
@@ -138,12 +138,12 @@ export class TdLoadingService {
    * - name: string
    * - registers?: number
    * returns: true if successful
-   * 
+   *
    * Resolves a request for the loading mask referenced by the name parameter.
    * Can optionally pass registers argument to set a number of register calls.
-   * 
+   *
    * If no paramemeters are used, then default main mask will be used.
-   * 
+   *
    * e.g. loadingService.register()
    */
   public register(name: string = 'td-loading-main', registers: number = 1): boolean {
@@ -161,12 +161,12 @@ export class TdLoadingService {
    * - name: string
    * - resolves?: number
    * returns: true if successful
-   * 
+   *
    * Registers a request for the loading mask referenced by the name parameter.
    * Can optionally pass resolves argument to set a number of resolve calls.
-   * 
+   *
    * If no paramemeters are used, then default main mask will be used.
-   * 
+   *
    * e.g. loadingService.register()
    */
   public resolve(name: string = 'td-loading-main', resolves: number = 1): boolean {
@@ -188,7 +188,7 @@ export class TdLoadingService {
    * - name: string
    * - value: number
    * returns: true if successful
-   * 
+   *
    * Set value on a loading mask referenced by the name parameter.
    * Usage only available if its mode is 'determinate' and if loading is showing.
    */

--- a/src/platform/core/media/services/media.service.ts
+++ b/src/platform/core/media/services/media.service.ts
@@ -39,7 +39,7 @@ export class TdMediaService {
   }
 
   /**
-   * Registers a media query and returns an [Observable] that will re-evaluate and 
+   * Registers a media query and returns an [Observable] that will re-evaluate and
    * return if the given media query matches on window resize.
    * Note: don't forget to unsubscribe from [Observable] when finished watching.
    */

--- a/src/platform/core/steps/steps.component.ts
+++ b/src/platform/core/steps/steps.component.ts
@@ -100,7 +100,7 @@ export class TdStepsComponent implements OnDestroy, AfterContentInit {
   }
 
   /**
-   * Wraps previous and new [TdStepComponent] numbers in an object that implements [IStepChangeEvent] 
+   * Wraps previous and new [TdStepComponent] numbers in an object that implements [IStepChangeEvent]
    * and emits [onStepChange] event.
    */
   private _onStepSelection(step: TdStepComponent): void {

--- a/src/platform/dynamic-forms/dynamic-forms.component.spec.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.component.spec.ts
@@ -89,7 +89,7 @@ describe('Component: TdDynamicForms', () => {
       let dynamicFormsComponent: TdDynamicFormsComponent =
           fixture.debugElement.query(By.directive(TdDynamicFormsComponent)).componentInstance;
       expect(dynamicFormsComponent.valid).toBeFalsy();
-      /* tslint:disable-next-line */ 
+      /* tslint:disable-next-line */
       expect(JSON.stringify(dynamicFormsComponent.value)).toBe(JSON.stringify({first_name: null, on_it: true}));
     });
   })));
@@ -116,7 +116,7 @@ describe('Component: TdDynamicForms', () => {
       let dynamicFormsComponent: TdDynamicFormsComponent =
           fixture.debugElement.query(By.directive(TdDynamicFormsComponent)).componentInstance;
       expect(dynamicFormsComponent.valid).toBeFalsy();
-      /* tslint:disable-next-line */ 
+      /* tslint:disable-next-line */
       expect(JSON.stringify(dynamicFormsComponent.value)).toBe(JSON.stringify({first_name: null, age: 17}));
     });
   })));
@@ -145,7 +145,7 @@ describe('Component: TdDynamicForms', () => {
       let dynamicFormsComponent: TdDynamicFormsComponent =
           fixture.debugElement.query(By.directive(TdDynamicFormsComponent)).componentInstance;
       expect(dynamicFormsComponent.valid).toBeTruthy();
-      /* tslint:disable-next-line */ 
+      /* tslint:disable-next-line */
       expect(JSON.stringify(dynamicFormsComponent.value)).toBe(JSON.stringify({first_name: 'name', age: 20}));
     });
   })));

--- a/src/platform/highlight/highlight.component.ts
+++ b/src/platform/highlight/highlight.component.ts
@@ -1,6 +1,6 @@
 import { Component, AfterViewInit, ElementRef, Input, Renderer, SecurityContext } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
-/* tslint:disable-next-line */ 
+/* tslint:disable-next-line */
 let hljs: any = require('highlight.js/lib');
 
 @Component({
@@ -14,10 +14,10 @@ export class TdHighlightComponent implements AfterViewInit {
 
   /**
    * content?: string
-   * 
+   *
    * Code content to be parsed as highlighted html.
    * Used to load data dynamically.
-   * 
+   *
    * e.g. `.html`, `.ts` , etc.
    */
   @Input('content')
@@ -28,10 +28,10 @@ export class TdHighlightComponent implements AfterViewInit {
 
   /**
    * lang?: string
-   * 
+   *
    * Language of the code content to be parsed as highlighted html.
    * Defaults to `typescript`
-   * 
+   *
    * e.g. `typescript`, `html` , etc.
    */
   @Input('lang') language: string = 'typescript';

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -14,10 +14,10 @@ export class TdMarkdownComponent implements AfterViewInit {
 
   /**
    * content?: string
-   * 
+   *
    * Markdown format content to be parsed as html markup.
    * Used to load data dynamically.
-   * 
+   *
    * e.g. README.md content.
    */
   @Input('content')

--- a/src/tests/utilities/covalent-tests.ts
+++ b/src/tests/utilities/covalent-tests.ts
@@ -3,7 +3,7 @@ import { DebugElement } from '@angular/core';
 export class CovalentTests {
 
   /*
-  * Utility function that traverses down the DOM to find the dialog overlay and then 
+  * Utility function that traverses down the DOM to find the dialog overlay and then
   * traverses down the DOM of that overlay to get the Update/Stop button.
   * This could be a brittle way of doing this so best to keep this in a utility
   * function that can be changed for all places needing this.
@@ -12,7 +12,7 @@ export class CovalentTests {
       let elements: NodeList = document.querySelectorAll('[id^=cdk-overlay]');
       for (let index: number = 0; index < elements.length; index++) {
           let dialogOverlayId: string = elements.item(index).attributes.getNamedItem('id').value;
-          // try to click update on any error dialogs found.  If there is an error trying to click one just 
+          // try to click update on any error dialogs found.  If there is an error trying to click one just
           // hide the error as it may not be clickable yet in the DOM or something
           try {
             let confirmButton: Element = document.getElementById(dialogOverlayId).children.item(0)
@@ -24,7 +24,7 @@ export class CovalentTests {
   }
 
   /*
-  * Utility function that traverses down the DOM to find the dialog overlay and then 
+  * Utility function that traverses down the DOM to find the dialog overlay and then
   * traverses down the DOM of that overlay to get the Share button.
   * This could be a brittle way of doing this so best to keep this in a utility
   * function that can be changed for all places needing this.
@@ -32,7 +32,7 @@ export class CovalentTests {
   public static clickDialogButton(component: any, buttonText: string): void {
       let elements: NodeList = document.querySelectorAll('[md-button]');
       for (let index: number = 0; index < elements.length; index++) {
-          // try to click share on any buttons found with share as the text content.  If there is an error trying to click one just 
+          // try to click share on any buttons found with share as the text content.  If there is an error trying to click one just
           // hide the error as it may not be clickable yet in the DOM or something
           try {
             let button: Node = elements.item(index);
@@ -90,7 +90,7 @@ export class CovalentTests {
       let elements: NodeList = document.querySelectorAll('[id^=cdk-overlay]');
       for (let index: number = 0; index < elements.length; index++) {
           let dialogOverlayId: string = elements.item(index).attributes.getNamedItem('id').value;
-          // try to close any error dialogs found.  If there is an error trying to close one just 
+          // try to close any error dialogs found.  If there is an error trying to close one just
           // hide the error as it may not be clickable yet in the DOM or something
           try {
             let closeButton: Element = document.getElementById(dialogOverlayId).children.item(0)
@@ -102,7 +102,7 @@ export class CovalentTests {
   }
 
   /*
-  * Utility function that queires the DOM for all cdk-overlay-* and returns true 
+  * Utility function that queires the DOM for all cdk-overlay-* and returns true
   * if it finds one that has "There was a problem" as the firstChild Text
   * This could be a brittle way of doing this so best to keep this in a utility
   * function that can be changed for all places needing this.


### PR DESCRIPTION
## Description

After upgrading lint we are encountering many lint errors with trailing whitespace.  This PR fixes those.

### What's included?

- modified:   src/platform/charts/abstract-chart.component.ts
- modified:   src/platform/core/common/animations/collapse/collapse.animation.ts
- modified:   src/platform/core/common/animations/fade/fadeInOut.animation.ts
- modified:   src/platform/core/common/pipes/bytes/bytes.pipe.ts
- modified:   src/platform/core/common/services/router.service.spec.ts
- modified:   src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
- modified:   src/platform/core/data-table/data-table-column/data-table-column.component.ts
- modified:   src/platform/core/data-table/data-table-row/data-table-row.component.ts
- modified:   src/platform/core/data-table/data-table-table/data-table-table.component.ts
- modified:   src/platform/core/data-table/services/data-table.service.ts
- modified:   src/platform/core/dialogs/services/dialog.service.ts
- modified:   src/platform/core/file/services/file.service.ts
- modified:   src/platform/core/json-formatter/json-formatter.component.spec.ts
- modified:   src/platform/core/loading/directives/loading.directive.ts
- modified:   src/platform/core/loading/services/loading.factory.ts
- modified:   src/platform/core/loading/services/loading.service.ts
- modified:   src/platform/core/media/services/media.service.ts
- modified:   src/platform/core/steps/steps.component.ts
- modified:   src/platform/dynamic-forms/dynamic-forms.component.spec.ts
- modified:   src/platform/highlight/highlight.component.ts
- modified:   src/platform/markdown/markdown.component.ts
- modified:   src/tests/utilities/covalent-tests.ts

#### Test Steps

- [ ] checkout branch feature/fix-linting
- [ ] run ng lint
- [ ] run ng test
- [ ] see both pass without error
