### PR TITLE
bugfix(general): fixes for `chips` and `search`.

### DIFF
--- a/src/platform/core/chips/chips.component.html
+++ b/src/platform/core/chips/chips.component.html
@@ -17,7 +17,7 @@
                    (blur)="handleBlur() && (matches = autocomplete.clear())"
                    (itemSelect)="(matches = addItem($event)) && autocomplete.clear()"></td-autocomplete>
   <div class="md-input-underline"
-       [class.md-disabled]="disabled">
+       [class.md-disabled]="readOnly">
     <span class="md-input-ripple"
           [class.md-focused]="focused"
           [class.md-warn]="!matches"></span>

--- a/src/platform/core/data-table/_data-table-theme.scss
+++ b/src/platform/core/data-table/_data-table-theme.scss
@@ -20,7 +20,7 @@
       font-weight: 400;
       letter-spacing: 0.010em;
       line-height: 20px;
-      md-input {
+      md-input-container {
         .md-input-underline {
           display: none;
         }

--- a/src/platform/core/search/search-input/search-input.component.html
+++ b/src/platform/core/search/search-input/search-input.component.html
@@ -4,8 +4,8 @@
             #searchElement
             [class.md-hide-underline]="!showUnderline"
             type="search"
+            [(ngModel)]="value"
             [placeholder]="placeholder"
-            [formControl]="searchTermControl"
             (blur)="handleBlur()"
             (search)="stopPropagation($event)"
             (keyup.enter)="handleSearch($event)"/>

--- a/src/platform/core/search/search-input/search-input.component.html
+++ b/src/platform/core/search/search-input/search-input.component.html
@@ -1,8 +1,7 @@
 <div class="td-search-input" layout="row" layout-align="end center">
-  <md-input-container flex>
+  <md-input-container [class.md-hide-underline]="!showUnderline" flex>
     <input md-input
             #searchElement
-            [class.md-hide-underline]="!showUnderline"
             type="search"
             [(ngModel)]="value"
             [placeholder]="placeholder"

--- a/src/platform/core/search/search-input/search-input.component.scss
+++ b/src/platform/core/search/search-input/search-input.component.scss
@@ -1,7 +1,7 @@
 .td-search-input {
   height: 64px;
   overflow-x: hidden;
-  /deep/ md-input.md-hide-underline {
+  /deep/ md-input-container.md-hide-underline {
     .md-input-underline {
       display: none;
     }

--- a/src/platform/core/search/search-input/search-input.component.ts
+++ b/src/platform/core/search/search-input/search-input.component.ts
@@ -25,16 +25,9 @@ import 'rxjs/add/operator/debounceTime';
 })
 export class TdSearchInputComponent implements OnInit {
 
-  set value(value: any) {
-    this.searchTermControl.setValue(value);
-  }
-  get value(): any {
-    return this.searchTermControl.value;
-  }
-
   @ViewChild(MdInputDirective) private _input: MdInputDirective;
 
-  searchTermControl: FormControl = new FormControl();
+  value: string;
 
   /**
    * showUnderline?: boolean
@@ -79,7 +72,7 @@ export class TdSearchInputComponent implements OnInit {
   @Output('blur') onBlur: EventEmitter<void> = new EventEmitter<void>();
 
   ngOnInit(): void {
-    this.searchTermControl.valueChanges
+    this._input._ngControl.valueChanges
       .debounceTime(this.debounce)
       .subscribe((value: string) => {
         this._searchTermChanged(value);
@@ -103,11 +96,11 @@ export class TdSearchInputComponent implements OnInit {
 
   handleSearch(event: Event): void {
     this.stopPropagation(event);
-    this.onSearch.emit(this.searchTermControl.value);
+    this.onSearch.emit(this.value);
   }
 
   clearSearch(): void {
-    this.searchTermControl.setValue('');
+    this.value = '';
     this.onClear.emit(undefined);
   }
 

--- a/src/platform/core/search/search.module.ts
+++ b/src/platform/core/search/search.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule } from '@angular/forms';
 
 import { MaterialModule } from '@angular/material';
 
@@ -13,7 +13,7 @@ export { TdSearchInputComponent } from './search-input/search-input.component';
 
 @NgModule({
   imports: [
-    ReactiveFormsModule,
+    FormsModule,
     CommonModule,
     MaterialModule.forRoot(),
   ],


### PR DESCRIPTION
## Description

- **bugfix(chips):** `[readOnly]` state was not being shown properly.
- **bugfix(search):** clear button was not working properly since `input` was not considered empty and label would stay floating.
- **bugfix(search):** scss for `hide-underline` was wrong (md-input deprecation)

#### Test Steps

- [x] Go to chips, and search in getcovalent.com and compare with `ng serve`
