### PR TITLE
feat(chips): make chips preserve input height when chipAddition is false

### DIFF
--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -7,7 +7,13 @@
       <ng-template md-tab-label>Demo</ng-template>
       <div class="push">
         <div class="md-body-1">Type and select a preset option:</div>
-        <td-chips [chipAddition]="chipAddition" [items]="items" [(ngModel)]="itemsRequireMatch" placeholder="Enter autocomplete strings" [readOnly]="readOnly" requireMatch></td-chips>
+        <td-chips [chipAddition]="chipAddition"
+                  [items]="items"
+                  [(ngModel)]="itemsRequireMatch"
+                  placeholder="Enter autocomplete strings"
+                  [readOnly]="readOnly"
+                  requireMatch>
+        </td-chips>
       </div>
     </md-tab>
     <md-tab>
@@ -16,7 +22,13 @@
         <p>HTML:</p>
         <td-highlight lang="html">
           <![CDATA[
-            <td-chips [items]="items" [chipAddition]="chipAddition" [(ngModel)]="itemsRequireMatch" placeholder="Enter autocomplete strings" [readOnly]="readOnly" requireMatch></td-chips>
+            <td-chips [chipAddition]="chipAddition"
+                      [items]="items"
+                      [(ngModel)]="itemsRequireMatch"
+                      placeholder="Enter autocomplete strings"
+                      [readOnly]="readOnly"
+                      requireMatch>
+            </td-chips>
           ]]>
         </td-highlight>
         <p>Typescript:</p>
@@ -24,6 +36,7 @@
           <![CDATA[
             export class ChipsDemoComponent {
               readOnly: boolean = false;
+              chipAddition: boolean = true;
 
               items: string[] = [
                 'stepper',
@@ -41,9 +54,6 @@
 
               itemsRequireMatch: string[] = this.items.slice(0, 6);
 
-              toggleReadOnly(): void {
-                this.readOnly = !this.readOnly;
-              }
             }
           ]]>
         </td-highlight>
@@ -52,8 +62,17 @@
   </md-tab-group>
   <md-divider></md-divider>
   <md-card-actions>
-    <button md-button color="primary" (click)="toggleReadOnly()" class="text-upper">Toggle ReadOnly</button>
-    <button md-button color="primary" (click)="toggleChipAddition()" class="text-upper">Toggle Chip Addition</button>
+    <div class="pad-sm">
+      <md-slide-toggle color="accent" [(ngModel)]="readOnly">
+        Read only
+      </md-slide-toggle>
+    </div>
+    <md-divider></md-divider>
+    <div class="pad-sm">
+      <md-slide-toggle color="accent" [(ngModel)]="chipAddition">
+        Chip addition
+      </md-slide-toggle>
+    </div>
   </md-card-actions>
 </md-card>
 <md-card>

--- a/src/app/components/components/chips/chips.component.ts
+++ b/src/app/components/components/chips/chips.component.ts
@@ -65,11 +65,4 @@ export class ChipsDemoComponent {
 
   itemsRequireMatch: string[] = this.items.slice(0, 6);
 
-  toggleReadOnly(): void {
-    this.readOnly = !this.readOnly;
-  }
-  toggleChipAddition(): void {
-    this.chipAddition = !this.chipAddition;
-  }
-
 }

--- a/src/platform/core/chips/chips.component.html
+++ b/src/platform/core/chips/chips.component.html
@@ -9,22 +9,20 @@
         </md-icon>
       </md-basic-chip>
     </ng-template>
-    <div *ngIf="chipAddition">
-      <md-input-container floatPlaceholder="never"
-                          [style.width.px]="readOnly ? 0 : null"
-                          [color]="matches ? 'primary' : 'warn'">
-        <input mdInput
-                flex="100" 
-                #input
-                [mdAutocomplete]="autocomplete"
-                [formControl]="inputControl"
-                [placeholder]="readOnly? '' : placeholder"
-                (keydown)="_inputKeydown($event)"
-                (keyup.enter)="addChip(input.value)"
-                (focus)="handleFocus()"
-                (blur)="handleBlur()">
-      </md-input-container>
-    </div>
+    <md-input-container floatPlaceholder="never"
+                        [style.width.px]="chipAddition ? null : 0"
+                        [color]="matches ? 'primary' : 'warn'">
+      <input mdInput
+              flex="100" 
+              #input
+              [mdAutocomplete]="autocomplete"
+              [formControl]="inputControl"
+              [placeholder]="chipAddition? placeholder : ''"
+              (keydown)="_inputKeydown($event)"
+              (keyup.enter)="addChip(input.value)"
+              (focus)="handleFocus()"
+              (blur)="handleBlur()">
+    </md-input-container>
     <md-autocomplete #autocomplete="mdAutocomplete">
       <ng-template let-item ngFor [ngForOf]="filteredItems | async">
         <md-option (click)="addChip(item)" [value]="item">{{item}}</md-option>

--- a/src/platform/core/chips/chips.component.spec.ts
+++ b/src/platform/core/chips/chips.component.spec.ts
@@ -1,0 +1,215 @@
+import {
+  TestBed,
+  async,
+  ComponentFixture,
+} from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Component, DebugElement } from '@angular/core';
+import {
+  FormControl, FormsModule, ReactiveFormsModule,
+} from '@angular/forms';
+import { OverlayContainer, MdInputDirective, DOWN_ARROW, UP_ARROW, ENTER, SPACE, TAB } from '@angular/material';
+import { By } from '@angular/platform-browser';
+import { CovalentChipsModule, TdChipsComponent } from './chips.module';
+
+describe('Component: Chips', () => {
+  let overlayContainerElement: HTMLElement;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CovalentChipsModule,
+        FormsModule,
+        ReactiveFormsModule,
+        NoopAnimationsModule,
+      ],
+      declarations: [
+        TdChipsBasicTestComponent,
+      ],
+      providers: [
+        {provide: OverlayContainer, useFactory: () => {
+          overlayContainerElement = document.createElement('div') as HTMLElement;
+          overlayContainerElement.classList.add('cdk-overlay-container');
+
+          document.body.appendChild(overlayContainerElement);
+
+          // remove body padding to keep consistent cross-browser
+          document.body.style.padding = '0';
+          document.body.style.margin = '0';
+
+          return {getContainerElement: () => overlayContainerElement};
+        }},
+      ],
+    });
+    TestBed.compileComponents();
+  }));
+
+  describe('panel usage and filtering: ', () => {
+    let fixture: ComponentFixture<TdChipsBasicTestComponent>;
+    let input: DebugElement;
+    let chips: DebugElement;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TdChipsBasicTestComponent);
+      fixture.detectChanges();
+
+      input = fixture.debugElement.query(By.css('input'));
+      chips = fixture.debugElement.query(By.directive(TdChipsComponent));
+    });
+
+    it('should open the panel chips are focused', (done: DoneFn) => {
+      input.triggerEventHandler('focus', new Event('focus'));
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(overlayContainerElement.textContent).toContain('steak');
+          expect(overlayContainerElement.textContent).toContain('pizza');
+          expect(overlayContainerElement.textContent).toContain('tacos');
+          expect(overlayContainerElement.textContent).toContain('sandwich');
+          expect(overlayContainerElement.textContent).toContain('chips');
+          expect(overlayContainerElement.textContent).toContain('pasta');
+          expect(overlayContainerElement.textContent).toContain('sushi');
+          input.triggerEventHandler('blur', new Event('blur'));
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(overlayContainerElement.textContent).not.toContain('steak');
+            expect(overlayContainerElement.textContent).not.toContain('pizza');
+            expect(overlayContainerElement.textContent).not.toContain('tacos');
+            expect(overlayContainerElement.textContent).not.toContain('sandwich');
+            expect(overlayContainerElement.textContent).not.toContain('chips');
+            expect(overlayContainerElement.textContent).not.toContain('pasta');
+            expect(overlayContainerElement.textContent).not.toContain('sushi');
+            done();
+          });
+        });
+      });
+    });
+
+    it('should open the panel and filter the list', (done: DoneFn) => {
+      input.triggerEventHandler('focus', new Event('focus'));
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(overlayContainerElement.textContent).toContain('steak');
+          expect(overlayContainerElement.textContent).toContain('pizza');
+          expect(overlayContainerElement.textContent).toContain('tacos');
+          expect(overlayContainerElement.textContent).toContain('sandwich');
+          expect(overlayContainerElement.textContent).toContain('chips');
+          expect(overlayContainerElement.textContent).toContain('pasta');
+          expect(overlayContainerElement.textContent).toContain('sushi');
+          (<TdChipsComponent>chips.componentInstance).inputControl.setValue('a');
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            setTimeout(() => {
+              fixture.detectChanges();
+              fixture.whenStable().then(() => {
+                expect(overlayContainerElement.textContent).toContain('steak');
+                expect(overlayContainerElement.textContent).toContain('pizza');
+                expect(overlayContainerElement.textContent).toContain('tacos');
+                expect(overlayContainerElement.textContent).toContain('sandwich');
+                expect(overlayContainerElement.textContent).not.toContain('chips');
+                expect(overlayContainerElement.textContent).toContain('pasta');
+                expect(overlayContainerElement.textContent).not.toContain('sushi');
+                input.triggerEventHandler('blur', new Event('blur'));
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                  expect(overlayContainerElement.textContent).not.toContain('steak');
+                  expect(overlayContainerElement.textContent).not.toContain('pizza');
+                  expect(overlayContainerElement.textContent).not.toContain('tacos');
+                  expect(overlayContainerElement.textContent).not.toContain('sandwich');
+                  expect(overlayContainerElement.textContent).not.toContain('chips');
+                  expect(overlayContainerElement.textContent).not.toContain('pasta');
+                  expect(overlayContainerElement.textContent).not.toContain('sushi');
+                  done();
+                });
+              });
+            }, 100);
+          });
+        });
+      });
+    });
+
+    it('should open the panel, filter selectedItems and filter the list', (done: DoneFn) => {
+      fixture.componentInstance.selectedItems.push('steak');
+      fixture.componentInstance.selectedItems.push('sandwich');
+      input.triggerEventHandler('focus', new Event('focus'));
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(overlayContainerElement.textContent).not.toContain('steak');
+          expect(overlayContainerElement.textContent).toContain('pizza');
+          expect(overlayContainerElement.textContent).toContain('tacos');
+          expect(overlayContainerElement.textContent).not.toContain('sandwich');
+          expect(overlayContainerElement.textContent).toContain('chips');
+          expect(overlayContainerElement.textContent).toContain('pasta');
+          expect(overlayContainerElement.textContent).toContain('sushi');
+          (<TdChipsComponent>chips.componentInstance).inputControl.setValue('a');
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            setTimeout(() => {
+              fixture.detectChanges();
+              fixture.whenStable().then(() => {
+                expect(overlayContainerElement.textContent).not.toContain('steak');
+                expect(overlayContainerElement.textContent).toContain('pizza');
+                expect(overlayContainerElement.textContent).toContain('tacos');
+                expect(overlayContainerElement.textContent).not.toContain('sandwich');
+                expect(overlayContainerElement.textContent).not.toContain('chips');
+                expect(overlayContainerElement.textContent).toContain('pasta');
+                expect(overlayContainerElement.textContent).not.toContain('sushi');
+                input.triggerEventHandler('blur', new Event('blur'));
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                  expect(overlayContainerElement.textContent).not.toContain('steak');
+                  expect(overlayContainerElement.textContent).not.toContain('pizza');
+                  expect(overlayContainerElement.textContent).not.toContain('tacos');
+                  expect(overlayContainerElement.textContent).not.toContain('sandwich');
+                  expect(overlayContainerElement.textContent).not.toContain('chips');
+                  expect(overlayContainerElement.textContent).not.toContain('pasta');
+                  expect(overlayContainerElement.textContent).not.toContain('sushi');
+                  done();
+                });
+              });
+            }, 100);
+          });
+        });
+      });
+    });
+  });
+
+  // TODO
+
+  // requireMatch usage
+
+  // readOnly usage
+
+  // chipAddition usage
+
+  // add event test
+
+  // remove event test
+
+  // required reactive forms (dirty, pristine, valid)
+
+});
+
+@Component({
+  template: `
+      <td-chips [placeholder]="placeholder" [items]="items" [(ngModel)]="selectedItems">
+      </td-chips>`,
+})
+class TdChipsBasicTestComponent {
+  placeholder: string;
+  selectedItems: string[] = [];
+  items: string[] = [
+    'steak',
+    'pizza',
+    'tacos',
+    'sandwich',
+    'chips',
+    'pasta',
+    'sushi',
+  ];
+}

--- a/src/platform/core/chips/chips.component.spec.ts
+++ b/src/platform/core/chips/chips.component.spec.ts
@@ -3,7 +3,7 @@ import {
   async,
   ComponentFixture,
 } from '@angular/core/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Component, DebugElement } from '@angular/core';
 import {
   FormControl, FormsModule, ReactiveFormsModule,
@@ -21,7 +21,7 @@ describe('Component: Chips', () => {
         CovalentChipsModule,
         FormsModule,
         ReactiveFormsModule,
-        NoopAnimationsModule,
+        BrowserAnimationsModule,
       ],
       declarations: [
         TdChipsBasicTestComponent,

--- a/src/platform/core/chips/chips.component.ts
+++ b/src/platform/core/chips/chips.component.ts
@@ -32,6 +32,7 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck, OnInit {
   private _length: number = 0;
   private _requireMatch: boolean = false;
   private _readOnly: boolean = false;
+  private _chipAddition: boolean = true;
 
   @ViewChild(MdInputDirective) _inputChild: MdInputDirective;
   @ViewChildren(MdChip) _chipsChildren: QueryList<MdChip>;
@@ -86,11 +87,7 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck, OnInit {
   @Input('readOnly')
   set readOnly(readOnly: boolean) {
     this._readOnly = readOnly;
-    if (readOnly) {
-      this.inputControl.disable();
-    } else {
-      this.inputControl.enable();
-    }
+    this._toggleInput();
   }
   get readOnly(): boolean {
     return this._readOnly;
@@ -99,8 +96,16 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck, OnInit {
   /**
    * chipAddition?: boolean
    * Disables the ability to add chips. If it doesn't exist chip addition defaults to true.
+   * When setting readOnly as true, this will be overriden.
    */
-  @Input('chipAddition') chipAddition: boolean = true;
+  @Input('chipAddition')
+  set chipAddition(chipAddition: boolean) {
+    this._chipAddition = chipAddition;
+    this._toggleInput();
+  }
+  get chipAddition(): boolean {
+    return this._chipAddition && !this.readOnly;
+  }
 
   /**
    * placeholder?: string
@@ -235,7 +240,6 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck, OnInit {
       case DELETE:
       case BACKSPACE:
         /** Check to see if input is empty when pressing left arrow to move to the last chip */
-        
         if (!this._inputChild.value) {
           this._focusLastChip();
           event.preventDefault();
@@ -351,9 +355,20 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck, OnInit {
     this._focusChip(0);
   }
 
-  /** MEthod to focus last chip */
+  /** Method to focus last chip */
   private _focusLastChip(): void {
     this._focusChip(this._totalChips - 1);
   }
 
+  /**
+   * Method to toggle the disable state of input
+   * Checks if not in readOnly state and if chipAddition is set to 'true'
+   */
+  private _toggleInput(): void {
+    if (this.chipAddition) {
+      this.inputControl.enable();
+    } else {
+      this.inputControl.disable();
+    }
+  }
 }

--- a/src/platform/core/chips/chips.component.ts
+++ b/src/platform/core/chips/chips.component.ts
@@ -5,6 +5,7 @@ import { MdChip, MdInputDirective, ESCAPE, LEFT_ARROW, RIGHT_ARROW, DELETE, BACK
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/observable/timer';
+import 'rxjs/add/operator/debounceTime';
 
 const noop: any = () => {
   // empty method


### PR DESCRIPTION
## Description

currently the chip element disappeared, so the space should remain there to let the user know something is there on screen.

Also update docs to use toggles instead of buttons

### What's included?

- Disable input, set its width to 0 and remove its placeholder when state is `readOnly="true"` or `chipAddition="false"`
- Changed demo/docs to use toggles instead of buttons since its a better look and feel for it.
- fix(chips): added missing rxjs/add/operator/debounceTime import
- code-health(chips): added initial unit tests for chips component

#### Test Steps

- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/chips
- [ ] Play with demo

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle

![image](https://cloud.githubusercontent.com/assets/5846742/25766815/c58675a2-31a9-11e7-8cd0-77c525e26293.png)
