### PR TITLE
feat(layout): make navigation optional if there are no routes to navigate to.

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <td-layout #layout>
-  <td-navigation-drawer sidenavTitle="Covalent" logo="assets:teradata">
+  <td-navigation-drawer sidenavTitle="Covalent" logo="assets:teradata" navigationRoute="/">
     <md-nav-list>
       <a *ngFor="let item of routes" md-list-item (click)="layout.close()" [routerLink]="[item.route]"><md-icon>{{item.icon}}</md-icon>{{item.title}}</a>
     </md-nav-list>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <td-layout #layout>
-  <td-navigation-drawer sidenavTitle="Covalent" logo="assets:teradata">
+  <td-navigation-drawer navigationRoute="/" sidenavTitle="Covalent" logo="assets:teradata">
     <md-nav-list>
       <a *ngFor="let item of routes" md-list-item (click)="layout.close()" [routerLink]="[item.route]"><md-icon>{{item.icon}}</md-icon>{{item.title}}</a>
     </md-nav-list>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <td-layout #layout>
-  <td-navigation-drawer navigationRoute="/" sidenavTitle="Covalent" logo="assets:teradata">
+  <td-navigation-drawer sidenavTitle="Covalent" logo="assets:teradata">
     <md-nav-list>
       <a *ngFor="let item of routes" md-list-item (click)="layout.close()" [routerLink]="[item.route]"><md-icon>{{item.icon}}</md-icon>{{item.title}}</a>
     </md-nav-list>

--- a/src/app/components/components/components.component.html
+++ b/src/app/components/components/components.component.html
@@ -1,4 +1,5 @@
 <td-layout-nav-list #navList
+                    navigationRoute="/"
                     #root="$implicit" dir="ltr"
                     logo="assets:teradata"
                     toolbarTitle="Covalent"

--- a/src/app/components/components/components.component.html
+++ b/src/app/components/components/components.component.html
@@ -1,5 +1,4 @@
 <td-layout-nav-list #navList
-                    navigationRoute="/"
                     #root="$implicit" dir="ltr"
                     logo="assets:teradata"
                     toolbarTitle="Covalent"

--- a/src/app/components/components/components.component.html
+++ b/src/app/components/components/components.component.html
@@ -2,6 +2,7 @@
                     #root="$implicit" dir="ltr"
                     logo="assets:teradata"
                     toolbarTitle="Covalent"
+                    navigationRoute="/"
                     [opened]="media.registerQuery('gt-sm') | async"
                     [mode]="(media.registerQuery('gt-sm') | async) ? 'side' : ((media.registerQuery('sm') | async) ? 'push' : 'over')"
                     [sidenavWidth]="(media.registerQuery('gt-xs') | async) ? '350px' : '100%'">

--- a/src/app/components/docs/docs.component.html
+++ b/src/app/components/docs/docs.component.html
@@ -1,6 +1,7 @@
 <td-layout-nav-list #navList
                     logo="assets:teradata"
                     toolbarTitle="Covalent"
+                    navigationRoute="/"
                     [opened]="media.registerQuery('gt-sm') | async"
                     [mode]="(media.registerQuery('gt-sm') | async) ? 'side' : ((media.registerQuery('sm') | async) ? 'push' : 'over')"
                     [sidenavWidth]="(media.registerQuery('gt-xs') | async) ? '350px' : '100%'">

--- a/src/app/components/docs/docs.component.html
+++ b/src/app/components/docs/docs.component.html
@@ -1,5 +1,4 @@
 <td-layout-nav-list #navList
-                    navigationRoute="/"
                     logo="assets:teradata"
                     toolbarTitle="Covalent"
                     [opened]="media.registerQuery('gt-sm') | async"

--- a/src/app/components/docs/docs.component.html
+++ b/src/app/components/docs/docs.component.html
@@ -1,4 +1,5 @@
 <td-layout-nav-list #navList
+                    navigationRoute="/"
                     logo="assets:teradata"
                     toolbarTitle="Covalent"
                     [opened]="media.registerQuery('gt-sm') | async"

--- a/src/app/components/layouts/card-over/card-over.component.html
+++ b/src/app/components/layouts/card-over/card-over.component.html
@@ -1,4 +1,4 @@
-<td-layout-nav navigationRoute="/" logo="assets:teradata" toolbarTitle="Covalent">
+<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent">
   <td-layout-card-over cardWidth="75">
     <md-card-title>Card Over Layout</md-card-title>
     <md-card-subtitle>A card overlaying a toolbar (this page is using card over)</md-card-subtitle>

--- a/src/app/components/layouts/card-over/card-over.component.html
+++ b/src/app/components/layouts/card-over/card-over.component.html
@@ -1,4 +1,4 @@
-<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent">
+<td-layout-nav navigationRoute="/" logo="assets:teradata" toolbarTitle="Covalent">
   <td-layout-card-over cardWidth="75">
     <md-card-title>Card Over Layout</md-card-title>
     <md-card-subtitle>A card overlaying a toolbar (this page is using card over)</md-card-subtitle>
@@ -18,7 +18,7 @@
       <div layout-gt-md="row">
         <div flex-gt-md="45">
           <td-steps>
-            <td-step label="td-layout-nav" sublabel="the content wrapper of the layout">
+            <td-step label="td-layout-nav" sublabel="the content wrapper of the layout" active="true">
               <md-list>
                 <md-list-item>
                   <h3 md-line><code><![CDATA[<td-layout-nav>]]></code></h3>

--- a/src/app/components/layouts/card-over/card-over.component.html
+++ b/src/app/components/layouts/card-over/card-over.component.html
@@ -1,4 +1,4 @@
-<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent">
+<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent" navigationRoute="/">
   <td-layout-card-over cardWidth="75">
     <md-card-title>Card Over Layout</md-card-title>
     <md-card-subtitle>A card overlaying a toolbar (this page is using card over)</md-card-subtitle>

--- a/src/app/components/layouts/manage-list/manage-list.component.html
+++ b/src/app/components/layouts/manage-list/manage-list.component.html
@@ -1,4 +1,4 @@
-<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent">
+<td-layout-nav navigationRoute="/" logo="assets:teradata" toolbarTitle="Covalent">
   <td-layout-manage-list #manageList 
                         [opened]="media.registerQuery('gt-sm') | async"
                         [mode]="(media.registerQuery('gt-sm') | async) ? 'side' :  'over'"
@@ -37,7 +37,7 @@
         <div layout-gt-md="row">
           <div flex-gt-md="50">
             <td-steps>
-              <td-step label="td-layout-nav" sublabel="the main content wrapper">
+              <td-step label="td-layout-nav" sublabel="the main content wrapper" active="true">
                 <md-list>
                   <md-list-item>
                     <h3 md-line><code><![CDATA[<td-layout-nav>]]></code></h3>

--- a/src/app/components/layouts/manage-list/manage-list.component.html
+++ b/src/app/components/layouts/manage-list/manage-list.component.html
@@ -1,4 +1,4 @@
-<td-layout-nav navigationRoute="/" logo="assets:teradata" toolbarTitle="Covalent">
+<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent">
   <td-layout-manage-list #manageList 
                         [opened]="media.registerQuery('gt-sm') | async"
                         [mode]="(media.registerQuery('gt-sm') | async) ? 'side' :  'over'"

--- a/src/app/components/layouts/manage-list/manage-list.component.html
+++ b/src/app/components/layouts/manage-list/manage-list.component.html
@@ -1,4 +1,4 @@
-<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent">
+<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent" navigationRoute="/">
   <td-layout-manage-list #manageList 
                         [opened]="media.registerQuery('gt-sm') | async"
                         [mode]="(media.registerQuery('gt-sm') | async) ? 'side' :  'over'"

--- a/src/app/components/layouts/nav-list/nav-list.component.html
+++ b/src/app/components/layouts/nav-list/nav-list.component.html
@@ -1,5 +1,4 @@
 <td-layout-nav-list #navList
-                    navigationRoute="/"
                     logo="assets:teradata"
                     toolbarTitle="Covalent"
                     [opened]="media.registerQuery('gt-sm') | async"

--- a/src/app/components/layouts/nav-list/nav-list.component.html
+++ b/src/app/components/layouts/nav-list/nav-list.component.html
@@ -61,7 +61,7 @@
                 <md-divider></md-divider>
                 <md-list-item>
                   <h3 md-line><code>navigationRoute?: string</code></h3>
-                  <p md-line>Optional route on logo/icon/title</p>
+                  <p md-line>Route on logo/icon/title (defaults to '/')</p>
                 </md-list-item>
                 <md-divider></md-divider>
                 <md-list-item>

--- a/src/app/components/layouts/nav-list/nav-list.component.html
+++ b/src/app/components/layouts/nav-list/nav-list.component.html
@@ -1,4 +1,5 @@
 <td-layout-nav-list #navList
+                    navigationRoute="/"
                     logo="assets:teradata"
                     toolbarTitle="Covalent"
                     [opened]="media.registerQuery('gt-sm') | async"
@@ -42,7 +43,7 @@
       <div layout-gt-lg="row">
         <div flex-gt-lg="50">
           <td-steps>
-            <td-step label="td-layout-nav-list" sublabel="the main content area of the layout">
+            <td-step label="td-layout-nav-list" sublabel="the main content area of the layout" active="true">
               <md-list>
                 <md-list-item>
                   <h3 md-line><code><![CDATA[<td-layout-nav-list>]]></code></h3>
@@ -61,7 +62,7 @@
                 <md-divider></md-divider>
                 <md-list-item>
                   <h3 md-line><code>navigationRoute?: string</code></h3>
-                  <p md-line>Route on logo/icon/title (defaults to '/')</p>
+                  <p md-line>Optional route on logo/icon/title</p>
                 </md-list-item>
                 <md-divider></md-divider>
                 <md-list-item>

--- a/src/app/components/layouts/nav-list/nav-list.component.html
+++ b/src/app/components/layouts/nav-list/nav-list.component.html
@@ -61,7 +61,7 @@
                 <md-divider></md-divider>
                 <md-list-item>
                   <h3 md-line><code>navigationRoute?: string</code></h3>
-                  <p md-line>Route on logo/icon/title (defaults to '/')</p>
+                  <p md-line>Optional route navigation on logo/icon/title</p>
                 </md-list-item>
                 <md-divider></md-divider>
                 <md-list-item>

--- a/src/app/components/layouts/nav-list/nav-list.component.html
+++ b/src/app/components/layouts/nav-list/nav-list.component.html
@@ -1,6 +1,7 @@
 <td-layout-nav-list #navList
                     logo="assets:teradata"
                     toolbarTitle="Covalent"
+                    navigationRoute="/"
                     [opened]="media.registerQuery('gt-sm') | async"
                     [mode]="(media.registerQuery('gt-sm') | async) ? 'side' : 'over'"
                     [sidenavWidth]="(media.registerQuery('gt-xs') | async) ? '350px' : '100%'">

--- a/src/app/components/layouts/nav-view/nav-view.component.html
+++ b/src/app/components/layouts/nav-view/nav-view.component.html
@@ -1,4 +1,4 @@
-<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent">
+<td-layout-nav navigationRoute="/" logo="assets:teradata" toolbarTitle="Covalent">
   <div class="md-padding">
     <md-card>
       <md-card-title>Nav View</md-card-title>
@@ -21,7 +21,7 @@
         <div layout-gt-md="row">
           <div flex-gt-md="50">
             <td-steps>
-              <td-step label="td-layout-nav" sublabel="the main content area of the layout">
+              <td-step label="td-layout-nav" sublabel="the main content area of the layout" active="true">
                 <md-list>
                   <md-list-item>
                     <h3 md-line><code><![CDATA[<td-layout-nav>]]></code></h3>
@@ -45,7 +45,7 @@
                   <md-divider></md-divider>
                   <md-list-item>
                     <h3 md-line><code>navigationRoute?: string</code></h3>
-                    <p md-line>Route on logo/icon/title (defaults to '/')</p>
+                    <p md-line>Optional route on logo/icon/title</p>
                   </md-list-item>
                   <md-divider></md-divider>
                   <md-list-item>

--- a/src/app/components/layouts/nav-view/nav-view.component.html
+++ b/src/app/components/layouts/nav-view/nav-view.component.html
@@ -1,4 +1,4 @@
-<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent">
+<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent" navigationRoute="/">
   <div class="md-padding">
     <md-card>
       <md-card-title>Nav View</md-card-title>

--- a/src/app/components/layouts/nav-view/nav-view.component.html
+++ b/src/app/components/layouts/nav-view/nav-view.component.html
@@ -1,4 +1,4 @@
-<td-layout-nav navigationRoute="/" logo="assets:teradata" toolbarTitle="Covalent">
+<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent">
   <div class="md-padding">
     <md-card>
       <md-card-title>Nav View</md-card-title>

--- a/src/app/components/layouts/nav-view/nav-view.component.html
+++ b/src/app/components/layouts/nav-view/nav-view.component.html
@@ -45,7 +45,7 @@
                   <md-divider></md-divider>
                   <md-list-item>
                     <h3 md-line><code>navigationRoute?: string</code></h3>
-                    <p md-line>Route on logo/icon/title (defaults to '/')</p>
+                    <p md-line>Optional route navigation on logo/icon/title</p>
                   </md-list-item>
                   <md-divider></md-divider>
                   <md-list-item>

--- a/src/app/components/layouts/nav-view/nav-view.component.html
+++ b/src/app/components/layouts/nav-view/nav-view.component.html
@@ -45,7 +45,7 @@
                   <md-divider></md-divider>
                   <md-list-item>
                     <h3 md-line><code>navigationRoute?: string</code></h3>
-                    <p md-line>Optional route on logo/icon/title</p>
+                    <p md-line>Route on logo/icon/title (defaults to '/')</p>
                   </md-list-item>
                   <md-divider></md-divider>
                   <md-list-item>

--- a/src/app/components/layouts/overview/overview.component.html
+++ b/src/app/components/layouts/overview/overview.component.html
@@ -1,4 +1,4 @@
-<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent">
+<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent" navigationRoute="/">
   <td-layout-card-over cardWidth="80" cardTitle="Layout Options" cardSubtitle="We offer 4 Material Design layouts for you">
     <md-card-content hide-xs hide-sm>
       <p>For your entire app or for different sections of your app, select one of these Material Design layout options:</p>

--- a/src/app/components/layouts/overview/overview.component.html
+++ b/src/app/components/layouts/overview/overview.component.html
@@ -1,4 +1,4 @@
-<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent">
+<td-layout-nav navigationRoute="/" logo="assets:teradata" toolbarTitle="Covalent">
   <td-layout-card-over cardWidth="80" cardTitle="Layout Options" cardSubtitle="We offer 4 Material Design layouts for you">
     <md-card-content hide-xs hide-sm>
       <p>For your entire app or for different sections of your app, select one of these Material Design layout options:</p>

--- a/src/app/components/layouts/overview/overview.component.html
+++ b/src/app/components/layouts/overview/overview.component.html
@@ -1,4 +1,4 @@
-<td-layout-nav navigationRoute="/" logo="assets:teradata" toolbarTitle="Covalent">
+<td-layout-nav logo="assets:teradata" toolbarTitle="Covalent">
   <td-layout-card-over cardWidth="80" cardTitle="Layout Options" cardSubtitle="We offer 4 Material Design layouts for you">
     <md-card-content hide-xs hide-sm>
       <p>For your entire app or for different sections of your app, select one of these Material Design layout options:</p>

--- a/src/app/components/style-guide/style-guide.component.html
+++ b/src/app/components/style-guide/style-guide.component.html
@@ -1,6 +1,7 @@
 <td-layout-nav-list #navList
                     logo="assets:teradata"
                     toolbarTitle="Covalent"
+                    navigationRoute="/"
                     [opened]="media.registerQuery('gt-sm') | async"
                     [mode]="(media.registerQuery('gt-sm') | async) ? 'side' : ((media.registerQuery('sm') | async) ? 'push' : 'over')"
                     [sidenavWidth]="(media.registerQuery('gt-xs') | async) ? '350px' : '100%'">

--- a/src/app/components/style-guide/style-guide.component.html
+++ b/src/app/components/style-guide/style-guide.component.html
@@ -1,5 +1,4 @@
 <td-layout-nav-list #navList
-                    navigationRoute="/"
                     logo="assets:teradata"
                     toolbarTitle="Covalent"
                     [opened]="media.registerQuery('gt-sm') | async"

--- a/src/app/components/style-guide/style-guide.component.html
+++ b/src/app/components/style-guide/style-guide.component.html
@@ -1,4 +1,5 @@
 <td-layout-nav-list #navList
+                    navigationRoute="/"
                     logo="assets:teradata"
                     toolbarTitle="Covalent"
                     [opened]="media.registerQuery('gt-sm') | async"

--- a/src/platform/core/layout/README.md
+++ b/src/platform/core/layout/README.md
@@ -47,7 +47,7 @@ See [theming](https://teradata.github.io/covalent/#/docs/theme) in the covalent 
 | icon | string | icon name to be displayed before the title
 | logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
 | color | string | optional sidenav toolbar color.
-| navigationRoute | string | route for the icon, logo, and sidenavTitle. Defaults to '/'.
+| navigationRoute | string | optional route for the icon, logo, and sidenavTitle.
 | backgroundUrl | SafeResourceUrl | image to be displayed as the background of the toolbar. URL used will be sanitized, but it should be always from a trusted source to avoid XSS.
 | name | string | string to be displayed as part of the navigation drawer sublabel. if [email] is not set, then [name] will be the toggle menu text.
 | email | string | string to be displayed as part of the navigation drawer sublabel in the [toggle] menu text. if [email] and [name] are not set, then the toggle menu is not rendered.

--- a/src/platform/core/layout/README.md
+++ b/src/platform/core/layout/README.md
@@ -47,7 +47,7 @@ See [theming](https://teradata.github.io/covalent/#/docs/theme) in the covalent 
 | icon | string | icon name to be displayed before the title
 | logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
 | color | string | optional sidenav toolbar color.
-| navigationRoute | string | optional route for the icon, logo, and sidenavTitle.
+| navigationRoute | string | route for the icon, logo, and sidenavTitle. Defaults to '/'.
 | backgroundUrl | SafeResourceUrl | image to be displayed as the background of the toolbar. URL used will be sanitized, but it should be always from a trusted source to avoid XSS.
 | name | string | string to be displayed as part of the navigation drawer sublabel. if [email] is not set, then [name] will be the toggle menu text.
 | email | string | string to be displayed as part of the navigation drawer sublabel in the [toggle] menu text. if [email] and [name] are not set, then the toggle menu is not rendered.

--- a/src/platform/core/layout/README.md
+++ b/src/platform/core/layout/README.md
@@ -47,7 +47,7 @@ See [theming](https://teradata.github.io/covalent/#/docs/theme) in the covalent 
 | icon | string | icon name to be displayed before the title
 | logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
 | color | string | optional sidenav toolbar color.
-| navigationRoute | string | route for the icon, logo, and sidenavTitle. Defaults to '/'.
+| navigationRoute | string | option to set the combined route for the icon, logo, and sidenavTitle.
 | backgroundUrl | SafeResourceUrl | image to be displayed as the background of the toolbar. URL used will be sanitized, but it should be always from a trusted source to avoid XSS.
 | name | string | string to be displayed as part of the navigation drawer sublabel. if [email] is not set, then [name] will be the toggle menu text.
 | email | string | string to be displayed as part of the navigation drawer sublabel in the [toggle] menu text. if [email] and [name] are not set, then the toggle menu is not rendered.
@@ -63,7 +63,7 @@ Example for Main Layout / Navigation Drawer Combo:
 
 ```html
 <td-layout>
-  <td-navigation-drawer sidenavTitle="title" logo="logo" icon="icon" name="name" password="password" color="color"  navigationRoute="/">
+  <td-navigation-drawer sidenavTitle="title" logo="logo" icon="icon" name="name" password="password" color="color" navigationRoute="/">
     .. main drawer content
     <div td-navigation-drawer-menu>
       .. menu drawer content

--- a/src/platform/core/layout/layout-nav-list/README.md
+++ b/src/platform/core/layout/layout-nav-list/README.md
@@ -11,7 +11,7 @@
 | icon | string | icon name to be displayed before the title
 | logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
 | color | string | optional toolbar color. Defaults to primary.
-| navigationRoute | string | route for the icon, logo, and toolbarTitle. Defaults to '/'.
+| navigationRoute | string | option to set the combined route for the icon, logo, and toolbarTitle.
 | mode | 'over', 'side' or 'push' | The mode or styling of the sidenav. Defaults to 'side'.
 | opened | boolean | Whether or not the sidenav is opened. Use this binding to open/close the sidenav. Defaults to 'true'.
 | sidenavWidth | string | Sets the 'width' of the sidenav in either 'px' or '%' ('%' is not well supported yet as stated in the layout docs). Defaults to '257px'.
@@ -32,7 +32,7 @@
 Example for Nav List Layout:
 
 ```html
-<td-layout-nav-list sidenavTitle="title" logo="logo" icon="icon" opened="true" mode="side" sidenavWidth="350px" color="color"  navigationRoute="/">
+<td-layout-nav-list sidenavTitle="title" logo="logo" icon="icon" opened="true" mode="side" sidenavWidth="350px" color="color" navigationRoute="/">
   <div td-sidenav-toolbar-content>
     ... left toolbar content
   </div>

--- a/src/platform/core/layout/layout-nav-list/README.md
+++ b/src/platform/core/layout/layout-nav-list/README.md
@@ -11,7 +11,7 @@
 | icon | string | icon name to be displayed before the title
 | logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
 | color | string | optional toolbar color. Defaults to primary.
-| navigationRoute | string | route for the icon, logo, and toolbarTitle. Defaults to '/'.
+| navigationRoute | string | optional route for the icon, logo, and toolbarTitle.
 | mode | 'over', 'side' or 'push' | The mode or styling of the sidenav. Defaults to 'side'.
 | opened | boolean | Whether or not the sidenav is opened. Use this binding to open/close the sidenav. Defaults to 'true'.
 | sidenavWidth | string | Sets the 'width' of the sidenav in either 'px' or '%' ('%' is not well supported yet as stated in the layout docs). Defaults to '257px'.

--- a/src/platform/core/layout/layout-nav-list/README.md
+++ b/src/platform/core/layout/layout-nav-list/README.md
@@ -11,7 +11,7 @@
 | icon | string | icon name to be displayed before the title
 | logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
 | color | string | optional toolbar color. Defaults to primary.
-| navigationRoute | string | route for the icon, logo, and sidenavTitle. Defaults to '/'.
+| navigationRoute | string | route for the icon, logo, and toolbarTitle. Defaults to '/'.
 | mode | 'over', 'side' or 'push' | The mode or styling of the sidenav. Defaults to 'side'.
 | opened | boolean | Whether or not the sidenav is opened. Use this binding to open/close the sidenav. Defaults to 'true'.
 | sidenavWidth | string | Sets the 'width' of the sidenav in either 'px' or '%' ('%' is not well supported yet as stated in the layout docs). Defaults to '257px'.

--- a/src/platform/core/layout/layout-nav-list/README.md
+++ b/src/platform/core/layout/layout-nav-list/README.md
@@ -11,7 +11,7 @@
 | icon | string | icon name to be displayed before the title
 | logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
 | color | string | optional toolbar color. Defaults to primary.
-| navigationRoute | string | optional route for the icon, logo, and toolbarTitle.
+| navigationRoute | string | route for the icon, logo, and sidenavTitle. Defaults to '/'.
 | mode | 'over', 'side' or 'push' | The mode or styling of the sidenav. Defaults to 'side'.
 | opened | boolean | Whether or not the sidenav is opened. Use this binding to open/close the sidenav. Defaults to 'true'.
 | sidenavWidth | string | Sets the 'width' of the sidenav in either 'px' or '%' ('%' is not well supported yet as stated in the layout docs). Defaults to '257px'.

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
@@ -14,9 +14,15 @@
           <button md-icon-button class="td-menu-button" *ngIf="isMainSidenavAvailable" (click)="openMainSidenav()">
             <md-icon class="md-24">menu</md-icon>
           </button>
-          <md-icon *ngIf="icon" [routerLink]="navigationRoute" class="cursor-pointer">{{icon}}</md-icon>
-          <md-icon *ngIf="logo && !icon" class="md-icon-logo cursor-pointer" [svgIcon]="logo" [routerLink]="navigationRoute"></md-icon>
-          <span *ngIf="toolbarTitle" class="cursor-pointer" [routerLink]="navigationRoute">{{toolbarTitle}}</span>
+
+          <md-icon *ngIf="icon && navigationRoute" [routerLink]="navigationRoute" class="cursor-pointer">{{icon}}</md-icon>
+          <md-icon *ngIf="logo && !icon && navigationRoute" class="md-icon-logo cursor-pointer" [svgIcon]="logo" [routerLink]="navigationRoute"></md-icon>
+          <span *ngIf="toolbarTitle && navigationRoute" class="cursor-pointer" [routerLink]="navigationRoute">{{toolbarTitle}}</span>
+
+          <md-icon *ngIf="icon && !navigationRoute">{{icon}}</md-icon>
+          <md-icon *ngIf="logo && !icon && !navigationRoute" class="md-icon-logo" [svgIcon]="logo"></md-icon>
+          <span *ngIf="toolbarTitle && !navigationRoute">{{toolbarTitle}}</span>
+
           <ng-content select="[td-sidenav-toolbar-content]"></ng-content>
         </md-toolbar>
         <div flex class="list md-content">

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
@@ -18,7 +18,7 @@
                 [class.cursor-pointer]="routerEnabled"
                 (click)="handleNavigationClick()"
                 layout="row"
-                layout-align="start end">
+                layout-align="start center">
             <md-icon *ngIf="icon">{{icon}}</md-icon>
             <md-icon *ngIf="logo && !icon" class="md-icon-logo" [svgIcon]="logo"></md-icon>
             <span *ngIf="toolbarTitle">{{toolbarTitle}}</span>

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
@@ -14,15 +14,15 @@
           <button md-icon-button class="td-menu-button" *ngIf="isMainSidenavAvailable" (click)="openMainSidenav()">
             <md-icon class="md-24">menu</md-icon>
           </button>
-
-          <md-icon *ngIf="icon && navigationRoute" [routerLink]="navigationRoute" class="cursor-pointer">{{icon}}</md-icon>
-          <md-icon *ngIf="logo && !icon && navigationRoute" class="md-icon-logo cursor-pointer" [svgIcon]="logo" [routerLink]="navigationRoute"></md-icon>
-          <span *ngIf="toolbarTitle && navigationRoute" class="cursor-pointer" [routerLink]="navigationRoute">{{toolbarTitle}}</span>
-
-          <md-icon *ngIf="icon && !navigationRoute">{{icon}}</md-icon>
-          <md-icon *ngIf="logo && !icon && !navigationRoute" class="md-icon-logo" [svgIcon]="logo"></md-icon>
-          <span *ngIf="toolbarTitle && !navigationRoute">{{toolbarTitle}}</span>
-
+          <span *ngIf="icon || logo || toolbarTitle"
+                [class.cursor-pointer]="routerEnabled"
+                (click)="handleNavigationClick()"
+                layout="row"
+                layout-align="start end">
+            <md-icon *ngIf="icon">{{icon}}</md-icon>
+            <md-icon *ngIf="logo && !icon" class="md-icon-logo" [svgIcon]="logo"></md-icon>
+            <span *ngIf="toolbarTitle">{{toolbarTitle}}</span>
+          </span>
           <ng-content select="[td-sidenav-toolbar-content]"></ng-content>
         </md-toolbar>
         <div flex class="list md-content">

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.ts
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, ViewChild, forwardRef, Optional, Inject } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { MdSidenav, MdSidenavToggleResult } from '@angular/material';
 
@@ -80,7 +81,7 @@ export class TdLayoutNavListComponent {
    * option to set the combined logo, icon, toolbar title route
    * defaults to '/'
    */
-  @Input('navigationRoute') navigationRoute: string;
+  @Input('navigationRoute') navigationRoute: string = '/';
 
   /**
    * Checks if there is a [TdLayoutComponent] as parent.
@@ -97,8 +98,21 @@ export class TdLayoutNavListComponent {
     return this.mode === 'side';
   }
 
-  constructor(@Optional() @Inject(forwardRef(() => TdLayoutComponent))
-              private _layout: TdLayoutComponent) { }
+  /**
+   * Checks if router was injected.
+   */
+  get routerEnabled(): boolean {
+    return !!this._router;
+  }
+
+  constructor(@Optional() @Inject(forwardRef(() => TdLayoutComponent)) private _layout: TdLayoutComponent,
+              @Optional() private _router: Router) {}
+
+  handleNavigationClick(): void {
+    if (this.routerEnabled) {
+      this._router.navigateByUrl(this.navigationRoute);
+    }
+  }
 
   /**
    * Proxy toggle method to access sidenav from outside (from td-layout template).

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.ts
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.ts
@@ -80,7 +80,7 @@ export class TdLayoutNavListComponent {
    * option to set the combined logo, icon, toolbar title route
    * defaults to '/'
    */
-  @Input('navigationRoute') navigationRoute: string = '/';
+  @Input('navigationRoute') navigationRoute: string;
 
   /**
    * Checks if there is a [TdLayoutComponent] as parent.

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.ts
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.ts
@@ -78,10 +78,9 @@ export class TdLayoutNavListComponent {
   /**
    * navigationRoute?: string
    *
-   * option to set the combined logo, icon, toolbar title route
-   * defaults to '/'
+   * option to set the combined route for the icon, logo, and toolbarTitle.
    */
-  @Input('navigationRoute') navigationRoute: string = '/';
+  @Input('navigationRoute') navigationRoute: string;
 
   /**
    * Checks if there is a [TdLayoutComponent] as parent.
@@ -102,7 +101,7 @@ export class TdLayoutNavListComponent {
    * Checks if router was injected.
    */
   get routerEnabled(): boolean {
-    return !!this._router;
+    return !!this._router && !!this.navigationRoute;
   }
 
   constructor(@Optional() @Inject(forwardRef(() => TdLayoutComponent)) private _layout: TdLayoutComponent,

--- a/src/platform/core/layout/layout-nav/README.md
+++ b/src/platform/core/layout/layout-nav/README.md
@@ -11,7 +11,7 @@
 | icon | string | icon name to be displayed before the title
 | logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
 | color | string | optional toolbar color. Defaults to primary.
-| navigationRoute | string | route for the icon, logo, and toolbarTitle. Defaults to '/'.
+| navigationRoute | string | option to set the combined route for the icon, logo, and toolbarTitle.
 
 
 ## Usage

--- a/src/platform/core/layout/layout-nav/README.md
+++ b/src/platform/core/layout/layout-nav/README.md
@@ -11,7 +11,7 @@
 | icon | string | icon name to be displayed before the title
 | logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
 | color | string | optional toolbar color. Defaults to primary.
-| navigationRoute | string | route for the icon, logo, and sidenavTitle. Defaults to '/'.
+| navigationRoute | string | route for the icon, logo, and toolbarTitle. Defaults to '/'.
 
 
 ## Usage

--- a/src/platform/core/layout/layout-nav/README.md
+++ b/src/platform/core/layout/layout-nav/README.md
@@ -11,7 +11,7 @@
 | icon | string | icon name to be displayed before the title
 | logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
 | color | string | optional toolbar color. Defaults to primary.
-| navigationRoute | string | route for the icon, logo, and toolbarTitle. Defaults to '/'.
+| navigationRoute | string | optional route for the icon, logo, and toolbarTitle.
 
 
 ## Usage

--- a/src/platform/core/layout/layout-nav/README.md
+++ b/src/platform/core/layout/layout-nav/README.md
@@ -11,7 +11,7 @@
 | icon | string | icon name to be displayed before the title
 | logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
 | color | string | optional toolbar color. Defaults to primary.
-| navigationRoute | string | optional route for the icon, logo, and toolbarTitle.
+| navigationRoute | string | route for the icon, logo, and sidenavTitle. Defaults to '/'.
 
 
 ## Usage

--- a/src/platform/core/layout/layout-nav/layout-nav.component.html
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.html
@@ -3,9 +3,15 @@
     <button md-icon-button class="td-menu-button" *ngIf="isMainSidenavAvailable" (click)="openMainSidenav()">
       <md-icon class="md-24">menu</md-icon>
     </button>
-    <md-icon *ngIf="icon" [routerLink]="navigationRoute" class="cursor-pointer">{{icon}}</md-icon>
-    <md-icon *ngIf="logo && !icon" class="md-icon-logo cursor-pointer" [svgIcon]="logo" [routerLink]="navigationRoute"></md-icon>
-    <span *ngIf="toolbarTitle" class="cursor-pointer" [routerLink]="navigationRoute">{{toolbarTitle}}</span>
+
+    <md-icon *ngIf="icon && navigationRoute" [routerLink]="navigationRoute" class="cursor-pointer">{{icon}}</md-icon>
+    <md-icon *ngIf="logo && !icon && navigationRoute" class="md-icon-logo cursor-pointer" [svgIcon]="logo" [routerLink]="navigationRoute"></md-icon>
+    <span *ngIf="toolbarTitle && navigationRoute" class="cursor-pointer" [routerLink]="navigationRoute">{{toolbarTitle}}</span>
+
+    <md-icon *ngIf="icon && !navigationRoute">{{icon}}</md-icon>
+    <md-icon *ngIf="logo && !icon && !navigationRoute" class="md-icon-logo" [svgIcon]="logo"></md-icon>
+    <span *ngIf="toolbarTitle && !navigationRoute">{{toolbarTitle}}</span>
+
     <ng-content select="[td-toolbar-content]"></ng-content>
   </md-toolbar>
   <div flex layout="column" class="content md-content">

--- a/src/platform/core/layout/layout-nav/layout-nav.component.html
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.html
@@ -3,15 +3,15 @@
     <button md-icon-button class="td-menu-button" *ngIf="isMainSidenavAvailable" (click)="openMainSidenav()">
       <md-icon class="md-24">menu</md-icon>
     </button>
-
-    <md-icon *ngIf="icon && navigationRoute" [routerLink]="navigationRoute" class="cursor-pointer">{{icon}}</md-icon>
-    <md-icon *ngIf="logo && !icon && navigationRoute" class="md-icon-logo cursor-pointer" [svgIcon]="logo" [routerLink]="navigationRoute"></md-icon>
-    <span *ngIf="toolbarTitle && navigationRoute" class="cursor-pointer" [routerLink]="navigationRoute">{{toolbarTitle}}</span>
-
-    <md-icon *ngIf="icon && !navigationRoute">{{icon}}</md-icon>
-    <md-icon *ngIf="logo && !icon && !navigationRoute" class="md-icon-logo" [svgIcon]="logo"></md-icon>
-    <span *ngIf="toolbarTitle && !navigationRoute">{{toolbarTitle}}</span>
-
+    <span *ngIf="icon || logo || toolbarTitle"
+          [class.cursor-pointer]="routerEnabled"
+          (click)="handleNavigationClick()"
+          layout="row"
+          layout-align="start end">
+      <md-icon *ngIf="icon">{{icon}}</md-icon>
+      <md-icon *ngIf="logo && !icon" class="md-icon-logo" [svgIcon]="logo"></md-icon>
+      <span *ngIf="toolbarTitle">{{toolbarTitle}}</span>
+    </span>
     <ng-content select="[td-toolbar-content]"></ng-content>
   </md-toolbar>
   <div flex layout="column" class="content md-content">

--- a/src/platform/core/layout/layout-nav/layout-nav.component.html
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.html
@@ -7,7 +7,7 @@
           [class.cursor-pointer]="routerEnabled"
           (click)="handleNavigationClick()"
           layout="row"
-          layout-align="start end">
+          layout-align="start center">
       <md-icon *ngIf="icon">{{icon}}</md-icon>
       <md-icon *ngIf="logo && !icon" class="md-icon-logo" [svgIcon]="logo"></md-icon>
       <span *ngIf="toolbarTitle">{{toolbarTitle}}</span>

--- a/src/platform/core/layout/layout-nav/layout-nav.component.ts
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, forwardRef, Optional, Inject } from '@angular/core';
-
+import { Router } from '@angular/router';
 import { TdLayoutComponent } from '../layout.component';
 
 @Component({
@@ -45,7 +45,7 @@ export class TdLayoutNavComponent {
    * option to set the combined logo, icon, toolbar title route
    * defaults to '/'
    */
-  @Input('navigationRoute') navigationRoute: string;
+  @Input('navigationRoute') navigationRoute: string = '/';
 
   /**
    * Checks if there is a [TdLayoutComponent] as parent.
@@ -54,8 +54,21 @@ export class TdLayoutNavComponent {
     return !!this._layout;
   }
 
-  constructor(@Optional() @Inject(forwardRef(() => TdLayoutComponent))
-              private _layout: TdLayoutComponent) { }
+  /**
+   * Checks if router was injected.
+   */
+  get routerEnabled(): boolean {
+    return !!this._router;
+  }
+
+  constructor(@Optional() @Inject(forwardRef(() => TdLayoutComponent)) private _layout: TdLayoutComponent,
+              @Optional() private _router: Router) {}
+
+  handleNavigationClick(): void {
+    if (this.routerEnabled) {
+      this._router.navigateByUrl(this.navigationRoute);
+    }
+  }
 
   /**
    * If main sidenav is available, it will open the sidenav of the parent [TdLayoutComponent].

--- a/src/platform/core/layout/layout-nav/layout-nav.component.ts
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.ts
@@ -42,10 +42,9 @@ export class TdLayoutNavComponent {
   /**
    * navigationRoute?: string
    *
-   * option to set the combined logo, icon, toolbar title route
-   * defaults to '/'
+   * option to set the combined route for the icon, logo, and toolbarTitle.
    */
-  @Input('navigationRoute') navigationRoute: string = '/';
+  @Input('navigationRoute') navigationRoute: string;
 
   /**
    * Checks if there is a [TdLayoutComponent] as parent.
@@ -58,7 +57,7 @@ export class TdLayoutNavComponent {
    * Checks if router was injected.
    */
   get routerEnabled(): boolean {
-    return !!this._router;
+    return !!this._router && !!this.navigationRoute;
   }
 
   constructor(@Optional() @Inject(forwardRef(() => TdLayoutComponent)) private _layout: TdLayoutComponent,

--- a/src/platform/core/layout/layout-nav/layout-nav.component.ts
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.ts
@@ -45,7 +45,7 @@ export class TdLayoutNavComponent {
    * option to set the combined logo, icon, toolbar title route
    * defaults to '/'
    */
-  @Input('navigationRoute') navigationRoute: string = '/';
+  @Input('navigationRoute') navigationRoute: string;
 
   /**
    * Checks if there is a [TdLayoutComponent] as parent.

--- a/src/platform/core/layout/layout.module.ts
+++ b/src/platform/core/layout/layout.module.ts
@@ -2,7 +2,6 @@ import { Type } from '@angular/core';
 import { NgModule, ModuleWithProviders } from '@angular/core';
 
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
 import { MdSidenavModule, MdToolbarModule, MdButtonModule, MdIconModule, MdCardModule, MdListModule } from '@angular/material';
 
 import { TdLayoutComponent } from './layout.component';
@@ -33,7 +32,6 @@ export { TdLayoutComponent, TdLayoutNavComponent, TdLayoutNavListComponent,
 @NgModule({
   imports: [
     CommonModule,
-    RouterModule,
     MdSidenavModule,
     MdToolbarModule,
     MdButtonModule,

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.html
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.html
@@ -1,16 +1,13 @@
 <md-toolbar [color]="color" [style.background-image]="backgroundImage" [class.td-toolbar-background]="!!isBackgroundAvailable">
   <div layout="column" flex>
-    <span *ngIf="icon || logo || sidenavTitle" layout="row" layout-align="start end">
-      <span *ngIf="navigationRoute">
-        <md-icon *ngIf="icon" (click)="close()" [routerLink]="navigationRoute" class="cursor-pointer">{{icon}}</md-icon>
-        <md-icon *ngIf="logo && !icon" class="md-icon-logo cursor-pointer" [svgIcon]="logo" (click)="close()" [routerLink]="navigationRoute"></md-icon>
-        <span class="md-subhead cursor-pointer" *ngIf="sidenavTitle" (click)="close()" [routerLink]="navigationRoute">{{sidenavTitle}}</span>
-      </span>
-      <span *ngIf="!navigationRoute">
-        <md-icon *ngIf="icon">{{icon}}</md-icon>
-        <md-icon *ngIf="logo && !icon" class="md-icon-logo" [svgIcon]="logo"></md-icon>
-        <span class="md-subhead" *ngIf="sidenavTitle">{{sidenavTitle}}</span>
-      </span>
+    <span *ngIf="icon || logo || sidenavTitle"
+          [class.cursor-pointer]="routerEnabled"
+          (click)="handleNavigationClick()"
+          layout="row"
+          layout-align="start end">
+      <md-icon *ngIf="icon">{{icon}}</md-icon>
+      <md-icon *ngIf="logo && !icon" class="md-icon-logo" [svgIcon]="logo"></md-icon>
+      <span *ngIf="sidenavTitle" class="md-subhead">{{sidenavTitle}}</span>
     </span>
     <div class="md-body-2" *ngIf="email && name">{{name}}</div>
     <div class="md-body-1" layout="row" href *ngIf="email || name" (click)="toggleMenu()">

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.html
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.html
@@ -1,9 +1,16 @@
 <md-toolbar [color]="color" [style.background-image]="backgroundImage" [class.td-toolbar-background]="!!isBackgroundAvailable">
   <div layout="column" flex>
     <span *ngIf="icon || logo || sidenavTitle" layout="row" layout-align="start end">
-      <md-icon *ngIf="icon" (click)="close()" [routerLink]="navigationRoute" class="cursor-pointer">{{icon}}</md-icon>
-      <md-icon *ngIf="logo && !icon" class="md-icon-logo cursor-pointer" [svgIcon]="logo" (click)="close()" [routerLink]="navigationRoute"></md-icon>
-      <span class="md-subhead cursor-pointer" *ngIf="sidenavTitle" (click)="close()" [routerLink]="navigationRoute">{{sidenavTitle}}</span>
+      <span *ngIf="navigationRoute">
+        <md-icon *ngIf="icon" (click)="close()" [routerLink]="navigationRoute" class="cursor-pointer">{{icon}}</md-icon>
+        <md-icon *ngIf="logo && !icon" class="md-icon-logo cursor-pointer" [svgIcon]="logo" (click)="close()" [routerLink]="navigationRoute"></md-icon>
+        <span class="md-subhead cursor-pointer" *ngIf="sidenavTitle" (click)="close()" [routerLink]="navigationRoute">{{sidenavTitle}}</span>
+      </span>
+      <span *ngIf="!navigationRoute">
+        <md-icon *ngIf="icon">{{icon}}</md-icon>
+        <md-icon *ngIf="logo && !icon" class="md-icon-logo" [svgIcon]="logo"></md-icon>
+        <span class="md-subhead" *ngIf="sidenavTitle">{{sidenavTitle}}</span>
+      </span>
     </span>
     <div class="md-body-2" *ngIf="email && name">{{name}}</div>
     <div class="md-body-1" layout="row" href *ngIf="email || name" (click)="toggleMenu()">

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
@@ -81,10 +81,9 @@ export class TdNavigationDrawerComponent implements OnInit, OnDestroy {
   /**
    * navigationRoute?: string
    *
-   * option to set the combined logo, icon, toolbar title route
-   * defaults to '/'
+   * option to set the combined route for the icon, logo, and sidenavTitle.
    */
-  @Input('navigationRoute') navigationRoute: string = '/';
+  @Input('navigationRoute') navigationRoute: string;
 
   /**
    * backgroundUrl?: SafeResourceUrl
@@ -125,7 +124,7 @@ export class TdNavigationDrawerComponent implements OnInit, OnDestroy {
    * Checks if router was injected.
    */
   get routerEnabled(): boolean {
-    return !!this._router;
+    return !!this._router && !!this.navigationRoute;
   }
 
   constructor(@Inject(forwardRef(() => TdLayoutComponent)) private _layout: TdLayoutComponent,

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
@@ -83,7 +83,7 @@ export class TdNavigationDrawerComponent implements OnInit, OnDestroy {
    * option to set the combined logo, icon, toolbar title route
    * defaults to '/'
    */
-  @Input('navigationRoute') navigationRoute: string = '/';
+  @Input('navigationRoute') navigationRoute: string;
 
   /**
    * backgroundUrl?: SafeResourceUrl

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
@@ -1,5 +1,6 @@
 import { Component, Directive, Input, ContentChildren, OnInit, OnDestroy, forwardRef, Inject,
-         QueryList, SecurityContext } from '@angular/core';
+         QueryList, SecurityContext, Optional } from '@angular/core';
+import { Router } from '@angular/router';
 import { SafeResourceUrl, SafeStyle, DomSanitizer } from '@angular/platform-browser';
 import { Subscription } from 'rxjs/Subscription';
 
@@ -83,7 +84,7 @@ export class TdNavigationDrawerComponent implements OnInit, OnDestroy {
    * option to set the combined logo, icon, toolbar title route
    * defaults to '/'
    */
-  @Input('navigationRoute') navigationRoute: string;
+  @Input('navigationRoute') navigationRoute: string = '/';
 
   /**
    * backgroundUrl?: SafeResourceUrl
@@ -120,7 +121,15 @@ export class TdNavigationDrawerComponent implements OnInit, OnDestroy {
    */
   @Input('email') email: string;
 
+  /**
+   * Checks if router was injected.
+   */
+  get routerEnabled(): boolean {
+    return !!this._router;
+  }
+
   constructor(@Inject(forwardRef(() => TdLayoutComponent)) private _layout: TdLayoutComponent,
+              @Optional() private _router: Router,
               private _sanitize: DomSanitizer) {}
 
   ngOnInit(): void {
@@ -139,6 +148,13 @@ export class TdNavigationDrawerComponent implements OnInit, OnDestroy {
   toggleMenu(): void {
     if (this.isMenuAvailable) {
       this._menuToggled = !this._menuToggled;
+    }
+  }
+
+  handleNavigationClick(): void {
+    if (this.routerEnabled) {
+      this._router.navigateByUrl(this.navigationRoute);
+      this.close();
     }
   }
 


### PR DESCRIPTION
## Description

Remove usage of `[routerLink]` directive and make use of an `@Optional` `Router` explicitly to decide whether or not to set the navigation style and to navigate on click.

Also removes the default `/` navigation, and makes it more explicit.

This will allow you to use logo & text in our plunker w/o router fail.

### What's included?

- remove `RouterModule` as required dependency
- Remove `[routerLink]` usage.
- Use of `Optional` `Router` to indicate whether there are routes to be navigate or not.
- Make `navigationRoute` required if you want navigation (still validates for `Optional` `Router`)
- Set cursor pointer if there is a router injected.

#### Test Steps

- [x] This can be tested if you use the following markup without the creation of routes:

```
<td-layout-nav toolbarTitle="title" icon="apps"></td-layout-nav>
```
- [x] Also can be tested by adding or removing `navigationRoute="/"`

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![optional-nav-route](https://cloud.githubusercontent.com/assets/867883/25768194/649bf3dc-31b5-11e7-808b-40a91b648217.gif)
