### PR TITLE
chore(expansion-panel): updated docs with better examples (closes #475)

### DIFF
--- a/src/app/components/components/expansion-panel/expansion-panel.component.html
+++ b/src/app/components/components/expansion-panel/expansion-panel.component.html
@@ -1,17 +1,91 @@
 <md-card>
-  <md-card-title>Expansion Panels</md-card-title>
-  <md-card-subtitle>Expand & collapse containers</md-card-subtitle>
+  <md-card-title>Expansion panels</md-card-title>
+  <md-card-subtitle>Use single or multiple expansion panels</md-card-subtitle>
   <md-divider></md-divider>
-  <md-card-content>
-  <p>Expand/Collapse Event for Expansion 1: {{expandCollapseExpansion1Msg}}</p>
-  <div layout-gt-xs="row" layout-align-gt-xs="center start">
-    <div flex-gt-xs="90">
-      <td-expansion-panel label="Google" 
-                          sublabel="1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA" 
-                          [expand]="expansion1" 
-                          [disabled]="disabled"
-                          (expanded)="expandExpansion1Event()"
-                          (collapsed)="collapseExpansion1Event()">
+  <md-tab-group md-stretch-tabs dynamicHeight>
+    <md-tab>
+      <ng-template md-tab-label>Demo</ng-template>
+      <td-expansion-panel label="Label goes here" sublabel="sublabel goes here" [disabled]="disabled">
+        <div class="md-padding">
+          <h3 class="md-subhead">md-padding class</h3>
+          <div>Demo 1</div>
+          <div>Demo 2</div>
+          <div>Demo 3</div>
+          <div>Demo 4</div>
+        </div>
+      </td-expansion-panel>
+      <td-expansion-panel label="Another label goes here" [disabled]="disabled">
+        <div class="md-padding">
+          <h3 class="md-subhead">md-padding class</h3>
+          <div>Demo 5</div>
+          <div>Demo 6</div>
+          <div>Demo 7</div>
+          <div>Demo 8</div>
+        </div>
+      </td-expansion-panel>
+    </md-tab>
+    <md-tab>
+      <ng-template md-tab-label>Code</ng-template>
+      <md-card-content>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-expansion-panel label="Label goes here" sublabel="sublabel goes here" [disabled]="disabled">
+              <div class="md-padding">
+                <h3 class="md-subhead">md-padding class</h3>
+                <div>Demo 1</div>
+                <div>Demo 2</div>
+                <div>Demo 3</div>
+                <div>Demo 4</div>
+              </div>
+            </td-expansion-panel>
+            <td-expansion-panel label="Another label goes here" [disabled]="disabled">
+              <div class="md-padding">
+                <h3 class="md-subhead">md-padding class</h3>
+                <div>Demo 5</div>
+                <div>Demo 6</div>
+                <div>Demo 7</div>
+                <div>Demo 8</div>
+              </div>
+            </td-expansion-panel>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            export class ChipsDemoComponent {
+              disabled: boolean = false;
+            }
+          ]]>
+        </td-highlight>
+      </md-card-content>
+    </md-tab>
+  </md-tab-group>
+  <md-divider></md-divider>
+  <md-card-actions>
+    <div class="pad-sm">
+      <md-slide-toggle color="accent" [(ngModel)]="disabled">
+        Disabled
+      </md-slide-toggle>
+    </div>
+  </md-card-actions>
+</md-card>
+
+<md-card>
+  <md-card-title>Expansion panel with summary and templates</md-card-title>
+  <md-card-subtitle>Expand to view form, collapse to view summary</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-tab-group md-stretch-tabs dynamicHeight>
+    <md-tab>
+      <ng-template md-tab-label>Demo</ng-template>
+      <td-expansion-panel [expand]="true">
+        <ng-template td-expansion-panel-label>
+          <md-icon>star</md-icon>
+          <span>Google</span>
+        </ng-template>
+        <ng-template td-expansion-panel-sublabel>
+          <span>1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA</span>
+        </ng-template>
         <td-expansion-summary>
           <md-list>
             <md-list-item>
@@ -38,201 +112,155 @@
           <button md-button color="accent" class="text-upper">Save</button>
         </div>
       </td-expansion-panel>
-      <td-expansion-panel label="Label goes here" sublabel="sublabel goes here" [disabled]="disabled">
-        <div class="md-padding">
-          <h3 class="md-subhead">md-padding class</h3>
-          <div>Demo 1</div>
-          <div>Demo 2</div>
-          <div>Demo 3</div>
-          <div>Demo 4</div>
-        </div>
-      </td-expansion-panel>
-      <td-expansion-panel label="Label goes here" sublabel="sublabel goes here" [disabled]="disabled">
-        <ng-template td-expansion-panel-label>
-          <md-icon>star</md-icon>
-          <span>Custom Label (template)</span>
-        </ng-template>
-        <ng-template td-expansion-panel-sublabel>
-          <md-icon>list</md-icon>
-          <span>Custom Sublabel (template)</span>
-        </ng-template>
-        <div class="md-padding">
-          <h3 class="md-subhead">md-padding class</h3>
-          <div>Phase 1</div>
-          <div>Phase 2</div>
-          <div>Phase 3</div>
-        </div>
-      </td-expansion-panel>
-    </div>
-  </div>
-  <p>The entire panel header can be replaced as well:</p>
-  <div layout-gt-xs="row" layout-align-gt-xs="center start">
-    <div flex-gt-xs="90">
-      <td-expansion-panel [disabled]="disabled">
-        <ng-template td-expansion-panel-header>
-          <md-toolbar color="accent">
-            <span>Custom td-expansion-panel-header</span>
-          </md-toolbar>
-        </ng-template>
-        <td-expansion-summary>
-          <div class="md-padding">
-            <div flex layout-gt-xs="row" layout-align="start center">
-              <span flex="30" class="md-subhead">Owner</span>
-              <span flex="5" hide-xs><md-icon class="tc-grey-500">chevron_right</md-icon></span>
-              <span flex>John Jameson</span>
-            </div>
-            <div flex layout-gt-xs="row" layout-align="start center">
-              <span flex="30" class="md-subhead">API Key</span>
-              <span flex="5" hide-xs><md-icon class="tc-grey-500">chevron_right</md-icon></span>
-              <span flex>1141e8e8-8d24-4956-93c2</span>
-            </div>
-            <div flex layout-gt-xs="row" layout-align="start center">
-              <span flex="30" class="md-subhead">Last Updated</span>
-              <span flex="5" hide-xs><md-icon class="tc-grey-500">chevron_right</md-icon></span>
-              <span flex>Wed, July 6, 2016 11:13 AM</span>
-            </div>
-          </div>
-        </td-expansion-summary>
-        <md-list>
-          <h3 md-subheader>Metadata</h3>
-          <md-list-item>
-              <md-icon md-list-avatar>account_box</md-icon>
-              <h4 md-line>John Jameson</h4>
-              <p md-line>Owner</p>
-          </md-list-item>
-          <md-divider md-inset></md-divider>
-          <md-list-item>
-              <md-icon md-list-avatar>description</md-icon>
-              <h4 md-line>An item description</h4>
-              <p md-line>Description</p>
-          </md-list-item>
-          <md-divider md-inset></md-divider>
-          <md-list-item>
-              <md-icon md-list-avatar>vpn_key</md-icon>
-              <h4 md-line>1141e8e8-8d24-4956-93c2</h4>
-              <p md-line>API Key</p>
-          </md-list-item>
-          <md-divider></md-divider>
-          <h3 md-subheader>Dates</h3>
-          <md-list-item>
-              <md-icon md-list-avatar>access_time</md-icon>
-              <h4 md-line>Wed, July 6, 2016 11:13 AM</h4>
-              <p md-line>Last Updated</p>
-          </md-list-item>
-          <md-divider md-inset></md-divider>
-          <md-list-item>
-              <md-icon md-list-avatar>today</md-icon>
-              <h4 md-line>Wed, July 4, 2016 09:11 AM</h4>
-              <p md-line>Created</p>
-          </md-list-item>
-        </md-list>
-      </td-expansion-panel>
-    </div>
-  </div>
- </md-card-content>
- <md-divider></md-divider>
-  <md-card-actions>
-    <button md-button color="primary" (click)="toggleDisabled()" class="text-upper">Toggle disable</button>
-    <button md-button color="primary" (click)="toggleExpansion1()" class="text-upper">Toggle first</button>
-  </md-card-actions>
+    </md-tab>
+    <md-tab>
+      <ng-template md-tab-label>Code</ng-template>
+      <md-card-content>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-expansion-panel [expand]="true">
+              <ng-template td-expansion-panel-label>
+                <md-icon>star</md-icon>
+                <span>Google</span>
+              </ng-template>
+              <ng-template td-expansion-panel-sublabel>
+                <span>1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA</span>
+              </ng-template>
+              <td-expansion-summary>
+                <md-list>
+                  <md-list-item>
+                    <md-icon md-list-avatar>pin_drop</md-icon>
+                    <h3 md-line>Google</h3>
+                    <h4 md-line>Headquarters</h4>
+                    <p md-line>
+                      1600 Amphitheatre Pkwy<br/>Mountain View, CA 94043, USA
+                    </p>
+                  </md-list-item>
+                </md-list>
+              </td-expansion-summary>
+              <form class="md-padding" layout="column">
+                <md-input-container flex>
+                  <input mdInput placeholder="Company (disabled)" disabled value="Google"/>
+                </md-input-container>
+                <md-input-container flex>
+                  <textarea mdInput placeholder="Description" rows="4"></textarea>
+                </md-input-container>
+              </form>
+              <md-divider></md-divider>
+              <div layout="row" layout-margin layout-align="end center">
+                <button md-button class="text-upper">Cancel</button>
+                <button md-button color="accent" class="text-upper">Save</button>
+              </div>
+            </td-expansion-panel>
+          ]]>
+        </td-highlight>
+      </md-card-content>
+    </md-tab>
+  </md-tab-group>
 </md-card>
+
 <md-card>
-  <md-card-title>TdExpansionPanelComponent</md-card-title>
-  <md-card-subtitle>How to use this component</md-card-subtitle>
+  <md-card-title>Expansion panel with header template</md-card-title>
+  <md-card-subtitle>replace the entire header as needed</md-card-subtitle>
   <md-divider></md-divider>
-  <md-card-content>
-    <h2><code><![CDATA[<td-expansion-panel>]]></code></h2>
-    <p>Use <code><![CDATA[<td-expansion-panel>]]></code> element to add expand/collapse feature to your html blocks</p>
-    <p>Place your html in <code><![CDATA[<td-expansion-panel>]]></code> element.</p>
-    <h3>Behavior:</h3>
-    <md-list>
-        <a md-list-item layout-align="row">
-          <h3 md-line> Collapsed panel</h3>
-          <p md-line> A collapsed panel displays summary information. Upon selecting the collapsed panel, it expands to display the full expansion panel. </p>
-        </a>
-        <md-divider></md-divider>
-        <a md-list-item layout-align="row">
-          <h3 md-line> Expanded panel</h3>
-          <p md-line> Upon selection, a collapsed panel expands, allowing users to add or edit information. Helper text may be added to the panel to assist the user. </p>
-        </a>
-    </md-list>
-    <h3>Usage:</h3>
-    <p>The <code><![CDATA[<td-expansion-panel>]]></code> component can be used two ways:</p>
-    <md-list>  
-        <a md-list-item layout-align="row">
-          <h3 md-line> Editing</h3>
-          <p md-line> Expansion panels are best used for lightweight editing of an element, such as selecting a value for a setting. </p>
-        </a>
-        <md-divider></md-divider>
-        <a md-list-item layout-align="row">
-          <h3 md-line> Creation flows</h3>
-          <p md-line> Expansion panels may be displayed in a sequence to form creation flows. </p>
-        </a>
-    </md-list>
-    <h3>Properties:</h3>
-    <p>The <code><![CDATA[<td-expansion-panel>]]></code> component has {{expansionAttrs.length}} properties:</p>
-    <md-list>
-      <ng-template let-attr let-last="last" ngFor [ngForOf]="expansionAttrs">
-        <a md-list-item layout-align="row">
-          <h3 md-line> {{attr.name}}: <span>{{attr.type}}</span></h3>
-          <p md-line> {{attr.description}} </p>
-        </a>
-        <md-divider *ngIf="!last"></md-divider>
-      </ng-template>
-    </md-list>
-    <h3>Example:</h3>
-    <p>HTML:</p>
-    <td-highlight lang="html">
-      <![CDATA[
-        <td-expansion-panel label="label" sublabel="sublabel" expand="true|false" disabled="true|false" (expanded)="expandedEvent()" (collapsed)="collapsedEvent()">
+  <md-tab-group md-stretch-tabs dynamicHeight>
+    <md-tab>
+      <ng-template md-tab-label>Demo</ng-template>
+        <td-expansion-panel>
           <ng-template td-expansion-panel-header>
-            ... add header content (overrides label and sublabel)
-          </ng-template>
-          <ng-template td-expansion-panel-label>
-            ... add label content (if not used, falls back to [label] input)
-          </ng-template>
-          <ng-template td-expansion-panel-sublabel>
-            ... add sublabel content (if not used, falls back to [sublabel] input)
+            <md-toolbar color="accent">
+              <span>Custom td-expansion-panel-header</span>
+            </md-toolbar>
           </ng-template>
           <td-expansion-summary>
-            ... add summary that will be shown when expansion-panel is "collapsed".
+            <div class="md-padding">
+              <div flex layout-gt-xs="row" layout-align="start center">
+                <span flex="30" class="md-subhead">Owner</span>
+                <span flex="5" hide-xs><md-icon class="tc-grey-500">chevron_right</md-icon></span>
+                <span flex>John Jameson</span>
+              </div>
+              <div flex layout-gt-xs="row" layout-align="start center">
+                <span flex="30" class="md-subhead">API Key</span>
+                <span flex="5" hide-xs><md-icon class="tc-grey-500">chevron_right</md-icon></span>
+                <span flex>1141e8e8-8d24-4956-93c2</span>
+              </div>
+            </div>
           </td-expansion-summary>
-          ... add content that will be shown when the step is "expanded"
+          <md-list>
+            <h3 md-subheader>Metadata</h3>
+            <md-list-item>
+                <md-icon md-list-avatar>account_box</md-icon>
+                <h4 md-line>John Jameson</h4>
+                <p md-line>Owner</p>
+            </md-list-item>
+            <md-divider md-inset></md-divider>
+            <md-list-item>
+                <md-icon md-list-avatar>description</md-icon>
+                <h4 md-line>An item description</h4>
+                <p md-line>Description</p>
+            </md-list-item>
+            <md-divider md-inset></md-divider>
+            <md-list-item>
+                <md-icon md-list-avatar>vpn_key</md-icon>
+                <h4 md-line>1141e8e8-8d24-4956-93c2</h4>
+                <p md-line>API Key</p>
+            </md-list-item>
+          </md-list>
         </td-expansion-panel>
-      ]]>
-    </td-highlight>
-    <p>Typescript:</p>
-    <td-highlight lang="typescript">
-      <![CDATA[
-        ...
-        })
-        export class Demo {
-          
-          expandedEvent(): void {
-            ...
-          }
-          
-          collapsedEvent(): void {
-            ...
-          }
-        }
-      ]]>
-    </td-highlight>
-    <h3>Setup:</h3>
-    <p>Import the [CovalentExpansionPanelModule] in your NgModule:</p>
-    <td-highlight lang="typescript">
-      <![CDATA[
-        import { CovalentExpansionPanelModule } from '@covalent/core';
-        @NgModule({
-          imports: [
-            CovalentExpansionPanelModule,
-            ...
-          ],
-          ...
-        })
-        export class MyModule {}
-      ]]>
-    </td-highlight>
-  </md-card-content>
- </md-card>
+      </md-tab>
+    <md-tab>
+      <ng-template md-tab-label>Code</ng-template>
+      <md-card-content>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-expansion-panel>
+              <ng-template td-expansion-panel-header>
+                <md-toolbar color="accent">
+                  <span>Custom td-expansion-panel-header</span>
+                </md-toolbar>
+              </ng-template>
+              <td-expansion-summary>
+                <div class="md-padding">
+                  <div flex layout-gt-xs="row" layout-align="start center">
+                    <span flex="30" class="md-subhead">Owner</span>
+                    <span flex="5" hide-xs><md-icon class="tc-grey-500">chevron_right</md-icon></span>
+                    <span flex>John Jameson</span>
+                  </div>
+                  <div flex layout-gt-xs="row" layout-align="start center">
+                    <span flex="30" class="md-subhead">API Key</span>
+                    <span flex="5" hide-xs><md-icon class="tc-grey-500">chevron_right</md-icon></span>
+                    <span flex>1141e8e8-8d24-4956-93c2</span>
+                  </div>
+                </div>
+              </td-expansion-summary>
+              <md-list>
+                <h3 md-subheader>Metadata</h3>
+                <md-list-item>
+                    <md-icon md-list-avatar>account_box</md-icon>
+                    <h4 md-line>John Jameson</h4>
+                    <p md-line>Owner</p>
+                </md-list-item>
+                <md-divider md-inset></md-divider>
+                <md-list-item>
+                    <md-icon md-list-avatar>description</md-icon>
+                    <h4 md-line>An item description</h4>
+                    <p md-line>Description</p>
+                </md-list-item>
+                <md-divider md-inset></md-divider>
+                <md-list-item>
+                    <md-icon md-list-avatar>vpn_key</md-icon>
+                    <h4 md-line>1141e8e8-8d24-4956-93c2</h4>
+                    <p md-line>API Key</p>
+                </md-list-item>
+              </md-list>
+            </td-expansion-panel>
+          ]]>
+        </td-highlight>
+      </md-card-content>
+    </md-tab>
+  </md-tab-group>
+</md-card>
 
+<td-readme-loader resourceUrl="platform/core/expansion-panel/README.md"></td-readme-loader>

--- a/src/app/components/components/expansion-panel/expansion-panel.component.ts
+++ b/src/app/components/components/expansion-panel/expansion-panel.component.ts
@@ -13,67 +13,6 @@ export class ExpansionPanelDemoComponent {
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
 
-  expansionAttrs: Object[] = [{
-    description: 'Sets label of [TdExpansionPanelComponent] header. Defaults to "Click to expand"',
-    name: 'label?',
-    type: 'string',
-  }, {
-    description: 'Sets sublabel of [TdExpansionPanelComponent] header.',
-    name: 'sublabel?',
-    type: 'string',
-  }, {
-    description: 'Toggles [TdExpansionPanelComponent] between expand/collapse.',
-    name: 'expand?',
-    type: 'boolean',
-  }, {
-    description: `Hides icon and disables header, blocks click event and sets [TdExpansionPanelComponent]
-                  to collapse if "true".`,
-    name: 'disabled?',
-    type: 'boolean',
-  }, {
-    description: 'Event emitted when [TdExpansionPanelComponent] is expanded.',
-    name: 'expanded?',
-    type: 'function()',
-  }, {
-    description: 'Event emitted when [TdExpansionPanelComponent] is collapsed.',
-    name: 'collapsed?',
-    type: 'function()',
-  }, {
-    description: `Toggle active state of [TdExpansionPanelComponent]. Retuns "true" if successful, else "false".
-                  Can be accessed by referencing element in local variable.`,
-    name: 'toggle',
-    type: 'function()',
-  }, {
-    description: `Opens [TdExpansionPanelComponent]. Retuns "true" if successful, else "false".
-                  Can be accessed by referencing element in local variable.`,
-    name: 'open',
-    type: 'function()',
-  }, {
-    description: `Closes [TdExpansionPanelComponent]. Retuns "true" if successful, else "false".
-                  Can be accessed by referencing element in local variable.`,
-    name: 'close',
-    type: 'function()',
-  }];
-
-  expandCollapseExpansion1Msg: string = 'No expanded/collapsed detected yet';
-  expansion1: boolean = false;
   disabled: boolean = false;
 
-  toggleExpansion1(): void {
-    if (!this.disabled) {
-      this.expansion1 = !this.expansion1;
-    }
-  }
-
-  toggleDisabled(): void {
-    this.disabled = !this.disabled;
-  }
-
-  expandExpansion1Event(): void {
-    this.expandCollapseExpansion1Msg = 'Expand event emitted.';
-  }
-
-  collapseExpansion1Event(): void {
-    this.expandCollapseExpansion1Msg = 'Collapse event emitted.';
-  }
 }

--- a/src/platform/core/expansion-panel/README.md
+++ b/src/platform/core/expansion-panel/README.md
@@ -1,0 +1,58 @@
+# td-expansion-panel
+
+`td-expansion-panel` element adds expand/collapse features to your html blocks
+
+It also contains an optional summary to display anything in collapsed state.
+
+## API Summary
+
+Properties:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `label?` | `string` | Sets label of component header.
+| `sublabel?` | `string` | Sets sublabel of component header.
+| `expand?` | `boolean` | Toggles component between expand/collapse state.
+| `expanded?` | `function` | Event emitted when component is expanded.
+| `collapsed?` | `function` | Event emitted when component is collapsed.
+| `toggle?` | `function` | Toggle state of component. Returns "true" if successful, else "false".
+| `open?` | `function` | Opens component and sets state to expanded. Retuns "true" if successful, else "false".
+| `close?` | `function` | Closes component and sets state to collapsed. Retuns "true" if successful, else "false".
+
+## Setup
+
+Import the [CovalentExpansionPanelModule] in your NgModule:
+
+```typescript
+import { CovalentExpansionPanelModule } from '@covalent/core';
+@NgModule({
+  imports: [
+    CovalentExpansionPanelModule,
+    ...
+  ],
+  ...
+})
+export class MyModule {}
+```
+
+## Usage
+
+Example for HTML usage:
+
+```html
+<td-expansion-panel label="label" sublabel="sublabel" expand="true|false" disabled="true|false" (expanded)="expandedEvent()" (collapsed)="collapsedEvent()">
+  <ng-template td-expansion-panel-header>
+    ... add header content (overrides label and sublabel)
+  </ng-template>
+  <ng-template td-expansion-panel-label>
+    ... add label content (if not used, falls back to [label] input)
+  </ng-template>
+  <ng-template td-expansion-panel-sublabel>
+    ... add sublabel content (if not used, falls back to [sublabel] input)
+  </ng-template>
+  <td-expansion-summary>
+    ... add summary that will be shown when expansion-panel is "collapsed".
+  </td-expansion-summary>
+  ... add content that
+</td-expansion-panel>
+```

--- a/src/platform/core/expansion-panel/expansion-panel.component.html
+++ b/src/platform/core/expansion-panel/expansion-panel.component.html
@@ -14,11 +14,11 @@
           layout="row" 
           layout-align="start center" 
           flex>
-      <div class="md-subhead td-expansion-label" flex-gt-xs="33">
+      <div *ngIf="label || expansionPanelLabel" class="md-subhead td-expansion-label" [attr.flex-gt-xs]="(sublabel || expansionPanelSublabel) ? 40 : null">
         <ng-template [cdkPortalHost]="expansionPanelLabel"></ng-template>
         <ng-template [ngIf]="!expansionPanelLabel">{{label}}</ng-template>
       </div>
-      <div class="md-body-1 td-expansion-sublabel">
+      <div *ngIf="sublabel || expansionPanelSublabel" class="md-body-1 td-expansion-sublabel">
         <ng-template [cdkPortalHost]="expansionPanelSublabel"></ng-template>
         <ng-template [ngIf]="!expansionPanelSublabel">{{sublabel}}</ng-template>
       </div>


### PR DESCRIPTION
## Description

https://github.com/Teradata/covalent/issues/475

also created README.md and loaded it in docs + added code blocks in the examples

### What's included?

- chore(expansion-panel): updated docs with better examples
- fix(expansion-panel): only render label and sublabel when its needed

#### Test Steps

- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/expansion-panel
- [ ] See new docs , demos and README.md being loaded

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle