### PR TITLE
fix(): change directive selectors to use `ng-template` for ng4

### DIFF
--- a/src/platform/core/data-table/directives/data-table-template.directive.ts
+++ b/src/platform/core/data-table/directives/data-table-template.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
 import { TemplatePortalDirective } from '@angular/material';
 
-@Directive({selector: '[tdDataTableTemplate]template'})
+@Directive({selector: '[tdDataTableTemplate]ng-template'})
 export class TdDataTableTemplateDirective extends TemplatePortalDirective {
 
   @Input() tdDataTableTemplate: string;

--- a/src/platform/core/expansion-panel/expansion-panel.component.ts
+++ b/src/platform/core/expansion-panel/expansion-panel.component.ts
@@ -5,7 +5,7 @@ import { TemplatePortalDirective } from '@angular/material';
 import { TdCollapseAnimation } from '../common/common.module';
 
 @Directive({
-  selector: '[td-expansion-panel-header]template',
+  selector: '[td-expansion-panel-header]ng-template',
 })
 export class TdExpansionPanelHeaderDirective extends TemplatePortalDirective {
   constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
@@ -14,7 +14,7 @@ export class TdExpansionPanelHeaderDirective extends TemplatePortalDirective {
 }
 
 @Directive({
-  selector: '[td-expansion-panel-label]template',
+  selector: '[td-expansion-panel-label]ng-template',
 })
 export class TdExpansionPanelLabelDirective extends TemplatePortalDirective {
   constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
@@ -23,7 +23,7 @@ export class TdExpansionPanelLabelDirective extends TemplatePortalDirective {
 }
 
 @Directive({
-  selector: '[td-expansion-panel-sublabel]template',
+  selector: '[td-expansion-panel-sublabel]ng-template',
 })
 export class TdExpansionPanelSublabelDirective extends TemplatePortalDirective {
   constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {

--- a/src/platform/core/file/file-input/file-input.component.ts
+++ b/src/platform/core/file/file-input/file-input.component.ts
@@ -14,7 +14,7 @@ export const FILE_INPUT_CONTROL_VALUE_ACCESSOR: any = {
 };
 
 @Directive({
-  selector: '[td-file-input-label]template',
+  selector: '[td-file-input-label]ng-template',
 })
 export class TdFileInputLabelDirective extends TemplatePortalDirective {
   constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {

--- a/src/platform/core/steps/step.component.ts
+++ b/src/platform/core/steps/step.component.ts
@@ -10,7 +10,7 @@ export enum StepState {
 }
 
 @Directive({
-  selector: '[td-step-label]template',
+  selector: '[td-step-label]ng-template',
 })
 export class TdStepLabelDirective extends TemplatePortalDirective {
   constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
@@ -19,7 +19,7 @@ export class TdStepLabelDirective extends TemplatePortalDirective {
 }
 
 @Directive({
-  selector: '[td-step-actions]template',
+  selector: '[td-step-actions]ng-template',
 })
 export class TdStepActionsDirective extends TemplatePortalDirective {
   constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {
@@ -28,7 +28,7 @@ export class TdStepActionsDirective extends TemplatePortalDirective {
 }
 
 @Directive({
-  selector: '[td-step-summary]template',
+  selector: '[td-step-summary]ng-template',
 })
 export class TdStepSummaryDirective extends TemplatePortalDirective {
   constructor(templateRef: TemplateRef<any>, viewContainerRef: ViewContainerRef) {


### PR DESCRIPTION
## Description

When upgrading to ng4 missed some directives that used `template` instead of `ng-template`

This fixes the unit tests and makes every component work well in ng4

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.