### PR TITLE
fix(stepper): horizontal scroll was not appearing when needed in certain cases. (closes #282)

### DIFF
--- a/src/app/components/components/components.module.ts
+++ b/src/app/components/components/components.module.ts
@@ -94,6 +94,7 @@ import { DocumentationToolsModule } from '../../documentation-tools';
     MdTabsModule,
     MdTooltipModule,
     MdProgressBarModule,
+    MdAutocompleteModule,
     /** Covalent Modules */
     CovalentCommonModule,
     CovalentLayoutModule,

--- a/src/platform/core/steps/step-body/step-body.component.html
+++ b/src/platform/core/steps/step-body/step-body.component.html
@@ -1,6 +1,6 @@
 <div layout="row" flex>
   <ng-content></ng-content>
-  <div flex>
+  <div class="td-step-body" flex>
     <div class="td-step-content-wrapper"
          [@tdCollapse]="!active">
       <div #contentRef [class.td-step-content]="contentRef.children.length || contentRef.textContent.trim()">

--- a/src/platform/core/steps/step-body/step-body.component.html
+++ b/src/platform/core/steps/step-body/step-body.component.html
@@ -3,7 +3,7 @@
   <div class="td-step-body" flex>
     <div class="td-step-content-wrapper"
          [@tdCollapse]="!active">
-      <div #contentRef [class.td-step-content]="contentRef.children.length || contentRef.textContent.trim()">
+      <div #contentRef cdkScrollable [class.td-step-content]="contentRef.children.length || contentRef.textContent.trim()">
         <ng-content select="[td-step-body-content]"></ng-content>
       </div>
       <div #actionsRef layout="row" [class.td-step-actions]="actionsRef.children.length || actionsRef.textContent.trim()">

--- a/src/platform/core/steps/step-body/step-body.component.scss
+++ b/src/platform/core/steps/step-body/step-body.component.scss
@@ -1,0 +1,3 @@
+.td-step-body {
+  overflow-x: hidden;
+}

--- a/src/platform/core/steps/step-body/step-body.component.scss
+++ b/src/platform/core/steps/step-body/step-body.component.scss
@@ -1,3 +1,6 @@
 .td-step-body {
   overflow-x: hidden;
+  .td-step-content {
+    overflow-x: auto; 
+  }
 }

--- a/src/platform/core/steps/steps.module.ts
+++ b/src/platform/core/steps/steps.module.ts
@@ -2,7 +2,7 @@ import { Type } from '@angular/core';
 import { NgModule, ModuleWithProviders } from '@angular/core';
 
 import { CommonModule } from '@angular/common';
-import { MdIconModule, MdRippleModule, PortalModule } from '@angular/material';
+import { MdIconModule, MdRippleModule, PortalModule, ScrollDispatchModule } from '@angular/material';
 
 import { CovalentCommonModule } from '../common/common.module';
 
@@ -32,6 +32,7 @@ export { TdStepsComponent, IStepChangeEvent, StepMode } from './steps.component'
     MdIconModule,
     MdRippleModule,
     PortalModule,
+    ScrollDispatchModule,
     CovalentCommonModule,
   ],
   declarations: [


### PR DESCRIPTION
https://github.com/Teradata/covalent/issues/282

Certain elements overflowed out of the stepper and no scroll would appear. With this the `data-table` doesnt overflow.

#### Test Steps

- [ ] `ng serve`
- [ ] Go to stepper demo
- [ ] But any element with a long `width` inside a stepper.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle