### PR TITLE
fix(tabindex): remove default outline

### DIFF
--- a/src/platform/core/common/styles/utilities/_general.scss
+++ b/src/platform/core/common/styles/utilities/_general.scss
@@ -3,6 +3,10 @@
 // --------------------------------------------------
 
 body {
+  // Angular 4 added tabindex to everything, this style removes the outline:
+  [tabindex]:focus {
+    outline: none;
+  }
   .radius-none {
     border-radius: 0;
   }


### PR DESCRIPTION
## Description

Angular 4 added tabindex to everything which is good for a11y but it added the default outline to everything. This removes the outline from icons, cards, etc.

### What's included?

- remove outline style from items w/ [tabindex]

#### Test Steps

- [ ] npm i
- [ ] ng serve
- [ ] click on card and logo on homepage

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle

Before
![before](https://cloud.githubusercontent.com/assets/867883/24526686/db3d8a24-1553-11e7-90fb-26c19be98a36.gif)

After
![after](https://cloud.githubusercontent.com/assets/867883/24526691/e209ddee-1553-11e7-9406-2db66d105c29.gif)

