### PR TITLE
chore(docs): make covalent homepage look right in IE11

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -57,9 +57,10 @@
         <md-divider *ngIf="!last" md-inset></md-divider>
       </ng-template>
     </md-nav-list>
-    <div layout="row" layout-wrap hide-xs hide-sm class="push-sm">
+    <div>
+    <div layout="row" hide-xs hide-sm class="push-sm">
       <ng-template let-item let-last="last" ngFor [ngForOf]="items">
-        <div flex-md="50" flex-gt-md="25" layout="column">
+        <div flex-md="50" flex-gt-md="25" layout="row">
           <md-card href [routerLink]="[item.route]" class="md-card-colored" flex>
             <md-toolbar class="bgc-{{item.color}} " layout="column" layout-align="center center" layout-padding>
               <md-icon class="md-icon-font-xl tc-white">{{item.icon}}</md-icon>
@@ -74,7 +75,7 @@
         </div>
       </ng-template>
     </div>
-    <md-divider></md-divider>
+    </div>
     <md-card-actions>
       <div layout="row">
         <a href="https://gitter.im/Teradata/covalent" target="_blank" md-button color="primary" class="text-upper">Gitter Chat</a>

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -57,8 +57,7 @@
         <md-divider *ngIf="!last" md-inset></md-divider>
       </ng-template>
     </md-nav-list>
-    <div>
-    <div layout="row" hide-xs hide-sm class="push-sm">
+    <div layout="row" layout-wrap hide-xs hide-sm class="push-sm">
       <ng-template let-item let-last="last" ngFor [ngForOf]="items">
         <div flex-md="50" flex-gt-md="25" layout="row">
           <md-card href [routerLink]="[item.route]" class="md-card-colored" flex>
@@ -75,7 +74,7 @@
         </div>
       </ng-template>
     </div>
-    </div>
+    <md-divider></md-divider>
     <md-card-actions>
       <div layout="row">
         <a href="https://gitter.im/Teradata/covalent" target="_blank" md-button color="primary" class="text-upper">Gitter Chat</a>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -14,5 +14,4 @@
   html[dir="rtl"] & {
     direction: rtl;
   }
-  
 }


### PR DESCRIPTION
## Description
Even though IE11 isn't officially supported by Covalent, angular-material supports IE11 and all the components work in IE11. However, the Covalent home page doesn't really look that great in IE11. We want to show off Covalent at an upcoming demo, and stakeholders want to see that Covalent is compatible with IE11 so that we can continue to use it in TDAA applications. 

This change makes the Covalent homepage work and display well in IE11.

Before:
![covalent_homepage_ie11_before](https://cloud.githubusercontent.com/assets/7390124/26074583/4d54012e-3980-11e7-8f04-24327093df88.png)

### What's included?

- .../app/components/home/home.component.html
- .../app/styles.scss (not needed, just picked up a white space change)

#### Test Steps

View in IE 11

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
After:
![covalent_homepage_ie11_after](https://cloud.githubusercontent.com/assets/7390124/26074619/6bc96252-3980-11e7-92fc-26b317c38e09.png)



