### PR TITLE
fix(): remove @Injectable decorator from HttpInterceptorService. (closes #340)

### DIFF
--- a/src/platform/http/interceptors/http-interceptor.service.ts
+++ b/src/platform/http/interceptors/http-interceptor.service.ts
@@ -13,7 +13,6 @@ export interface IHttpInterceptorConfig {
   paths: string[];
 }
 
-@Injectable()
 export class HttpInterceptorService {
 
   private _requestInterceptors: IHttpInterceptorMapping[] = [];


### PR DESCRIPTION
## Description

https://github.com/Teradata/covalent/issues/340
we can remove this decorator since this service isnt intended to be injected alone, it needs to be provided via factory. (e.g. Router)

### What's included?

- Removal @Injectable decorator from HttpInterceptorService so we can support @angular@4.X

#### Test Steps

- [ ] `ng serve --aot` in current version (see it working)
- [ ] point to `@angular/*/@4.0.0.beta.8` or up in the `package.json`
- [ ] `npm run reinstall`
- [ ] `ng serve --aot`

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
