### PR TITLE
fix(layout): fix layout directives not hidden element in certain scenarios

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "rxjs": "^5.2.0",
     "showdown": "1.6.4",
     "web-animations-js": "2.2.5",
-    "zone.js": "^0.8.12"
+    "zone.js": "0.8.12"
   },
   "devDependencies": {
     "@angular/cli": "1.2.0",
@@ -117,7 +117,7 @@
     "rollup-plugin-node-resolve": "2.0.0",
     "semver": "5.2.0",
     "ts-node": "~2.0.0",
-    "tslint": "^5.2.0",
+    "tslint": "5.2.0",
     "typescript": "2.3.2"
   }
 }

--- a/src/platform/core/layout/layout-toggle.class.ts
+++ b/src/platform/core/layout/layout-toggle.class.ts
@@ -1,4 +1,4 @@
-import { Input, HostBinding, HostListener, Renderer2, ElementRef, AfterViewInit } from '@angular/core';
+import { Input, HostBinding, HostListener, Renderer2, ElementRef, AfterViewInit, OnDestroy } from '@angular/core';
 
 import { MdSidenavToggleResult, MdSidenav } from '@angular/material';
 
@@ -13,7 +13,9 @@ export interface ILayoutTogglable {
   close(): Promise<MdSidenavToggleResult>;
 }
 
-export abstract class LayoutToggle implements AfterViewInit {
+export abstract class LayoutToggle implements AfterViewInit, OnDestroy {
+
+  private _toggleSubs: Subscription;
 
   private _initialized: boolean = false;
   private _disabled: boolean = false;
@@ -44,9 +46,17 @@ export abstract class LayoutToggle implements AfterViewInit {
 
   ngAfterViewInit(): void {
     this._initialized = true;
-    merge(this._layout.sidenav.onOpenStart, this._layout.sidenav.onCloseStart).subscribe(() => {
+    this._toggleSubs = merge(this._layout.sidenav.onOpenStart, this._layout.sidenav.onCloseStart).subscribe(() => {
       this._toggleVisibility();
     });
+    this._toggleVisibility();
+  }
+
+  ngOnDestroy(): void {
+    if (this._toggleSubs) {
+      this._toggleSubs.unsubscribe();
+      this._toggleSubs = undefined;
+    }
   }
 
   /**

--- a/src/platform/core/layout/layout-toggle.class.ts
+++ b/src/platform/core/layout/layout-toggle.class.ts
@@ -49,6 +49,8 @@ export abstract class LayoutToggle implements AfterViewInit, OnDestroy {
     this._toggleSubs = merge(this._layout.sidenav.onOpenStart, this._layout.sidenav.onCloseStart).subscribe(() => {
       this._toggleVisibility();
     });
+    // execute toggleVisibility since the onOpenStart and onCloseStart
+    // methods might not be executed always when the element is rendered
     this._toggleVisibility();
   }
 


### PR DESCRIPTION
when the route changes without the sidenav opening/closing, the visibility check wasnt toggled and the element wasnt hidden.

now we execute the visibility method in `ngAfterViewInit` always.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle