### PR TITLE
chore(getting-started): load our GETTING_STARTED.md in the docs (closes #504)

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -8,6 +8,7 @@
       "root": "src",
       "outDir": "dist",
       "assets": [
+        { "glob": "**/*", "input": "../docs", "output": "./docs/" },
         "app/assets",
         "platform",
         "favicon.ico"

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,3 +1,5 @@
+# Getting Started
+
 Get started with Covalent using the Angular CLI.
 
 See the  [material getting started](https://github.com/angular/material2/blob/master/guides/getting-started.md) for instructions.
@@ -113,7 +115,8 @@ or
 
 If you're not using the Angular CLI, you can use any existing Sass tooling to build the file (such as gulp-sass or grunt-sass). The simplest approach is to use the node-sass CLI; you simply run:
 
-node-sass src/themes.scss dist/themes.css
+`node-sass src/themes.scss dist/themes.css`
+
 and then include the output file in your application.
 
 The theme file can be concatenated and minified with the rest of the application's css.

--- a/src/app/components/docs/docs.module.ts
+++ b/src/app/components/docs/docs.module.ts
@@ -14,6 +14,8 @@ import { TestingComponent } from './testing/testing.component';
 import { ThemeComponent } from './theme/theme.component';
 import { MockDataComponent } from './mock-data/mock-data.component';
 
+import { DocumentationToolsModule } from '../../documentation-tools';
+
 import { CovalentCoreModule } from '../../../platform/core';
 import { CovalentHighlightModule } from '../../../platform/highlight';
 
@@ -34,6 +36,7 @@ import { CovalentHighlightModule } from '../../../platform/highlight';
   imports: [
     CovalentCoreModule,
     CovalentHighlightModule,
+    DocumentationToolsModule,
     docsRoutes,
   ],
 })

--- a/src/app/components/docs/overview/overview.component.html
+++ b/src/app/components/docs/overview/overview.component.html
@@ -1,6 +1,7 @@
+<td-readme-loader resourceUrl="docs/GETTING_STARTED.md"></td-readme-loader>
 <md-card>
-  <md-card-title>Getting Started</md-card-title>
-  <md-card-subtitle>Start using the Teradata UI Platform</md-card-subtitle>
+  <md-card-title>Quickstart Setup</md-card-title>
+  <md-card-subtitle>Start using the Covalent Quickstart</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
      <h3>Covalent Quickstart</h3>
@@ -41,9 +42,9 @@
       <td-highlight lang="bash">
         npm i -g @angular/cli@latest
       </td-highlight>
-      <h4>Install Typescript 2.0:</h4>
+      <h4>Install Typescript:</h4>
       <td-highlight lang="bash">
-        npm install -g typescript@2.0.2
+        npm install -g typescript
       </td-highlight>
       <h4>To install Protractor & TSLint for testing:</h4>
       <td-highlight lang="bash">


### PR DESCRIPTION
we need to show our GETTING_STARTED information easier by loading it in the docs site.

https://github.com/Teradata/covalent/issues/504

### What's included?

- load our `docs/` dir as part of the build.
- Loading `GETTING_STARTED.md` with our `pretty-markdown` component

#### Test Steps

- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/docs
- [ ] See the https://github.com/Teradata/covalent/blob/develop/docs/GETTING_STARTED.md being loaded

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![image](https://cloud.githubusercontent.com/assets/5846742/24970320/bf9c775c-1f68-11e7-9652-f19e8f2ebee3.png)
