### PR TITLE
fix(flex): flex=“value” for grow/initial/auto/none/noshink/nogrow (closes #586)

### DIFF
--- a/src/platform/core/common/styles/_layout.scss
+++ b/src/platform/core/common/styles/_layout.scss
@@ -174,26 +174,32 @@ $layout-breakpoint-lg: 1920px !default;
     }
   }
 
+  [#{$flexName}="grow"],
   [#{$flexName}-grow] {
     flex: 1 1 100%;
     box-sizing: border-box;
   }
+  [#{$flexName}="initial"],
   [#{$flexName}-initial] {
     flex: 0 1 auto;
     box-sizing: border-box;
   }
+  [#{$flexName}="auto"],
   [#{$flexName}-auto] {
     flex: 1 1 auto;
     box-sizing: border-box;
   }
+  [#{$flexName}="none"],
   [#{$flexName}-none] {
     flex: 0 0 auto;
     box-sizing: border-box;
   }
+  [#{$flexName}="noshrink"],
   [#{$flexName}-noshrink] {
     flex: 1 0 auto;
     box-sizing: border-box;
   }
+  [#{$flexName}="nogrow"],
   [#{$flexName}-nogrow] {
     flex: 0 1 auto;
     box-sizing: border-box;
@@ -567,8 +573,3 @@ $layout-breakpoint-lg: 1920px !default;
     display: none;
   }
 }
-
-[flex="none"] {
-  flex: none;
-}
-


### PR DESCRIPTION
## Description

updated layout scss to suppor the existing `[flex-noshrink]` with expected `[flex="noshrink"]` syntax

### What's included?

- updated _layout.scss

#### Test Steps

- [ ] npm i
- [ ] ng serve
- [ ] test to see flex layout working everywhere
- [ ] inspect and change flex markup for flex="grow/initial/auto/none/noshink/nogrow" support

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle