### PR TITLE
update(home): beta 4 notification menu

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -2,7 +2,7 @@
   <div td-toolbar-content layout="row" layout-align="center center" flex>
     <span flex></span>
     <button md-icon-button [mdMenuTriggerFor]="notificationsMenu">
-      <td-notification-count color="accent" [notifications]="updates.length + 2">
+      <td-notification-count color="accent" [notifications]="updates.length + 1">
         <md-icon>notifications</md-icon>
       </td-notification-count>
     </button>
@@ -18,19 +18,13 @@
             </a>
             <md-divider></md-divider>
           </ng-template>
-          <a md-list-item href="https://github.com/Teradata/covalent/pulls?q=is%3Apr+is%3Aclosed+milestone%3A%22Beta+3%22+label%3Abug" target="_blank">
-            <md-icon md-list-avatar>bug_report</md-icon>
-            <h4 md-line><span class="text-wrap">Beta 3 bugfixes</span></h4>
-            <p md-line>Stabililty</p>
-          </a>
-          <md-divider></md-divider>
-          <a md-list-item href="https://github.com/Teradata/covalent/blob/develop/package.json#L57-L68" target="_blank">
+          <a md-list-item href="https://github.com/Teradata/covalent/blob/develop/package.json#L58-L79" target="_blank">
             <md-icon md-list-avatar>change_history</md-icon>
-            <h4 md-line><span class="text-wrap">Angular v4 and material@beta.3 support</span></h4>
+            <h4 md-line><span class="text-wrap">Angular v4.1 and material@beta.5 support</span></h4>
             <p md-line>Dependencies updated</p>
           </a>
         </md-nav-list>
-        <a md-button color="accent" td-menu-footer href="https://github.com/Teradata/covalent/blob/develop/docs/CHANGELOG.md" target="_blank">
+        <a md-button color="accent" td-menu-footer href="https://github.com/Teradata/covalent/blob/develop/docs/CHANGELOG.md#100-beta4-johnny-b-goode-2017-05-16" target="_blank">
           View Full Changelog
         </a>
       </td-menu>

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -91,6 +91,11 @@ export class HomeComponent implements OnInit {
       route: 'components/markdown',
       title: 'Markdown feature',
     }, {
+      description: 'New contentReady event binding',
+      icon: 'code',
+      route: 'components/highlight',
+      title: 'Highlight feature',
+    }, {
       description: 'Make navigationRoute optional',
       icon: 'view_quilt',
       route: 'components/layouts',

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -46,25 +46,55 @@ export class HomeComponent implements OnInit {
   ];
 
   updates: Object[] = [{
-      description: 'Refactored Autocomplete Chips',
-      icon: 'label_outline',
+      description: 'Keyboard support for selection',
+      icon: 'grid_on',
+      route: 'components/data-table',
+      title: 'Data Table feature',
+    }, {
+      description: 'Row click events',
+      icon: 'grid_on',
+      route: 'components/data-table',
+      title: 'Data Table feature',
+    }, {
+      description: 'Hide columns & exclude from filtering',
+      icon: 'grid_on',
+      route: 'components/data-table',
+      title: 'Data Table feature',
+    }, {
+      description: 'Async & boolean loading',
+      icon: 'hourglass_empty',
+      route: 'components/loading',
+      title: 'Loading features',
+    }, {
+      description: 'Component for alerts/info/warning/error/success',
+      icon: 'info_outline',
+      route: 'components/message',
+      title: 'New Messages component',
+    }, {
+      description: 'Numbered page links to jump ahead',
+      icon: 'swap_horiz',
+      route: 'components/paging',
+      title: 'Pagination feature',
+    }, {
+      description: 'Disable adding of chips',
+      icon: 'label',
       route: 'components/chips',
-      title: 'Component updated',
+      title: 'Chips feature',
     }, {
-      description: 'Refactored Toggle Directives',
-      icon: 'wb_iridescent',
-      route: 'components/directives',
-      title: 'Directives updated',
+      description: 'New formData property',
+      icon: 'attach_file',
+      route: 'components/file-upload',
+      title: 'File service feature',
     }, {
-      description: 'Refactored Stepper',
-      icon: 'view_list',
-      route: 'components/steps',
-      title: 'Stepper updated',
+      description: 'New contentReady event binding',
+      icon: 'chrome_reader_mode',
+      route: 'components/markdown',
+      title: 'Markdown feature',
     }, {
-      description: 'Refactored/Improved Expansion Panel',
-      icon: 'open_with',
-      route: 'components/expansion-panel',
-      title: 'Directives updated',
+      description: 'Make navigationRoute optional',
+      icon: 'view_quilt',
+      route: 'components/layouts',
+      title: 'Layouts feature',
     },
   ];
 


### PR DESCRIPTION
## Description

Beta 4 features in notification menu

#### Test Steps

- [x] npm i
- [x] ng serve
- [x] view notifications and click on them

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![image](https://cloud.githubusercontent.com/assets/867883/26116516/46d023e4-3a18-11e7-8803-69d45da28c79.png)
