### PR TITLE
feat(preload): add selective preload strategy for lazy loading

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,7 +23,7 @@ import { CovalentDynamicFormsModule } from '../platform/dynamic-forms';
 
 import { ToolbarModule } from './components/toolbar/toolbar.module';
 
-import { GitHubService, InternalDocsService } from './services';
+import { GitHubService, InternalDocsService, SelectivePreloadingStrategyService } from './services';
 import { getSelectedLanguage, createTranslateLoader } from './utilities/translate';
 
 @NgModule({
@@ -77,6 +77,7 @@ import { getSelectedLanguage, createTranslateLoader } from './utilities/translat
       // Configure LOCALE_ID depending on the language set in browser
       provide: LOCALE_ID, useFactory: getSelectedLanguage, deps: [TranslateService],
     },
+    SelectivePreloadingStrategyService,
   ], // additional providers needed for this module
   entryComponents: [ ],
   bootstrap: [ DocsAppComponent ],

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,7 +2,7 @@ import { Routes, RouterModule } from '@angular/router';
 
 import { HomeComponent } from './components/home/home.component';
 import { TemplatesComponent } from './components/templates/templates.component';
-import {SelectivePreloadingStrategyService} from './services';
+import { SelectivePreloadingStrategyService } from './services';
 
 const routes: Routes = [{
     component: HomeComponent,
@@ -11,28 +11,16 @@ const routes: Routes = [{
     component: TemplatesComponent,
     path: 'templates',
   }, {
-
-    /**
-     * preload: true loads the module immediately
-     */
-    path: '', data: { preload: true, }, loadChildren: './components/docs/docs.module#DocsModule',
+    // preload: true loads the module immediately
+    path: '', data: { preload: false, }, loadChildren: './components/docs/docs.module#DocsModule',
   }, {
-
-    /**
-     * preload: true loads the module immediately
-     */
-    path: '', data: { preload: true, }, loadChildren: './components/style-guide/style-guide.module#StyleGuideModule',
+    // preload: true loads the module immediately
+    path: '', data: { preload: false, }, loadChildren: './components/style-guide/style-guide.module#StyleGuideModule',
   }, {
-
-    /**
-     * preload: true loads the module immediately
-     */
-    path: '', data: { preload: true, }, loadChildren: './components/layouts/layouts.module#LayoutsModule',
+    // preload: true loads the module immediately
+    path: '', data: { preload: false, }, loadChildren: './components/layouts/layouts.module#LayoutsModule',
   }, {
-
-    /**
-     * preload: true loads the module immediately
-     */
+    // preload: true loads the module immediately
     path: '', data: { preload: true, }, loadChildren: './components/components/components.module#ComponentsModule',
   }, {
     path: '**', redirectTo: '/',

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes, RouterModule } from '@angular/router';
 
 import { HomeComponent } from './components/home/home.component';
 import { TemplatesComponent } from './components/templates/templates.component';
+import {SelectivePreloadingStrategyService} from './services';
 
 const routes: Routes = [{
     component: HomeComponent,
@@ -10,13 +11,13 @@ const routes: Routes = [{
     component: TemplatesComponent,
     path: 'templates',
   }, {
-    path: '', loadChildren: './components/docs/docs.module#DocsModule',
+    path: '', data: { preload: true, }, loadChildren: './components/docs/docs.module#DocsModule',
   }, {
-    path: '', loadChildren: './components/style-guide/style-guide.module#StyleGuideModule',
+    path: '', data: { preload: true, }, loadChildren: './components/style-guide/style-guide.module#StyleGuideModule',
   }, {
-    path: '', loadChildren: './components/layouts/layouts.module#LayoutsModule',
+    path: '', data: { preload: true, }, loadChildren: './components/layouts/layouts.module#LayoutsModule',
   }, {
-    path: '', loadChildren: './components/components/components.module#ComponentsModule',
+    path: '', data: { preload: true, }, loadChildren: './components/components/components.module#ComponentsModule',
   }, {
     path: '**', redirectTo: '/',
   },
@@ -26,4 +27,7 @@ export const appRoutingProviders: any[] = [
 
 ];
 
-export const appRoutes: any = RouterModule.forRoot(routes, { useHash: true });
+export const appRoutes: any = RouterModule.forRoot(routes, {
+  useHash: true,
+  preloadingStrategy: SelectivePreloadingStrategyService,
+});

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -11,12 +11,28 @@ const routes: Routes = [{
     component: TemplatesComponent,
     path: 'templates',
   }, {
+
+    /**
+     * preload: true loads the module immediately
+     */
     path: '', data: { preload: true, }, loadChildren: './components/docs/docs.module#DocsModule',
   }, {
+
+    /**
+     * preload: true loads the module immediately
+     */
     path: '', data: { preload: true, }, loadChildren: './components/style-guide/style-guide.module#StyleGuideModule',
   }, {
+
+    /**
+     * preload: true loads the module immediately
+     */
     path: '', data: { preload: true, }, loadChildren: './components/layouts/layouts.module#LayoutsModule',
   }, {
+
+    /**
+     * preload: true loads the module immediately
+     */
     path: '', data: { preload: true, }, loadChildren: './components/components/components.module#ComponentsModule',
   }, {
     path: '**', redirectTo: '/',

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -1,2 +1,3 @@
 export { GitHubService } from './github.service';
 export { InternalDocsService, ITemplate } from './internal-docs.service';
+export { SelectivePreloadingStrategyService } from './selective-preloading-strategy.service';

--- a/src/app/services/selective-preloading-strategy.service.ts
+++ b/src/app/services/selective-preloading-strategy.service.ts
@@ -1,0 +1,19 @@
+import 'rxjs/add/observable/of';
+import { Injectable } from '@angular/core';
+import { PreloadingStrategy, Route } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+
+@Injectable()
+export class SelectivePreloadingStrategyService implements PreloadingStrategy {
+
+  preload(route: Route, load: () => Observable<any>): Observable<any> {
+
+    // Configured on lazyload module route
+    if (route.data && route.data.preload) {
+      return load();
+    } else {
+      /* tslint:disable-next-line */
+      return Observable.of(null);
+    }
+  }
+}

--- a/src/app/services/selective-preloading-strategy.service.ts
+++ b/src/app/services/selective-preloading-strategy.service.ts
@@ -1,7 +1,7 @@
-import 'rxjs/add/observable/of';
 import { Injectable } from '@angular/core';
 import { PreloadingStrategy, Route } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
 
 @Injectable()
 export class SelectivePreloadingStrategyService implements PreloadingStrategy {


### PR DESCRIPTION
## Description

Preload modules that are lazy loaded to prevent load delay for parent routes.

### What's included?

- Added a SelectivePreloadingStrategyService
- Added config to each parent route ( set to true for now for preloading )

#### Test Steps

- [ ] Load the application to it's default route
- [ ] Select a parent route ( docs, style-guide, layouts, components )
- [ ] No . delay should occur

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle