### PR TITLE
fix(aot): remove private keyword from @View and @Content children. (closes #384)

### DIFF
--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -69,7 +69,7 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
 
   /** template fetching support */
   private _templateMap: Map<string, TemplateRef<any>> = new Map<string, TemplateRef<any>>();
-  @ContentChildren(TdDataTableTemplateDirective) private _templates: QueryList<TdDataTableTemplateDirective>;
+  @ContentChildren(TdDataTableTemplateDirective) _templates: QueryList<TdDataTableTemplateDirective>;
 
   /**
    * Implemented as part of ControlValueAccessor.

--- a/src/platform/core/file/file-input/file-input.component.ts
+++ b/src/platform/core/file/file-input/file-input.component.ts
@@ -49,7 +49,7 @@ export class TdFileInputComponent implements ControlValueAccessor {
   private _disabled: boolean = false;
 
   /** The native `<input type="file"> element */
-  @ViewChild('fileInput') private _inputElement: ElementRef;
+  @ViewChild('fileInput') _inputElement: ElementRef;
   get inputElement(): HTMLInputElement {
     return this._inputElement.nativeElement;
   }

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
@@ -32,7 +32,7 @@ export class TdNavigationDrawerComponent implements OnInit, OnDestroy {
     return this._menuToggled;
   }
 
-  @ContentChildren(TdNavigationDrawerMenuDirective) private _drawerMenu: QueryList<TdNavigationDrawerMenuDirective>;
+  @ContentChildren(TdNavigationDrawerMenuDirective) _drawerMenu: QueryList<TdNavigationDrawerMenuDirective>;
 
   /**
    * Checks if there is a [TdNavigationDrawerMenuDirective] as content.

--- a/src/platform/core/search/search-box/search-box.component.ts
+++ b/src/platform/core/search/search-box/search-box.component.ts
@@ -27,7 +27,7 @@ import { TdSearchInputComponent } from '../search-input/search-input.component';
 export class TdSearchBoxComponent {
 
   private _searchVisible: boolean = false;
-  @ViewChild(TdSearchInputComponent) private _searchInput: TdSearchInputComponent;
+  @ViewChild(TdSearchInputComponent) _searchInput: TdSearchInputComponent;
 
   set value(value: any) {
     this._searchInput.value = value;

--- a/src/platform/core/search/search-input/search-input.component.ts
+++ b/src/platform/core/search/search-input/search-input.component.ts
@@ -29,7 +29,7 @@ import 'rxjs/add/operator/debounceTime';
 })
 export class TdSearchInputComponent implements OnInit {
 
-  @ViewChild(MdInputDirective) private _input: MdInputDirective;
+  @ViewChild(MdInputDirective) _input: MdInputDirective;
 
   value: string;
 

--- a/src/platform/core/steps/step.component.ts
+++ b/src/platform/core/steps/step.component.ts
@@ -51,7 +51,7 @@ export class TdStepComponent implements OnInit {
     return this._contentPortal;
   }
 
-  @ViewChild(TemplateRef) private _content: TemplateRef<any>;
+  @ViewChild(TemplateRef) _content: TemplateRef<any>;
   @ContentChild(TdStepLabelDirective) stepLabel: TdStepLabelDirective;
   @ContentChild(TdStepActionsDirective) stepActions: TdStepActionsDirective;
   @ContentChild(TdStepSummaryDirective) stepSummary: TdStepSummaryDirective;


### PR DESCRIPTION
## Description

https://github.com/Teradata/covalent/issues/384
Need to remove the `private` access modifier from properties that have `@ViewChild`, `@ViewChildren`, `@ContentChild` and `@ContentChildren` since they are accessed from outside the class they are declared in and hence the `compiler` complains about it.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.