### PR TITLE
fix(rollup): add missing dep to options.globals

### DIFF
--- a/scripts/rollup.js
+++ b/scripts/rollup.js
@@ -28,6 +28,7 @@ gulp.task('rollup-code', '', function() {
     '@angular/platform-browser': 'ng.platformBrowser',
     '@angular/platform-browser-dynamic': 'ng.platformBrowserDynamic',
     '@angular/material': 'ng.material',
+    '@angular/flex-layout': 'ng.flexLayout',
 
     // Rxjs dependencies
     'rxjs/Subject': 'Rx',


### PR DESCRIPTION
## Description

Flex-Layout was added as a dependency but was omitted from the rollup script.

### What's included?

- Adds flex-layout prop to rollup.js `options.globals` .

#### Test Steps

Executing  `build-release` will currently emit a warning when executing rollup.

```
Treating '@angular/flex-layout' as external dependency
No name was provided for external module '@angular/flex-layout' in options.globals – guessing '_angular_flexLayout'
Treating '@angular/flex-layout' as external dependency
No name was provided for external module '@angular/flex-layout' in options.globals – guessing '_angular_flexLayout'
```