### PR TITLE
fix(expansion-panel): remove hardcoded string

### DIFF
--- a/src/platform/core/expansion-panel/expansion-panel.component.html
+++ b/src/platform/core/expansion-panel/expansion-panel.component.html
@@ -15,7 +15,7 @@
            flex>
         <div class="md-subhead td-expansion-primary" flex-gt-xs="33">
           <template [cdkPortalHost]="expansionPanelLabel"></template>
-          <template [ngIf]="!expansionPanelLabel">{{label || 'Click to expand '}}</template>
+          <template [ngIf]="!expansionPanelLabel">{{label}}</template>
         </div>
         <div class="md-body-1 td-expansion-secondary">
           <template [cdkPortalHost]="expansionPanelSublabel"></template>


### PR DESCRIPTION
## Description

Remove `Click to expand!` string from `expansion-panel`.
Part of https://github.com/Teradata/covalent/issues/324

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle