### PR TITLE
chore(node): update version to 6.11.1 due to DDOS vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-- '6.9.4'
+- '6.11.1'
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Covalent is a reusable UI platform from Teradata for building web applications w
 
 ## Setup
 
-* Ensure you have Node 6.9.1 or up and NPM 3+ installed.
+* Ensure you have Node 6.11.1 or up and NPM 3+ installed.
 * Install Angular CLI `npm i -g @angular/cli@latest`
 * Install Typescript `npm i -g typescript`
 * Install TSLint `npm install -g tslint`

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "finish-release": "bash scripts/finish-release"
   },
   "engines": {
-    "node": ">6.9",
+    "node": ">=6.11.1 < 7",
     "npm": ">3"
   },
   "repository": {

--- a/src/platform/core/package.json
+++ b/src/platform/core/package.json
@@ -16,7 +16,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">=6.9",
+    "node": ">=6.11.1 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/dynamic-forms/package.json
+++ b/src/platform/dynamic-forms/package.json
@@ -15,7 +15,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">=6.9",
+    "node": ">=6.11.1 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/highlight/package.json
+++ b/src/platform/highlight/package.json
@@ -15,7 +15,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">=6.9",
+    "node": ">=6.11.1 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/http/package.json
+++ b/src/platform/http/package.json
@@ -16,7 +16,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">=6.9",
+    "node": ">=6.11.1 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/markdown/package.json
+++ b/src/platform/markdown/package.json
@@ -13,7 +13,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">=6.9",
+    "node": ">=6.11.1 < 7",
     "npm": ">= 3"
   },
   "repository": {


### PR DESCRIPTION
## Description

update node to 6.11.1 due to this vulnerability:
https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/

### What's included?

- package.json
- platform/X/package.json
- .travis.yml
- README.md

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.