### PR TITLE
feat(): leverage coerceBooleanProperty from cdk

### DIFF
--- a/src/platform/core/chips/chips.component.ts
+++ b/src/platform/core/chips/chips.component.ts
@@ -5,7 +5,7 @@ import { DOCUMENT } from '@angular/platform-browser';
 import { EventEmitter } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor, FormControl } from '@angular/forms';
 
-import { TemplatePortalDirective, UP_ARROW, DOWN_ARROW,
+import { coerceBooleanProperty, TemplatePortalDirective, UP_ARROW, DOWN_ARROW,
          ESCAPE, LEFT_ARROW, RIGHT_ARROW, DELETE, BACKSPACE, ENTER, SPACE, TAB, HOME } from '@angular/cdk';
 import { MdChip, MdInputDirective, MdOption, MdAutocompleteTrigger } from '@angular/material';
 
@@ -123,10 +123,10 @@ export class TdChipsComponent extends _TdChipsMixinBase implements ControlValueA
    * Defaults to false.
    */
   @Input('stacked')
-  set stacked(stacked: any) {
-    this._stacked = stacked !== '' ? (stacked === 'true' || stacked === true) : true;
+  set stacked(stacked: boolean) {
+    this._stacked = coerceBooleanProperty(stacked);
   }
-  get stacked(): any {
+  get stacked(): boolean {
     return this._stacked;
   }
   
@@ -135,10 +135,10 @@ export class TdChipsComponent extends _TdChipsMixinBase implements ControlValueA
    * Blocks custom inputs and only allows selections from the autocomplete list.
    */
   @Input('requireMatch')
-  set requireMatch(requireMatch: any) {
-    this._requireMatch = requireMatch !== '' ? (requireMatch === 'true' || requireMatch === true) : true;
+  set requireMatch(requireMatch: boolean) {
+    this._requireMatch = coerceBooleanProperty(requireMatch);
   }
-  get requireMatch(): any {
+  get requireMatch(): boolean {
     return this._requireMatch;
   }
 

--- a/src/platform/core/common/behaviors/disabled.mixin.ts
+++ b/src/platform/core/common/behaviors/disabled.mixin.ts
@@ -1,5 +1,5 @@
 import { Constructor } from './constructor';
-
+import { coerceBooleanProperty } from '@angular/cdk';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 
@@ -22,7 +22,7 @@ export function mixinDisabled<T extends Constructor<{}>>(base: T): Constructor<I
       return this._disabled;
     }
     set disabled(value: boolean) {
-      let newValue: boolean = <any>value !== '' ? (<any>value === 'true' || value === true) : true;
+      let newValue: boolean = coerceBooleanProperty(value);
       if (this._disabled !== newValue) {
         this._disabled = newValue;
         this.onDisabledChange(this._disabled);

--- a/src/platform/core/data-table/data-table.component.html
+++ b/src/platform/core/data-table/data-table.component.html
@@ -1,11 +1,11 @@
 <div class="mat-table-container" title>
   <table td-data-table
-         [class.mat-selectable]="isSelectable"
-         [class.mat-clickable]="isClickable">
-    <th td-data-table-column class="mat-checkbox-column" *ngIf="isSelectable">
+         [class.mat-selectable]="selectable"
+         [class.mat-clickable]="clickable">
+    <th td-data-table-column class="mat-checkbox-column" *ngIf="selectable">
       <md-checkbox
         #checkBoxAll
-        *ngIf="isMultiple"
+        *ngIf="multiple"
         [disabled]="!hasData"
         [indeterminate]="indeterminate && !allSelected && hasData"
         [checked]="allSelected && hasData"
@@ -19,8 +19,8 @@
         *ngFor="let column of columns"
         [name]="column.name"
         [numeric]="column.numeric"
-        [active]="(column.sortable || isSortable) && column === sortByColumn"
-        [sortable]="column.sortable ||  isSortable"
+        [active]="(column.sortable || sortable) && column === sortByColumn"
+        [sortable]="column.sortable ||  sortable"
         [sortOrder]="sortOrderEnum"
         [hidden]="column.hidden"
         (sortChange)="handleSort(column)">
@@ -28,16 +28,16 @@
     </th>
     <tr td-data-table-row
         #dtRow
-        [tabIndex]="isSelectable ? 0 : -1"
-        [selected]="(isClickable || isSelectable) && isRowSelected(row)"
+        [tabIndex]="selectable ? 0 : -1"
+        [selected]="(clickable || selectable) && isRowSelected(row)"
         *ngFor="let row of data; let rowIndex = index"
         (click)="handleRowClick(row, $event)"
-        (keyup)="isSelectable && _rowKeyup($event, row, rowIndex)"
+        (keyup)="selectable && _rowKeyup($event, row, rowIndex)"
         (keydown.space)="blockEvent($event)"
         (keydown.shift.space)="blockEvent($event)"
         (keydown.shift)="disableTextSelection()"
         (keyup.shift)="enableTextSelection()">
-      <td td-data-table-cell class="mat-checkbox-cell" *ngIf="isSelectable">
+      <td td-data-table-cell class="mat-checkbox-cell" *ngIf="selectable">
         <md-pseudo-checkbox
           [state]="dtRow.selected ? 'checked' : 'unchecked'"
           (mousedown)="disableTextSelection()"

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -3,7 +3,7 @@ import { Component, Input, Output, EventEmitter, forwardRef, ChangeDetectionStra
 import { DOCUMENT } from '@angular/platform-browser';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 
-import { ENTER, SPACE, UP_ARROW, DOWN_ARROW } from '@angular/cdk';
+import { coerceBooleanProperty, ENTER, SPACE, UP_ARROW, DOWN_ARROW } from '@angular/cdk';
 
 import { TdDataTableRowComponent } from './data-table-row/data-table-row.component';
 import { ITdDataTableSortChangeEvent } from './data-table-column/data-table-column.component';
@@ -171,10 +171,10 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    * Defaults to 'false'
    */
   @Input('selectable')
-  set selectable(selectable: string | boolean) {
-    this._selectable = selectable !== '' ? (selectable === 'true' || selectable === true) : true;
+  set selectable(selectable: boolean) {
+    this._selectable = coerceBooleanProperty(selectable);
   }
-  get isSelectable(): boolean {
+  get selectable(): boolean {
     return this._selectable;
   }
 
@@ -184,10 +184,10 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    * Defaults to 'false'
    */
   @Input('clickable')
-  set clickable(clickable: string | boolean) {
-    this._clickable = clickable !== '' ? (clickable === 'true' || clickable === true) : true;
+  set clickable(clickable: boolean) {
+    this._clickable = coerceBooleanProperty(clickable);
   }
-  get isClickable(): boolean {
+  get clickable(): boolean {
     return this._clickable;
   }
 
@@ -197,10 +197,10 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    * Defaults to 'false'
    */
   @Input('multiple')
-  set multiple(multiple: string | boolean) {
-    this._multiple = multiple !== '' ? (multiple === 'true' || multiple === true) : true;
+  set multiple(multiple: boolean) {
+    this._multiple = coerceBooleanProperty(multiple);
   }
-  get isMultiple(): boolean {
+  get multiple(): boolean {
     return this._multiple;
   }
 
@@ -210,10 +210,10 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    * Defaults to 'false'
    */
   @Input('sortable')
-  set sortable(sortable: string | boolean) {
-    this._sortable = sortable !== '' ? (sortable === 'true' || sortable === true) : true;
+  set sortable(sortable: boolean) {
+    this._sortable = coerceBooleanProperty(sortable);
   }
-  get isSortable(): boolean {
+  get sortable(): boolean {
     return this._sortable;
   }
 
@@ -384,17 +384,17 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
   }
 
   /**
-   * Selects or clears a row depending on 'checked' value if the row 'isSelectable'
+   * Selects or clears a row depending on 'checked' value if the row is 'selected'
    * handles cntrl clicks and shift clicks for multi-select
    */
   select(row: any, event: Event, currentSelected: number): void {
-    if (this.isSelectable) {
+    if (this.selectable) {
       this.blockEvent(event);
       this._doSelection(row);
 
       // Check to see if Shift key is selected and need to select everything in between
       let mouseEvent: MouseEvent = event as MouseEvent;
-      if (this.isMultiple && mouseEvent && mouseEvent.shiftKey && this._lastSelectedIndex > -1) {
+      if (this.multiple && mouseEvent && mouseEvent.shiftKey && this._lastSelectedIndex > -1) {
         let firstIndex: number = currentSelected;
         let lastIndex: number = this._lastSelectedIndex;
         if (currentSelected > this._lastSelectedIndex) {
@@ -445,7 +445,7 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    * if clickable is true and selectable is false then select the row
    */
   handleRowClick(row: any, event: Event): void {
-    if (this.isClickable) {
+    if (this.clickable) {
       // ignoring linting rules here because attribute it actually null or not there
       // can't check for undefined
       const srcElement: any = event.srcElement || event.currentTarget;
@@ -502,7 +502,7 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
           rows[index - 1].focus();
         }
         this.blockEvent(event);
-        if (this.isMultiple && event.shiftKey) {
+        if (this.multiple && event.shiftKey) {
           this._doSelection(this._data[index - 1]);
           // if the checkboxes are all unselected then start over otherwise handle changing direction
           this._lastArrowKeyDirection = (!this._allSelected && !this._indeterminate) ? undefined : TdDataTableArrowKeyDirection.Ascending;
@@ -528,7 +528,7 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
           rows[index + 1].focus();
         }
         this.blockEvent(event);
-        if (this.isMultiple && event.shiftKey) {
+        if (this.multiple && event.shiftKey) {
           this._doSelection(this._data[index + 1]);
           // if the checkboxes are all unselected then start over otherwise handle changing direction
           this._lastArrowKeyDirection = (!this._allSelected && !this._indeterminate) ? undefined : TdDataTableArrowKeyDirection.Descending;

--- a/src/platform/core/expansion-panel/expansion-panel.component.ts
+++ b/src/platform/core/expansion-panel/expansion-panel.component.ts
@@ -1,7 +1,7 @@
 import { Component, Directive, Input, Output, TemplateRef, ViewContainerRef, ContentChild,
          ElementRef, Renderer2 } from '@angular/core';
 import { EventEmitter } from '@angular/core';
-import { TemplatePortalDirective } from '@angular/cdk';
+import { coerceBooleanProperty, TemplatePortalDirective } from '@angular/cdk';
 
 import { TdCollapseAnimation, ICanDisable, mixinDisabled } from '../common/common.module';
 
@@ -80,7 +80,7 @@ export class TdExpansionPanelComponent extends _TdExpansionPanelMixinBase implem
    */
   @Input('disableRipple')
   set disableRipple(disableRipple: boolean) {
-    this._disableRipple = <any>disableRipple !== '' ? (<any>disableRipple === 'true' || disableRipple === true) : true;
+    this._disableRipple = coerceBooleanProperty(disableRipple);
   }
   get disableRipple(): boolean {
     return this._disableRipple;
@@ -92,7 +92,7 @@ export class TdExpansionPanelComponent extends _TdExpansionPanelMixinBase implem
    */
   @Input('expand')
   set expand(expand: boolean) {
-    this._setExpand(<any>expand === 'true' || expand === true);
+    this._setExpand(coerceBooleanProperty(expand));
   }
   get expand(): boolean {
     return this._expand;

--- a/src/platform/core/file/directives/file-drop.directive.ts
+++ b/src/platform/core/file/directives/file-drop.directive.ts
@@ -1,5 +1,6 @@
 import { Directive, Input, Output, EventEmitter } from '@angular/core';
 import { HostListener, HostBinding, ElementRef, Renderer2 } from '@angular/core';
+import { coerceBooleanProperty } from '@angular/cdk';
 
 import { ICanDisable, mixinDisabled } from '../../common/common.module';
 
@@ -22,8 +23,8 @@ export class TdFileDropDirective extends _TdFileDropMixinBase implements ICanDis
    * Can also be 'multiple' native attribute.
    */
   @Input('multiple')
-  set multiple(multiple: string | boolean) {
-    this._multiple = multiple !== '' ? (multiple === 'true' || multiple === true) : true;
+  set multiple(multiple: boolean) {
+    this._multiple = coerceBooleanProperty(multiple);
   }
 
   /**

--- a/src/platform/core/file/directives/file-select.directive.ts
+++ b/src/platform/core/file/directives/file-select.directive.ts
@@ -1,5 +1,6 @@
 import { Directive, Input, Output, EventEmitter } from '@angular/core';
 import { HostListener, HostBinding, Host, Optional } from '@angular/core';
+import { coerceBooleanProperty } from '@angular/cdk';
 import { NgModel } from '@angular/forms';
 
 @Directive({
@@ -15,8 +16,8 @@ export class TdFileSelectDirective {
    * Can also be 'multiple' native attribute.
    */
   @Input('multiple')
-  set multiple(multiple: string | boolean) {
-    this._multiple = multiple !== '' ? (multiple === 'true' || multiple === true) : true;
+  set multiple(multiple: boolean) {
+    this._multiple = coerceBooleanProperty(multiple);
   }
 
   /**

--- a/src/platform/core/file/file-input/file-input.component.ts
+++ b/src/platform/core/file/file-input/file-input.component.ts
@@ -1,6 +1,6 @@
 import { Component, Directive, Input, Output, EventEmitter, ChangeDetectionStrategy, ViewChild,
          ElementRef, Renderer2, TemplateRef, ViewContainerRef, ChangeDetectorRef, forwardRef } from '@angular/core';
-import { TemplatePortalDirective } from '@angular/cdk';
+import { coerceBooleanProperty, TemplatePortalDirective } from '@angular/cdk';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 
 import { ICanDisable, mixinDisabled } from '../../common/common.module';
@@ -72,10 +72,10 @@ export class TdFileInputComponent extends _TdFileInputMixinBase implements Contr
    * Sets if multiple files can be dropped/selected at once in [TdFileInputComponent].
    */
   @Input('multiple')
-  set multiple(multiple: string | boolean) {
-    this._multiple = multiple !== '' ? (multiple === 'true' || multiple === true) : true;
+  set multiple(multiple: boolean) {
+    this._multiple = coerceBooleanProperty(multiple);
   }
-  get multiple(): string | boolean {
+  get multiple(): boolean {
     return this._multiple;
   }
 

--- a/src/platform/core/file/file-upload/file-upload.component.ts
+++ b/src/platform/core/file/file-upload/file-upload.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy, ContentChild, ChangeDetectorRef } from '@angular/core';
+import { coerceBooleanProperty } from '@angular/cdk';
 
 import { ICanDisable, mixinDisabled } from '../../common/common.module';
 
@@ -47,10 +48,10 @@ export class TdFileUploadComponent extends _TdFileUploadMixinBase implements ICa
    * Sets if multiple files can be dropped/selected at once in [TdFileUploadComponent].
    */
   @Input('multiple')
-  set multiple(multiple: string | boolean) {
-    this._multiple = multiple !== '' ? (multiple === 'true' || multiple === true) : true;
+  set multiple(multiple: boolean) {
+    this._multiple = coerceBooleanProperty(multiple);
   }
-  get multiple(): string | boolean {
+  get multiple(): boolean {
     return this._multiple;
   }
 

--- a/src/platform/core/steps/step.component.ts
+++ b/src/platform/core/steps/step.component.ts
@@ -1,7 +1,7 @@
 import { Component, Directive, Input, Output, TemplateRef, ViewChild,
          ViewContainerRef, ContentChild, OnInit } from '@angular/core';
 import { EventEmitter } from '@angular/core';
-import { TemplatePortalDirective, TemplatePortal } from '@angular/cdk';
+import { coerceBooleanProperty, TemplatePortalDirective, TemplatePortal } from '@angular/cdk';
 
 import { ICanDisable, mixinDisabled } from '../common/common.module';
 
@@ -83,7 +83,7 @@ export class TdStepComponent extends _TdStepMixinBase implements OnInit, ICanDis
    */
   @Input('disableRipple')
   set disableRipple(disableRipple: boolean) {
-    this._disableRipple = <any>disableRipple !== '' ? (<any>disableRipple === 'true' || disableRipple === true) : true;
+    this._disableRipple = coerceBooleanProperty(disableRipple);
   }
   get disableRipple(): boolean {
     return this._disableRipple;
@@ -95,7 +95,7 @@ export class TdStepComponent extends _TdStepMixinBase implements OnInit, ICanDis
    */
   @Input('active')
   set active(active: boolean) {
-    this._setActive(<any>active === 'true' || active === true);
+    this._setActive(coerceBooleanProperty(active));
   }
   get active(): boolean {
     return this._active;


### PR DESCRIPTION
## Description

Instead of validating boolean | string inputs to take them as `true` if undefined and parse strings properly, we will leverage the `coerceBooleanProperty` from `@angular/cdk`

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle