### PR TITLE
fix(loading): support OnPush change detection strategy

### DIFF
--- a/src/app/components/components/loading/loading.component.ts
+++ b/src/app/components/components/loading/loading.component.ts
@@ -5,7 +5,7 @@ import { slideInDownAnimation } from '../../../app.animations';
 import { TdLoadingService, ITdLoadingConfig, LoadingType, LoadingMode } from '../../../../platform/core';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.Default,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'loading-demo',
   styleUrls: ['./loading.component.scss' ],
   templateUrl: './loading.component.html',

--- a/src/platform/core/loading/services/loading.factory.ts
+++ b/src/platform/core/loading/services/loading.factory.ts
@@ -1,4 +1,4 @@
-import { Injectable, ComponentFactoryResolver } from '@angular/core';
+import { Injectable, ComponentFactoryResolver, ChangeDetectorRef } from '@angular/core';
 import { Injector, ComponentRef, ViewContainerRef, TemplateRef } from '@angular/core';
 import { TemplatePortal, Overlay, OverlayState, OverlayRef, OverlayOrigin, ComponentPortal } from '@angular/material';
 import { Subject } from 'rxjs/Subject';
@@ -121,8 +121,12 @@ export class TdLoadingFactory {
         loading = false;
         let subs: Subscription = loadingRef.componentRef.instance.startOutAnimation().subscribe(() => {
           subs.unsubscribe();
-          viewContainerRef.createEmbeddedView(templateRef);
+          let cdr: ChangeDetectorRef = viewContainerRef.createEmbeddedView(templateRef);
           viewContainerRef.detach(viewContainerRef.indexOf(loadingRef.componentRef.hostView));
+          /** Need to call "markForCheck" on attached template, so its detected by parent component when attached 
+           * with "OnPush" change detection
+           */
+          cdr.markForCheck();
         });
       }
     });

--- a/src/platform/core/loading/services/loading.factory.ts
+++ b/src/platform/core/loading/services/loading.factory.ts
@@ -123,7 +123,8 @@ export class TdLoadingFactory {
           subs.unsubscribe();
           let cdr: ChangeDetectorRef = viewContainerRef.createEmbeddedView(templateRef);
           viewContainerRef.detach(viewContainerRef.indexOf(loadingRef.componentRef.hostView));
-          /** Need to call "markForCheck" on attached template, so its detected by parent component when attached 
+          /**
+           * Need to call "markForCheck" on attached template, so its detected by parent component when attached
            * with "OnPush" change detection
            */
           cdr.markForCheck();


### PR DESCRIPTION
## Description

Part of https://github.com/Teradata/covalent/issues/325
Addding support for `OnPush` change detection strategy into the loading component.

Currently it wasnt working correctly on replace mode under `OnPush`.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.