### PR TITLE
fix(data-table): add missing export for ITdDataTableSelectAllEvent (closes #439)

### DIFF
--- a/src/platform/core/data-table/data-table.module.ts
+++ b/src/platform/core/data-table/data-table.module.ts
@@ -22,7 +22,7 @@ const TD_DATA_TABLE: Type<any>[] = [
 ];
 
 export { TdDataTableComponent, TdDataTableSortingOrder,
-         ITdDataTableColumn, ITdDataTableSelectEvent } from './data-table.component';
+         ITdDataTableColumn, ITdDataTableSelectEvent, ITdDataTableSelectAllEvent } from './data-table.component';
 export { TdDataTableService } from './services/data-table.service';
 export { TdDataTableColumnComponent,
          ITdDataTableSortChangeEvent } from './data-table-column/data-table-column.component';


### PR DESCRIPTION
## Description

https://github.com/Teradata/covalent/issues/439
Add missing interface export for `ITdDataTableSelectAllEvent`

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle