### PR TITLE
chore(all): remove forRoot() deprecations.

### DIFF
--- a/src/app/components/components/http/http.component.html
+++ b/src/app/components/components/http/http.component.html
@@ -85,7 +85,7 @@
 
         @NgModule({
           imports: [
-            HttpModule, /* or CovalentCoreModule.forRoot() */
+            HttpModule, /* or CovalentCoreModule */
             CovalentHttpModule.forRoot({
               interceptors: [{
                 interceptor: CustomInterceptor, paths: ['**'],

--- a/src/platform/core/chips/chips.module.ts
+++ b/src/platform/core/chips/chips.module.ts
@@ -25,15 +25,5 @@ export { TdChipsComponent } from './chips.component';
   ],
 })
 export class CovalentChipsModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentChipsModule,
-      providers: [],
-    };
-  }
+
 }

--- a/src/platform/core/common/common.module.ts
+++ b/src/platform/core/common/common.module.ts
@@ -90,15 +90,5 @@ export { TdTimeAgoPipe, TdTimeDifferencePipe,
   ],
 })
 export class CovalentCommonModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentCommonModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/data-table/data-table.module.ts
+++ b/src/platform/core/data-table/data-table.module.ts
@@ -49,15 +49,5 @@ export { TdDataTableTableComponent } from './data-table-table/data-table-table.c
   ],
 })
 export class CovalentDataTableModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentDataTableModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/dialogs/dialogs.module.ts
+++ b/src/platform/core/dialogs/dialogs.module.ts
@@ -54,15 +54,5 @@ export { TdDialogService, TdDialogComponent, TdDialogTitleDirective,
   ],
 })
 export class CovalentDialogsModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentDialogsModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/expansion-panel/expansion-panel.module.ts
+++ b/src/platform/core/expansion-panel/expansion-panel.module.ts
@@ -32,15 +32,5 @@ export { TdExpansionPanelComponent } from './expansion-panel.component';
   ],
 })
 export class CovalentExpansionPanelModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentExpansionPanelModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/file/file.module.ts
+++ b/src/platform/core/file/file.module.ts
@@ -48,15 +48,5 @@ export { TdFileService, IUploadOptions } from './services/file.service';
   ],
 })
 export class CovalentFileModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentFileModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/index.ts
+++ b/src/platform/core/index.ts
@@ -164,15 +164,5 @@ export * from './steps/steps.module';
   ],
 })
 export class CovalentCoreModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentCoreModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/json-formatter/json-formatter.module.ts
+++ b/src/platform/core/json-formatter/json-formatter.module.ts
@@ -21,15 +21,5 @@ export { TdJsonFormatterComponent } from './json-formatter.component';
   ],
 })
 export class CovalentJsonFormatterModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentJsonFormatterModule,
-      providers: [],
-    };
-  }
+
 }

--- a/src/platform/core/layout/layout.module.ts
+++ b/src/platform/core/layout/layout.module.ts
@@ -49,15 +49,5 @@ export { TdLayoutComponent, TdLayoutNavComponent, TdLayoutNavListComponent,
   ],
 })
 export class CovalentLayoutModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentLayoutModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/loading/loading.module.ts
+++ b/src/platform/core/loading/loading.module.ts
@@ -44,15 +44,5 @@ export { TdLoadingService, ITdLoadingConfig } from './services/loading.service';
   ],
 })
 export class CovalentLoadingModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentLoadingModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/media/media.module.ts
+++ b/src/platform/core/media/media.module.ts
@@ -27,15 +27,5 @@ export { TdMediaService, TdMediaToggleDirective };
   ],
 })
 export class CovalentMediaModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentMediaModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/menu/menu.module.ts
+++ b/src/platform/core/menu/menu.module.ts
@@ -26,15 +26,5 @@ export { TdMenuComponent } from './menu.component';
   ],
 })
 export class CovalentMenuModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentMenuModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/notifications/notifications.module.ts
+++ b/src/platform/core/notifications/notifications.module.ts
@@ -25,15 +25,5 @@ export { TdNotificationCountComponent, TdNotificationCountPositionX, TdNotificat
   ],
 })
 export class CovalentNotificationsModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentNotificationsModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/paging/paging.module.ts
+++ b/src/platform/core/paging/paging.module.ts
@@ -25,15 +25,5 @@ export { TdPagingBarComponent, IPageChangeEvent } from './paging-bar.component';
   ],
 })
 export class CovalentPagingModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentPagingModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/search/search.module.ts
+++ b/src/platform/core/search/search.module.ts
@@ -29,15 +29,5 @@ export { TdSearchInputComponent } from './search-input/search-input.component';
   ],
 })
 export class CovalentSearchModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentSearchModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/core/steps/steps.module.ts
+++ b/src/platform/core/steps/steps.module.ts
@@ -42,15 +42,5 @@ export { TdStepsComponent, IStepChangeEvent, StepMode } from './steps.component'
   ],
 })
 export class CovalentStepsModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentStepsModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/dynamic-forms/dynamic-forms.module.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.module.ts
@@ -61,15 +61,5 @@ const TD_DYNAMIC_FORMS_ENTRY_COMPONENTS: Type<any>[] = [
   entryComponents: [ TD_DYNAMIC_FORMS_ENTRY_COMPONENTS ],
 })
 export class CovalentDynamicFormsModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentDynamicFormsModule,
-      providers: [ ],
-    };
-  }
+
 }

--- a/src/platform/highlight/highlight.module.ts
+++ b/src/platform/highlight/highlight.module.ts
@@ -15,15 +15,5 @@ import { TdHighlightComponent } from './highlight.component';
   ],
 })
 export class CovalentHighlightModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentHighlightModule,
-      providers: [],
-    };
-  }
+
 }

--- a/src/platform/markdown/markdown.module.ts
+++ b/src/platform/markdown/markdown.module.ts
@@ -15,15 +15,5 @@ import { TdMarkdownComponent } from './markdown.component';
   ],
 })
 export class CovalentMarkdownModule {
-  /**
-   * @deprecated in 1.0.0-beta.3
-   *
-   * Please use without calling forRoot()
-   */
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: CovalentMarkdownModule,
-      providers: [],
-    };
-  }
+
 }


### PR DESCRIPTION
they were deprecated in beta.3, so we can remove them for beta.4 now

### What's included?

- Removal of `forRoot()` methods deprecated in beta.3

#### Test Steps

- [ ] `ng serve`
- [ ] See docs working fine, and only referencing `forRoot()` for the `http` module

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle