### PR TITLE
docs(chips): chips & autocomplete docs

### DIFF
--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -50,7 +50,19 @@
           <![CDATA[
             export class ChipsDemoComponent {
 
-              items: string[] = [...];
+              items: string[] = [
+                'stepper',
+                'expansion-panel',
+                'markdown',
+                'highlight',
+                'loading',
+                'media',
+                'chips',
+                'http',
+                'json-formatter',
+                'pipes',
+                'need more?',
+              ];
 
             }
           ]]>
@@ -80,6 +92,20 @@
           <![CDATA[
             export class ChipsDemoComponent {
               readOnly: boolean = false;
+
+              items: string[] = [
+                'stepper',
+                'expansion-panel',
+                'markdown',
+                'highlight',
+                'loading',
+                'media',
+                'chips',
+                'http',
+                'json-formatter',
+                'pipes',
+                'need more?',
+              ];
 
               itemsRequireMatch: string[] = this.items.slice(0, 6);
 

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -3,14 +3,70 @@
   <md-card-subtitle>Small blocks for multiple items</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
-    <p>Basic Demo</p>
+    <h3 class="md-title">Basic Demo</h3>
     <md-tab-group md-stretch-tabs>
       <md-tab>
         <template md-tab-label>Demo</template>
-        <td-chips placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
-        <p>Autocomplete Demo</p>
-        <td-chips [items]="items" placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
-        <p>Autocomplete and requireMatch Demo</p>
+        <td-chips placeholder="Enter any string"></td-chips>
+      </md-tab>
+      <md-tab>
+        <template md-tab-label>Code</template>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-chips placeholder="Enter any string"></td-chips>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            export class ChipsDemoComponent {
+              
+            }
+          ]]>
+        </td-highlight>
+      </md-tab>
+    </md-tab-group>
+  </md-card-content>
+</md-card>
+<md-card>
+  <md-card-content>
+    <h3 class="md-title">Autocomplete Demo</h3>
+    <md-tab-group md-stretch-tabs>
+      <md-tab>
+        <template md-tab-label>Demo</template>
+        <td-chips [items]="items" placeholder="Enter any string"></td-chips>
+      </md-tab>
+      <md-tab>
+        <template md-tab-label>Code</template>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-chips [items]="items" placeholder="Enter any string"></td-chips>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            export class ChipsDemoComponent {
+
+              items: string[] = [...];
+              
+              itemsReadOnly: string[] = this.items.slice(2, 8);
+
+            }
+          ]]>
+        </td-highlight>
+      </md-tab>
+    </md-tab-group>
+  </md-card-content>
+</md-card>
+<md-card>
+  <md-card-content>
+    <h3 class="md-title">Autocomplete and requireMatch Demo</h3>
+    <md-tab-group md-stretch-tabs>
+      <md-tab>
+        <template md-tab-label>Demo</template>
         <td-chips [items]="items" [(ngModel)]="itemsRequireMatch" placeholder="Enter autocomplete strings" [readOnly]="readOnly" requireMatch></td-chips>
       </md-tab>
       <md-tab>
@@ -18,10 +74,6 @@
         <p>HTML:</p>
         <td-highlight lang="html">
           <![CDATA[
-            <td-chips placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
-            <p>Autocomplete Demo</p>
-            <td-chips [items]="items" placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
-            <p>Autocomplete and requireMatch Demo</p>
             <td-chips [items]="items" [(ngModel)]="itemsRequireMatch" placeholder="Enter autocomplete strings" [readOnly]="readOnly" requireMatch></td-chips>
           ]]>
         </td-highlight>
@@ -32,10 +84,6 @@
               readOnly: boolean = false;
 
               itemsRequireMatch: string[] = this.items.slice(0, 6);
-
-              itemsReadOnly: string[] = this.items.slice(2, 8);
-
-              itemsForms: string[] = this.items.slice(6, 11);
 
               toggleReadOnly(): void {
                 this.readOnly = !this.readOnly;

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -51,8 +51,6 @@
             export class ChipsDemoComponent {
 
               items: string[] = [...];
-              
-              itemsReadOnly: string[] = this.items.slice(2, 8);
 
             }
           ]]>

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -4,11 +4,47 @@
   <md-divider></md-divider>
   <md-card-content>
     <p>Basic Demo</p>
-    <td-chips placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
-    <p>Autocomplete Demo</p>
-    <td-chips [items]="items" placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
-    <p>Autocomplete and requireMatch Demo</p>
-    <td-chips [items]="items" [(ngModel)]="itemsRequireMatch" placeholder="Enter autocomplete strings" [readOnly]="readOnly" requireMatch></td-chips>      
+    <md-tab-group md-stretch-tabs>
+      <md-tab>
+        <template md-tab-label>Demo</template>
+        <td-chips placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
+        <p>Autocomplete Demo</p>
+        <td-chips [items]="items" placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
+        <p>Autocomplete and requireMatch Demo</p>
+        <td-chips [items]="items" [(ngModel)]="itemsRequireMatch" placeholder="Enter autocomplete strings" [readOnly]="readOnly" requireMatch></td-chips>
+      </md-tab>
+      <md-tab>
+        <template md-tab-label>Code</template>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-chips placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
+            <p>Autocomplete Demo</p>
+            <td-chips [items]="items" placeholder="Enter any string" [readOnly]="readOnly"></td-chips>
+            <p>Autocomplete and requireMatch Demo</p>
+            <td-chips [items]="items" [(ngModel)]="itemsRequireMatch" placeholder="Enter autocomplete strings" [readOnly]="readOnly" requireMatch></td-chips>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            export class ChipsDemoComponent {
+              readOnly: boolean = false;
+
+              itemsRequireMatch: string[] = this.items.slice(0, 6);
+
+              itemsReadOnly: string[] = this.items.slice(2, 8);
+
+              itemsForms: string[] = this.items.slice(6, 11);
+
+              toggleReadOnly(): void {
+                this.readOnly = !this.readOnly;
+              }
+            }
+          ]]>
+        </td-highlight>
+      </md-tab>
+    </md-tab-group>
   </md-card-content>
   <md-divider></md-divider>
   <md-card-actions>

--- a/src/app/components/components/chips/chips.component.ts
+++ b/src/app/components/components/chips/chips.component.ts
@@ -60,10 +60,6 @@ export class ChipsDemoComponent {
 
   itemsRequireMatch: string[] = this.items.slice(0, 6);
 
-  itemsReadOnly: string[] = this.items.slice(2, 8);
-
-  itemsForms: string[] = this.items.slice(6, 11);
-
   toggleReadOnly(): void {
     this.readOnly = !this.readOnly;
   }


### PR DESCRIPTION
## Description

Docs updated to show demo & code both in tabs

#### Test Steps

- [x] ng serve
- [x] navigate to http://localhost:4200/#/components/chips
- [x] test docs

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle

![chips-docs](https://cloud.githubusercontent.com/assets/4469548/23476542/f4475b1c-fe6f-11e6-9f5c-4f5071f91c5f.gif)

