### PR TITLE
fix(data-table): block (rowClick) event when clicking on checkbox (closes #611)

### DIFF
--- a/src/platform/core/data-table/data-table.component.html
+++ b/src/platform/core/data-table/data-table.component.html
@@ -30,7 +30,7 @@
         [tabIndex]="isSelectable ? 0 : -1"
         [class.mat-selected]="(isClickable || isSelectable) && isRowSelected(row)"
         *ngFor="let row of data; let rowIndex = index"
-        (click)="handleRowClick(row, $event, rowIndex)"
+        (click)="handleRowClick(row, $event)"
         (keyup)="isSelectable && _rowKeyup($event, row, rowIndex)"
         (keydown.space)="blockEvent($event)"
         (keydown.shift.space)="blockEvent($event)"

--- a/src/platform/core/data-table/data-table.component.html
+++ b/src/platform/core/data-table/data-table.component.html
@@ -41,7 +41,7 @@
           [state]="isRowSelected(row) ? 'checked' : 'unchecked'"
           (mousedown)="disableTextSelection()"
           (mouseup)="enableTextSelection()"
-          stopEventPropogation="true"
+          stopRowClick
           (click)="select(row, $event, rowIndex)">
         </md-pseudo-checkbox>
       </td>

--- a/src/platform/core/data-table/data-table.component.html
+++ b/src/platform/core/data-table/data-table.component.html
@@ -41,6 +41,7 @@
           [state]="isRowSelected(row) ? 'checked' : 'unchecked'"
           (mousedown)="disableTextSelection()"
           (mouseup)="enableTextSelection()"
+          stopEventPropogation="true"
           (click)="select(row, $event, rowIndex)">
         </md-pseudo-checkbox>
       </td>

--- a/src/platform/core/data-table/data-table.component.spec.ts
+++ b/src/platform/core/data-table/data-table.component.spec.ts
@@ -29,6 +29,7 @@ describe('Component: DataTable', () => {
         TdDataTableBasicTestComponent,
         TdDataTableSelectableTestComponent,
         TdDataTableRowClickTestComponent,
+        TdDataTableSelectableRowClickTestComponent,
       ],
       providers: [
         TdDataTableService,
@@ -330,6 +331,38 @@ describe('Component: DataTable', () => {
           });
         });
     })));
+
+    it('should click on a row and see the rowClick event only when clicking on row',
+      async(inject([], () => {
+        let fixture: ComponentFixture<any> = TestBed.createComponent(TdDataTableSelectableRowClickTestComponent);
+        let component: TdDataTableSelectableRowClickTestComponent = fixture.debugElement.componentInstance;
+
+        component.clickable = true;
+        component.selectable = true;
+
+        let clickEventSpy: jasmine.Spy = spyOn(component, 'clickEvent');
+        let selectEventSpy: jasmine.Spy = spyOn(component, 'selectEvent');
+
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          fixture.debugElement.queryAll(By.directive(TdDataTableRowComponent))[1].nativeElement.click();
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(clickEventSpy.calls.count()).toBe(1);
+            expect(selectEventSpy.calls.count()).toBe(0);
+
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+              fixture.debugElement.queryAll(By.directive(MdPseudoCheckbox))[0].nativeElement.click();
+              fixture.detectChanges();
+              fixture.whenStable().then(() => {
+                expect(clickEventSpy.calls.count()).toBe(1);
+                expect(selectEventSpy.calls.count()).toBe(1);
+              });
+            });
+          });
+        });
+    })));
   });
 });
 
@@ -389,6 +422,37 @@ class TdDataTableRowClickTestComponent {
   ];
   clickable: boolean = false;
   clickEvent(): void {
+    /* noop */
+  }
+}
+
+@Component({
+  template: `
+    <td-data-table
+        [data]="data"
+        [columns]="columns"
+        [selectable]="selectable"
+        [clickable]="clickable"
+        (rowClick)="clickEvent()"
+        (rowSelect)="selectEvent()">
+    </td-data-table>`,
+})
+class TdDataTableSelectableRowClickTestComponent {
+  data: any[] = [
+    { sku: '1452-2', item: 'Pork Chops', price: 32.11 },
+    { sku: '1421-0', item: 'Prime Rib', price: 41.15 },
+  ];
+  columns: ITdDataTableColumn[] = [
+    { name: 'sku', label: 'SKU #' },
+    { name: 'item', label: 'Item name' },
+    { name: 'price', label: 'Price (US$)', numeric: true },
+  ];
+  selectable: boolean = false;
+  clickable: boolean = false;
+  clickEvent(): void {
+    /* noop */
+  }
+  selectEvent(): void {
     /* noop */
   }
 }

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -435,9 +435,11 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    * emits the onRowClickEvent when a row is clicked
    * if clickable is true and selectable is false then select the row
    */
-  handleRowClick(row: any, event: Event, currentSelected: number): void {
+  handleRowClick(row: any, event: Event): void {
     if (this.isClickable) {
-      this.onRowClick.emit({row: row});
+      if (event.srcElement.tagName !== 'MD-PSEUDO-CHECKBOX') {
+        this.onRowClick.emit({row: row});
+      }
     }
   }
 

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -437,7 +437,7 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    */
   handleRowClick(row: any, event: Event): void {
     if (this.isClickable) {
-      if (event.srcElement.tagName !== 'MD-PSEUDO-CHECKBOX') {
+      if (event.srcElement.getAttribute('stopEventPropogation') !== 'true') {
         this.onRowClick.emit({row: row});
       }
     }

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -437,7 +437,10 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    */
   handleRowClick(row: any, event: Event): void {
     if (this.isClickable) {
-      if (event.srcElement.getAttribute('stopEventPropogation') !== 'true') {
+      // ignoring linting rules here because attribute it actually null or not there
+      // can't check for undefined
+      /* tslint:disable-next-line */
+      if (event.srcElement.getAttribute('stopRowClick') === null) {
         this.onRowClick.emit({row: row});
       }
     }


### PR DESCRIPTION
even though clicking on the checkbox is still clicking on the row, we need to block this since people want to navigate when clicking on row and select when clicking on checkbox.

https://github.com/Teradata/covalent/issues/611

### What's included?

- block `(rowClick)` event when click event target is `md-pseudo-checkbox`
- unit test for this particular use case

#### Test Steps

- [ ] `ng serve`
- [ ] Go to data-table demo http://localhost:4200/#/components/data-table
- [ ] Go to last demo and `enable` clickable
- [ ] See that now it only shows the dialog when clicking on the row and not when toggling the checkboxes.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.