### PR TITLE
hotfix(node): upgrade node version due to vulnerability in boron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-- '6.9.4'
+- '6.11.1'
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Covalent is a reusable UI platform from Teradata for building web applications w
 
 ## Setup
 
-* Ensure you have Node 6.9.1 or up and NPM 3+ installed.
+* Ensure you have Node 6.11.1 or up and NPM 3+ installed.
 * Install Angular CLI `npm i -g @angular/cli@latest`
 * Install Typescript `npm i -g typescript`
 * Install TSLint `npm install -g tslint`

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "finish-release": "bash scripts/finish-release"
   },
   "engines": {
-    "node": ">6.9",
+    "node": ">=6.11.1 < 7",
     "npm": ">3"
   },
   "repository": {

--- a/src/app/components/docs/build-tasks/build-tasks.component.html
+++ b/src/app/components/docs/build-tasks/build-tasks.component.html
@@ -4,7 +4,7 @@
   <md-divider></md-divider>
   <md-card-content>
      <h3>Command Line Build Tasks</h3>
-     <h4>Important: Make sure you have Node 6.9 or greater!</h4>
+     <h4>Important: Make sure you have Node 6.11.1 or greater!</h4>
      <p>
        First install the CLI
      </p>

--- a/src/app/components/docs/overview/overview.component.html
+++ b/src/app/components/docs/overview/overview.component.html
@@ -32,7 +32,7 @@
       <h3>Start Developing!</h3>
       <h4>Prerequisites</h4>
       <ul>
-        <li>Node 6.9+</li>
+        <li>Node 6.11.1+</li>
         <li>NPM 3+</li>
         <li>Angular CLI</li>
         <li>Protractor (for testing)</li>

--- a/src/platform/core/package.json
+++ b/src/platform/core/package.json
@@ -16,7 +16,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">=6.9",
+    "node": ">=6.11.1 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/dynamic-forms/package.json
+++ b/src/platform/dynamic-forms/package.json
@@ -15,7 +15,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">=6.9",
+    "node": ">=6.11.1 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/highlight/package.json
+++ b/src/platform/highlight/package.json
@@ -15,7 +15,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">=6.9",
+    "node": ">=6.11.1 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/http/package.json
+++ b/src/platform/http/package.json
@@ -16,7 +16,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">=6.9",
+    "node": ">=6.11.1 < 7",
     "npm": ">= 3"
   },
   "repository": {

--- a/src/platform/markdown/package.json
+++ b/src/platform/markdown/package.json
@@ -13,7 +13,7 @@
   "scripts": {
   },
   "engines": {
-    "node": ">=6.9",
+    "node": ">=6.11.1 < 7",
     "npm": ">= 3"
   },
   "repository": {


### PR DESCRIPTION
## Description

update node to 6.11.1 due to this vulnerability:
https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/

### What's included?

- package.json
- platform/X/package.json
- .travis.yml
- README.md

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.