### PR TITLE
bugfix(loading): fixed bug between `tdLoading` and `[routerLinkActive]`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="1.0.0-beta.1-1"></a>
+# [1.0.0-beta.1-1](https://github.com/Teradata/covalent/tree/v1.0.0-beta.1) (2017-01-31)
+
+## Bug Fixes
+* **loading**: Fixed edge case that tried to create the same `tdLoading` twice a component that uses `[routerLinkActive]` when navigating into it.
+
+
 <a name="1.0.0-beta.1"></a>
 # [1.0.0-beta.1 Purple Rain](https://github.com/Teradata/covalent/tree/v1.0.0-beta.1) (2017-01-30)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "covalent",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.1-1",
   "private": true,
   "description": "Teradata UI Platform built on Angular Material 2",
   "keywords": [

--- a/scripts/publish-release
+++ b/scripts/publish-release
@@ -6,7 +6,10 @@ npm login --scope=$scope
 
 for package in ./deploy/platform/*
 do
-  npm publish ${package} --access=public
+  if [ -d ${package} ]
+  then
+    npm publish ${package} --access=public
+  fi
 done
 
 #logout when finished

--- a/src/platform/charts/package.json
+++ b/src/platform/charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/charts",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.1-1",
   "description": "Teradata UI Platform Charts Module",
   "keywords": [
     "angular",

--- a/src/platform/core/package.json
+++ b/src/platform/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/core",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.1-1",
   "description": "Teradata UI Platform built on Angular Material 2",
   "main": "./core.umd.js",
   "module": "./index.js",

--- a/src/platform/dynamic-forms/package.json
+++ b/src/platform/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/dynamic-forms",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.1-1",
   "description": "Teradata UI Platform Dynamic Forms Module",
   "main": "./dynamic-forms.umd.js",
   "module": "./index.js",
@@ -36,6 +36,6 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@covalent/core": "1.0.0-beta.1"
+    "@covalent/core": "1.0.0-beta.1-1"
   }
 }

--- a/src/platform/highlight/package.json
+++ b/src/platform/highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/highlight",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.1-1",
   "description": "Teradata UI Platform Highlight Module",
   "main": "./highlight.umd.js",
   "module": "./index.js",

--- a/src/platform/http/package.json
+++ b/src/platform/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/http",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.1-1",
   "description": "Teradata UI Platform Http Helper Module",
   "main": "./http.umd.js",
   "module": "./index.js",

--- a/src/platform/markdown/package.json
+++ b/src/platform/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/markdown",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.1-1",
   "description": "Teradata UI Platform Markdown Module",
   "main": "./markdown.umd.js",
   "module": "./index.js",


### PR DESCRIPTION
## Description

- **bugfix(loading):** Fixed edge case that tried to create the same `tdLoading` twice when using `tdLoading` directive inside a component that uses `[routerLinkActive]` when navigating into it.
- **bugfix(publish):** Fixed publish script to only loop through directories inside `deploy/platform/`

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.