### PR TITLE
fix(layout): upgrade to material@beta.6 to use exposed `ScrollDispatchModule` (closes #620)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@angular/core": "^4.1.0",
     "@angular/forms": "^4.1.0",
     "@angular/http": "^4.1.0",
-    "@angular/material": "2.0.0-beta.5",
+    "@angular/material": "2.0.0-beta.6",
     "@angular/platform-browser": "^4.1.0",
     "@angular/platform-browser-dynamic": "^4.1.0",
     "@angular/platform-server": "^4.1.0",

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.html
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.html
@@ -20,7 +20,7 @@
       </button>
       <ng-content select="[td-toolbar-content]"></ng-content>
     </md-toolbar>
-    <div class="md-content" flex>
+    <div class="md-content" flex cdkScrollable>
       <ng-content></ng-content>
     </div>
     <ng-content select="td-layout-footer-inner"></ng-content>

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.html
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.html
@@ -9,7 +9,7 @@
               layout-fill
               class="md-whiteframe-z1">
     <ng-content select="md-toolbar[td-sidenav-content]"></ng-content>
-    <div flex class="list md-content">
+    <div flex class="list md-content" cdkScrollable>
       <ng-content select="[td-sidenav-content]"></ng-content>
     </div>
   </md-sidenav>

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
@@ -36,7 +36,7 @@
           </button>
           <ng-content select="[td-toolbar-content]"></ng-content>
         </md-toolbar>
-        <div class="md-content" flex>
+        <div class="md-content" flex cdkScrollable>
           <ng-content></ng-content>
         </div>
         <ng-content select="td-layout-footer-inner"></ng-content>

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
@@ -25,7 +25,7 @@
           </span>
           <ng-content select="[td-sidenav-toolbar-content]"></ng-content>
         </md-toolbar>
-        <div flex class="list md-content">
+        <div flex class="list md-content" cdkScrollable>
           <ng-content select="[td-sidenav-content]"></ng-content>
         </div>
       </md-sidenav>

--- a/src/platform/core/layout/layout-nav/layout-nav.component.html
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.html
@@ -14,7 +14,7 @@
     </span>
     <ng-content select="[td-toolbar-content]"></ng-content>
   </md-toolbar>
-  <div flex layout="column" class="content md-content">
+  <div flex layout="column" class="content md-content" cdkScrollable>
     <ng-content></ng-content>
   </div>
   <ng-content select="td-layout-footer"></ng-content>

--- a/src/platform/core/layout/layout.module.ts
+++ b/src/platform/core/layout/layout.module.ts
@@ -2,7 +2,7 @@ import { Type } from '@angular/core';
 import { NgModule, ModuleWithProviders } from '@angular/core';
 
 import { CommonModule } from '@angular/common';
-import { MdSidenavModule, MdToolbarModule, MdButtonModule, MdIconModule, MdCardModule, MdListModule } from '@angular/material';
+import { MdSidenavModule, MdToolbarModule, MdButtonModule, MdIconModule, MdCardModule, MdListModule, ScrollDispatchModule } from '@angular/material';
 
 import { TdLayoutComponent } from './layout.component';
 import { TdLayoutNavComponent } from './layout-nav/layout-nav.component';
@@ -32,6 +32,7 @@ export { TdLayoutComponent, TdLayoutNavComponent, TdLayoutNavListComponent,
 @NgModule({
   imports: [
     CommonModule,
+    ScrollDispatchModule,
     MdSidenavModule,
     MdToolbarModule,
     MdButtonModule,

--- a/src/platform/core/package.json
+++ b/src/platform/core/package.json
@@ -43,6 +43,6 @@
     "@angular/forms": "^4.1.0",
     "@angular/http": "^4.1.0",
     "@angular/router": "^4.1.0",
-    "@angular/material": "2.0.0-beta.5"
+    "@angular/material": "2.0.0-beta.6"
   }
 }


### PR DESCRIPTION
https://github.com/Teradata/covalent/issues/620
we need to add `cdkScrollable` in our layouts so components like `md-autocomplete` can hook into them and reposition themselves when a user scrolls.

#### Test Steps

- [ ] `ng serve`
- [ ] Put an autocomplete anywhere in the docs and scroll.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.