### PR TITLE
feat(dynamic-forms): add `password` element. (closes #449)

### DIFF
--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
@@ -58,6 +58,11 @@ export class DynamicFormsDemoComponent {
     type: TdDynamicType.Text,
     required: false,
     default: 'Default',
+  }, {
+    name: 'required-password',
+    label: 'Password Label',
+    type: TdDynamicElement.Password,
+    required: true,
   }];
 
   numberElements: ITdDynamicElementConfig[] = [{

--- a/src/platform/dynamic-forms/dynamic-forms.component.spec.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.component.spec.ts
@@ -48,6 +48,9 @@ describe('Component: TdDynamicForms', () => {
       name: 'first_name',
       type: TdDynamicType.Text,
     }, {
+      name: 'password',
+      type: TdDynamicElement.Password,
+    }, {
       name: 'on_it',
       type: TdDynamicType.Boolean,
     }, {
@@ -66,7 +69,7 @@ describe('Component: TdDynamicForms', () => {
     }];
     fixture.detectChanges();
     fixture.whenStable().then(() => {
-      expect(fixture.debugElement.queryAll(By.directive(TdDynamicElementComponent)).length).toBe(6);
+      expect(fixture.debugElement.queryAll(By.directive(TdDynamicElementComponent)).length).toBe(7);
     });
   })));
 

--- a/src/platform/dynamic-forms/services/dynamic-forms.service.ts
+++ b/src/platform/dynamic-forms/services/dynamic-forms.service.ts
@@ -19,6 +19,7 @@ export enum TdDynamicType {
 
 export enum TdDynamicElement {
   Input = <any>'input',
+  Password = <any>'password',
   Textarea = <any>'textarea',
   Slider = <any>'slider',
   SlideToggle = <any>'slide-toggle',
@@ -61,6 +62,7 @@ export class TdDynamicFormsService {
       case TdDynamicType.Text:
       case TdDynamicType.Number:
       case TdDynamicElement.Input:
+      case TdDynamicElement.Password:
         return TdDynamicInputComponent;
       case TdDynamicElement.Textarea:
         return TdDynamicTextareaComponent;
@@ -89,6 +91,7 @@ export class TdDynamicFormsService {
       case TdDynamicType.Number:
       case TdDynamicElement.Slider:
       case TdDynamicElement.Input:
+      case TdDynamicElement.Password:
       case TdDynamicType.Array:
       case TdDynamicElement.Select:
         return 45;


### PR DESCRIPTION
## Description

https://github.com/Teradata/covalent/issues/449
Add support for `password` element in `dynamic-forms` module.

### What's included?

- `TdDynamicElement.Password` enum value.

#### Test Steps

- [x] `ng serve`
- [x] Go to http://localhost:4200/#/components/dynamic-forms
- [x] See `password` element being rendered

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle

![image](https://cloud.githubusercontent.com/assets/5846742/24368677/3054c110-12d6-11e7-990c-1607b809166b.png)
