### PR TITLE
fix(pipes): convert bytes using powers of 2 in `TdBytesPipe`. (closes #527)

### DIFF
--- a/src/platform/core/common/pipes/bytes/bytes.pipe.spec.ts
+++ b/src/platform/core/common/pipes/bytes/bytes.pipe.spec.ts
@@ -17,15 +17,16 @@ describe('TdBytesPipe', () => {
   it('should return a formatted bytes to larger units', () => {
     expect(pipe.transform(0, undefined)).toEqual('0 B');
     expect(pipe.transform(535, undefined)).toEqual('535 B');
-    expect(pipe.transform(138540, undefined)).toEqual('138.54 KB');
-    expect(pipe.transform(138540, 1)).toEqual('138.5 KB');
-    expect(pipe.transform(1571800, undefined)).toEqual('1.57 MB');
-    expect(pipe.transform(1571800, 4)).toEqual('1.5718 MB');
-    expect(pipe.transform(10000000, undefined)).toEqual('10 MB');
-    expect(pipe.transform(10200000, undefined)).toEqual('10.2 MB');
-    expect(pipe.transform(10201000, 3)).toEqual('10.201 MB');
-    expect(pipe.transform(3.81861e+10, undefined)).toEqual('38.19 GB');
-    expect(pipe.transform(1.890381861e+14, undefined)).toEqual('189.04 TB');
-    expect(pipe.transform(5.35765e+16, undefined)).toEqual('53.58 PB');
+    expect(pipe.transform(1024, undefined)).toEqual('1 KB');
+    expect(pipe.transform(138540, undefined)).toEqual('135.29 KB');
+    expect(pipe.transform(138540, 1)).toEqual('135.3 KB');
+    expect(pipe.transform(1571800, undefined)).toEqual('1.5 MB');
+    expect(pipe.transform(1571800, 4)).toEqual('1.499 MB');
+    expect(pipe.transform(10000000, undefined)).toEqual('9.54 MB');
+    expect(pipe.transform(10485760, undefined)).toEqual('10 MB');
+    expect(pipe.transform(10201000, 3)).toEqual('9.728 MB');
+    expect(pipe.transform(3.81861e+10, undefined)).toEqual('35.56 GB');
+    expect(pipe.transform(1.890381861e+14, undefined)).toEqual('171.93 TB');
+    expect(pipe.transform(5.35765e+16, undefined)).toEqual('47.59 PB');
   });
 });

--- a/src/platform/core/common/pipes/bytes/bytes.pipe.ts
+++ b/src/platform/core/common/pipes/bytes/bytes.pipe.ts
@@ -14,7 +14,7 @@ export class TdBytesPipe implements PipeTransform {
       /* If not a valid number, return 'Invalid Number' */
       return 'Invalid Number';
     }
-    let k: number = 1000;
+    let k: number = 1024;
     let sizes: string[] = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
     let i: number = Math.floor(Math.log(bytes) / Math.log(k));
     // if less than 1


### PR DESCRIPTION
## Description

Modified the TdBytesPipe to convert using 1024 bytes per Kilobyte (technically [Kilibyte](https://en.wikipedia.org/wiki/Kibibyte)).

Closes #527

### What's included?

- Updated pipe conversion
- Updated unit test numbers

#### Test Steps

- [ ] npm test
- [ ] ng serve and view docs

#### General Tests for Every PR

- [ ] `ng serve --aot` still works. _(Hung at 92% chunk asset optimization on local machine)_
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
Per #527 http://plnkr.co/edit/gLMsYWq064zvaN9FOl32