### PR TITLE
chore(): bump to 1.0.0 beta.2-1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="1.0.0-beta.2-1"></a>
+# [1.0.0-beta.2-1](https://github.com/Teradata/covalent/tree/v1.0.0-beta.2) (2017-02-27)
+
+## Bug Fixes
+* **animations:** remove overflow from styles in steps and expansion-panel. ([52e74da50e55ea6b6b7aaaaad4724ab610d6f468](https://github.com/Teradata/covalent/commit/52e74da50e55ea6b6b7aaaaad4724ab610d6f468))
+* **loading:**  center loading component on replace mode. ([3e40f4bc35dee88941ec398f7575d7b6fd201117](https://github.com/Teradata/covalent/commit/3e40f4bc35dee88941ec398f7575d7b6fd201117))
+
+## Internal
+* **docs:** upgrade guide for [beta.2](https://github.com/Teradata/covalent/blob/develop/docs/UPGRADE.md#upgrade-from-100-beta1-to-100-beta2) ([98a5a19650d2bdfd552456fe17cee76de4319d39](https://github.com/Teradata/covalent/commit/98a5a19650d2bdfd552456fe17cee76de4319d39))
+
+
 <a name="1.0.0-beta.2"></a>
 # [1.0.0-beta.2 Hotel California](https://github.com/Teradata/covalent/tree/v1.0.0-beta.2) (2017-02-23)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "covalent",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.2-1",
   "private": true,
   "description": "Teradata UI Platform built on Angular Material 2",
   "keywords": [

--- a/src/platform/charts/package.json
+++ b/src/platform/charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/charts",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.2-1",
   "description": "Teradata UI Platform Charts Module",
   "keywords": [
     "angular",

--- a/src/platform/core/package.json
+++ b/src/platform/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/core",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.2-1",
   "description": "Teradata UI Platform built on Angular Material 2",
   "main": "./core.umd.js",
   "module": "./index.js",

--- a/src/platform/dynamic-forms/package.json
+++ b/src/platform/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/dynamic-forms",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.2-1",
   "description": "Teradata UI Platform Dynamic Forms Module",
   "main": "./dynamic-forms.umd.js",
   "module": "./index.js",
@@ -36,6 +36,6 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>"
   ],
   "dependencies": {
-    "@covalent/core": "1.0.0-beta.2"
+    "@covalent/core": "1.0.0-beta.2-1"
   }
 }

--- a/src/platform/highlight/package.json
+++ b/src/platform/highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/highlight",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.2-1",
   "description": "Teradata UI Platform Highlight Module",
   "main": "./highlight.umd.js",
   "module": "./index.js",

--- a/src/platform/http/package.json
+++ b/src/platform/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/http",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.2-1",
   "description": "Teradata UI Platform Http Helper Module",
   "main": "./http.umd.js",
   "module": "./index.js",

--- a/src/platform/markdown/package.json
+++ b/src/platform/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/markdown",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.2-1",
   "description": "Teradata UI Platform Markdown Module",
   "main": "./markdown.umd.js",
   "module": "./index.js",


### PR DESCRIPTION
## Description

Patch release for `beta.2`

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.