### PR TITLE
feat(search): make placeholder stay in place when focused. (closes #226)

### DIFF
--- a/src/platform/core/search/search-box/search-box.component.scss
+++ b/src/platform/core/search/search-box/search-box.component.scss
@@ -5,10 +5,5 @@
   height: 64px;
   td-search-input {
     margin-left: 12px;
-    /deep/ {
-      .mat-input-placeholder.mat-focused {
-        visibility: hidden;
-      }
-    }
   }
 }

--- a/src/platform/core/search/search-input/search-input.component.html
+++ b/src/platform/core/search/search-input/search-input.component.html
@@ -1,5 +1,5 @@
 <div class="td-search-input" layout="row" layout-align="end center">
-  <md-input-container [class.mat-hide-underline]="!showUnderline" flex>
+  <md-input-container [class.mat-hide-underline]="!showUnderline" floatPlaceholder="never" flex>
     <input mdInput
             #searchElement
             type="search"


### PR DESCRIPTION
## Description

leverage [floatPlaceholder] to make the placeholde stay in place when focused
https://github.com/Teradata/covalent/issues/226

#### Test Steps

- [x] `ng serve`
- [x] Go to http://localhost:4200/#/components/search
- [x] See placeholder not going to the top when focusing input.

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.