### PR TITLE
chore(): upgrade guide for beta.2

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,3 +1,13 @@
+## Upgrade from 1.0.0-beta.1 to 1.0.0-beta.2
+
+Upgraded dependencies:
+ - angular-cli@1.0.0-beta.26 to 1.0.0-rc.0
+ - material@2.0.0-beta.1 to 2.0.0-beta.2
+ - flex-layout@2.0.0-beta.5 addition
+ - ngx-charts@3.1.2 to 4.1.3
+
+[1.0.0-beta.2 Upgrade Steps](https://github.com/Teradata/covalent-quickstart/pull/46/commits) and [Changelog](https://github.com/Teradata/covalent/blob/develop/docs/CHANGELOG.md#100-beta2-hotel-california-2017-02-23)
+
 ## Upgrade from 0.10 to 1.0.0-beta.1
 
 Upgraded dependencies:

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -3,7 +3,7 @@
 Upgraded dependencies:
  - angular-cli@1.0.0-beta.26 to 1.0.0-rc.0
  - material@2.0.0-beta.1 to 2.0.0-beta.2
- - flex-layout@2.0.0-beta.5 addition
+ - flex-layout@2.0.0-rc.1 addition
  - ngx-charts@3.1.2 to 4.1.3
 
 [1.0.0-beta.2 Upgrade Steps](https://github.com/Teradata/covalent-quickstart/pull/46/commits) and [Changelog](https://github.com/Teradata/covalent/blob/develop/docs/CHANGELOG.md#100-beta2-hotel-california-2017-02-23)


### PR DESCRIPTION
#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.