### PR TITLE
fix(steps): issue margin-inline style in certain conditions. (closes #501)

### DIFF
--- a/src/platform/core/steps/step-header/step-header.component.scss
+++ b/src/platform/core/steps/step-header/step-header.component.scss
@@ -53,12 +53,17 @@ $step-circle: 24px;
     font-size: 0;
   }
   .td-circle,
+  .td-triangle,
   .td-complete {
-    margin-inline-start: 8px;
-    font-size: 14px;
+    margin-left: 8px;
+    /deep/ [dir='rtl'] & {
+      margin-left: 0px !important;
+      margin-right: 8px;
+    }
   }
-  .td-triangle {
-    margin-inline-start: 8px;
+  .td-circle,
+  .td-complete {
+    font-size: 14px;
   }
   .td-step-label-wrapper {
     padding-left: 8px;

--- a/src/platform/core/steps/step-header/step-header.component.scss
+++ b/src/platform/core/steps/step-header/step-header.component.scss
@@ -55,10 +55,17 @@ $step-circle: 24px;
   .td-circle,
   .td-triangle,
   .td-complete {
-    margin-left: 8px;
+    /deep/ :not([dir='rtl']) & {
+      margin: {
+        left: 8px;
+        right: 0px;
+      }
+    }
     /deep/ [dir='rtl'] & {
-      margin-left: 0px !important;
-      margin-right: 8px;
+      margin: {
+        left: 0px;
+        right: 8px;
+      }
     }
   }
   .td-circle,

--- a/src/platform/core/steps/steps.component.scss
+++ b/src/platform/core/steps/steps.component.scss
@@ -29,8 +29,10 @@
   position: absolute;
   /deep/ :not([dir='rtl']) & {
     left: 20px;
+    right: auto;
   }
   /deep/ [dir='rtl'] & {
+    left: auto;
     right: 20px;
   }
   bottom: -16px;

--- a/src/platform/core/steps/steps.component.scss
+++ b/src/platform/core/steps/steps.component.scss
@@ -14,8 +14,10 @@
   height: 1px;
   position: relative;
   top: 36px;
-  left: -6px;
-  right: -3px;
+  /deep/ :not([dir='rtl']) & {
+    left: -6px;
+    right: -3px;
+  }
   /deep/ [dir='rtl'] & {
     left: -3px;
     right: -6px;
@@ -25,9 +27,10 @@
 
 .td-vertical-line {
   position: absolute;
-  left: 20px;
+  /deep/ :not([dir='rtl']) & {
+    left: 20px;
+  }
   /deep/ [dir='rtl'] & {
-    left: auto;
     right: 20px;
   }
   bottom: -16px;

--- a/src/platform/core/steps/steps.component.scss
+++ b/src/platform/core/steps/steps.component.scss
@@ -14,14 +14,22 @@
   height: 1px;
   position: relative;
   top: 36px;
-  margin-inline-start: -6px;
-  margin-inline-end: -3px;
+  left: -6px;
+  right: -3px;
+  /deep/ [dir='rtl'] & {
+    left: -3px;
+    right: -6px;
+  }
   min-width: 15px;
 }
 
 .td-vertical-line {
   position: absolute;
-  margin-inline-start: 20px;
+  left: 20px;
+  /deep/ [dir='rtl'] & {
+    left: auto;
+    right: 20px;
+  }
   bottom: -16px;
   top: -16px;
   border-left-width: 1px;


### PR DESCRIPTION
instead of using margin-inline-start or margin-inline-end, its better to just use proper styles depending on ltr or rtl

https://github.com/Teradata/covalent/issues/501

### What's included?

- fix(steps): add proper styles depending if its rtl or lrt

#### Test Steps

- [ ] `ng serve`
- [ ] Go to stepper docs
- [ ] See it work fine in rtl and ltr with proper styles in the step icons and lines.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle