### PR TITLE
chore(): update documentation with the way to use media.broadcast (closes #684)

### DIFF
--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,5 +1,4 @@
 import { Component, HostBinding, AfterViewInit } from '@angular/core';
-import { TdMediaService } from '@covalent/core';
 import { GitHubService } from '../../services';
 
 import { fadeAnimation } from '../../app.animations';
@@ -72,12 +71,10 @@ export class HomeComponent implements AfterViewInit {
     },
   ];
 
-  constructor(private _gitHubService: GitHubService,
-              public media: TdMediaService) {
+  constructor(private _gitHubService: GitHubService) {
   }
 
   ngAfterViewInit(): void {
-    this.media.broadcast();
     this._gitHubService.queryStartCount().subscribe((starsCount: number) => {
       this.starCount = starsCount;
     });

--- a/src/app/components/layouts/manage-list/manage-list.component.html
+++ b/src/app/components/layouts/manage-list/manage-list.component.html
@@ -171,15 +171,20 @@
             <h3 class="md-title">Typescript</h3>
             <td-highlight lang="typescript">
               <![CDATA[
+                import { ChangeDetectorRef } from '@angular/core';
                 import { TdMediaService } from '@covalent/core';
                 ...
                 export class MyComponent {
 
-                  constructor(public media: TdMediaService) {}
+                  constructor(private _changeDetectorRef: ChangeDetectorRef,
+                              public media: TdMediaService) {}
 
                   ngAfterViewInit(): void {
                     // broadcast to all listener observables when loading the page
                     this.media.broadcast();
+                    // force a new change detection cycle since change detections
+                    // have finished when `ngAfterViewInit` is executed
+                    this._changeDetectorRef.detectChanges();
                   }
                 }
               ]]>

--- a/src/app/components/layouts/manage-list/manage-list.component.ts
+++ b/src/app/components/layouts/manage-list/manage-list.component.ts
@@ -20,10 +20,8 @@ export class ManageListComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
     // broadcast to all listener observables when loading the page
-    Promise.resolve(undefined).then(() => {
-      this.media.broadcast();
-      this._changeDetectorRef.markForCheck();
-    });
+    this.media.broadcast();
+    this._changeDetectorRef.detectChanges();
   }
 
 }

--- a/src/app/components/layouts/nav-list/nav-list.component.html
+++ b/src/app/components/layouts/nav-list/nav-list.component.html
@@ -157,15 +157,20 @@
           <h3 class="md-title">Typescript</h3>
           <td-highlight lang="typescript">
             <![CDATA[
+              import { ChangeDetectorRef } from '@angular/core';
               import { TdMediaService } from '@covalent/core';
               ...
               export class MyComponent {
 
-                constructor(public media: TdMediaService) {}
+                constructor(private _changeDetectorRef: ChangeDetectorRef,
+                            public media: TdMediaService) {}
 
                 ngAfterViewInit(): void {
                   // broadcast to all listener observables when loading the page
                   this.media.broadcast();
+                  // force a new change detection cycle since change detections
+                  // have finished when `ngAfterViewInit` is executed
+                  this._changeDetectorRef.detectChanges();
                 }
               }
             ]]>

--- a/src/app/components/layouts/nav-list/nav-list.component.ts
+++ b/src/app/components/layouts/nav-list/nav-list.component.ts
@@ -20,10 +20,8 @@ export class NavListComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
     // broadcast to all listener observables when loading the page
-    Promise.resolve(undefined).then(() => {
-      this.media.broadcast();
-      this._changeDetectorRef.markForCheck();
-    });
+    this.media.broadcast();
+    this._changeDetectorRef.detectChanges();
   }
 
 }


### PR DESCRIPTION
angular is more restrictive now and complains if we dont explicitly call a change detection cycle when changing any input via a life hook cycle such as `ngAfterViewInit` and `ngAfterContentInit`..

this happens because the change detections have finished by then, so if you must change anything at that point, you need to call explicitly for a new change detection cycle via `detectChanges`

https://github.com/Teradata/covalent/issues/684

#### Test Steps

- [ ] Go and see layout docs like `nav-list` and `manage-list` referencing how to use media in the html example comments.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.