### PR TITLE
fix(data-table): td-data-table-column return proper name in sort event. (closes #349)

### DIFF
--- a/src/platform/core/data-table/data-table-column/data-table-column.component.ts
+++ b/src/platform/core/data-table/data-table-column/data-table-column.component.ts
@@ -93,7 +93,7 @@ export class TdDataTableColumnComponent {
   }
 
   handleSortBy(): void {
-    this.onSortChange.emit({name: name, order: this._sortOrder});
+    this.onSortChange.emit({name: this.name, order: this._sortOrder});
   }
 
   isAscending(): boolean {


### PR DESCRIPTION
## Description

The td-data-table-column wasnt setting the name properly and getting it from a global name. https://github.com/Teradata/covalent/issues/349

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.