### PR TITLE
update(home): notification updates for beta2

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -18,9 +18,9 @@
             </a>
             <md-divider></md-divider>
           </template>
-          <a md-list-item href="https://github.com/Teradata/covalent/blob/develop/package.json#L56-L65" target="_blank">
+          <a md-list-item href="https://github.com/Teradata/covalent/blob/develop/package.json#L57-L81" target="_blank">
             <md-icon md-list-avatar>change_history</md-icon>
-            <h4 md-line><span class="text-wrap">Angular 2.4.4 &amp; CLI beta.26</span></h4>
+            <h4 md-line><span class="text-wrap">Angular 2.4.5, Material beta2 &amp; CLI beta.32.3</span></h4>
             <p md-line>Dependencies updated</p>
           </a>
         </md-nav-list>

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -46,40 +46,35 @@ export class HomeComponent implements OnInit {
   ];
 
   updates: Object[] = [{
-      description: 'Navigation Drawer sidenav component',
-      icon: 'kitchen',
-      route: 'style-guide/navigation-drawer',
-      title: 'New component & pattern',
+      description: 'File Input component',
+      icon: 'space_bar',
+      route: 'components/file-input',
+      title: 'New component',
     }, {
-      description: 'Management list (data-list) pattern',
-      icon: 'view_list',
-      route: 'style-guide/management-list',
-      title: 'New pattern',
+      description: 'NGX Translate',
+      icon: 'language',
+      route: 'components/ngx-translate',
+      title: 'New supported feature',
     }, {
-      description: 'Responsive layout modes & toggles',
+      description: 'Route on toolbar logos',
       icon: 'dashboard',
       route: 'layouts',
       title: 'Component updated',
     }, {
-      description: 'Highlight themes & hardening',
-      icon: 'code',
-      route: 'components/syntax-highlighting',
+      description: 'Data Table additional features',
+      icon: 'grid_on',
+      route: 'components/data-table',
       title: 'Component updated',
     }, {
-      description: 'Markdown file support & hardening',
-      icon: 'chrome_reader_mode',
-      route: 'components/markdown',
+      description: 'File upload refactored',
+      icon: 'attach_file',
+      route: 'components/file-upload',
       title: 'Component updated',
     }, {
-      description: 'Loading colors & enhancements',
-      icon: 'hourglass_empty',
-      route: 'components/loading',
+      description: 'Paging Bar additional features',
+      icon: 'swap_horiz',
+      route: 'components/paging',
       title: 'Component updated',
-    }, {
-      description: 'Sketch template updated',
-      icon: 'cloud_download',
-      route: 'style-guide/resources',
-      title: 'Resource updated',
     },
   ];
 


### PR DESCRIPTION
## Description

![image](https://cloud.githubusercontent.com/assets/867883/23274333/fc7d884e-f9c7-11e6-9440-85e93c6d93ba.png)

### What's included?

- updated notifications menu on homepage

#### Test Steps

- [ ] npm i
- [ ] ng serve
- [ ] click notification button

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle