### PR TITLE
chore(): removal of `beta.1` deprecations

### DIFF
--- a/src/platform/core/loading/directives/loading.directive.ts
+++ b/src/platform/core/loading/directives/loading.directive.ts
@@ -26,17 +26,6 @@ export class TdLoadingDirective implements OnInit, OnDestroy {
   }
 
   /**
-   * @deprecated in 1.0.0-beta.1
-   *
-   * Please use the `tdLoadingType` method.
-   */
-  @Input('loadingType')
-  set typeDeprecated(type: LoadingType) {
-    /* tslint:disable-next-line */
-    console.warn("loadingType is deprecated.  Please use tdLoadingType instead");
-    this.type = type;
-  }
-  /**
    * tdLoadingType?: LoadingType or ['linear' | 'circular']
    * Sets the type of loading mask depending on value.
    * Defaults to [LoadingType.Circular | 'circular'].
@@ -53,17 +42,6 @@ export class TdLoadingDirective implements OnInit, OnDestroy {
     }
   }
 
-  /**
-   * @deprecated in 1.0.0-beta.1
-   *
-   * Please use the `tdLoadingMode` method.
-   */
-  @Input('loadingMode')
-  set modeDeprecated(mode: LoadingMode) {
-    /* tslint:disable-next-line */
-    console.warn("loadingMode is deprecated.  Please use tdLoadingMode instead");
-    this.mode = mode;
-  }
   /**
    * tdLoadingMode?: LoadingMode or ['determinate' | 'indeterminate']
    * Sets the mode of loading mask depending on value.

--- a/src/platform/core/loading/loading.module.ts
+++ b/src/platform/core/loading/loading.module.ts
@@ -19,7 +19,7 @@ const TD_LOADING_ENTRY_COMPONENTS: Type<any>[] = [
 ];
 
 export { LoadingType, LoadingMode, LoadingStrategy } from './loading.component';
-export { TdLoadingService, ITdLoadingConfig, ILoadingOptions } from './services/loading.service';
+export { TdLoadingService, ITdLoadingConfig } from './services/loading.service';
 
 @NgModule({
   imports: [

--- a/src/platform/core/loading/services/loading.service.ts
+++ b/src/platform/core/loading/services/loading.service.ts
@@ -7,15 +7,6 @@ import { Subscription } from 'rxjs/Subscription';
 import { TdLoadingComponent, LoadingMode, LoadingStrategy, LoadingType } from '../loading.component';
 import { TdLoadingFactory, ILoadingRef } from './loading.factory';
 
-/**
- * @deprecated in 1.0.0-beta.1
- */
-export interface ILoadingOptions {
-  name: string;
-  type?: LoadingType;
-  mode?: LoadingMode;
-}
-
 export interface ITdLoadingConfig {
   name: string;
   type?: LoadingType;
@@ -103,17 +94,6 @@ export class TdLoadingService {
     let fullscreenConfig: TdLoadingConfig = new TdLoadingConfig(config);
     this.removeComponent(fullscreenConfig.name);
     this._context[fullscreenConfig.name] = this._loadingFactory.createFullScreenComponent(fullscreenConfig);
-  }
-
-  /**
-   * @deprecated in 1.0.0-beta.1
-   *
-   * Please use the `create()` method.
-   */
-  public createOverlayComponent(config: ITdLoadingConfig, viewContainerRef: ViewContainerRef): void {
-    /* tslint:disable-next-line */
-    console.warn("createOverlayComponent() is deprecated.  Please use create() instead");
-    this.create(config);
   }
 
   /**


### PR DESCRIPTION
## Description

Removing the `beta.1` deprecations from code.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle