### PR TITLE
bugfix(build): cleanse the build by removing the `ts` source files.

### DIFF
--- a/scripts/build-release
+++ b/scripts/build-release
@@ -15,6 +15,12 @@ echo "Preparing files for AoT build"
 npm run aot
 echo "Compiled TS and generated *.metadata.json files..."
 
+# Clean source .ts files
+cd deploy/
+find . -name "*.ts" ! -name "*.d.ts" -type f -delete
+cd ..
+echo "Remove source .ts files so they arent published"
+
 # Inline the css and html into the component files.
 gulp inline-resource-files
 echo "Resources inlined..."


### PR DESCRIPTION

## Description

There is a need to remove the source files (`ts`) from the release code since the `@angular-cli` picks them up instead of the `js` files which in term breaks `aot` with their new release.

We still needed to do this since those files shouldnt be there either way.

### What's included?

- Cleanse of build when running the `npm run build` script.

#### Test Steps

- [ ] `npm run build` in `develop` and see that all the `ts` files are in `deploy/platform/`
- [ ] `npm run build` in this branch and see that they are removed now.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle