### PR TITLE
fix(travis): fix npm install for now while we check why yarn install gives AoT errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 - sh -e /etc/init.d/xvfb start
 install:
 - npm i process-nextick-args util-deprecate buffer-shims
-- yarn install
+- npm install
 - npm rebuild node-sass # Workaround for https://github.com/yarnpkg/yarn/issues/1981
 script:
 - npm run lint


### PR DESCRIPTION
## Description

Use `npm install` instead of `yarn install` while we debug the issue for AoT errors.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle