### PR TITLE
feat(rxjs): remove uses of rxjs patch operators

### DIFF
--- a/src/app/services/selective-preloading-strategy.service.ts
+++ b/src/app/services/selective-preloading-strategy.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { PreloadingStrategy, Route } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
+import { of } from 'rxjs/observable/of';
 
 @Injectable()
 export class SelectivePreloadingStrategyService implements PreloadingStrategy {
@@ -13,7 +13,7 @@ export class SelectivePreloadingStrategyService implements PreloadingStrategy {
       return load();
     } else {
       /* tslint:disable-next-line */
-      return Observable.of(null);
+      return of(null);
     }
   }
 }

--- a/src/platform/core/common/common.module.ts
+++ b/src/platform/core/common/common.module.ts
@@ -53,7 +53,6 @@ import { TdTimeDifferencePipe } from './pipes/time-difference/time-difference.pi
 import { TdBytesPipe } from './pipes/bytes/bytes.pipe';
 import { TdDigitsPipe } from './pipes/digits/digits.pipe';
 import { TdTruncatePipe } from './pipes/truncate/truncate.pipe';
-import { RouterPathService } from './services/router.path.service';
 
 const TD_PIPES: Type<any>[] = [
   TdTimeAgoPipe,
@@ -65,6 +64,12 @@ const TD_PIPES: Type<any>[] = [
 
 export { TdTimeAgoPipe, TdTimeDifferencePipe,
          TdBytesPipe, TdDigitsPipe, TdTruncatePipe };
+
+/**
+ * Services
+ */
+
+import { RouterPathService } from './services/router-path.service';
 
 @NgModule({
   imports: [

--- a/src/platform/core/common/services/router-path.service.spec.ts
+++ b/src/platform/core/common/services/router-path.service.spec.ts
@@ -7,7 +7,7 @@ import {
 import { Component } from '@angular/core';
 import { Router, Routes, RoutesRecognized } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { RouterPathService } from './router.path.service';
+import { RouterPathService } from './router-path.service';
 
 @Component({
   selector: 'fake',

--- a/src/platform/core/common/services/router-path.service.ts
+++ b/src/platform/core/common/services/router-path.service.ts
@@ -1,14 +1,16 @@
 import { Injectable } from '@angular/core';
 import { Router, RoutesRecognized } from '@angular/router';
 
+import { filter } from 'rxjs/operator/filter';
+import { pairwise } from 'rxjs/operator/pairwise';
+
 @Injectable()
 export class RouterPathService {
 private static _previousRoute: string = '/';
   constructor(private _router: Router) {
-    this._router.events
-    .filter((e: any) => e instanceof RoutesRecognized)
-    .pairwise()
-    .subscribe((e: any[]) => {
+    pairwise.call(
+      filter.call(this._router.events, (e: any) => e instanceof RoutesRecognized),
+    ).subscribe((e: any[]) => {
       RouterPathService._previousRoute = e[0].urlAfterRedirects;
     });
   }

--- a/src/platform/core/loading/directives/loading.directive.spec.ts
+++ b/src/platform/core/loading/directives/loading.directive.spec.ts
@@ -10,6 +10,8 @@ import { Subject } from 'rxjs/Subject';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
 import { CovalentLoadingModule, LoadingMode, LoadingType, LoadingStrategy, TdLoadingService } from '../loading.module';
+import { of } from 'rxjs/observable/of';
+import { _catch } from 'rxjs/operator/catch';
 
 describe('Directive: Loading', () => {
 
@@ -380,9 +382,9 @@ class TdLoadingNamedErrorStarUntilAsyncTestComponent {
   constructor(private _loadingService: TdLoadingService) {}
 
   createObservable(): void {
-    this.observable = this._subject.asObservable().catch(() => {
+    this.observable = _catch.call(this._subject.asObservable(), () => {
       this._loadingService.resolveAll('name1');
-      return Observable.of(undefined);
+      return of(undefined);
     });
   }
 

--- a/src/platform/core/media/services/media.service.ts
+++ b/src/platform/core/media/services/media.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NgZone, SkipSelf, Optional, Provider } from '@angular/core'
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
-import 'rxjs/add/observable/fromEvent';
+import { fromEvent } from 'rxjs/observable/fromEvent';
 
 @Injectable()
 export class TdMediaService {
@@ -30,7 +30,7 @@ export class TdMediaService {
     this._resizing = false;
     // we make sure that the resize checking happend outside of angular since it happens often
     this._globalSubscription = this._ngZone.runOutsideAngular(() => {
-      return Observable.fromEvent(window, 'resize').subscribe(() => {
+      return fromEvent(window, 'resize').subscribe(() => {
         // way to prevent the resize event from triggering the match media if there is already one event running already.
         if (!this._resizing) {
           this._resizing = true;

--- a/src/platform/core/search/search-input/search-input.component.ts
+++ b/src/platform/core/search/search-input/search-input.component.ts
@@ -3,8 +3,8 @@ import { trigger, state, style, transition, animate } from '@angular/animations'
 import { FormControl } from '@angular/forms';
 import { Dir } from '@angular/cdk';
 import { MdInputDirective } from '@angular/material';
-import 'rxjs/add/operator/debounceTime';
-import 'rxjs/add/operator/skip';
+import { debounceTime } from 'rxjs/operator/debounceTime';
+import { skip } from 'rxjs/operator/skip';
 
 @Component({
   selector: 'td-search-input',
@@ -88,9 +88,9 @@ export class TdSearchInputComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this._input._ngControl.valueChanges
-      .skip(1) // skip first change when value is set to undefined
-      .debounceTime(this.debounce)
+    debounceTime.call(
+      skip.call(this._input._ngControl.valueChanges, 1), // skip first change when value is set to undefined
+      this.debounce)
       .subscribe((value: string) => {
         this._searchTermChanged(value);
       });

--- a/src/platform/http/http-rest.service.spec.ts
+++ b/src/platform/http/http-rest.service.spec.ts
@@ -8,7 +8,6 @@ import { XHRBackend, Response, ResponseOptions, Headers, RequestMethod } from '@
 import { MockBackend, MockConnection } from '@angular/http/testing';
 import { HttpModule, Http } from '@angular/http';
 import { RESTService } from './http-rest.service';
-import 'rxjs/Rx';
 
 @Injectable()
 export class BasicTestRESTService extends RESTService<any> {

--- a/src/platform/http/http-rest.service.ts
+++ b/src/platform/http/http-rest.service.ts
@@ -1,6 +1,8 @@
 import { Headers, RequestOptionsArgs, Response, Request } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
+import { map } from 'rxjs/operator/map';
+import { _catch } from 'rxjs/operator/catch';
 
 export interface IRestTransform {
   (response: Response): any;
@@ -49,12 +51,12 @@ export abstract class RESTService<T> {
 
   public query(query?: IRestQuery, transform?: IRestTransform): Observable<any> {
     let request: Observable<Response> = this.http.get(this.buildUrl(undefined, query), this.buildRequestOptions());
-    return request.map((res: Response) => {
+    return _catch.call(map.call(request, (res: Response) => {
       if (transform) {
         return transform(res);
       }
       return this.transform(res);
-    }).catch((error: Response) => {
+    }), (error: Response) => {
       return new Observable<any>((subscriber: Subscriber<any>) => {
         try {
           subscriber.error(this.transform(error));
@@ -67,12 +69,12 @@ export abstract class RESTService<T> {
 
   public get(id: string | number, transform?: IRestTransform): Observable<any> {
     let request: Observable<Response> = this.http.get(this.buildUrl(id), this.buildRequestOptions());
-    return request.map((res: Response) => {
+    return _catch.call(map.call(request, (res: Response) => {
       if (transform) {
         return transform(res);
       }
       return this.transform(res);
-    }).catch((error: Response) => {
+    }), (error: Response) => {
       return new Observable<any>((subscriber: Subscriber<any>) => {
         try {
           subscriber.error(this.transform(error));
@@ -86,7 +88,7 @@ export abstract class RESTService<T> {
   public create(obj: T, transform?: IRestTransform): Observable<any> {
     let requestOptions: RequestOptionsArgs = this.buildRequestOptions();
     let request: Observable<Response> = this.http.post(this.buildUrl(), obj, requestOptions);
-    return request.map((res: Response) => {
+    return _catch.call(map.call(request, (res: Response) => {
       if (res.status === 201) {
         if (transform) {
           return transform(res);
@@ -95,7 +97,7 @@ export abstract class RESTService<T> {
       } else {
         return res;
       }
-    }).catch((error: Response) => {
+    }), (error: Response) => {
       return new Observable<any>((subscriber: Subscriber<any>) => {
         try {
           subscriber.error(this.transform(error));
@@ -109,7 +111,7 @@ export abstract class RESTService<T> {
   public update(id: string | number, obj: T, transform?: IRestTransform): Observable<any> {
     let requestOptions: RequestOptionsArgs = this.buildRequestOptions();
     let request: Observable<Response> = this.http.patch(this.buildUrl(id), obj, requestOptions);
-    return request.map((res: Response) => {
+    return _catch.call(map.call(request, (res: Response) => {
       if (res.status === 200) {
         if (transform) {
           return transform(res);
@@ -118,7 +120,7 @@ export abstract class RESTService<T> {
       } else {
         return res;
       }
-    }).catch((error: Response) => {
+    }), (error: Response) => {
       return new Observable<any>((subscriber: Subscriber<any>) => {
         try {
           subscriber.error(this.transform(error));
@@ -131,7 +133,7 @@ export abstract class RESTService<T> {
 
   public delete(id: string | number, transform?: IRestTransform): Observable<any> {
     let request: Observable<Response> = this.http.delete(this.buildUrl(id), this.buildRequestOptions());
-    return request.map((res: Response) => {
+    return _catch.call(map.call(request, (res: Response) => {
       if (res.status === 200) {
         if (transform) {
           return transform(res);
@@ -140,7 +142,7 @@ export abstract class RESTService<T> {
       } else {
         return res;
       }
-    }).catch((error: Response) => {
+    }), (error: Response) => {
       return new Observable<any>((subscriber: Subscriber<any>) => {
         try {
           subscriber.error(this.transform(error));

--- a/src/platform/http/interceptors/http-interceptor.service.spec.ts
+++ b/src/platform/http/interceptors/http-interceptor.service.spec.ts
@@ -10,7 +10,9 @@ import { MockBackend, MockConnection } from '@angular/http/testing';
 import { HttpModule, Http } from '@angular/http';
 import { HttpInterceptorService, HttpConfig, CovalentHttpModule, IHttpInterceptor } from '../';
 import { URLRegExpInterceptorMatcher } from './url-regexp-interceptor-matcher.class';
-import 'rxjs/Rx';
+import { map } from 'rxjs/operator/map';
+import { toPromise } from 'rxjs/operator/toPromise';
+import { forkJoin } from 'rxjs/observable/forkJoin';
 
 @Injectable()
 export class ResponseOverrideInterceptor {
@@ -108,13 +110,13 @@ describe('Service: HttpInterceptor', () => {
         )));
       });
 
-      service.patch('http://www.test.com/recovery/id/id2/fromerror', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBe('success', '/error/*/fromerror was intercepted');
-      });
+      map.call(service.patch('http://www.test.com/recovery/id/id2/fromerror', {}),
+        (res: Response) => res.json()).subscribe((data: string) => {
+          expect(data).toBe('success', '/error/*/fromerror was intercepted');
+        });
 
-      service.patch('http://www.test.com/recovery/id/fromerror', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.patch('http://www.test.com/recovery/id/fromerror', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBe('recovered', '/error/*/fromerror was not intercepted');
       });
     }),
@@ -129,12 +131,12 @@ describe('Service: HttpInterceptor', () => {
         )));
       });
 
-      service.patch('http://www.test.com/error', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBeUndefined('/error was not intercepted so request didnt fail');
-      }, (error: Error) => {
-        expect(error.message).toBe('error');
-      });
+      map.call(service.patch('http://www.test.com/error', {}),
+        (res: Response) => res.json()).subscribe((data: string) => {
+          expect(data).toBeUndefined('/error was not intercepted so request didnt fail');
+        }, (error: Error) => {
+          expect(error.message).toBe('error');
+        });
     }),
   ));
 
@@ -148,43 +150,43 @@ describe('Service: HttpInterceptor', () => {
         )));
       });
 
-      service.post('http://www.test.com/url/with/any-path/another-path?query=1&query=2', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.post('http://www.test.com/url/with/any-path/another-path?query=1&query=2', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBeTruthy();
       });
 
-      service.post('http://www.test.com/any_path?query=1&query=2', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.post('http://www.test.com/any_path?query=1&query=2', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBeTruthy();
       });
 
-      service.get('http://www.test.com/url/any-path/111')
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.get('http://www.test.com/url/any-path/111'),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBeTruthy();
       });
 
-      service.get('http://www.test.com/anypath/url')
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.get('http://www.test.com/anypath/url'),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBeTruthy();
       });
 
-      service.delete('http://www.test.com/any_path?', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.delete('http://www.test.com/any_path?', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBeTruthy();
       });
 
-      service.delete('http://www.test.com', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.delete('http://www.test.com', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBeTruthy();
       });
 
-      service.patch('http://www.test.com/any_path/111/url/another_path', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.patch('http://www.test.com/any_path/111/url/another_path', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBeTruthy();
       });
 
-      service.patch('http://www.test.com/any-path/111/another_path/', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.patch('http://www.test.com/any-path/111/another_path/', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBeTruthy();
       });
     }),
@@ -199,43 +201,43 @@ describe('Service: HttpInterceptor', () => {
         )));
       });
 
-      service.post('http://www.test.com/url/with/any-path/another-path?query=1&query=2', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.post('http://www.test.com/url/with/any-path/another-path?query=1&query=2', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBe('override', 'didnt intercept url with `/url`');
       });
 
-      service.post('http://www.test.com/any_path?query=1&query=2', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.post('http://www.test.com/any_path?query=1&query=2', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBe('success', 'intercepted url without `/url`');
       });
 
-      service.get('http://www.test.com/url/any-path/111')
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.get('http://www.test.com/url/any-path/111'),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBe('override', 'didnt intercept url with `/url`');
       });
 
-      service.get('http://www.test.com/anypath/url')
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.get('http://www.test.com/anypath/url'),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBe('override', 'didnt intercept url with `/url`');
       });
 
-      service.delete('http://www.test.com/any_path?', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.delete('http://www.test.com/any_path?', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBe('success', 'intercepted url without `/url`');
       });
 
-      service.delete('http://www.test.com', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.delete('http://www.test.com', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBe('success', 'intercepted url without `/url`');
       });
 
-      service.patch('http://www.test.com/any_path/111/url/another_path', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.patch('http://www.test.com/any_path/111/url/another_path', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBe('override', 'didnt intercept url with `/url`');
       });
 
-      service.patch('http://www.test.com/any-path/111/another_path/', {})
-      .map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.patch('http://www.test.com/any-path/111/another_path/', {}),
+      (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBe('success', 'intercepted url without `/url`');
       });
     }),
@@ -277,7 +279,7 @@ describe('Service: HttpInterceptor', () => {
       let error: boolean = false;
       let complete: boolean = false;
 
-      Observable.forkJoin(
+      forkJoin(
         service.get('testurl'),
         service.get('testurl'))
       .subscribe((response: Response[]) => {
@@ -305,7 +307,7 @@ describe('Service: HttpInterceptor', () => {
       let success: boolean = false;
       let error: boolean = false;
       let complete: boolean = false;
-      service.post('testurl', {}).map((res: Response) => res.json()).subscribe((data: string) => {
+      map.call(service.post('testurl', {}), (res: Response) => res.json()).subscribe((data: string) => {
         expect(data).toBe('success');
         success = true;
       }, () => {
@@ -327,7 +329,7 @@ describe('Service: HttpInterceptor', () => {
       let success: boolean = false;
       let error: boolean = false;
       let complete: boolean = false;
-      service.post('testurl', {}).map((res: Response) => res.json()).subscribe(() => {
+      map.call(service.post('testurl', {}), (res: Response) => res.json()).subscribe(() => {
         success = true;
       }, (err: Error) => {
         expect(err.message).toBe('error');
@@ -351,7 +353,7 @@ describe('Service: HttpInterceptor', () => {
       });
       let success: boolean = false;
       let error: boolean = false;
-      service.post('testurl', {}).map((res: Response) => res.json()).toPromise().then((data: string) => {
+      toPromise.call(map.call(service.post('testurl', {}), (res: Response) => res.json())).then((data: string) => {
         expect(data).toBe('success');
         success = true;
       }, () => {
@@ -371,7 +373,7 @@ describe('Service: HttpInterceptor', () => {
       });
       let success: boolean = false;
       let error: boolean = false;
-      service.post('testurl', {}).map((res: Response) => res.json()).toPromise().then(() => {
+      toPromise.call(map.call(service.post('testurl', {}), (res: Response) => res.json())).then(() => {
         success = true;
       }, (err: Error) => {
         expect(err.message).toBe('error');


### PR DESCRIPTION
https://github.com/angular/material2/pull/5314

Remove patch imports from rxjs since they affect the user's setup, which can affect the developers later on if we remove those imports.

### What's included?

- User rxjs function call chaining rather than patch imports

#### Test Steps

- [ ] `ng serve`
- [ ] See components working fine.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle