### PR TITLE
chore(): hard set typescript dependency to 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,6 @@
     "semver": "5.2.0",
     "ts-node": "~2.0.0",
     "tslint": "^5.2.0",
-    "typescript": "^2.3.2"
+    "typescript": "2.3.2"
   }
 }


### PR DESCRIPTION
## Description
Hard setting typescript dependency to 2.3.2 to avoid incompatability with rxjs

Talk about the great work you've done!

### What's included?

- package.json

#### Test Steps

- [ ] checkout branch
- [ ] run npm run test
- [ ] works

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
