### PR TITLE
fix(search): overflow search-input fix + stop hiding label when focusing. (closes #412)

### DIFF
--- a/src/app/components/components/notifications/notifications.component.html
+++ b/src/app/components/components/notifications/notifications.component.html
@@ -4,7 +4,7 @@
   <md-divider></md-divider>
   <md-card-content>
     <h3 class="md-title">Toolbar notification &amp; menu</h3>
-    <md-tab-group md-stretch-tabs>
+    <md-tab-group md-stretch-tabs dynamicHeight>
       <md-tab>
         <template md-tab-label>Demo</template>
         <md-toolbar color="accent">

--- a/src/platform/core/search/search-box/search-box.component.scss
+++ b/src/platform/core/search/search-box/search-box.component.scss
@@ -2,7 +2,6 @@
   display: block;
 }
 .td-search-box {
-  height: 64px;
   td-search-input {
     /deep/ {
       .mat-input-placeholder.mat-focused {

--- a/src/platform/core/search/search-box/search-box.component.scss
+++ b/src/platform/core/search/search-box/search-box.component.scss
@@ -3,11 +3,6 @@
 }
 .td-search-box {
   td-search-input {
-    /deep/ {
-      .mat-input-placeholder.mat-focused {
-        visibility: hidden;
-      }
-    }
 
     [dir='ltr'] & { 
       margin-left: 12px;

--- a/src/platform/core/search/search-input/search-input.component.scss
+++ b/src/platform/core/search/search-input/search-input.component.scss
@@ -1,6 +1,5 @@
 .td-search-input {
-  height: 64px;
-  overflow: hidden;
+  overflow-x: hidden;
   /deep/ md-input-container.mat-hide-underline {
     .mat-input-underline {
       display: none;


### PR DESCRIPTION
## Description

https://github.com/Teradata/covalent/issues/412
There was a scrollbar appearing in the `td-search-input` since we set a height on the component.

### What's included?

- fix(search): removed fixed height in search-box and search-input
- fix(search): stop hiding label when focusing

#### Test Steps

- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/search
- [ ] See scrollbar not appearing anymore.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle