### PR TITLE
fix(loading): center loading component in replace mode

### DIFF
--- a/src/platform/core/loading/loading.component.html
+++ b/src/platform/core/loading/loading.component.html
@@ -1,6 +1,7 @@
 <div class="td-loading-wrapper" [style.min-height]="getHeight()" [class.td-overlay]="isOverlay() || isFullScreen()" [class.td-fullscreen]="isFullScreen()">
   <div [@tdFadeInOut]="animation"
      (@tdFadeInOut.done)="animationComplete($event)"
+     [style.min-height]="getHeight()"
      class="td-loading"
      layout="row"
      layout-align="center center"


### PR DESCRIPTION
## Description

Center loading component on replace mode. (it was sticking to the top)

#### Test Steps

- [x] `ng serve`
- [x] Go to http://localhost:4200/#/components/loading
- [x] Check second demo.

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.