### PR TITLE
fix(typings) fix tsconfig typeRoots file path (closes #554)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "target": "es5",
     "typeRoots": [
-      "../node_modules/@types"
+      "./node_modules/@types"
     ],
     "paths": {
       "@covalent/*": ["./platform/*"]


### PR DESCRIPTION
## Description

Fixed tsconfig typeRoots file path. (closes [#554](https://github.com/Teradata/covalent/issues/554))

### What's included?

- modified: tsconfig.json

#### Test Steps

- [x] `ng serve`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle