### PR TITLE
fix(dynamic-forms): fix AoT issue with min/max validators (closes #508)

### DIFF
--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.html
@@ -11,8 +11,8 @@
             flex>
     <md-hint align="start">
       <span class="tc-red-600">
-        <span *ngIf="control.errors?.max">Max: {{control.errors?.max.maxValue}}</span>
-        <span *ngIf="control.errors?.min">Min: {{control.errors?.min.minValue}}</span>
+        <span *ngIf="control.hasError('max')">Max: {{control.get('max')?.maxValue}}</span>
+        <span *ngIf="control.hasError('min')">Min: {{control.get('min')?.minValue}}</span>
       </span>
     </md-hint>
   </md-input-container>


### PR DESCRIPTION
## Description

https://github.com/Teradata/covalent/issues/508
There is a problem when accessing certain properties in an `AbstractControl`. So we need to use methods like `hasError()` and `get()` to get the proper data for AoT.

#### Test Steps

- [ ] `ng serve --aot`
- [ ] Validations still work in dynamic-forms input and show error.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle