### PR TITLE
fix(steps): change internal class to mat-inactive

### DIFF
--- a/src/platform/core/steps/_steps-theme.scss
+++ b/src/platform/core/steps/_steps-theme.scss
@@ -33,7 +33,7 @@
         .md-caption {
           color: mat-color($foreground, secondary-text);
         }
-        &.mat-disabled {
+        &.mat-inactive {
           &, & * {
             color: mat-color($foreground, disabled);
           }

--- a/src/platform/core/steps/step-header/step-header.component.html
+++ b/src/platform/core/steps/step-header/step-header.component.html
@@ -23,7 +23,7 @@
       <md-icon class="mat-warn">warning</md-icon>
     </div>
     <div class="td-step-label-wrapper"
-          [class.mat-disabled]="(!active && !isComplete()) || disabled"
+          [class.mat-inactive]="(!active && !isComplete()) || disabled"
           [class.mat-warn]="isRequired() && !disabled">
       <div class="md-body-2 td-step-label">
         <ng-content select="[td-step-header-label]"></ng-content>


### PR DESCRIPTION
## Description

Makes more sense to call it `mat-inactive` since it just colors it and helps out in unit testing when trying to figure out if a step is disabled or inactive.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle