### PR TITLE
Add sortOrder property to ITdDataTableColumn interface

### DIFF
--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -28,6 +28,7 @@ export interface ITdDataTableColumn {
   format?: (value: any) => any;
   nested?: boolean;
   sortable?: boolean;
+  sortOrder?: TdDataTableSortingOrder;
 };
 
 export interface ITdDataTableSelectEvent {


### PR DESCRIPTION
Useful when using [Data Table (Atomic) Components](https://teradata.github.io/covalent/#/components/data-table).