### PR TITLE
chore(): add second example to file-input doc

### DIFF
--- a/src/app/components/components/file-input/file-input.component.html
+++ b/src/app/components/components/file-input/file-input.component.html
@@ -100,5 +100,105 @@
     </md-tab>
   </md-tab-group>
 </md-card>
-
+<md-card>
+  <md-card-title>File Input with Custom Icon</md-card-title>
+  <md-card-subtitle>use custom buttons</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-tab-group md-stretch-tabs>
+    <md-tab>
+      <ng-template md-tab-label>Demo</ng-template>
+      <md-card-content>
+        <div layout="row" flex>
+          <button md-menu-item flex="20" (click)="customFileInput.inputElement.click()">
+            <md-icon>attachment</md-icon>Attach
+            <td-file-input #customFileInput [(ngModel)]="customFiles" [disabled]="disabled" [style.display]="'none'"  multiple></td-file-input>
+          </button>
+          <div class="push-left" flex="80" *ngIf="customFiles">
+            <md-input-container tdFileDrop
+                                  [disabled]="disabled"
+                                  (fileDrop)="customFiles = $event"
+                                  (click)="customFileInput.inputElement.click()"
+                                  (keyup.enter)="customFileInput.inputElement.click()"
+                                  (keyup.delete)="customFileInput.clear()"
+                                  (keyup.backspace)="customFileInput.clear()"
+                                  flex>
+                <input mdInput 
+                      placeholder="selected"
+                      [value]="customFiles?.length ? (customFiles?.length + ' files') : '1 file'"
+                      [disabled]="disabled"
+                      readonly/>
+              </md-input-container>
+              <button md-icon-button (click)="customFileInput.clear()" 
+                      (keyup.enter)="customFileInput.clear()">
+                <md-icon>cancel</md-icon>
+              </button>
+              <button md-raised-button 
+                      color="accent" 
+                      [disabled]="!customFiles" 
+                      class="text-upper">Submit
+              </button>
+          </div>
+        </div>
+      </md-card-content>
+    </md-tab>
+    <md-tab>
+      <ng-template md-tab-label>Code</ng-template>
+      <md-card-content>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <div layout="row" flex>
+              <button md-menu-item flex="20" (click)="customFileInput.inputElement.click()">
+                <md-icon>attachment</md-icon>Attach
+                <td-file-input #customFileInput [(ngModel)]="customFiles" [disabled]="disabled" [style.display]="'none'"  multiple></td-file-input>
+              </button>
+              <div class="push-left" flex="80" *ngIf="customFiles">
+                <md-input-container tdFileDrop
+                                      [disabled]="disabled"
+                                      (fileDrop)="customFiles = $event"
+                                      (click)="customFileInput.inputElement.click()"
+                                      (keyup.enter)="customFileInput.inputElement.click()"
+                                      (keyup.delete)="customFileInput.clear()"
+                                      (keyup.backspace)="customFileInput.clear()"
+                                      flex>
+                    <input mdInput 
+                          placeholder="selected"
+                          [value]="customFiles?.length ? (customFiles?.length + ' files') : '1 file'"
+                          [disabled]="disabled"
+                          readonly/>
+                  </md-input-container>
+                  <button md-icon-button (click)="customFileInput.clear()" 
+                          (keyup.enter)="customFileInput.clear()">
+                    <md-icon>cancel</md-icon>
+                  </button>
+                  <button md-raised-button 
+                          color="accent" 
+                          [disabled]="!customFiles" 
+                          class="text-upper">Submit
+                  </button>
+              </div>
+            </div>
+          ]]>
+        </td-highlight>
+        <p>CSS:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            export class Demo {
+              files: any;
+              disabled: boolean = false;
+              toggleDisabled(): void {
+                this.disabled = !this.disabled;
+              }
+            }
+          ]]>
+        </td-highlight>
+      </md-card-content>
+    </md-tab>
+  </md-tab-group>
+</md-card>
 <td-readme-loader resourceUrl="platform/core/file/file-input/README.md"></td-readme-loader>


### PR DESCRIPTION
## Description

- Second example for file input component using custom 
- Closes #719 

#### Test Steps

- [ ] navigate to Components & Addons
- [ ] then select "File Input"
- [ ] finally in the second example, with the paperclip icon, attach a file

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![fileinput](https://user-images.githubusercontent.com/17860952/28189894-0deae904-67dd-11e7-91c9-62ce9bc34d78.gif)

