### PR TITLE
fix(chips): protect against case where click would close the autocomplete

### DIFF
--- a/src/platform/core/chips/chips.component.ts
+++ b/src/platform/core/chips/chips.component.ts
@@ -49,6 +49,8 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck, OnInit, 
 
   private _outsideClickSubs: Subscription;
 
+  private _isMousedown: boolean = false;
+
   /**
    * Implemented as part of ControlValueAccessor.
    */
@@ -207,8 +209,23 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck, OnInit, 
    */
   @HostListener('focus', ['$event'])
   focusListener(event: FocusEvent): void {
-    this.focus();
+    // should only focus if its not via mousedown to prevent clashing with autocomplete
+    if (!this._isMousedown) {
+      this.focus();
+    }
     event.preventDefault();
+  }
+
+  /**
+   * Listens to host mousedown event to act on it
+   */
+  @HostListener('mousedown', ['$event'])
+  mousedownListener(event: FocusEvent): void {
+     // sets a flag to know if there was a mousedown and then it returns it back to false
+    this._isMousedown = true;
+    Observable.timer().toPromise().then(() => {
+      this._isMousedown = false;
+    });
   }
 
   /**
@@ -220,6 +237,7 @@ export class TdChipsComponent implements ControlValueAccessor, DoCheck, OnInit, 
     const clickTarget: HTMLElement = <HTMLElement>event.target;
     if (clickTarget === this._elementRef.nativeElement || 
         clickTarget.className.indexOf('td-chips-wrapper') > -1) {
+      this.focus();
       event.preventDefault();
       event.stopPropagation();
     }


### PR DESCRIPTION
when clicking near the bottom of the input, the focus would make the autocomplete render, but the click event would close it since its technically outside of it.

we need to disable the focus listener when its via click user interaction

#### Test Steps

- [x] `ng serve`
- [x] Go to chips demo
- [x] type `j` in the first demo
- [x] click outside of the chips component
- [x] then click near the underline under the `input` in chips

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.