### PR TITLE
chore(docs): add covalent-electron and covalent-data to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Covalent is a reusable UI platform from Teradata for building web applications w
 * [Quickstart Repo](https://github.com/teradata/covalent-quickstart)
 * [Plunker Template](http://plnkr.co/edit/7uZQn4mLNJkL6XN9WSNd)
 * [Nightly Build Plunker Template](http://plnkr.co/edit/XhSrUWBw2RhCkXPoE4fn)
+* [Covalent Electron](https://github.com/Teradata/covalent-electron)
+* [Covalent Mock Data Server](https://github.com/Teradata/covalent-data)
 
 ---
 

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -227,6 +227,28 @@
           </a>
         </md-nav-list>
       </td-expansion-panel>
+      <td-expansion-panel label="What is Covalent Electron?" sublabel="desktop apps with Covalent?">
+        <div class="md-padding">
+          Covalent is a UI Platform that combines proven design language with a comprehensive web framework, built on Angular & Angular-Material (Design).
+          Electron is a framework for creating native desktop applications with web technologies like JavaScript, HTML, and CSS.
+          Covalent Electron is the Electron Platform to build desktop apps using Covalent and Electron
+          <ul>
+            <li>Covalent Electron Repo:</li>
+            <li><a md-list-item href="https://github.com/Teradata/covalent-electron" target="_blank">https://github.com/Teradata/covalent-electron</a></li>
+          </ul>
+        </div>
+      </td-expansion-panel>
+      <td-expansion-panel label="What is Covalent Data?" sublabel="mock data server?">
+        <div class="md-padding">
+          Covalent Data is a Mock API server for rapid prototyping and API standards
+          Built on Golang
+          Allows for quick prototyping for your Covalent Applications with an easy to mock http backend server
+          <ul>
+            <li>Covalent Data Repo:</li>
+            <li><a md-list-item href="https://github.com/Teradata/covalent-data" target="_blank">https://github.com/Teradata/covalent-data</a></li>
+          </ul>
+        </div>
+      </td-expansion-panel>
     </div>
   </td-layout-card-over>
   <td-layout-footer>

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -227,26 +227,20 @@
           </a>
         </md-nav-list>
       </td-expansion-panel>
-      <td-expansion-panel label="What is Covalent Electron?" sublabel="desktop apps with Covalent?">
+      <td-expansion-panel label="Does Covalent support desktop apps?" sublabel="Build desktop apps with Covalent Electron">
         <div class="md-padding">
           Covalent is a UI Platform that combines proven design language with a comprehensive web framework, built on Angular & Angular-Material (Design).
           Electron is a framework for creating native desktop applications with web technologies like JavaScript, HTML, and CSS.
           Covalent Electron is the Electron Platform to build desktop apps using Covalent and Electron
-          <ul>
-            <li>Covalent Electron Repo:</li>
-            <li><a md-list-item href="https://github.com/Teradata/covalent-electron" target="_blank">https://github.com/Teradata/covalent-electron</a></li>
-          </ul>
+          <a md-button color="primary" href="https://github.com/Teradata/covalent-electron" target="_blank">View Repo</a>
         </div>
       </td-expansion-panel>
-      <td-expansion-panel label="What is Covalent Data?" sublabel="mock data server?">
+      <td-expansion-panel label="Is a backend API required?" sublabel="Mock API endpoints with Covalent Data">
         <div class="md-padding">
           Covalent Data is a Mock API server for rapid prototyping and API standards
           Built on Golang
           Allows for quick prototyping for your Covalent Applications with an easy to mock http backend server
-          <ul>
-            <li>Covalent Data Repo:</li>
-            <li><a md-list-item href="https://github.com/Teradata/covalent-data" target="_blank">https://github.com/Teradata/covalent-data</a></li>
-          </ul>
+          <a md-button color="primary" href="https://github.com/Teradata/covalent-data" target="_blank">View Repo</a>
         </div>
       </td-expansion-panel>
     </div>


### PR DESCRIPTION
## Description

Adding both Covalent-Electron and Covalent-Data to Readme and docs of Covalent

### What's included?

- modified:   README.md
- modified:   src/app/components/home/home.component.html

#### Test Steps

- [x] checkout branch
- [x] ng serve
- [x] go to docs home page and see updated FAQ section

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
<img width="1409" alt="screen shot 2017-04-04 at 9 25 42 am" src="https://cloud.githubusercontent.com/assets/10502797/24667548/b9d29578-1918-11e7-824d-0b9c26fddf98.png">
