### PR TITLE
fix(language-service): complain with loading directive (template with no implicit value) (closes #732)

### DIFF
--- a/src/platform/core/loading/directives/loading.directive.ts
+++ b/src/platform/core/loading/directives/loading.directive.ts
@@ -118,7 +118,7 @@ export class TdLoadingDirective implements OnInit, OnDestroy {
   @Input('tdLoadingColor') color: 'primary' | 'accent' | 'warn' = 'primary';
 
   constructor(private _viewContainerRef: ViewContainerRef,
-              private _templateRef: TemplateRef<Object>,
+              private _templateRef: TemplateRef<TdLoadingContext>,
               private _loadingService: TdLoadingService) {}
 
   /**


### PR DESCRIPTION
## Description

https://github.com/Teradata/covalent/issues/732

Language service was complaining because we had the generic of `TemplateRef` as `Object` when it needs to be a class that has a `$implicit` value.. in this case `TdLoadingContext`.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle