### PR TITLE
fix(): animation not working correctly in navigation-drawer

### DIFF
--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.scss
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.scss
@@ -10,4 +10,7 @@
       height: auto !important;
     }
   }
+  > div {
+    overflow: hidden;
+  }
 }


### PR DESCRIPTION
## Description

Added `overflow:hidden` to animations in `td-navigation-drawer`

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
