### PR TITLE
Fixed closing html tags

### DIFF
--- a/src/platform/core/message/README.md
+++ b/src/platform/core/message/README.md
@@ -42,8 +42,8 @@ Example for HTML usage:
 
 ```html
 <td-message #message label="Label" sublabel="Sublabel goes here" icon="warning" color="primary | blue | red" [opened]="true">
-  <button td-message-actions md-button>View More<button>
-  <button td-message-actions md-button (click)="message.close()">Close<button>
+  <button td-message-actions md-button>View More</button>
+  <button td-message-actions md-button (click)="message.close()">Close</button>
   // .. body goes here
 </td-message>  
 ```


### PR DESCRIPTION
## Description

Fixed closing `button` html tags in **message** `README.md`

### What's included?

- Example `docs` changes

#### Test Steps

- N/A

#### General Tests for Every PR

- N/A

##### Screenshots or link to CodePen/Plunker/JSfiddle

<img width="1226" alt="screenshot 2017-06-30 09 43 46" src="https://user-images.githubusercontent.com/11989248/27728018-ad423b16-5d78-11e7-9b06-bf129ed3c767.png">

