### PR TITLE
fix(loading): remove OnPush from `td-loading`

### DIFF
--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -11,10 +11,10 @@
         <div *tdLoading="'overlayStarSyntax'; mode:'indeterminate'; type:'circle'; strategy:'overlay'; color:'accent'">
           <div layout="column" flex>
             <md-input-container flex>
-              <input mdInput placeholder="Name"/>
+              <input mdInput [(ngModel)]="overlayDemo.name" placeholder="Name"/>
             </md-input-container>
             <md-input-container flex>
-              <textarea mdInput placeholder="Description" rows="4"></textarea>
+              <textarea mdInput [(ngModel)]="overlayDemo.description" placeholder="Description" rows="4"></textarea>
             </md-input-container>
           </div>
         </div>
@@ -30,10 +30,10 @@
             <div *tdLoading="'overlayStarSyntax'; mode:'indeterminate'; type:'circle'; strategy:'overlay'; color:'accent'">
               <div layout="column" flex>
                 <md-input-container flex>
-                  <input mdInput placeholder="Name"/>
+                  <input mdInput [(ngModel)]="overlayDemo.name" placeholder="Name"/>
                 </md-input-container>
                 <md-input-container flex>
-                  <textarea mdInput placeholder="Description" rows="4"></textarea>
+                  <textarea mdInput [(ngModel)]="overlayDemo.description" placeholder="Description" rows="4"></textarea>
                 </md-input-container>
               </div>
             </div>
@@ -49,6 +49,11 @@
             ...
             export class Demo implements OnInit {
               overlayStarSyntax: boolean = false;
+
+              overlayDemo: any = {
+                name: '',
+                description: '',
+              };
 
               constructor(private _loadingService: TdLoadingService) {}
 
@@ -81,14 +86,14 @@
         <ng-template tdLoading="replaceTemplateSyntax" tdLoadingMode="determinate" tdLoadingType="linear" tdLoadingStrategy="replace" tdLoadingColor="warn">
           <div layout="column" flex>
             <md-input-container flex>
-              <input mdInput placeholder="Name"/>
+              <input mdInput [(ngModel)]="replaceDemo.name" placeholder="Name"/>
             </md-input-container>
-            <md-select placeholder="Select">
-              <md-option>Demo 1</md-option>
-              <md-option>Demo 2</md-option>
+            <md-select placeholder="Type" [(ngModel)]="replaceDemo.type">
+              <md-option [value]="1">Some type</md-option>
+              <md-option [value]="2">Another type</md-option>
             </md-select>
             <md-input-container flex>
-              <textarea mdInput placeholder="Description" rows="4"></textarea>
+              <textarea mdInput [(ngModel)]="replaceDemo.description" placeholder="Description" rows="4"></textarea>
             </md-input-container>
           </div>
         </ng-template>
@@ -104,14 +109,14 @@
             <ng-template tdLoading="replaceTemplateSyntax" tdLoadingMode="determinate" tdLoadingType="linear" tdLoadingStrategy="replace" tdLoadingColor="warn">
               <div layout="column" flex>
                 <md-input-container flex>
-                  <input mdInput placeholder="Name"/>
+                  <input mdInput [(ngModel)]="replaceDemo.name" placeholder="Name"/>
                 </md-input-container>
-                <md-select placeholder="Select">
-                  <md-option>Demo 1</md-option>
-                  <md-option>Demo 2</md-option>
+                <md-select placeholder="Type" [(ngModel)]="replaceDemo.type">
+                  <md-option [value]="1">Some type</md-option>
+                  <md-option [value]="2">Another type</md-option>
                 </md-select>
                 <md-input-container flex>
-                  <textarea mdInput placeholder="Description" rows="4"></textarea>
+                  <textarea mdInput [(ngModel)]="replaceDemo.description" placeholder="Description" rows="4"></textarea>
                 </md-input-container>
               </div>
             </ng-template>
@@ -126,6 +131,12 @@
             import { TdLoadingService } from '@covalent/core';
             ...
             export class Demo {
+              replaceDemo: any = {
+                name: '',
+                select: '',
+                description: '',
+              };
+
               constructor(private _loadingService: TdLoadingService) {}
 
               toggleReplaceTemplateSyntax(): void {

--- a/src/app/components/components/loading/loading.component.ts
+++ b/src/app/components/components/loading/loading.component.ts
@@ -65,6 +65,17 @@ export class LoadingDemoComponent implements OnInit {
 
   overlayStarSyntax: boolean = false;
 
+  overlayDemo: any = {
+    name: '',
+    description: '',
+  };
+
+  replaceDemo: any = {
+    name: '',
+    select: '',
+    description: '',
+  };
+
   constructor(private _loadingService: TdLoadingService) {
     this._loadingService.create({
       name: 'configFullscreenDemo',

--- a/src/platform/core/loading/loading.component.ts
+++ b/src/platform/core/loading/loading.component.ts
@@ -28,7 +28,6 @@ export enum LoadingStyle {
 import { TdFadeInOutAnimation } from '../common/common.module';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'td-loading',
   styleUrls: ['./loading.component.scss' ],
   templateUrl: './loading.component.html',

--- a/src/platform/core/loading/services/loading.factory.ts
+++ b/src/platform/core/loading/services/loading.factory.ts
@@ -124,9 +124,10 @@ export class TdLoadingFactory {
           let cdr: ChangeDetectorRef = viewContainerRef.createEmbeddedView(templateRef);
           viewContainerRef.detach(viewContainerRef.indexOf(loadingRef.componentRef.hostView));
           /**
-           * Need to call "markForCheck" on attached template, so its detected by parent component when attached
+           * Need to call "markForCheck" and "detectChanges" on attached template, so its detected by parent component when attached
            * with "OnPush" change detection
            */
+          cdr.detectChanges();
           cdr.markForCheck();
         });
       }


### PR DESCRIPTION
## Description

we need to remove OnPush from `td-loading` since its technically a container component and shouldnt affect the change detection of its children. The reason for this is that it was enforcing `OnPush` on its children when it shouldnt have.

Also we need to use `detectChanges` in the replace scenario so the change detection works well.

### What's included?

- remove `OnPush` from `TdLoadingComponent`.
- call `detectChanges` when the template replaced by the loading is re-attached.
- docs(loading): improve demo by adding `ngModel`.

#### Test Steps

- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/loading
- [ ] Play with demo

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.