### PR TITLE
Clarify instructions to include the platform.css

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -89,7 +89,27 @@ $theme: mat-light-theme($primary, $accent, $warn);
 
 You only need this single Sass file; you do not need to use Sass to style the rest of your app.
 
-If you are using the Angular CLI, support for compiling Sass to css is built-in; you only have to add a new entry to the "styles" list in .angular-cli.json pointing to the theme file (e.g., themes.scss).
+If you are using the Angular CLI, support for compiling Sass to css is built-in but you have to add a new entry to the "styles" list in .angular-cli.json pointing to the theme file and the platform.css as follows:
+
+### Using platform.css:
+
+- The core covalent styles need to be included either in your `index.html` or as a new entry to the "styles" list in .angular-cli.json
+load the Material Design font in your `index.html`.  
+       
+**src/index.html**
+```html
+<link href="../node_modules/@covalent/core/common/platform.css" rel="stylesheet">
+```
+
+or
+
+**.angular-cli.json**
+```json
+"styles": [
+  "../node_modules/@covalent/core/common/platform.scss"
+],
+```
+### Other build tools
 
 If you're not using the Angular CLI, you can use any existing Sass tooling to build the file (such as gulp-sass or grunt-sass). The simplest approach is to use the node-sass CLI; you simply run:
 
@@ -115,25 +135,6 @@ System.config({
     '@covalent/dynamic-forms': 'npm:@covalent/dynamic-forms/dynamic-forms.umd.js'
   }
 });
-```
-
-### Using platform.scss:
-
-- The core covalent styles need to be included either in your `index.html` or as a new entry to the "styles" list in .angular-cli.json
-load the Material Design font in your `index.html`.  
-       
-**src/index.html**
-```html
-<link href="../node_modules/@covalent/core/common/platform.css" rel="stylesheet">
-```
-
-or
-
-**.angular-cli.json**
-```json
-"styles": [
-  "../node_modules/@covalent/core/common/platform.scss"
-],
 ```
 
 ## Sample Covalent projects


### PR DESCRIPTION
Changing instructions from place to clarify that it is not only enough to use the SCSS file.

## Description

Modified Readme to clarify FAQs:
 https://github.com/Teradata/covalent/issues/451
https://github.com/Teradata/covalent/issues/436#issuecomment-288412639

### What's included?

- Readme.md

#### Test Steps

N/A

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
