### PR TITLE
feat(layout): add `color` input to `td-layout-footer`. (closes #489)

### DIFF
--- a/src/platform/core/layout/_layout-theme.scss
+++ b/src/platform/core/layout/_layout-theme.scss
@@ -2,6 +2,9 @@
 @import '../common/styles/theme-functions';
 
 @mixin td-layout-theme($theme) {
+  $primary: map-get($theme, primary);
+  $accent: map-get($theme, accent);
+  $warn: map-get($theme, warn);
   $background: map-get($theme, background);
   $foreground: map-get($theme, foreground);
 
@@ -27,5 +30,23 @@
     background: mat-color($background, app-bar);
     color: mat-color($foreground, text);
     @include mat-elevation(2);
+    &.mat-primary {
+      background: mat-color($primary);
+      &, md-icon {
+        color: mat-color($primary, default-contrast);
+      }
+    }
+    &.mat-accent {
+      background: mat-color($accent);
+      &, md-icon {
+        color: mat-color($accent, default-contrast);
+      }
+    }
+    &.mat-warn {
+      background: mat-color($warn);
+      &, md-icon {
+        color: mat-color($warn, default-contrast);
+      }
+    }
   }
 }

--- a/src/platform/core/layout/layout-card-over/README.md
+++ b/src/platform/core/layout/layout-card-over/README.md
@@ -22,14 +22,14 @@
 Example for Card Over Layout / Nav Layout combo:
 
 ```html
-<td-layout-nav toolbarTitle="title" logo="logo" icon="icon" color="color">
-  <td-layout-card-over cardTitle="title" cardSubtitle="subtitle" cardWidth="widthIn%" color="color">
+<td-layout-nav toolbarTitle="title" logo="logo" icon="icon" color="primary">
+  <td-layout-card-over cardTitle="title" cardSubtitle="subtitle" cardWidth="widthIn%" color="primary">
     .. main content
     <div td-after-card>
       .. content after card
     </div>
   </td-layout-card-over>
-  <td-layout-footer>
+  <td-layout-footer color="primary"> // color is optional
     ... main footer content
   </td-layout-footer>
 </td-layout-nav>

--- a/src/platform/core/layout/layout-footer/layout-footer.component.html
+++ b/src/platform/core/layout/layout-footer/layout-footer.component.html
@@ -1,3 +1,1 @@
-<div class="td-layout-footer">
-  <ng-content></ng-content>
-</div>
+<ng-content></ng-content>

--- a/src/platform/core/layout/layout-footer/layout-footer.component.scss
+++ b/src/platform/core/layout/layout-footer/layout-footer.component.scss
@@ -1,6 +1,4 @@
 :host {
   display: block;
-}
-.td-layout-footer {
   padding: 10px 16px;
 }

--- a/src/platform/core/layout/layout-footer/layout-footer.component.ts
+++ b/src/platform/core/layout/layout-footer/layout-footer.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input, Renderer2, ElementRef } from '@angular/core';
 
 @Component({
   /* tslint:disable-next-line */
@@ -7,5 +7,29 @@ import { Component } from '@angular/core';
   templateUrl: './layout-footer.component.html',
 })
 export class TdLayoutFooterComponent {
+
+  private _color: 'primary' | 'accent' | 'warn';
+
+  /**
+   * color?: string
+   *
+   * Optional color option: primary | accent | warn.
+   */
+  @Input('color')
+  set color(color: 'primary' | 'accent' | 'warn') {
+    if (color) {
+      this._renderer.removeClass(this._elementRef.nativeElement, 'mat-' + this._color);
+      this._color = color;
+      this._renderer.addClass(this._elementRef.nativeElement, 'mat-' + this._color);
+    }
+  }
+  get color(): 'primary' | 'accent' | 'warn' {
+    return this._color;
+  }
+
+  constructor(private _renderer: Renderer2,
+              private _elementRef: ElementRef) {
+    this._renderer.addClass(this._elementRef.nativeElement, 'td-layout-footer');
+  }
 
 }

--- a/src/platform/core/layout/layout-manage-list/README.md
+++ b/src/platform/core/layout/layout-manage-list/README.md
@@ -23,7 +23,7 @@
 Example for Manage List Layout / Nav Layout combo:
 
 ```html
-<td-layout-nav sidenavTitle="title" logo="logo" icon="icon" color="color">
+<td-layout-nav sidenavTitle="title" logo="logo" icon="icon" color="primary">
   <div td-toolbar-content>
     .. main toolbar content
   </div>
@@ -42,7 +42,7 @@ Example for Manage List Layout / Nav Layout combo:
       ... sub footer content
     </td-layout-footer-inner>
   </td-layout-manage-list>
-  <td-layout-footer>
+  <td-layout-footer color="primary"> // color is optional
     ... main footer content
   </td-layout-footer>
 </td-layout-nav>

--- a/src/platform/core/layout/layout-nav-list/README.md
+++ b/src/platform/core/layout/layout-nav-list/README.md
@@ -32,7 +32,7 @@
 Example for Nav List Layout:
 
 ```html
-<td-layout-nav-list sidenavTitle="title" logo="logo" icon="icon" opened="true" mode="side" sidenavWidth="350px" color="color" navigationRoute="/">
+<td-layout-nav-list sidenavTitle="title" logo="logo" icon="icon" opened="true" mode="side" sidenavWidth="350px" color="primary" navigationRoute="/">
   <div td-sidenav-toolbar-content>
     ... left toolbar content
   </div>
@@ -46,7 +46,7 @@ Example for Nav List Layout:
   <td-layout-footer-inner>
     ... sub footer content
   </td-layout-footer-inner>
-  <td-layout-footer>
+  <td-layout-footer color="primary"> // color is optional
     ... main footer content
   </td-layout-footer>
 </td-layout-nav-list>

--- a/src/platform/core/layout/layout-nav/README.md
+++ b/src/platform/core/layout/layout-nav/README.md
@@ -23,12 +23,12 @@
 Example for Nav Layout:
 
 ```html
-<td-layout-nav toolbarTitle="title" logo="logo" icon="icon" color="color" navigationRoute="/">
+<td-layout-nav toolbarTitle="title" logo="logo" icon="icon" color="primary" navigationRoute="/">
   <div td-toolbar-content>
     .. main toolbar content
   </div>
   ... main content
-  <td-layout-footer>
+  <td-layout-footer color="primary"> // color is optional
     ... main footer content
   </td-layout-footer>
 </td-layout-nav>


### PR DESCRIPTION
https://github.com/Teradata/covalent/issues/489

this input will be optional since by default the background is gray and can be overriden by using primary, accent or warn

### What's included?

- `color` input in `td-layout-footer`

#### Test Steps

- [ ] Go anywhere in the app that uses `td-layout-footer` and set the color input.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.