### PR TITLE
fix(data-table): fix when data is undefined and multiple selection (closes #559)

### DIFF
--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -284,7 +284,7 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    */
   areAllSelected(): boolean {
     const match: string =
-      this._data.find((d: any) => !this.isRowSelected(d));
+      this._data ? this._data.find((d: any) => !this.isRowSelected(d)) : true;
     return typeof match === 'undefined';
   }
 


### PR DESCRIPTION
if you dont set data properly (undefined) and you have the data-table as selectable and multiple, it will error out will trying to see if all rows are selected.

https://github.com/Teradata/covalent/issues/559

### What's included?

- fix to allow data to be undefined when setting datatable as selectable/multiple.
- unit test for this specific case

#### Test Steps

- [x] `ng serve`
- [x] Go to data-table module and set any `data` property to undefined

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle