### PR TITLE
Upgrading to Covalent Code Editor 1.0.0-alpha.6-4

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@angular/platform-browser-dynamic": "^4.2.0",
     "@angular/platform-server": "^4.2.0",
     "@angular/router": "^4.2.0",
-    "@covalent/code-editor": "^1.0.0-alpha.6-3",
+    "@covalent/code-editor": "^1.0.0-alpha.6-4",
     "@ngx-translate/core": "7.0.0",
     "@ngx-translate/http-loader": "0.1.0",
     "@swimlane/ngx-charts": "5.3.1",


### PR DESCRIPTION
## Description

Upgrade Covalent-Electron to use Code Editor 1.0.0-alpha.6-4

### What's included?

- modified:   package.json

#### Test Steps

- [ ] `rm -rf node_modules` (if you have previously built)
- [ ]  `npm i`
- [ ]  `ng serve`
- [ ] Go to http://localhost:4200/#/components/code-editor
- [ ] See demo still works for code editor

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

