### PR TITLE
fix(card-images): sm/md/lg card images in title-group (closes #575)

### DIFF
--- a/src/app/components/style-guide/cards/cards.component.html
+++ b/src/app/components/style-guide/cards/cards.component.html
@@ -399,7 +399,7 @@
           <md-card-title-group>
             <md-card-title>Card with large image</md-card-title>
             <md-card-subtitle>152px x 152px image</md-card-subtitle>
-            <img md-card-lg-image class="mat-card-lg-image" src="https://placekitten.com/g/400/200">
+            <img md-card-lg-image class="mat-card-lg-image" src="https://placekitten.com/g/400/400">
           </md-card-title-group>
         </md-card>
       </div>

--- a/src/app/components/style-guide/cards/cards.component.html
+++ b/src/app/components/style-guide/cards/cards.component.html
@@ -443,7 +443,6 @@
               </md-card-title-group>
             </md-card>
           </div>
-        </div>
         ]]>
       </td-highlight>
   </md-card-content>

--- a/src/app/components/style-guide/cards/cards.component.html
+++ b/src/app/components/style-guide/cards/cards.component.html
@@ -300,8 +300,8 @@
   </md-card-content>
 </md-card>
 <md-card>
-  <md-card-title>Card with header & images</md-card-title>
-  <md-card-subtitle>A card with header, avatar & image</md-card-subtitle>
+  <md-card-title>Card with various components</md-card-title>
+  <md-card-subtitle>A card with header, images, action icons &amp; progress bar</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
     <div class="md-padding bgc-grey-200">
@@ -311,11 +311,23 @@
             <md-card-title>Header title</md-card-title>
             <md-card-subtitle>Header subtitle</md-card-subtitle>
         </md-card-header>
-        <img md-card-image src="https://placekitten.com/g/600/400">
+        <img md-card-image src="https://placekitten.com/g/600/200">
         <md-card-content>
           <h3 class="md-subhead">Content title</h3>
           <p class="md-body-1">Here is some more content</p>
         </md-card-content>
+        <md-divider></md-divider>
+        <md-card-actions>
+          <div layout="row" class="tc-grey-600">
+            <button md-icon-button mdTooltip="Like"><md-icon>favorite</md-icon></button>
+            <button md-icon-button mdTooltip="Comment"><md-icon>comment</md-icon></button>
+            <span flex></span>
+            <button md-icon-button mdTooltip="Share"><md-icon>share</md-icon></button>
+          </div>
+        </md-card-actions>
+        <md-card-footer>
+          <md-progress-bar mode="indeterminate"></md-progress-bar>
+        </md-card-footer>
       </md-card>
     </div>
     <td-highlight lang="html">
@@ -326,12 +338,112 @@
                 <md-card-title>Header title</md-card-title>
                 <md-card-subtitle>Header subtitle</md-card-subtitle>
             </md-card-header>
-            <img md-card-image src="https://placekitten.com/g/600/400">
+            <img md-card-image src="https://placekitten.com/g/600/200">
             <md-card-content>
               <h3 class="md-subhead">Content title</h3>
               <p class="md-body-1">Here is some more content</p>
             </md-card-content>
+            <md-divider></md-divider>
+            <md-card-actions>
+              <div layout="row" class="tc-grey-600">
+                <button md-icon-button mdTooltip="Like"><md-icon>favorite</md-icon></button>
+                <button md-icon-button mdTooltip="Comment"><md-icon>comment</md-icon></button>
+                <span flex></span>
+                <button md-icon-button mdTooltip="Share"><md-icon>share</md-icon></button>
+              </div>
+            </md-card-actions>
+            <md-card-footer>
+              <md-progress-bar mode="indeterminate"></md-progress-bar>
+            </md-card-footer>
           </md-card>
+        ]]>
+      </td-highlight>
+  </md-card-content>
+</md-card>
+<md-card>
+  <md-card-title>Card with image variations</md-card-title>
+  <md-card-subtitle>md-card-sm-image, md-card-md-image, md-card-lg-image &amp; md-card-title-group</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <div class="md-padding bgc-grey-200">
+      <div layout-gt-xs="row">
+        <md-card>
+          <img md-card-image src="https://placekitten.com/g/600/200">
+          <md-card-title>Card with image first</md-card-title>
+          <md-card-subtitle>100% width image</md-card-subtitle>
+          <md-card-content>
+            Notice if the image is first it has proper rounded corners.
+          </md-card-content>
+        </md-card>
+      </div>
+      <div layout-gt-xs="row">
+        <md-card>
+          <md-card-title-group>
+            <md-card-title class="text-xl">Card with small image</md-card-title>
+            <md-card-subtitle>80px x 80px image</md-card-subtitle>
+            <img md-card-sm-image src="https://placekitten.com/g/200/200">
+          </md-card-title-group>
+        </md-card>
+      </div>
+      <div layout-gt-xs="row">
+        <md-card>
+          <md-card-title-group>
+            <md-card-title class="text-xxl">Card with medium image</md-card-title>
+            <md-card-subtitle>112px x 112px image</md-card-subtitle>
+            <img md-card-md-image src="https://placekitten.com/g/300/300">
+          </md-card-title-group>
+        </md-card>
+      </div>
+      <div layout-gt-xs="row">
+        <md-card>
+          <md-card-title-group>
+            <md-card-title>Card with large image</md-card-title>
+            <md-card-subtitle>152px x 152px image</md-card-subtitle>
+            <img md-card-lg-image class="mat-card-lg-image" src="https://placekitten.com/g/400/200">
+          </md-card-title-group>
+        </md-card>
+      </div>
+    </div>
+    <td-highlight lang="html">
+        <![CDATA[
+          <div layout-gt-xs="row">
+            <md-card>
+              <img md-card-image src="https://placekitten.com/g/600/200">
+              <md-card-title>Card with image first</md-card-title>
+              <md-card-subtitle>100% width image</md-card-subtitle>
+              <md-card-content>
+                Notice if the image is first it has proper rounded corners.
+              </md-card-content>
+            </md-card>
+          </div>
+          <div layout-gt-xs="row">
+            <md-card>
+              <md-card-title-group>
+                <md-card-title class="text-xl">Card with small image</md-card-title>
+                <md-card-subtitle>80px x 80px image</md-card-subtitle>
+                <img md-card-sm-image src="https://placekitten.com/g/200/200">
+              </md-card-title-group>
+            </md-card>
+          </div>
+          <div layout-gt-xs="row">
+            <md-card>
+              <md-card-title-group>
+                <md-card-title class="text-xxl">Card with medium image</md-card-title>
+                <md-card-subtitle>112px x 112px image</md-card-subtitle>
+                <img md-card-md-image src="https://placekitten.com/g/300/300">
+              </md-card-title-group>
+            </md-card>
+          </div>
+          <div layout-gt-xs="row">
+            <md-card>
+              <md-card-title-group>
+                <md-card-title>Card with large image</md-card-title>
+                <md-card-subtitle>152px x 152px image</md-card-subtitle>
+                <img md-card-lg-image src="https://placekitten.com/g/400/200">
+              </md-card-title-group>
+            </md-card>
+          </div>
+        </div>
         ]]>
       </td-highlight>
   </md-card-content>
@@ -343,6 +455,11 @@
     <a md-list-item href="https://material.google.com/components/cards.html" target="_blank">
       <md-icon>launch</md-icon>
       <span md-line>Card Specs</span>
+    </a>
+    <md-divider></md-divider>
+    <a md-list-item href="https://material.angular.io/components/component/card" target="_blank">
+      <md-icon>launch</md-icon>
+      <span md-line>Angular Material Card Docs</span>
     </a>
     <md-divider></md-divider>
     <a md-list-item href="https://www.google.com/search/about/learn-more/now/" target="_blank">

--- a/src/app/components/style-guide/style-guide.module.ts
+++ b/src/app/components/style-guide/style-guide.module.ts
@@ -18,7 +18,8 @@ import { ResourcesComponent } from './resources/resources.component';
 import { NavigationDrawerComponent } from './navigation-drawer/navigation-drawer.component';
 
 import { MdButtonModule, MdListModule, MdIconModule, MdCardModule, MdToolbarModule, MdCoreModule, MdSnackBarModule,
-         MdInputModule, MdMenuModule, MdSelectModule, MdGridListModule, MdTabsModule, MdSidenavModule } from '@angular/material';
+         MdInputModule, MdMenuModule, MdSelectModule, MdGridListModule, MdTabsModule, MdSidenavModule,
+         MdTooltipModule, MdProgressBarModule } from '@angular/material';
 
 import { CovalentLayoutModule, CovalentMediaModule, CovalentSearchModule, CovalentPagingModule,
          CovalentExpansionPanelModule, CovalentDialogsModule } from '../../../platform/core';
@@ -59,6 +60,8 @@ import { ToolbarModule } from '../../components/toolbar/toolbar.module';
     MdTabsModule,
     MdSidenavModule,
     MdSnackBarModule,
+    MdTooltipModule,
+    MdProgressBarModule,
     /** Covalent Modules */
     CovalentLayoutModule,
     CovalentMediaModule,

--- a/src/platform/core/common/styles/_card.scss
+++ b/src/platform/core/common/styles/_card.scss
@@ -43,6 +43,10 @@ html {
                 margin: 0;
             }
         }
+        .mat-card-actions:last-child {
+            margin-bottom: 0px;
+            padding-bottom: 8px;
+        }
     }
     &:not([dir='rtl']) {
         .mat-card-title-group {

--- a/src/platform/core/common/styles/_card.scss
+++ b/src/platform/core/common/styles/_card.scss
@@ -1,6 +1,6 @@
 @import 'variables';
 
-body {
+html {
     .mat-card {
         padding: 0;
         margin: 8px;
@@ -15,8 +15,14 @@ body {
             margin: 16px 0 0 15px;
             border-radius: 50%;
         }
-        [md-card-image] {
+        .mat-card-image {
             width: 100%;
+        }
+        .mat-card-image,
+        .mat-card-lg-image,
+        .mat-card-md-image,
+        .mat-card-sm-image,
+        .mat-card-title-group {
             margin: 0;
         }
         md-card-title {
@@ -32,9 +38,65 @@ body {
             padding: $padding;
         }
         &, & .mat-card {
-            & .mat-card-actions:last-child {
+            & .mat-card-actions {
                 padding: $padding / 2;
                 margin: 0;
+            }
+        }
+    }
+    &:not([dir='rtl']) {
+        .mat-card-title-group {
+            .mat-card-image,
+            .mat-card-lg-image,
+            .mat-card-md-image,
+            .mat-card-sm-image {
+                &:last-child {
+                    border-top-right-radius: $md-card-radius;
+                    border-bottom-right-radius: $md-card-radius;
+                }
+            }
+        }
+        .mat-card {
+            .mat-card-image {
+                &:first-child {
+                    border-top-left-radius: $md-card-radius;
+                    border-top-right-radius: $md-card-radius;
+                }
+            }
+            .mat-card-lg-image,
+            .mat-card-md-image,
+            .mat-card-sm-image {
+                &:first-child {
+                    border-top-left-radius: $md-card-radius;
+                }
+            }
+        }
+    }
+    &[dir='rtl'] {
+        .mat-card-title-group {
+            .mat-card-image,
+            .mat-card-lg-image,
+            .mat-card-md-image,
+            .mat-card-sm-image {
+                &:last-child {
+                    border-top-left-radius: $md-card-radius;
+                    border-bottom-left-radius: $md-card-radius;
+                }
+            }
+        }
+        .mat-card {
+            .mat-card-image {
+                &:first-child {
+                    border-top-left-radius: $md-card-radius;
+                    border-top-right-radius: $md-card-radius;
+                }
+            }
+            .mat-card-lg-image,
+            .mat-card-md-image,
+            .mat-card-sm-image {
+                &:first-child {
+                    border-top-right-radius: $md-card-radius;
+                }
             }
         }
     }

--- a/src/platform/core/common/styles/_variables.scss
+++ b/src/platform/core/common/styles/_variables.scss
@@ -39,6 +39,7 @@ $app-bar-height: 64px;
 
 // card header variables
 $md-card-header-size: 40px;
+$md-card-radius: 2px;
 
 // Icons
 $icon-size: rem(2.4);


### PR DESCRIPTION
## Description

Fixed margins & borders (RTL/LTR) for card images in card title groups

#### Test Steps

- [ ] npm run reinstall
- [ ] ng serve
- [ ] http://localhost:4200/#/style-guide/cards (scroll to bottom)
- [ ] 🐈 cats!

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![image](https://cloud.githubusercontent.com/assets/867883/26740792/dfc53e2e-478b-11e7-9dee-535b1a565ec8.png)
