### PR TITLE
fix(loading): when using the full screen loader in `ngOnInit` it fails

### DIFF
--- a/src/app/components/components/loading/loading.component.ts
+++ b/src/app/components/components/loading/loading.component.ts
@@ -113,6 +113,7 @@ export class LoadingDemoComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.toggleDefaultFullscreenDemo();
     this.startDirectives();
   }
 

--- a/src/platform/core/loading/services/loading.factory.ts
+++ b/src/platform/core/loading/services/loading.factory.ts
@@ -52,6 +52,7 @@ export class TdLoadingFactory {
         loadingRef.componentRef = overlayRef.attach(new ComponentPortal(TdLoadingComponent));
         this._mapOptions(options, loadingRef.componentRef.instance);
         loadingRef.componentRef.instance.startInAnimation();
+        loadingRef.componentRef.changeDetectorRef.detectChanges();
       } else if (registered <= 0 && loading) {
         loading = false;
         let subs: Subscription = loadingRef.componentRef.instance.startOutAnimation().subscribe(() => {

--- a/src/platform/core/loading/services/loading.factory.ts
+++ b/src/platform/core/loading/services/loading.factory.ts
@@ -87,7 +87,6 @@ export class TdLoadingFactory {
       if (registered > 0 && !loading) {
         loading = true;
         loadingRef.componentRef.instance.startInAnimation();
-        loadingRef.componentRef.changeDetectorRef.detectChanges();
       } else if (registered <= 0 && loading) {
         loading = false;
         loadingRef.componentRef.instance.startOutAnimation();
@@ -121,7 +120,6 @@ export class TdLoadingFactory {
           viewContainerRef.insert(loadingRef.componentRef.hostView, 0);
         }
         loadingRef.componentRef.instance.startInAnimation();
-        loadingRef.componentRef.changeDetectorRef.detectChanges();
       } else if (registered <= 0 && loading) {
         loading = false;
         let subs: Subscription = loadingRef.componentRef.instance.startOutAnimation().subscribe(() => {

--- a/src/platform/core/loading/services/loading.factory.ts
+++ b/src/platform/core/loading/services/loading.factory.ts
@@ -87,6 +87,7 @@ export class TdLoadingFactory {
       if (registered > 0 && !loading) {
         loading = true;
         loadingRef.componentRef.instance.startInAnimation();
+        loadingRef.componentRef.changeDetectorRef.detectChanges();
       } else if (registered <= 0 && loading) {
         loading = false;
         loadingRef.componentRef.instance.startOutAnimation();
@@ -120,6 +121,7 @@ export class TdLoadingFactory {
           viewContainerRef.insert(loadingRef.componentRef.hostView, 0);
         }
         loadingRef.componentRef.instance.startInAnimation();
+        loadingRef.componentRef.changeDetectorRef.detectChanges();
       } else if (registered <= 0 && loading) {
         loading = false;
         let subs: Subscription = loadingRef.componentRef.instance.startOutAnimation().subscribe(() => {


### PR DESCRIPTION
it complains in change detection, so we have to explicitly call a change detection cycle when rendering it

Also: fix(loading): make sure to detect changes when creating the loading component in a hook like `ngAfterViewInit` or `ngAfterContentInit`

#### Test Steps

- [ ] Go to loading demo
- [ ] See full screen demo working again

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle