### PR TITLE
feat(expansion-panel) and (steps): add `[disableRipple]` input.

### DIFF
--- a/src/app/components/components/expansion-panel/expansion-panel.component.html
+++ b/src/app/components/components/expansion-panel/expansion-panel.component.html
@@ -162,12 +162,12 @@
 
 <md-card>
   <md-card-title>Expansion panel with header template</md-card-title>
-  <md-card-subtitle>replace the entire header as needed</md-card-subtitle>
+  <md-card-subtitle>replace the entire header as needed and disable ripple</md-card-subtitle>
   <md-divider></md-divider>
   <md-tab-group md-stretch-tabs dynamicHeight>
     <md-tab>
       <ng-template md-tab-label>Demo</ng-template>
-        <td-expansion-panel>
+        <td-expansion-panel disableRipple>
           <ng-template td-expansion-panel-header>
             <md-toolbar color="accent">
               <span>Custom td-expansion-panel-header</span>
@@ -215,7 +215,7 @@
         <p>HTML:</p>
         <td-highlight lang="html">
           <![CDATA[
-            <td-expansion-panel>
+            <td-expansion-panel disableRipple>
               <ng-template td-expansion-panel-header>
                 <md-toolbar color="accent">
                   <span>Custom td-expansion-panel-header</span>

--- a/src/app/components/components/steps/steps.component.html
+++ b/src/app/components/components/steps/steps.component.html
@@ -50,14 +50,14 @@
                 <ng-template td-step-label><span>Basic Usage (template)</span></ng-template>
                 Include any content you like for an active stepper
               </td-step>
-              <td-step #step2 label="Required State" sublabel="Toggle between active and inactive while in required state and disable ripple." [state]="stateStep2" [disabled]="disabled">
+              <td-step #step2 label="Required State" sublabel="Toggle between active and inactive while in required state and disable ripple." [state]="stateStep2" [disabled]="disabled" disableRipple>
                 This step is required!
                 <ng-template td-step-actions>
                   <button md-raised-button color="primary" (click)="toggleRequiredStep2()" class="text-upper">Toggle Require</button>
                   <button md-button (click)="step2.active = false" class="text-upper">Cancel</button>
                 </ng-template>
               </td-step>
-              <td-step #step3 label="Complete State" sublabel="Toggle between active and inactive while in complete state." [state]="stateStep3" [disabled]="disabled" disableRipple>
+              <td-step #step3 label="Complete State" sublabel="Toggle between active and inactive while in complete state." [state]="stateStep3" [disabled]="disabled">
                 Mark this step complete and get a summary
                 <ng-template td-step-summary>
                   Use an optional step summary to summarize the info in this step

--- a/src/app/components/components/steps/steps.component.html
+++ b/src/app/components/components/steps/steps.component.html
@@ -21,7 +21,7 @@
             <ng-template td-step-label><span>Basic Usage (template)</span></ng-template>
             Include any content you like for an active stepper
           </td-step>
-          <td-step #step2 label="Required State" sublabel="Toggle between active and inactive while in required state." [state]="stateStep2" [disabled]="disabled">
+          <td-step #step2 label="Required State" sublabel="Toggle between active and inactive while in required state and disable ripple." [state]="stateStep2" [disabled]="disabled" disableRipple>
             This step is required!
             <ng-template td-step-actions>
               <button md-raised-button color="primary" (click)="toggleRequiredStep2()" class="text-upper">Toggle Require</button>
@@ -50,14 +50,14 @@
                 <ng-template td-step-label><span>Basic Usage (template)</span></ng-template>
                 Include any content you like for an active stepper
               </td-step>
-              <td-step #step2 label="Required State" sublabel="Toggle between active and inactive while in required state." [state]="stateStep2" [disabled]="disabled">
+              <td-step #step2 label="Required State" sublabel="Toggle between active and inactive while in required state and disable ripple." [state]="stateStep2" [disabled]="disabled">
                 This step is required!
                 <ng-template td-step-actions>
                   <button md-raised-button color="primary" (click)="toggleRequiredStep2()" class="text-upper">Toggle Require</button>
                   <button md-button (click)="step2.active = false" class="text-upper">Cancel</button>
                 </ng-template>
               </td-step>
-              <td-step #step3 label="Complete State" sublabel="Toggle between active and inactive while in complete state." [state]="stateStep3" [disabled]="disabled">
+              <td-step #step3 label="Complete State" sublabel="Toggle between active and inactive while in complete state." [state]="stateStep3" [disabled]="disabled" disableRipple>
                 Mark this step complete and get a summary
                 <ng-template td-step-summary>
                   Use an optional step summary to summarize the info in this step
@@ -195,7 +195,7 @@
     <p>HTML:</p>
     <td-highlight lang="html">
       <![CDATA[
-        <td-step #step label="Label" sublabel="Sublabel" [active]="active" [disabled]="disabled" [state]="state" (activated)="activeEvent()" (deactivated)="deactiveEvent()">
+        <td-step #step label="Label" sublabel="Sublabel" [active]="active" [disabled]="disabled" [state]="state" (activated)="activeEvent()" (deactivated)="deactiveEvent()" [disableRipple]="false">
           <ng-template td-step-label>
             ... add label content (if not used, falls back to [label] input)
           </ng-template>

--- a/src/app/components/components/steps/steps.component.ts
+++ b/src/app/components/components/steps/steps.component.ts
@@ -47,6 +47,10 @@ export class StepsDemoComponent implements OnInit, OnDestroy {
     name: 'state?',
     type: 'StepState or ["none" | "required" | "complete"]',
   }, {
+    description: ' Whether the ripple effect for this component is disabled',
+    name: 'disableRipple?',
+    type: 'boolean',
+  }, {
     description: 'Event emitted when [TdStepComponent] is activated.',
     name: 'activated?',
     type: 'function()',

--- a/src/platform/core/expansion-panel/README.md
+++ b/src/platform/core/expansion-panel/README.md
@@ -13,6 +13,7 @@ Properties:
 | `label?` | `string` | Sets label of component header.
 | `sublabel?` | `string` | Sets sublabel of component header.
 | `expand?` | `boolean` | Toggles component between expand/collapse state.
+| `disableRipple?` | `boolean` | Whether the ripple effect for this component is disabled.
 | `expanded?` | `function` | Event emitted when component is expanded.
 | `collapsed?` | `function` | Event emitted when component is collapsed.
 | `toggle?` | `function` | Toggle state of component. Returns "true" if successful, else "false".
@@ -40,7 +41,7 @@ export class MyModule {}
 Example for HTML usage:
 
 ```html
-<td-expansion-panel label="label" sublabel="sublabel" expand="true|false" disabled="true|false" (expanded)="expandedEvent()" (collapsed)="collapsedEvent()">
+<td-expansion-panel label="label" sublabel="sublabel" expand="true" disabled="false" (expanded)="expandedEvent()" (collapsed)="collapsedEvent()" [disableRipple]="false">
   <ng-template td-expansion-panel-header>
     ... add header content (overrides label and sublabel)
   </ng-template>

--- a/src/platform/core/expansion-panel/_expansion-panel-theme.scss
+++ b/src/platform/core/expansion-panel/_expansion-panel-theme.scss
@@ -22,8 +22,8 @@
       }
     }
     .td-expansion-panel-header {
-      &:focus,
-      &:hover {
+      &:focus:not(.mat-disabled),
+      &:hover:not(.mat-disabled) {
         background: mat-color($background, 'hover');
       }
       .td-expansion-panel-header-content {

--- a/src/platform/core/expansion-panel/expansion-panel.component.html
+++ b/src/platform/core/expansion-panel/expansion-panel.component.html
@@ -3,7 +3,7 @@
   <div class="td-expansion-panel-header"
         [class.mat-disabled]="disabled"
         md-ripple
-        [mdRippleDisabled]="disabled"
+        [mdRippleDisabled]="disabled || disableRipple"
         [tabIndex]="disabled? -1 : 0"
         (keydown.enter)="clickEvent()"
         (click)="clickEvent()">

--- a/src/platform/core/expansion-panel/expansion-panel.component.scss
+++ b/src/platform/core/expansion-panel/expansion-panel.component.scss
@@ -5,13 +5,9 @@
     .td-expansion-panel-header {
       position: relative;
       outline: none;
-      &:focus,
-      &:hover {
+      &:focus:not(.mat-disabled),
+      &:hover:not(.mat-disabled) {
         cursor: pointer;
-      }
-      &.mat-disabled {
-        background: none;
-        cursor: auto;
       }
       .td-expansion-panel-header-content {
         height: 48px;

--- a/src/platform/core/expansion-panel/expansion-panel.component.ts
+++ b/src/platform/core/expansion-panel/expansion-panel.component.ts
@@ -47,6 +47,7 @@ export class TdExpansionPanelSummaryComponent {}
 })
 export class TdExpansionPanelComponent {
 
+  private _disableRipple: boolean = false;
   private _expand: boolean = false;
   private _disabled: boolean = false;
 
@@ -68,12 +69,24 @@ export class TdExpansionPanelComponent {
   @Input() sublabel: string;
 
   /**
+   * disableRipple?: string
+   * Whether the ripple effect for this component is disabled.
+   */
+  @Input('disableRipple')
+  get disableRipple(): boolean {
+    return this._disableRipple;
+  }
+  set disableRipple(disableRipple: boolean) {
+    this._disableRipple = <any>disableRipple !== '' ? (<any>disableRipple === 'true' || disableRipple === true) : true;
+  }
+
+  /**
    * expand?: boolean
    * Toggles [TdExpansionPanelComponent] between expand/collapse.
    */
   @Input('expand')
   set expand(expand: boolean) {
-    this._setExpand(expand);
+    this._setExpand(<any>expand === 'true' || expand === true);
   }
   get expand(): boolean {
     return this._expand;

--- a/src/platform/core/expansion-panel/expansion-panel.component.ts
+++ b/src/platform/core/expansion-panel/expansion-panel.component.ts
@@ -73,11 +73,11 @@ export class TdExpansionPanelComponent {
    * Whether the ripple effect for this component is disabled.
    */
   @Input('disableRipple')
-  get disableRipple(): boolean {
-    return this._disableRipple;
-  }
   set disableRipple(disableRipple: boolean) {
     this._disableRipple = <any>disableRipple !== '' ? (<any>disableRipple === 'true' || disableRipple === true) : true;
+  }
+  get disableRipple(): boolean {
+    return this._disableRipple;
   }
 
   /**

--- a/src/platform/core/steps/_steps-theme.scss
+++ b/src/platform/core/steps/_steps-theme.scss
@@ -25,8 +25,8 @@
     }
     // header
     .td-step-header {
-      &:focus,
-      &:hover {
+      &:focus:not(.mat-disabled),
+      &:hover:not(.mat-disabled) {
         background: mat-color($background, 'hover');
       }
       .td-step-label-wrapper {

--- a/src/platform/core/steps/step-header/step-header.component.html
+++ b/src/platform/core/steps/step-header/step-header.component.html
@@ -1,7 +1,7 @@
 <div class="td-step-header"
       [class.mat-disabled]="disabled"
       md-ripple
-      [mdRippleDisabled]="disabled"
+      [mdRippleDisabled]="disabled || disableRipple"
       [tabIndex]="disabled ? -1 : 0"
       flex>
   <div class="td-step-header-content"

--- a/src/platform/core/steps/step-header/step-header.component.scss
+++ b/src/platform/core/steps/step-header/step-header.component.scss
@@ -3,13 +3,8 @@ $step-circle: 24px;
 .td-step-header {
   position: relative;
   outline: none;
-  &:focus,
-  &:hover {
+  &:hover:not(.mat-disabled) {
     cursor: pointer;
-  }
-  &.mat-disabled {
-    background: none;
-    cursor: auto;
   }
   .td-step-header-content {
     height: 72px;

--- a/src/platform/core/steps/step-header/step-header.component.ts
+++ b/src/platform/core/steps/step-header/step-header.component.ts
@@ -15,6 +15,12 @@ export class TdStepHeaderComponent {
   @Input('number') number: number;
 
   /**
+   * disableRipple?: string
+   * Whether the ripple effect on header is disabled.
+   */
+  @Input('disableRipple') disableRipple: boolean;
+
+  /**
    * active?: boolean
    * Sets for active/inactive states on header.
    */

--- a/src/platform/core/steps/step.component.ts
+++ b/src/platform/core/steps/step.component.ts
@@ -76,7 +76,6 @@ export class TdStepComponent implements OnInit {
    */
   @Input('disableRipple')
   set disableRipple(disableRipple: boolean) {
-    console.log(disableRipple);
     this._disableRipple = <any>disableRipple !== '' ? (<any>disableRipple === 'true' || disableRipple === true) : true;
   }
   get disableRipple(): boolean {

--- a/src/platform/core/steps/step.component.ts
+++ b/src/platform/core/steps/step.component.ts
@@ -42,6 +42,7 @@ export class TdStepSummaryDirective extends TemplatePortalDirective {
 })
 export class TdStepComponent implements OnInit {
 
+  private _disableRipple: boolean = false;
   private _active: boolean = false;
   private _state: StepState = StepState.None;
   private _disabled: boolean = false;
@@ -70,12 +71,25 @@ export class TdStepComponent implements OnInit {
   @Input('sublabel') sublabel: string;
 
   /**
+   * disableRipple?: string
+   * Whether the ripple effect for this component is disabled.
+   */
+  @Input('disableRipple')
+  set disableRipple(disableRipple: boolean) {
+    console.log(disableRipple);
+    this._disableRipple = <any>disableRipple !== '' ? (<any>disableRipple === 'true' || disableRipple === true) : true;
+  }
+  get disableRipple(): boolean {
+    return this._disableRipple;
+  }
+
+  /**
    * active?: boolean
    * Toggles [TdStepComponent] between active/deactive.
    */
   @Input('active')
   set active(active: boolean) {
-    this._setActive(active);
+    this._setActive(<any>active === 'true' || active === true);
   }
   get active(): boolean {
     return this._active;

--- a/src/platform/core/steps/steps.component.html
+++ b/src/platform/core/steps/steps.component.html
@@ -3,7 +3,8 @@
     <td-step-header class="td-step-horizontal-header"
                     (keydown.enter)="step.toggle()"
                     [number]="index + 1"
-                    [active]="step.active" 
+                    [active]="step.active"
+                    [disableRipple]="step.disableRipple"
                     [disabled]="step.disabled" 
                     [state]="step.state"
                     (click)="step.toggle()">
@@ -19,7 +20,8 @@
                   (keydown.enter)="step.toggle()"
                   [number]="index + 1"
                   [active]="step.active" 
-                  [disabled]="step.disabled" 
+                  [disabled]="step.disabled"
+                  [disableRipple]="step.disableRipple"
                   [state]="step.state"
                   (click)="step.toggle()"
                   *ngIf="isVertical()">


### PR DESCRIPTION
## Description

Adding `[disableRipple]` input so developers can disable ripple effect on step header or expansion panel header.

Also small ninja fix for https://github.com/Teradata/covalent/issues/318

### What's included?

- feat(expansion-panel): add `[disableRipple]` input
- feat(expansion-panel): add `[disableRipple]` input
- fix(expansion-panel): expand input works with "true" string (closes #318)

#### Test Steps

- [ ] Go to http://localhost:4200/#/components/steps and http://localhost:4200/#/components/expansion-panel
- [ ] See demo mentioning `disableRipple` input and check how it works.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
