### PR TITLE
Upgrading to Covalent Code Editor 1.0.0-alpha.6-3

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@angular/platform-browser-dynamic": "^4.2.0",
     "@angular/platform-server": "^4.2.0",
     "@angular/router": "^4.2.0",
-    "@covalent/code-editor": "^1.0.0-alpha.6-2",
+    "@covalent/code-editor": "^1.0.0-alpha.6-3",
     "@ngx-translate/core": "7.0.0",
     "@ngx-translate/http-loader": "0.1.0",
     "@swimlane/ngx-charts": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@angular/platform-browser-dynamic": "^4.2.0",
     "@angular/platform-server": "^4.2.0",
     "@angular/router": "^4.2.0",
-    "@covalent/code-editor": "^1.0.0-alpha.5",
+    "@covalent/code-editor": "^1.0.0-alpha.6-2",
     "@ngx-translate/core": "7.0.0",
     "@ngx-translate/http-loader": "0.1.0",
     "@swimlane/ngx-charts": "5.3.1",

--- a/src/app/components/components/code-editor/code-editor.component.html
+++ b/src/app/components/components/code-editor/code-editor.component.html
@@ -17,7 +17,7 @@
   <md-divider></md-divider>
   <md-card-content>
     <div layout="row" layout-align="start center">
-      <td-code-editor #editor class="editor" [theme]="editorTheme" flex [language]="editorLanguage" [value]="editorVal"></td-code-editor>
+      <td-code-editor #editor class="editor" [theme]="editorTheme" flex [language]="editorLanguage" [(ngModel)]="editorVal"></td-code-editor>
     </div>
   </md-card-content>
   <md-divider></md-divider>


### PR DESCRIPTION
## Description

Upgrade Covalent-Electron to use Code Editor 1.0.0-alpha.6-3

### What's included?

- modified:   package.json

#### Test Steps

- [ ] `rm -rf node_modules` (if you have previously built)
- [ ]  `npm i`
- [ ]  `ng serve`
- [ ] Go to http://localhost:4200/#/components/code-editor
- [ ] See demo still works for code editor

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

