### PR TITLE
chore(docs): update overview.component.html to support IE11

### DIFF
--- a/src/app/components/components/overview/overview.component.html
+++ b/src/app/components/components/overview/overview.component.html
@@ -5,7 +5,7 @@
   <md-card-content>
      <div layout-gt-xs="row" layout-wrap>
        <ng-template let-item let-last="last" ngFor [ngForOf]="items">
-          <div flex-sm="50" flex-md="50" flex-gt-md="25" layout="column">
+          <div flex-sm="50" flex-md="50" flex-gt-md="25" layout="row">
             <md-card href [routerLink]="[item.route]" class="md-card-colored" flex>
               <md-toolbar class="bgc-{{item.color}} " layout="column" layout-align="center center" layout-padding>
                 <md-icon class="md-icon-font-xl tc-white">{{item.icon}}</md-icon>
@@ -28,7 +28,7 @@
   <md-card-content>
      <div layout-gt-xs="row" layout-wrap>
        <ng-template let-item let-last="last" ngFor [ngForOf]="optional">
-          <div flex-sm="50" flex-md="50" flex-gt-md="25" layout="column">
+          <div flex-sm="50" flex-md="50" flex-gt-md="25" layout="row">
             <md-card href [routerLink]="[item.route]" class="md-card-colored" flex>
               <md-toolbar class="bgc-{{item.color}} " layout="column" layout-align="center center" layout-padding>
                 <md-icon class="md-icon-font-xl tc-white">{{item.icon}}</md-icon>
@@ -51,7 +51,7 @@
   <md-card-content>
      <div layout-gt-xs="row" layout-wrap>
        <ng-template let-item let-last="last" ngFor [ngForOf]="external">
-          <div flex-sm="50" flex-md="50" flex-gt-md="25" layout="column">
+          <div flex-sm="50" flex-md="50" flex-gt-md="25" layout="row">
             <md-card href [routerLink]="[item.route]" class="md-card-colored" flex>
               <md-toolbar class="bgc-{{item.color}} " layout="column" layout-align="center center" layout-padding>
                 <md-icon class="md-icon-font-xl tc-white">{{item.icon}}</md-icon>


### PR DESCRIPTION
## Description
Even though IE11 isn't officially supported by Covalent, angular-material supports IE11 and all the components work in IE11. However, the Covalent component overview doesn't really look that great in IE11. We want to show off Covalent at an upcoming demo, and stakeholders want to see that Covalent is compatible with IE11 so that we can continue to use it in TDAA applications. 

This change makes the Covalent component overview work and display well in IE11.

Before:
![screen shot 2017-05-15 at 3 33 27 pm](https://cloud.githubusercontent.com/assets/7390124/26075614/e453593c-3983-11e7-9582-fdd146d396fc.png)

### What's included?

- .../app/components/overview/overview.component.html

#### Test Steps

View in IE 11

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
After:
![screen shot 2017-05-15 at 2 43 19 pm](https://cloud.githubusercontent.com/assets/7390124/26075618/ebabccf0-3983-11e7-9be0-00358c53c8dc.png)
