### PR TITLE
feat(dialog): improve prompt a11y by selection text in input when focused. (closes #616)

### DIFF
--- a/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.html
+++ b/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.html
@@ -7,6 +7,8 @@
     <form #form="ngForm" layout="row" novalidate flex>
       <md-input-container flex>
         <input mdInput
+               #input
+               (focus)="handleInputFocus()"
                (keydown.enter)="$event.preventDefault(); form.valid && accept()"
                [(ngModel)]="value"
                name="value"

--- a/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.ts
+++ b/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild, ElementRef, AfterViewInit } from '@angular/core';
 import { MdDialogRef } from '@angular/material';
 
 @Component({
@@ -6,14 +6,31 @@ import { MdDialogRef } from '@angular/material';
   templateUrl: './prompt-dialog.component.html',
   styleUrls: ['./prompt-dialog.component.scss' ],
 })
-export class TdPromptDialogComponent {
+export class TdPromptDialogComponent implements AfterViewInit {
   title: string;
   message: string;
   value: string;
   cancelButton: string = 'CANCEL';
   acceptButton: string = 'ACCEPT';
 
+  @ViewChild('input') _input: ElementRef;
+
   constructor(private _dialogRef: MdDialogRef<TdPromptDialogComponent>) {}
+
+  ngAfterViewInit(): void {
+    // focus input once everything is rendered and good to go
+    Promise.resolve().then(() => {
+      (<HTMLInputElement>this._input.nativeElement).focus();
+    });
+  }
+
+  /**
+   * Method executed when input is focused
+   * Selects all text
+   */
+  handleInputFocus(event: FocusEvent): void {
+    (<HTMLInputElement>this._input.nativeElement).select();
+  }
 
   cancel(): void {
     this._dialogRef.close(undefined);


### PR DESCRIPTION
https://github.com/Teradata/covalent/issues/616

Improved a11y in prompt dialog. 

Now we will select input text when pre-populated when focused.

#### Test Steps

- [ ] Go to http://localhost:4200/#/components/dialogs
- [ ] Click on `Open Prompt`
- [ ] See text in input be selected on focus.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.