### PR TITLE
fix(data-table): fix pseudo checkbox in data-table. (closes #525)

### DIFF
--- a/src/platform/core/data-table/data-table.component.scss
+++ b/src/platform/core/data-table/data-table.component.scss
@@ -39,8 +39,6 @@ table.td-data-table {
       width: $checkbox-size;
       height: $checkbox-size;
       /deep/ &.mat-pseudo-checkbox-checked::after {
-        top: 3px !important;        
-        left: 1px !important;
         width: 11px !important;
         height: 4px !important;
       }


### PR DESCRIPTION
the css was incorrect for the pseudo checkbox in this release because it was changed in material, we need to remove the top and left overrides from it

https://github.com/Teradata/covalent/issues/525

#### Test Steps

- [x] `ng serve`
- [x] Go to http://localhost:4200/#/components/data-table
- [x] See pseudo check box with the correct style now.

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle

![image](https://cloud.githubusercontent.com/assets/5846742/25783010/8185a042-3309-11e7-881b-366b6ec10c80.png)
