### PR TITLE
feat(table): add `[compareWith]` input to allow row comparison

### DIFF
--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -384,80 +384,9 @@
     </div>
   </md-card-actions>
 </md-card>
-<md-card>
-  <md-card-title>TdDataTableComponent</md-card-title>
-  <md-card-subtitle>How to use this component</md-card-subtitle>
-  <md-divider></md-divider>
-  <md-card-content>
-    <h2><code><![CDATA[<td-data-table>]]></code></h2>
-    <p>Use <code><![CDATA[<td-data-table>]]></code> element to generate a table.</p>
-    <p>Pass an array of javascript objects with the information to be displayed on the table to the [data] attribute.</p>
-    <p>Use [tdDataTableTemplate] directive for template support which gives context access to [value], [row] and [column].</p>
-    <h3>Properties:</h3>
-    <p>The <code><![CDATA[<td-data-table>]]></code> component has {{dataTableAttrs.length}} properties:</p>
-    <md-list>
-      <ng-template let-attr let-last="attr" ngFor [ngForOf]="dataTableAttrs">
-        <a md-list-item layout-align="row">
-          <h3 md-line> {{attr.name}}: <span>{{attr.type}}</span></h3>
-          <p md-line> {{attr.description}} </p>
-        </a>
-        <md-divider *ngIf="!last"></md-divider>
-      </ng-template>
-    </md-list>
-    <h3>Example:</h3>
-    <p>HTML:</p>
-    <td-highlight lang="html">
-      <![CDATA[
-        <td-data-table
-          [data]="data"
-          [columns]="columns"
-          [selectable]="true|false"
-          [multiple]="true|false"
-          [sortable]="true|false"
-          [sortBy]="sortBy"
-          [sortOrder]="'ASC'|'DESC'"
-          (sortChange)="sortEvent($event)"
-          (rowSelect)="selectEvent($event)"
-          (selectAll)="selectAllEvent($event)">
-        </td-data-table>
-      ]]>
-    </td-highlight>
-    <p>Typescript:</p>
-    <td-highlight lang="typescript">
-      <![CDATA[
-        import { ITdDataTableColumn } from '@covalent/core';
-        ...
-        })
-        export class Demo {
-          private data: any[] = [
-            { sku: '1452-2', item: 'Pork Chops', price: 32.11 },
-            { sku: '1421-0', item: 'Prime Rib', price: 41.15 },
-          ];
-          private columns: ITdDataTableColumn[] = [
-            { name: 'sku', label: 'SKU #', tooltip: 'Stock Keeping Unit', sortable: true },
-            { name: 'item', label: 'Item name' },
-            { name: 'price', label 'Price (US$)', numeric: true, format: v => v.toFixed(2) },
-          ];
-        }
-      ]]>
-    </td-highlight>
-    <h3>Setup:</h3>
-    <p>Import the [CovalentDataTableModule] in your NgModule:</p>
-    <td-highlight lang="typescript">
-      <![CDATA[
-        import { CovalentDataTableModule } from '@covalent/core';
-        @NgModule({
-          imports: [
-            CovalentDataTableModule,
-            ...
-          ],
-          ...
-        })
-        export class MyModule {}
-      ]]>
-    </td-highlight>
-  </md-card-content>
-</md-card>
+
+<td-readme-loader resourceUrl="platform/core/data-table/README.md"></td-readme-loader>
+
 <md-card>
   <md-card-title>TdDataTableService</md-card-title>
   <md-card-subtitle>How to use this service</md-card-subtitle>

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -21,66 +21,6 @@ export class DataTableDemoComponent implements OnInit {
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
 
-  dataTableAttrs: Object[] = [{
-    description: `Rows of data to be displayed`,
-    name: 'data',
-    type: 'any[]',
-  }, {
-    description: `List of columns to be displayed`,
-    name: 'columns?',
-    type: 'ITdDataTableColumn[]',
-  }, {
-    description: `Enables row selection, click events and selected row state.`,
-    name: 'selectable?',
-    type: 'boolean',
-  }, {
-    description: `Enables row click events and hover row state.`,
-    name: 'clickable?',
-    type: 'boolean',
-  }, {
-    description: `Enables multiple row selection. [selectable] needs to be enabled.`,
-    name: 'multiple?',
-    type: 'boolean',
-  }, {
-    description: `Enables sorting events, sort icons and active column states.`,
-    name: 'sortable?',
-    type: 'boolean',
-  }, {
-    description: `Sets the active sort column. [sortable] needs to be enabled.`,
-    name: 'sortBy?',
-    type: 'string',
-  }, {
-    description: `Sets the sort order of the [sortBy] column. [sortable] needs to be enabled.
-                  Defaults to 'ASC' or TdDataTableSortingOrder.Ascending`,
-    name: 'sortOrder?',
-    type: `['ASC' | 'DESC'] or TdDataTableSortingOrder`,
-  }, {
-    description: `Event emitted when the column headers are clicked. [sortable] needs to be enabled.
-                  Emits an [ITdDataTableSortEvent] implemented object.`,
-    name: 'sortChange',
-    type: `function()`,
-  }, {
-    description: `Event emitted when a row is selected/deselected. [selectable] needs to be enabled.
-                  Emits an [ITdDataTableSelectEvent] implemented object.`,
-    name: 'rowSelect',
-    type: `function()`,
-  }, {
-    description: `Event emitted when all rows are selected/deselected by the all checkbox.
-                  [selectable] needs to be enabled.
-                  Emits an [ITdDataTableSelectAllEvent] implemented object.`,
-    name: 'selectAll',
-    type: `function()`,
-  }, {
-    description: `Event emitted when a row is clicked.
-                  Emits an [ITdDataTableRowClickEvent] implemented object.`,
-    name: 'rowClick',
-    type: `function()`,
-  }, {
-    description: `Refreshes data table and updates [data] and [columns]`,
-    name: 'refresh',
-    type: `function()`,
-  }];
-
   cellAttrs: Object[] = [{
     description: `Makes cell follow the numeric data-table specs. Defaults to 'false'`,
     name: 'numeric',

--- a/src/platform/core/data-table/README.md
+++ b/src/platform/core/data-table/README.md
@@ -17,6 +17,7 @@ Properties:
 | `sortable?` | `boolean` | Enables sorting events, sort icons and active column states.
 | `sortBy?` | `string` | Sets the active sort column. [sortable] needs to be enabled.
 | `sortOrder?` | TdDataTableSortingOrder | Sets the sort order of the [sortBy] column. [sortable] needs to be enabled. Defaults to 'ASC' or TdDataTableSortingOrder.Ascending
+| `compareWith` | `function(row, model)` | Allows custom comparison between row and model to see if row is selected or not.
 | `sortChange` | `function` | Event emitted when the column headers are clicked. [sortable] needs to be enabled. Emits an [ITdDataTableSortEvent] implemented object.
 | `rowSelect` | `function` | Event emitted when a row is selected/deselected. [selectable] needs to be enabled. Emits an [ITdDataTableSelectEvent] implemented object.
 | `selectAll` | `function` | Event emitted when all rows are selected/deselected by the all checkbox. [selectable] needs to be enabled. Emits an [ITdDataTableSelectAllEvent] implemented object.
@@ -42,7 +43,7 @@ export class MyModule {}
 
 Example for HTML usage:
 
- ```html
+```html
 <td-data-table
   [data]="data"
   [columns]="columns"
@@ -51,6 +52,7 @@ Example for HTML usage:
   [sortable]="true|false"
   [sortBy]="sortBy"
   [sortOrder]="'ASC'|'DESC'"
+  [compareWith]="compareWith"
   (sortChange)="sortEvent($event)"
   (rowSelect)="selectEvent($event)"
   (selectAll)="selectAllEvent($event)">
@@ -61,4 +63,24 @@ Example for HTML usage:
     </div>
   </ng-template>
 </td-data-table>
- ```
+```
+
+```typescript
+import { ITdDataTableColumn } from '@covalent/core';
+...
+})
+export class Demo {
+  private data: any[] = [
+    { sku: '1452-2', item: 'Pork Chops', price: 32.11 },
+    { sku: '1421-0', item: 'Prime Rib', price: 41.15 },
+  ];
+  private columns: ITdDataTableColumn[] = [
+    { name: 'sku', label: 'SKU #', tooltip: 'Stock Keeping Unit', sortable: true },
+    { name: 'item', label: 'Item name' },
+    { name: 'price', label 'Price (US$)', numeric: true, format: v => v.toFixed(2) },
+  ];
+  compareWith(row: any: model: any): boolean {
+    return row.id === model.id; // or any property you want to compare by.
+  }
+}
+```

--- a/src/platform/core/data-table/data-table.component.spec.ts
+++ b/src/platform/core/data-table/data-table.component.spec.ts
@@ -7,6 +7,7 @@ import {
 import 'hammerjs';
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
 import { MdPseudoCheckbox } from '@angular/material';
 import { TdDataTableColumnComponent } from './data-table-column/data-table-column.component';
 import { TdDataTableRowComponent } from './data-table-row/data-table-row.component';
@@ -23,6 +24,7 @@ describe('Component: DataTable', () => {
     TestBed.configureTestingModule({
       imports: [
         NoopAnimationsModule,
+        FormsModule,
         CovalentDataTableModule,
       ],
       declarations: [
@@ -30,6 +32,8 @@ describe('Component: DataTable', () => {
         TdDataTableSelectableTestComponent,
         TdDataTableRowClickTestComponent,
         TdDataTableSelectableRowClickTestComponent,
+        TdDataTableModelTestComponent,
+        TdDataTableCompareWithTestComponent,
       ],
       providers: [
         TdDataTableService,
@@ -363,6 +367,51 @@ describe('Component: DataTable', () => {
           });
         });
     })));
+
+    it('should load table and have first row checked by reference',
+      async(inject([], () => {
+        let fixture: ComponentFixture<any> = TestBed.createComponent(TdDataTableModelTestComponent);
+        let component: TdDataTableModelTestComponent = fixture.debugElement.componentInstance;
+
+        component.selectedRows = [component.data[0]];
+
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(fixture.debugElement.queryAll(By.directive(MdPseudoCheckbox))[0].componentInstance.state).toBe('checked');
+          expect(fixture.debugElement.queryAll(By.directive(MdPseudoCheckbox))[1].componentInstance.state).toBe('unchecked');
+        });
+    })));
+
+    it('should load table and have no rows checked by reference',
+      async(inject([], () => {
+        let fixture: ComponentFixture<any> = TestBed.createComponent(TdDataTableModelTestComponent);
+        let component: TdDataTableModelTestComponent = fixture.debugElement.componentInstance;
+
+        component.selectedRows = [{ sku: '1452-2', item: 'Pork Chops', price: 32.11 }];
+
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(fixture.debugElement.queryAll(By.directive(MdPseudoCheckbox))[0].componentInstance.state).toBe('unchecked');
+          expect(fixture.debugElement.queryAll(By.directive(MdPseudoCheckbox))[1].componentInstance.state).toBe('unchecked');
+        });
+    })));
+
+    it('should load table and have first row checked using [compareWith]',
+      async(inject([], () => {
+        let fixture: ComponentFixture<any> = TestBed.createComponent(TdDataTableCompareWithTestComponent);
+        let component: TdDataTableCompareWithTestComponent = fixture.debugElement.componentInstance;
+
+        component.selectedRows = [{ sku: '1452-2', item: 'Pork Chops', price: 32.11 }];
+
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(fixture.debugElement.queryAll(By.directive(MdPseudoCheckbox))[0].componentInstance.state).toBe('checked');
+          expect(fixture.debugElement.queryAll(By.directive(MdPseudoCheckbox))[1].componentInstance.state).toBe('unchecked');
+        });
+    })));
   });
 });
 
@@ -454,5 +503,53 @@ class TdDataTableSelectableRowClickTestComponent {
   }
   selectEvent(): void {
     /* noop */
+  }
+}
+
+@Component({
+  template: `
+    <td-data-table
+        [data]="data"
+        [columns]="columns"
+        [selectable]="true"
+        [(ngModel)]="selectedRows">
+    </td-data-table>`,
+})
+class TdDataTableModelTestComponent {
+  data: any[] = [
+    { sku: '1452-2', item: 'Pork Chops', price: 32.11 },
+    { sku: '1421-0', item: 'Prime Rib', price: 41.15 },
+  ];
+  columns: ITdDataTableColumn[] = [
+    { name: 'sku', label: 'SKU #' },
+    { name: 'item', label: 'Item name' },
+    { name: 'price', label: 'Price (US$)', numeric: true },
+  ];
+  selectedRows: any[];
+}
+
+@Component({
+  template: `
+    <td-data-table
+        [data]="data"
+        [columns]="columns"
+        [selectable]="true"
+        [(ngModel)]="selectedRows"
+        [compareWith]="compareWith">
+    </td-data-table>`,
+})
+class TdDataTableCompareWithTestComponent {
+  data: any[] = [
+    { sku: '1452-2', item: 'Pork Chops', price: 32.11 },
+    { sku: '1421-0', item: 'Prime Rib', price: 41.15 },
+  ];
+  columns: ITdDataTableColumn[] = [
+    { name: 'sku', label: 'SKU #' },
+    { name: 'item', label: 'Item name' },
+    { name: 'price', label: 'Price (US$)', numeric: true },
+  ];
+  selectedRows: any[];
+  compareWith: (row: any, model: any) => boolean = (row: any, model: any) => {
+    return row.sku === model.sku;
   }
 }

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -124,12 +124,6 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
   get value(): any { return this._value; }
 
   /**
-   * uniqueId?: string
-   * Allows selection by [uniqueId] property.
-   */
-  @Input('uniqueId') uniqueId: string;
-
-  /**
    * data?: {[key: string]: any}[]
    * Sets the data to be rendered as rows.
    */
@@ -300,6 +294,15 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
               private _changeDetectorRef: ChangeDetectorRef) {}
 
   /**
+   * compareWith?: function(row, model): boolean
+   * Allows custom comparison between row and model to see if row is selected or not
+   * Default comparation is by object reference
+   */
+  @Input('compareWith') compareWith: (row: any, model: any) => boolean = (row: any, model: any) => {
+    return row === model;
+  }
+
+  /**
    * Loads templates and sets them in a map for faster access.
    */
   ngAfterContentInit(): void {
@@ -365,13 +368,10 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    * Checks if row is selected
    */
   isRowSelected(row: any): boolean {
-    // if selection is done by a [uniqueId] it uses it to compare, else it compares by reference.
-    if (this.uniqueId) {
-      return this._value ? this._value.filter((val: any) => {
-        return val[this.uniqueId] === row[this.uniqueId];
-      }).length > 0 : false;
-    }
-    return this._value ? this._value.indexOf(row) > -1 : false;
+    // compare items by [compareWith] function
+    return this._value ? this._value.filter((val: any) => {
+      return this.compareWith(row, val);
+    }).length > 0 : false;
   }
 
   /**
@@ -578,12 +578,10 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
     if (!wasSelected) {
       this._value.push(row);
     } else {
-      // if selection is done by a [uniqueId] it uses it to compare, else it compares by reference.
-      if (this.uniqueId) {
-        row = this._value.filter((val: any) => {
-          return val[this.uniqueId] === row[this.uniqueId];
-        })[0];
-      }
+      // compare items by [compareWith] function
+      row = this._value.filter((val: any) => {
+        return this.compareWith(row, val);
+      })[0];
       let index: number = this._value.indexOf(row);
       if (index > -1) {
         this._value.splice(index, 1);


### PR DESCRIPTION
## Description

Since sometimes we need to prepopulate `ngModel` and comparison by reference doesnt apply when using server side pagination and such, we need to be able to compare the rows and model by a set property or something.

### What's included?

- Added `[compareWith]` input so we can override the comparison by reference and compare the rows and model by anything we want to state whats selected when prepopulating.

#### Test Steps

- [ ] `ng serve`
- [ ] Prepopulate data table objects not part of `data` and use `compareWith` to select them automatically.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle