### PR TITLE
chore(): bump to beta.5-1 and update changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,16 @@
+<a name="1.0.0-beta.5-1"></a>
+# [1.0.0-beta.5-1](https://github.com/Teradata/covalent/tree/v1.0.0-beta.5) (2017-06-12)
+
+Small patch release to address a loading component issue and documentation updates with `angular@4.2.0` change detection since creating components or changing inputs on component life hooks cycles need to explicitly call a change detection cycle by developers.
+
+## Bug Fixes
+* **loading:** when using the full screen loader in `ngOnInit` it fails ([349d108033f13e1bce5491cc0185b69c596b17f7](https://github.com/Teradata/covalent/commit/349d108033f13e1bce5491cc0185b69c596b17f7))
+
+## Internal
+* **docs:** footer & expansion theme, update logo docs ([574e6d184864dbcc46206210ec7c9699807f9c90](https://github.com/Teradata/covalent/commit/574e6d184864dbcc46206210ec7c9699807f9c90)), closes [#578](https://github.com/Teradata/covalent/issues/578)
+* **docs:** update documentation with the way to use `media.broadcast` with layouts in `ngAfterViewInit` ([2606b754a303271c41b1d4dd7c37bf24b5b2d4c6](https://github.com/Teradata/covalent/commit/2606b754a303271c41b1d4dd7c37bf24b5b2d4c6)), closes [#684](https://github.com/Teradata/covalent/issues/684)
+
+
 <a name="1.0.0-beta.5"></a>
 # [1.0.0-beta.5 Blackhole Sun](https://github.com/Teradata/covalent/tree/v1.0.0-beta.5) (2017-06-09)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "covalent",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.5-1",
   "private": true,
   "description": "Teradata UI Platform built on Angular Material",
   "keywords": [

--- a/src/platform/core/package.json
+++ b/src/platform/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/core",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.5-1",
   "description": "Teradata UI Platform built on Angular Material",
   "main": "./core.umd.js",
   "module": "./index.js",

--- a/src/platform/dynamic-forms/package.json
+++ b/src/platform/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/dynamic-forms",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.5-1",
   "description": "Teradata UI Platform Dynamic Forms Module",
   "main": "./dynamic-forms.umd.js",
   "module": "./index.js",
@@ -37,6 +37,6 @@
     "Steven Ov <steven.ov@teradata.com>"
   ],
   "dependencies": {
-    "@covalent/core": "1.0.0-beta.5"
+    "@covalent/core": "1.0.0-beta.5-1"
   }
 }

--- a/src/platform/highlight/package.json
+++ b/src/platform/highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/highlight",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.5-1",
   "description": "Teradata UI Platform Highlight Module",
   "main": "./highlight.umd.js",
   "module": "./index.js",

--- a/src/platform/http/package.json
+++ b/src/platform/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/http",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.5-1",
   "description": "Teradata UI Platform Http Helper Module",
   "main": "./http.umd.js",
   "module": "./index.js",

--- a/src/platform/markdown/package.json
+++ b/src/platform/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covalent/markdown",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.5-1",
   "description": "Teradata UI Platform Markdown Module",
   "main": "./markdown.umd.js",
   "module": "./index.js",


### PR DESCRIPTION
## Description

Patch release for beta.5 and updated changelog.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.