### PR TITLE
perf(table): add selected input in row to preserve value

### DIFF
--- a/src/platform/core/data-table/_data-table-theme.scss
+++ b/src/platform/core/data-table/_data-table-theme.scss
@@ -46,10 +46,10 @@
       }
     }
     &.mat-selectable tbody > tr.td-data-table-row {
-      &:not([disabled]):not(.mat-selected):focus {
+      &:not([disabled]):not(.td-selected):focus {
         background-color: mat-color($background, 'hover');
       }
-      &.mat-selected {
+      &.td-selected {
         background-color: mat-color($accent, 0.12);
       }
     }

--- a/src/platform/core/data-table/data-table-row/data-table-row.component.ts
+++ b/src/platform/core/data-table/data-table-row/data-table-row.component.ts
@@ -1,4 +1,4 @@
-import { Component, Renderer2, ElementRef } from '@angular/core';
+import { Component, Input, Renderer2, ElementRef } from '@angular/core';
 
 @Component({
   /* tslint:disable-next-line */
@@ -8,10 +8,25 @@ import { Component, Renderer2, ElementRef } from '@angular/core';
 })
 export class TdDataTableRowComponent {
 
+  private _selected: boolean = false;
+
+  @Input('selected')
+  set selected(selected: boolean) {
+    if (selected) {
+      this._renderer.addClass(this._elementRef.nativeElement, 'td-selected');
+    } else {
+      this._renderer.removeClass(this._elementRef.nativeElement, 'td-selected');
+    }
+    this._selected = selected;
+  }
+  get selected(): boolean {
+    return this._selected;
+  }
+
   constructor(private _elementRef: ElementRef, private _renderer: Renderer2) {
     this._renderer.addClass(this._elementRef.nativeElement, 'td-data-table-row');
   }
-  
+
   focus(): void {
     this._elementRef.nativeElement.focus();
   }

--- a/src/platform/core/data-table/data-table.component.html
+++ b/src/platform/core/data-table/data-table.component.html
@@ -27,8 +27,9 @@
         <span [mdTooltip]="column.tooltip">{{column.label}}</span>
     </th>
     <tr td-data-table-row
+        #dtRow
         [tabIndex]="isSelectable ? 0 : -1"
-        [class.mat-selected]="(isClickable || isSelectable) && isRowSelected(row)"
+        [selected]="(isClickable || isSelectable) && isRowSelected(row)"
         *ngFor="let row of data; let rowIndex = index"
         (click)="handleRowClick(row, $event)"
         (keyup)="isSelectable && _rowKeyup($event, row, rowIndex)"
@@ -38,7 +39,7 @@
         (keyup.shift)="enableTextSelection()">
       <td td-data-table-cell class="mat-checkbox-cell" *ngIf="isSelectable">
         <md-pseudo-checkbox
-          [state]="isRowSelected(row) ? 'checked' : 'unchecked'"
+          [state]="dtRow.selected ? 'checked' : 'unchecked'"
           (mousedown)="disableTextSelection()"
           (mouseup)="enableTextSelection()"
           stopRowClick


### PR DESCRIPTION
## Description

To avoid executing the `isSelectable` method twice, we execute it once and assign it to the `row` component to reuse its value.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle