### PR TITLE
feat(layout): add `[mode]`, `[opened]` and `[sidenavWidth]` to main `td-layout`

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,10 @@
-<td-layout #layout>
+<td-layout #layout
+            [opened]="media.registerQuery('gt-md') | async"
+            [mode]="(media.registerQuery('gt-md') | async) ? 'side' : 'over'"
+            [sidenavWidth]="(media.registerQuery('gt-md') | async) ? '257px' : '320px'">
   <td-navigation-drawer sidenavTitle="Covalent" logo="assets:teradata" navigationRoute="/">
     <md-nav-list>
-      <a *ngFor="let item of routes" md-list-item (click)="layout.close()" [routerLink]="[item.route]"><md-icon>{{item.icon}}</md-icon>{{item.title}}</a>
+      <a *ngFor="let item of routes" md-list-item (click)="!media.query('gt-md') && layout.close()" [routerLink]="[item.route]"><md-icon>{{item.icon}}</md-icon>{{item.title}}</a>
     </md-nav-list>
   </td-navigation-drawer>
   <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MdIconRegistry } from '@angular/material';
-
+import { TdMediaService } from '@covalent/core';
 import { TranslateService } from '@ngx-translate/core';
 
 import { getSelectedLanguage } from './utilities/translate';
@@ -11,7 +11,7 @@ import { getSelectedLanguage } from './utilities/translate';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class DocsAppComponent {
+export class DocsAppComponent implements AfterViewInit {
 
   routes: Object[] = [{
       icon: 'home',
@@ -38,6 +38,8 @@ export class DocsAppComponent {
 
   constructor(private _iconRegistry: MdIconRegistry,
               private _domSanitizer: DomSanitizer,
+              private _changeDetectorRef: ChangeDetectorRef,
+              public media: TdMediaService,
               translateService: TranslateService) {
     // Set fallback language
     translateService.setDefaultLang('en');
@@ -62,5 +64,10 @@ export class DocsAppComponent {
       this._domSanitizer.bypassSecurityTrustResourceUrl('app/assets/icons/listener.svg'));
     this._iconRegistry.addSvgIconInNamespace('assets', 'querygrid',
       this._domSanitizer.bypassSecurityTrustResourceUrl('app/assets/icons/querygrid.svg'));
+  }
+
+  ngAfterViewInit(): void {
+    this.media.broadcast();
+    this._changeDetectorRef.detectChanges();
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,7 +12,8 @@ import { appRoutes, appRoutingProviders } from './app.routes';
 
 import { MdButtonModule, MdListModule, MdIconModule, MdCardModule, MdCoreModule, MdMenuModule } from '@angular/material';
 
-import { CovalentLayoutModule, CovalentExpansionPanelModule, CovalentNotificationsModule, CovalentMenuModule } from '../platform/core';
+import { CovalentLayoutModule, CovalentExpansionPanelModule, CovalentNotificationsModule, CovalentMenuModule,
+         CovalentMediaModule } from '../platform/core';
 import { CovalentHighlightModule } from '../platform/highlight';
 import { CovalentHttpModule } from '../platform/http';
 import { CovalentMarkdownModule } from '../platform/markdown';
@@ -49,6 +50,7 @@ import { getSelectedLanguage, createTranslateLoader } from './utilities/translat
     CovalentHighlightModule,
     CovalentMarkdownModule,
     CovalentDynamicFormsModule,
+    CovalentMediaModule,
     TranslateModule.forRoot({
       loader: {
         provide: TranslateLoader,

--- a/src/platform/core/layout/README.md
+++ b/src/platform/core/layout/README.md
@@ -3,6 +3,29 @@
 `<td-layout>` is a blank main sidenav component that gets hooked as parent of all the other layouts. (triggered by their menu buttons)
 
 
+## API Summary
+
+| Name | Type | Description |
+| --- | --- | --- |
+| mode | 'over', 'side' or 'push' | The mode or styling of the sidenav. Defaults to 'over'.
+| opened | boolean | Whether or not the sidenav is opened. Use this binding to open/close the sidenav. Defaults to 'false'.
+
+
+## Usage
+
+`[td-sidenav-content]` is used to include content in the main sidenav.
+
+Example for Main Layout:
+
+```html
+<td-layout [mode]="mode" [opened]="opened">
+  <div td-sidenav-content>
+   .. more sidenav content
+  </div>
+  .. main content
+</td-layout>
+```
+
 ## Installation
 
 This component can be installed as npm package.

--- a/src/platform/core/layout/README.md
+++ b/src/platform/core/layout/README.md
@@ -9,6 +9,7 @@
 | --- | --- | --- |
 | mode | 'over', 'side' or 'push' | The mode or styling of the sidenav. Defaults to 'over'.
 | opened | boolean | Whether or not the sidenav is opened. Use this binding to open/close the sidenav. Defaults to 'false'.
+| sidenavWidth | string | Sets the 'width' of the sidenav in either 'px' or '%' ('%' is not well supported yet as stated in the layout docs). Defaults to '320px'.
 
 
 ## Usage
@@ -18,7 +19,7 @@
 Example for Main Layout:
 
 ```html
-<td-layout [mode]="mode" [opened]="opened">
+<td-layout [mode]="side" [opened]="true" [sidenavWidth]="257px">
   <div td-sidenav-content>
    .. more sidenav content
   </div>

--- a/src/platform/core/layout/_layout-theme.scss
+++ b/src/platform/core/layout/_layout-theme.scss
@@ -20,6 +20,9 @@
       z-index: 1;
     }
   }
+  .mat-sidenav-side.td-layout-sidenav {
+    @include mat-elevation(2);
+  }
   .td-layout-footer {
     background: mat-color($background, app-bar);
     color: mat-color($foreground, text);

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.ts
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.ts
@@ -56,7 +56,7 @@ export class TdLayoutManageListComponent {
    * Proxy toggle method to access sidenav from outside (from td-layout template).
    */
   public toggle(): Promise<MdSidenavToggleResult> {
-    return this._sideNav.toggle();
+    return this._sideNav.toggle(!this._sideNav.opened);
   }
 
   /**

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.ts
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.ts
@@ -117,7 +117,7 @@ export class TdLayoutNavListComponent {
    * Proxy toggle method to access sidenav from outside (from td-layout template).
    */
   public toggle(): Promise<MdSidenavToggleResult> {
-    return this._sideNav.toggle();
+    return this._sideNav.toggle(!this._sideNav.opened);
   }
 
   /**
@@ -138,7 +138,7 @@ export class TdLayoutNavListComponent {
    * If main sidenav is available, it will open the sidenav of the parent [TdLayoutComponent].
    */
   openMainSidenav(): void {
-    this._layout.open();
+    this._layout.toggle();
   }
 
 }

--- a/src/platform/core/layout/layout-nav/layout-nav.component.ts
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.ts
@@ -73,6 +73,6 @@ export class TdLayoutNavComponent {
    * If main sidenav is available, it will open the sidenav of the parent [TdLayoutComponent].
    */
   openMainSidenav(): void {
-    this._layout.open();
+    this._layout.toggle();
   }
 }

--- a/src/platform/core/layout/layout.component.html
+++ b/src/platform/core/layout/layout.component.html
@@ -1,7 +1,9 @@
 <md-sidenav-container fullscreen>
   <md-sidenav #sidenav
+              class="td-layout-sidenav"
               [mode]="mode"
               [opened]="opened"
+              [style.max-width]="sidenavWidth"
               [disableClose]="disableClose">
     <ng-content select="td-navigation-drawer"></ng-content>
     <ng-content select="[td-sidenav-content]"></ng-content>

--- a/src/platform/core/layout/layout.component.html
+++ b/src/platform/core/layout/layout.component.html
@@ -1,5 +1,8 @@
 <md-sidenav-container fullscreen>
-  <md-sidenav>
+  <md-sidenav #sidenav
+              [mode]="mode"
+              [opened]="opened"
+              [disableClose]="disableClose">
     <ng-content select="td-navigation-drawer"></ng-content>
     <ng-content select="[td-sidenav-content]"></ng-content>
   </md-sidenav>

--- a/src/platform/core/layout/layout.component.ts
+++ b/src/platform/core/layout/layout.component.ts
@@ -35,6 +35,16 @@ export class TdLayoutComponent {
   @Input('opened') opened: boolean = false;
 
   /**
+   * sidenavWidth?: string
+   *
+   * Sets the "width" of the sidenav in either "px" or "%" ("%" is not well supported yet as stated in the layout docs)
+   * Defaults to "320px".
+   *
+   * https://github.com/angular/material2/tree/master/src/lib/sidenav
+   */
+  @Input('sidenavWidth') sidenavWidth: string = '320px';
+
+  /**
    * Checks if `ESC` should close the sidenav
    * Should only close it for `push` and `over` modes
    */

--- a/src/platform/core/layout/layout.component.ts
+++ b/src/platform/core/layout/layout.component.ts
@@ -12,10 +12,41 @@ export class TdLayoutComponent {
   @ViewChild(MdSidenav) sidenav: MdSidenav;
 
   /**
+   * mode?: 'side', 'push' or 'over'
+   *
+   * The mode or styling of the sidenav.
+   * Defaults to "over".
+   * See "MdSidenav" documentation for more info.
+   *
+   * https://github.com/angular/material2/tree/master/src/lib/sidenav
+   */
+  @Input('mode') mode: 'side' | 'push' | 'over' = 'over';
+
+  /**
+   * opened?: boolean
+   *
+   * Whether or not the sidenav is opened. Use this binding to open/close the sidenav.
+   * Defaults to "false".
+   *
+   * See "MdSidenav" documentation for more info.
+   *
+   * https://github.com/angular/material2/tree/master/src/lib/sidenav
+   */
+  @Input('opened') opened: boolean = false;
+
+  /**
+   * Checks if `ESC` should close the sidenav
+   * Should only close it for `push` and `over` modes
+   */
+  get disableClose(): boolean {
+    return this.mode === 'side';
+  }
+
+  /**
    * Proxy toggle method to access sidenav from outside (from td-layout template).
    */
   public toggle(): Promise<MdSidenavToggleResult> {
-    return this.sidenav.toggle();
+    return this.sidenav.toggle(!this.sidenav.opened);
   }
 
   /**


### PR DESCRIPTION
this so we can use diff types of modes for mid-small size projects in `td-layout`

### What's included?

- added `[mode]` and `[opened]` to td-layout so we can play around with both inputs and provide different experiences for users.
- Menu button in `td-layout-nav` and `td-layout-nav-list` now `toggle`s instead of just `open`ing

#### Test Steps

- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/layouts
- [ ] See new docs for `td-layout` and play with the inputs.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![screen shot 2017-05-21 at 4 38 13 pm](https://cloud.githubusercontent.com/assets/5846742/26288323/75c46112-3e44-11e7-81fe-57b1b4c3a8c0.png)
