### PR TITLE
fix(search): stop debounceSearch event when page loads. (closes #385)

### DIFF
--- a/src/platform/core/search/search-input/search-input.component.ts
+++ b/src/platform/core/search/search-input/search-input.component.ts
@@ -73,6 +73,7 @@ export class TdSearchInputComponent implements OnInit {
 
   ngOnInit(): void {
     this._input._ngControl.valueChanges
+      .skip(1) // skip first change when value is set to undefined
       .debounceTime(this.debounce)
       .subscribe((value: string) => {
         this._searchTermChanged(value);


### PR DESCRIPTION
## Description

we need to skip the first change event since its thrown when the value is set to undefined
https://github.com/Teradata/covalent/issues/385

#### Test Steps

- [ ] `ng serve`
- [ ] go to http://localhost:4200/#/components/search
- [ ] See event (debounceSearch) event is not thrown when the page loads.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.