### PR TITLE
fix(table): selectAll event will send toggled rows only

### DIFF
--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -344,21 +344,30 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    * Selects or clears all rows depending on 'checked' value.
    */
   selectAll(checked: boolean): void {
+    let toggledRows: any[] = [];
     if (checked) {
       this._data.forEach((row: any) => {
         // skiping already selected rows
         if (!this.isRowSelected(row)) {
           this._value.push(row);
+          // checking which ones are being toggled
+          toggledRows.push(row);
         }
       });
       this._allSelected = true;
       this._indeterminate = true;
     } else {
+      this._data.forEach((row: any) => {
+        // checking which ones are being toggled
+        if (this.isRowSelected(row)) {
+          toggledRows.push(row);
+        }
+      });
       this.clearModel();
       this._allSelected = false;
       this._indeterminate = false;
     }
-    this.onSelectAll.emit({rows: this._value, selected: checked});
+    this.onSelectAll.emit({rows: toggledRows, selected: checked});
   }
 
   /**


### PR DESCRIPTION
## Description

Before we where sending the `ngModel` which doesnt mean anything.. now we are gonna send the toggled rows when clicking in the select/deselect all checkbox.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle