### PR TITLE
chore(layout): remove deprecated selectors for `ng-content`

### DIFF
--- a/src/platform/core/layout/layout-card-over/layout-card-over.component.html
+++ b/src/platform/core/layout/layout-card-over/layout-card-over.component.html
@@ -8,6 +8,6 @@
       <md-divider *ngIf="cardTitle || cardSubtitle"></md-divider>
       <ng-content></ng-content>
     </md-card>
-    <ng-content select="[after-card], [td-after-card]"></ng-content>
+    <ng-content select="[td-after-card]"></ng-content>
   </div>
 </div>

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.html
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.html
@@ -8,9 +8,9 @@
               layout="column"
               layout-fill
               class="md-whiteframe-z1">
-    <ng-content select="md-toolbar[list-items], md-toolbar[td-sidenav-content]"></ng-content>
+    <ng-content select="md-toolbar[td-sidenav-content]"></ng-content>
     <div flex class="list md-content">
-      <ng-content select="[list-items], [td-sidenav-content]"></ng-content>
+      <ng-content select="[td-sidenav-content]"></ng-content>
     </div>
   </md-sidenav>
   <div layout="column" layout-fill class="md-content">
@@ -18,7 +18,7 @@
       <button md-icon-button class="td-menu-button" *ngIf="!sidenav.opened" (click)="open()">
         <md-icon class="md-24">arrow_back</md-icon>
       </button>
-      <ng-content select="[toolbar-buttons], [td-toolbar-content]"></ng-content>
+      <ng-content select="[td-toolbar-content]"></ng-content>
     </md-toolbar>
     <div class="md-content" flex>
       <ng-content></ng-content>

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
@@ -17,10 +17,10 @@
           <md-icon *ngIf="icon" [routerLink]="navigationRoute" class="cursor-pointer">{{icon}}</md-icon>
           <md-icon *ngIf="logo && !icon" class="md-icon-logo cursor-pointer" [svgIcon]="logo" [routerLink]="navigationRoute"></md-icon>
           <span *ngIf="toolbarTitle" class="cursor-pointer" [routerLink]="navigationRoute">{{toolbarTitle}}</span>
-          <ng-content select="[list-toolbar-content], [td-sidenav-toolbar-content]"></ng-content>
+          <ng-content select="[td-sidenav-toolbar-content]"></ng-content>
         </md-toolbar>
         <div flex class="list md-content">
-          <ng-content select="[list-items], [td-sidenav-content]"></ng-content>
+          <ng-content select="[td-sidenav-content]"></ng-content>
         </div>
       </md-sidenav>
       <div layout="column" layout-fill class="md-content">
@@ -28,7 +28,7 @@
           <button md-icon-button class="td-menu-button" *ngIf="!sidenav.opened" (click)="open()">
             <md-icon class="md-24">arrow_back</md-icon>
           </button>
-          <ng-content select="[nav-toolbar-content], [td-toolbar-content]"></ng-content>
+          <ng-content select="[td-toolbar-content]"></ng-content>
         </md-toolbar>
         <div class="md-content" flex>
           <ng-content></ng-content>

--- a/src/platform/core/layout/layout-nav/layout-nav.component.html
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.html
@@ -6,7 +6,7 @@
     <md-icon *ngIf="icon" [routerLink]="navigationRoute" class="cursor-pointer">{{icon}}</md-icon>
     <md-icon *ngIf="logo && !icon" class="md-icon-logo cursor-pointer" [svgIcon]="logo" [routerLink]="navigationRoute"></md-icon>
     <span *ngIf="toolbarTitle" class="cursor-pointer" [routerLink]="navigationRoute">{{toolbarTitle}}</span>
-    <ng-content select="[toolbar-content], [td-toolbar-content]"></ng-content>
+    <ng-content select="[td-toolbar-content]"></ng-content>
   </md-toolbar>
   <div flex layout="column" class="content md-content">
     <ng-content></ng-content>

--- a/src/platform/core/layout/layout.component.html
+++ b/src/platform/core/layout/layout.component.html
@@ -1,7 +1,7 @@
 <md-sidenav-container fullscreen>
   <md-sidenav>
     <ng-content select="td-navigation-drawer"></ng-content>
-    <ng-content select="[menu-items], [td-sidenav-content]"></ng-content>
+    <ng-content select="[td-sidenav-content]"></ng-content>
   </md-sidenav>
   <ng-content></ng-content>
 </md-sidenav-container>


### PR DESCRIPTION
This selectors were deprecated a few releases back so it should be ok to remove them now

### What's included?

- Removal of `ng-content` selectors that were deprecated in `beta.2`

#### Test Steps

- [ ] `ng serve`
- [ ] See docs working fine since we stopped using them a long time ago.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle