### PR TITLE
fix(media): check if subscription has been created before unsubscribing. (closes #396)

### DIFF
--- a/src/platform/core/media/directives/media-toggle.directive.ts
+++ b/src/platform/core/media/directives/media-toggle.directive.ts
@@ -67,7 +67,9 @@ export class TdMediaToggleDirective implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this._subscription.unsubscribe();
+    if (this._subscription) {
+      this._subscription.unsubscribe();
+    }
   }
 
   private _mediaChange(matches: boolean): void {


### PR DESCRIPTION
## Description

there are cases when `ngOnDestroy` is executed before `ngOnInit` can even execute, so we need to validate for that. https://github.com/Teradata/covalent/issues/396

more info: https://github.com/Teradata/covalent/issues/396#issuecomment-283879366

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.