### PR TITLE
feat(paging): refactor paging bar to allow devs leverage API for multiple usages

### DIFF
--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -236,8 +236,13 @@
         <div class="md-padding" *ngIf="!dataTable.hasData" layout="row" layout-align="center center">
           <h3>No results to display.</h3>
         </div>
-        <td-paging-bar #pagingBar [pageSizes]="[5, 10, 15, 20]" [total]="filteredTotal" (change)="page($event)">
-          <span td-paging-bar-label hide-xs>Row per page:</span>
+        <td-paging-bar #pagingBar [pageSize]="pageSize" [total]="filteredTotal" (change)="page($event)">
+          <span hide-xs>Rows per page:</span>
+          <md-select [(ngModel)]="pageSize">
+            <md-option *ngFor="let size of [5,10,15,20]" [value]="size">
+              {{size}}
+            </md-option>
+          </md-select>
           {{pagingBar.range}} <span hide-xs>of {{pagingBar.total}}</span>
         </td-paging-bar>
       </md-tab>
@@ -274,8 +279,13 @@
             <div class="md-padding" *ngIf="!dataTable.hasData" layout="row" layout-align="center center">
               <h3>No results to display.</h3>
             </div>
-            <td-paging-bar #pagingBar [pageSizes]="[5, 10, 15, 20]" [total]="filteredTotal" (change)="page($event)">
-              <span td-paging-bar-label hide-xs>Row per page:</span>
+            <td-paging-bar #pagingBar [pageSize]="pageSize" [total]="filteredTotal" (change)="page($event)">
+              <span hide-xs>Rows per page:</span>
+              <md-select [(ngModel)]="pageSize">
+                <md-option *ngFor="let size of [5,10,15,20]" [value]="size">
+                  { {size} }
+                </md-option>
+              </md-select>
               { {pagingBar.range} } <span hide-xs>of { {pagingBar.total} }</span>
             </td-paging-bar>
           ]]>

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -238,7 +238,7 @@
         </div>
         <td-paging-bar #pagingBar [pageSize]="pageSize" [total]="filteredTotal" (change)="page($event)">
           <span hide-xs>Rows per page:</span>
-          <md-select [(ngModel)]="pageSize">
+          <md-select [style.width.px]="50" [(ngModel)]="pageSize">
             <md-option *ngFor="let size of [5,10,15,20]" [value]="size">
               {{size}}
             </md-option>
@@ -281,7 +281,7 @@
             </div>
             <td-paging-bar #pagingBar [pageSize]="pageSize" [total]="filteredTotal" (change)="page($event)">
               <span hide-xs>Rows per page:</span>
-              <md-select [(ngModel)]="pageSize">
+              <md-select [style.width.px]="50" [(ngModel)]="pageSize">
                 <md-option *ngFor="let size of [5,10,15,20]" [value]="size">
                   { {size} }
                 </md-option>

--- a/src/app/components/components/paging/paging.component.html
+++ b/src/app/components/components/paging/paging.component.html
@@ -1,73 +1,6 @@
 <md-card>
   <md-card-title>Paging</md-card-title>
-  <md-card-subtitle>Paging for lists and tables</md-card-subtitle>
-  <md-divider></md-divider>
-    <md-tab-group md-stretch-tabs>
-      <md-tab>
-        <ng-template md-tab-label>Demo</ng-template>
-          <md-card-content>
-            <p>Change Event: </p>
-            <div>
-              <p>Page Size: {{event1?.pageSize || '100'}}</p>
-              <p>Page: {{event1?.page || '1'}} of {{event1?.maxPage || '14'}}</p>
-              <p>Rows: {{event1?.fromRow || '1'}} to {{event1?.toRow || '100'}}</p>
-            </div>
-            <p>Total: {{event1?.total || '1345'}}</p>
-          </md-card-content>
-          <md-divider></md-divider>
-          <td-paging-bar #pagingBar1 pageSizeAllText="All" [pageSizeAll]="true" [pageSizes]="[50,100,200,500,1000,2000]" pageLinkCount="5" [initialPage]="1" [firstLast]="firstLast" [pageSize]="100" [total]="1345" (change)="change1($event)">
-            <span td-paging-bar-label hide-xs>Row per page:</span>
-            {{pagingBar1.range}} <span hide-xs>of {{pagingBar1.total}}</span>
-          </td-paging-bar>
-      </md-tab>
-      <md-tab>
-        <ng-template md-tab-label>Code</ng-template>
-        <md-card-content>
-          <p>HTML:</p>
-          <td-highlight lang="html">
-            <![CDATA[
-              <td-paging-bar #pagingBar pageSizeAllText="All" [pageSizeAll]="true" [pageSizes]="[50,100,200,500,1000,2000]" pageLinkCount="5" [initialPage]="1" [firstLast]="firstLast" [pageSize]="100" [total]="1345" (change)="change($event)">
-                <span td-paging-bar-label hide-xs>Row per page:</span>
-                { {pagingBar.range} } <span hide-xs>of { {pagingBar.total} }</span>
-              </td-paging-bar>
-            ]]>
-          </td-highlight>
-          <p>Typescript:</p>
-          <td-highlight lang="typescript">
-            <![CDATA[
-              import { IPageChangeEvent } from '@covalent/core';
-              ...
-              export class Demo {
-                event: IPageChangeEvent;
-                firstLast: boolean = false;
-                pageSizeAll: boolean = false;
-
-                change(event: IPageChangeEvent): void {
-                  this.event = event;
-                }
-
-                toggleFirstLast(): void {
-                  this.firstLast = !this.firstLast;
-                }
-              }
-            ]]>
-          </td-highlight>
-        </md-card-content>
-      </md-tab>
-    </md-tab-group>
-  
-  <md-divider></md-divider>
-  <md-card-actions>
-    <div layout="row" layout-align="start center">
-      <button md-button color="primary" (click)="toggleFirstLast()" class="text-upper">Toggle First/Last</button>
-    </div>
-  </md-card-actions>
-</md-card>
-
-
-<md-card>
-  <md-card-title>Paging using input</md-card-title>
-  <md-card-subtitle>Navigate to a specific page</md-card-subtitle>
+  <md-card-subtitle>Paging bar for lists and tables</md-card-subtitle>
   <md-divider></md-divider>
   <md-tab-group md-stretch-tabs>
     <md-tab>
@@ -75,27 +8,15 @@
         <md-card-content>
           <p>Change Event: </p>
           <div>
-            <p>Page Size: {{event2?.pageSize || '100'}}</p>
-            <p>Page: {{event2?.page || '1'}} of {{event2?.maxPage || '14'}}</p>
-            <p>Rows: {{event2?.fromRow || '1'}} to {{event2?.toRow || '100'}}</p>
+            <p>Page Size: {{event?.pageSize || '100'}}</p>
+            <p>Page: {{event?.page || '1'}} of {{event?.maxPage || '14'}}</p>
+            <p>Rows: {{event?.fromRow || '1'}} to {{event?.toRow || '100'}}</p>
           </div>
-          <p>Total: {{event2?.total || '1345'}}</p>
+          <p>Total: {{event?.total || '1345'}}</p>
         </md-card-content>
         <md-divider></md-divider>
-        <td-paging-bar #pagingBar2 [pageSizes]="[50,100,200,500,1000,2000]" pageLinkCount="5" [firstLast]="false" [initialPage]="1" [pageSize]="100" [total]="1345" (change)="change2($event)">
-          <span td-paging-bar-label hide-xs>Row per page:</span>
-          {{pagingBar2.range}} <span hide-xs>of {{pagingBar2.total}}</span>
-          <p hide-xs>Go to:</p>
-          <md-input-container>
-            <input #goToInput
-                    mdInput
-                    type="number"
-                    [min]="1"
-                    [max]="pagingBar2.maxPage"
-                    [value]="pagingBar2.page"
-                    (blur)="goToInput.value = pagingBar2.page"
-                    (keyup.enter)="pagingBar2.navigateToPage(goToInput.value); goToInput.value = pagingBar2.page"/>
-          </md-input-container>
+        <td-paging-bar #pagingBar [firstLast]="firstLast" [pageSize]="100" [total]="1345" (change)="change($event)">
+          {{pagingBar.range}} of {{pagingBar.total}}
         </td-paging-bar>
     </md-tab>
     <md-tab>
@@ -104,20 +25,8 @@
         <p>HTML:</p>
         <td-highlight lang="html">
           <![CDATA[
-            <td-paging-bar #pagingBar [pageSizes]="[50,100,200,500,1000,2000]" pageLinkCount="5" [firstLast]="false" [initialPage]="1" [pageSize]="100" [total]="1345" (change)="change($event)">
-              <span td-paging-bar-label hide-xs>Row per page:</span>
-              { {pagingBar.range} } <span hide-xs>of { {pagingBar.total} }</span>
-              <p hide-xs>Go to:</p>
-              <md-input-container>
-                <input #goToInput
-                      mdInput
-                      type="number"
-                      [min]="1"
-                      [max]="pagingBar.maxPage"
-                      [value]="pagingBar.page"
-                      (blur)="goToInput.value = pagingBar.page"
-                      (keyup.enter)="pagingBar.navigateToPage(goToInput.value); goToInput.value = pagingBar.page"/>
-              </md-input-container>
+            <td-paging-bar #pagingBar [firstLast]="firstLast" [pageSize]="100" [total]="1345" (change)="change($event)">
+              { {pagingBar.range} } of { {pagingBar.total} }
             </td-paging-bar>
           ]]>
         </td-highlight>
@@ -128,9 +37,311 @@
             ...
             export class Demo {
               event: IPageChangeEvent;
+              firstLast: boolean = true;
 
               change(event: IPageChangeEvent): void {
                 this.event = event;
+              }
+
+              toggleFirstLast(): void {
+                this.firstLast = !this.firstLast;
+              }
+            }
+          ]]>
+        </td-highlight>
+      </md-card-content>
+    </md-tab>
+  </md-tab-group>
+  <md-divider></md-divider>
+  <md-card-actions>
+    <div layout="row" layout-align="start center">
+      <button md-button color="primary" (click)="toggleFirstLast()" class="text-upper">Toggle First/Last</button>
+    </div>
+  </md-card-actions>
+</md-card>
+
+<md-card>
+  <md-card-title>Paging with dynamic page size</md-card-title>
+  <md-card-subtitle>Set a select to change the page size on the fly</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-tab-group md-stretch-tabs>
+    <md-tab>
+      <ng-template md-tab-label>Demo</ng-template>
+      <md-card-content>
+        <p>Change Event: </p>
+        <div>
+          <p>Page Size: {{eventPageSize?.pageSize || '100'}}</p>
+          <p>Page: {{eventPageSize?.page || '1'}} of {{eventPageSize?.maxPage || '14'}}</p>
+          <p>Rows: {{eventPageSize?.fromRow || '1'}} to {{eventPageSize?.toRow || '100'}}</p>
+        </div>
+        <p>Total: {{eventPageSize?.total || '1345'}}</p>
+      </md-card-content>
+      <md-divider></md-divider>
+      <td-paging-bar #pagingBarPageSize [firstLast]="true" [pageSize]="pageSize" [total]="1345" (change)="changePageSize($event)">
+        <span hide-xs>Rows per page:</span>
+        <md-select [(ngModel)]="pageSize">
+          <md-option *ngFor="let size of [50,100,200,500,1000,2000]" [value]="size">
+            {{size}}
+          </md-option>
+        </md-select>
+        <span>{{pagingBarPageSize.range}} <span hide-xs>of {{pagingBarPageSize.total}}</span></span>
+      </td-paging-bar>
+    </md-tab>
+    <md-tab>
+      <ng-template md-tab-label>Code</ng-template>
+      <md-card-content>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-paging-bar #pagingBarPageSize [firstLast]="true" [pageSize]="pageSize" [total]="1345" (change)="changePageSize($event)">
+              <span hide-xs>Rows per page:</span>
+              <md-select [(ngModel)]="pageSize">
+                <md-option *ngFor="let size of [50,100,200,500,1000,2000]" [value]="size">
+                  { {size} }
+                </md-option>
+              </md-select>
+              <span>{ {pagingBarPageSize.range} } <span hide-xs>of { {pagingBarPageSize.total} }</span></span>
+            </td-paging-bar>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            import { IPageChangeEvent } from '@covalent/core';
+            ...
+            export class Demo {
+              eventPageSize: IPageChangeEvent;
+              pageSize: number = 100;
+
+              changePageSize(event: IPageChangeEvent): void {
+                this.eventPageSize = event;
+              }
+            }
+          ]]>
+        </td-highlight>
+      </md-card-content>
+    </md-tab>
+  </md-tab-group>
+</md-card>
+
+<md-card>
+  <md-card-title>Paging using page links</md-card-title>
+  <md-card-subtitle>Navigate to pages with button links</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-tab-group md-stretch-tabs>
+    <md-tab>
+      <ng-template md-tab-label>Demo</ng-template>
+        <md-card-content>
+          <p>Change Event: </p>
+          <div>
+            <p>Page Size: {{eventLinks?.pageSize || '100'}}</p>
+            <p>Page: {{eventLinks?.page || '1'}} of {{eventLinks?.maxPage || '14'}}</p>
+            <p>Rows: {{eventLinks?.fromRow || '1'}} to {{eventLinks?.toRow || '100'}}</p>
+          </div>
+          <p>Total: {{eventLinks?.total || '1345'}}</p>
+        </md-card-content>
+        <md-divider></md-divider>
+        <td-paging-bar #pagingBarLinks pageLinkCount="5" [firstLast]="false" [pageSize]="100" [total]="1345" (change)="changeLinks($event)">
+          <span hide-xs>{{pagingBarLinks.range}} of {{pagingBarLinks.total}}</span>
+        </td-paging-bar>
+    </md-tab>
+    <md-tab>
+      <ng-template md-tab-label>Code</ng-template>
+      <md-card-content>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-paging-bar #pagingBarLinks pageLinkCount="5" [firstLast]="false" [pageSize]="100" [total]="1345" (change)="changeLinks($event)">
+              <span hide-xs>{ {pagingBarLinks.range} } of { {pagingBarLinks.total} }</span>
+            </td-paging-bar>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            import { IPageChangeEvent } from '@covalent/core';
+            ...
+            export class Demo {
+              eventLinks: IPageChangeEvent;
+
+              changeLinks(event: IPageChangeEvent): void {
+                this.eventLinks = event;
+              }
+            }
+          ]]>
+        </td-highlight>
+      </md-card-content>
+    </md-tab>
+  </md-tab-group>
+</md-card>
+
+<md-card>
+  <md-card-title>Paging using input</md-card-title>
+  <md-card-subtitle>Navigate to a specific page</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-tab-group md-stretch-tabs>
+    <md-tab>
+      <ng-template md-tab-label>Demo</ng-template>
+      <md-card-content>
+          <p>Change Event: </p>
+          <div>
+            <p>Page Size: {{eventInput?.pageSize || '100'}}</p>
+            <p>Page: {{eventInput?.page || '1'}} of {{eventInput?.maxPage || '14'}}</p>
+            <p>Rows: {{eventInput?.fromRow || '1'}} to {{eventInput?.toRow || '100'}}</p>
+          </div>
+          <p>Total: {{eventInput?.total || '1345'}}</p>
+        </md-card-content>
+        <md-divider></md-divider>
+        <td-paging-bar #pagingBarInput pageLinkCount="5" [firstLast]="false" [pageSize]="100" [total]="1345" (change)="changeInput($event)">
+          <p hide-xs>Go to:</p>
+          <md-input-container>
+            <input #goToInput
+                    mdInput
+                    type="number"
+                    [min]="1"
+                    [max]="pagingBarInput.maxPage"
+                    [value]="pagingBarInput.page"
+                    (blur)="goToInput.value = pagingBarInput.page"
+                    (keyup.enter)="pagingBarInput.navigateToPage(goToInput.value); goToInput.value = pagingBarInput.page"/>
+          </md-input-container>
+          <span hide-xs>{{pagingBarInput.range}} of {{pagingBarInput.total}}</span>
+        </td-paging-bar>
+    </md-tab>
+    <md-tab>
+      <ng-template md-tab-label>Code</ng-template>
+      <md-card-content>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-paging-bar #pagingBarInput pageLinkCount="5" [firstLast]="false" [pageSize]="100" [total]="1345" (change)="changeInput($event)">
+              <p hide-xs>Go to:</p>
+              <md-input-container>
+                <input #goToInput
+                        mdInput
+                        type="number"
+                        [min]="1"
+                        [max]="pagingBarInput.maxPage"
+                        [value]="pagingBarInput.page"
+                        (blur)="goToInput.value = pagingBarInput.page"
+                        (keyup.enter)="pagingBarInput.navigateToPage(goToInput.value); goToInput.value = pagingBarInput.page"/>
+              </md-input-container>
+              <span hide-xs>{ {pagingBarInput.range} } of { {pagingBarInput.total} }</span>
+            </td-paging-bar>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            import { IPageChangeEvent } from '@covalent/core';
+            ...
+            export class Demo {
+              eventInput: IPageChangeEvent;
+
+              changeInput(event: IPageChangeEvent): void {
+                this.eventInput = event;
+              }
+            }
+          ]]>
+        </td-highlight>
+      </md-card-content>
+    </md-tab>
+  </md-tab-group>
+</md-card>
+
+<md-card>
+  <md-card-title>Paging with everything</md-card-title>
+  <md-card-subtitle>All the previous things + reponsiveness leveraging the `CovalentMediaModule`</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-tab-group md-stretch-tabs>
+    <md-tab>
+      <ng-template md-tab-label>Demo</ng-template>
+      <md-card-content>
+          <p>Change Event: </p>
+          <div>
+            <p>Page Size: {{eventResponsive?.pageSize || '100'}}</p>
+            <p>Page: {{eventResponsive?.page || '1'}} of {{eventResponsive?.maxPage || '14'}}</p>
+            <p>Rows: {{eventResponsive?.fromRow || '1'}} to {{eventResponsive?.toRow || '100'}}</p>
+          </div>
+          <p>Total: {{eventResponsive?.total || '1345'}}</p>
+        </md-card-content>
+        <md-divider></md-divider>
+        <td-paging-bar #pagingBarResponsive
+                       [pageLinkCount]="(media.registerQuery('md') | async) ? 0 : 5"
+                       [firstLast]="media.registerQuery('gt-xs') | async"
+                       [pageSize]="pageSize"
+                       [total]="1345"
+                       (change)="changeResponsive($event)">
+          <span hide-xs>Rows per page:</span>
+          <md-select *ngIf="media.registerQuery('gt-xs') | async" [(ngModel)]="pageSize">
+            <md-option *ngFor="let size of [50,100,200,500,1000,2000]" [value]="size">
+              {{size}}
+            </md-option>
+          </md-select>
+          <p hide-xs hide-sm hide-md>Go to:</p>
+          <md-input-container *ngIf="media.registerQuery('gt-sm') | async">
+            <input #goToResponsive
+                    mdInput
+                    type="number"
+                    [min]="1"
+                    [max]="pagingBarResponsive.maxPage"
+                    [value]="pagingBarResponsive.page"
+                    (blur)="goToResponsive.value = pagingBarResponsive.page"
+                    (keyup.enter)="pagingBarResponsive.navigateToPage(goToResponsive.value); goToResponsive.value = pagingBarResponsive.page"/>
+          </md-input-container>
+          <span>{{pagingBarResponsive.range}} <span hide-xs hide-sm hide-md>of {{pagingBarResponsive.total}}</span></span>
+        </td-paging-bar>
+    </md-tab>
+    <md-tab>
+      <ng-template md-tab-label>Code</ng-template>
+      <md-card-content>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-paging-bar #pagingBarResponsive
+                          [pageLinkCount]="(media.registerQuery('md') | async) ? 0 : 5"
+                          [firstLast]="media.registerQuery('gt-xs') | async"
+                          [pageSize]="pageSize"
+                          [total]="1345"
+                          (change)="changeResponsive($event)">
+              <span hide-xs>Rows per page:</span>
+              <md-select *ngIf="media.registerQuery('gt-xs') | async" [(ngModel)]="pageSize">
+                <md-option *ngFor="let size of [50,100,200,500,1000,2000]" [value]="size">
+                  { {size} }
+                </md-option>
+              </md-select>
+              <p hide-xs hide-sm hide-md>Go to:</p>
+              <md-input-container *ngIf="media.registerQuery('gt-sm') | async">
+                <input #goToResponsive
+                        mdInput
+                        type="number"
+                        [min]="1"
+                        [max]="pagingBarResponsive.maxPage"
+                        [value]="pagingBarResponsive.page"
+                        (blur)="goToResponsive.value = pagingBarResponsive.page"
+                        (keyup.enter)="pagingBarResponsive.navigateToPage(goToResponsive.value); goToResponsive.value = pagingBarResponsive.page"/>
+              </md-input-container>
+              <span>{ {pagingBarResponsive.range} } <span hide-xs hide-sm hide-md>of { {pagingBarResponsive.total} }</span></span>
+            </td-paging-bar>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            import { IPageChangeEvent } from '@covalent/core';
+            ...
+            export class Demo {
+              eventResponsive: IPageChangeEvent;
+
+              constructor(private _changeDetectorRef: ChangeDetectorRef,
+                          public media: TdMediaService) {}
+
+              ngAfterViewInit(): void {
+                this.media.broadcast();
+                this._changeDetectorRef.detectChanges();
+              }
+
+              changeResponsive(event: IPageChangeEvent): void {
+                this.eventResponsive = event;
               }
             }
           ]]>

--- a/src/app/components/components/paging/paging.component.html
+++ b/src/app/components/components/paging/paging.component.html
@@ -79,7 +79,7 @@
       <md-divider></md-divider>
       <td-paging-bar #pagingBarPageSize [firstLast]="true" [pageSize]="pageSize" [total]="1345" (change)="changePageSize($event)">
         <span hide-xs>Rows per page:</span>
-        <md-select [(ngModel)]="pageSize">
+        <md-select [style.width.px]="50" [(ngModel)]="pageSize">
           <md-option *ngFor="let size of [50,100,200,500,1000,2000]" [value]="size">
             {{size}}
           </md-option>
@@ -95,7 +95,7 @@
           <![CDATA[
             <td-paging-bar #pagingBarPageSize [firstLast]="true" [pageSize]="pageSize" [total]="1345" (change)="changePageSize($event)">
               <span hide-xs>Rows per page:</span>
-              <md-select [(ngModel)]="pageSize">
+              <md-select [style.width.px]="50" [(ngModel)]="pageSize">
                 <md-option *ngFor="let size of [50,100,200,500,1000,2000]" [value]="size">
                   { {size} }
                 </md-option>
@@ -268,11 +268,11 @@
         <td-paging-bar #pagingBarResponsive
                        [pageLinkCount]="(media.registerQuery('md') | async) ? 0 : 5"
                        [firstLast]="media.registerQuery('gt-xs') | async"
-                       [pageSize]="pageSize"
+                       [pageSize]="pageSizeResponsive"
                        [total]="1345"
                        (change)="changeResponsive($event)">
           <span hide-xs>Rows per page:</span>
-          <md-select *ngIf="media.registerQuery('gt-xs') | async" [(ngModel)]="pageSize">
+          <md-select *ngIf="media.registerQuery('gt-xs') | async" [style.width.px]="50" [(ngModel)]="pageSizeResponsive">
             <md-option *ngFor="let size of [50,100,200,500,1000,2000]" [value]="size">
               {{size}}
             </md-option>
@@ -300,11 +300,11 @@
             <td-paging-bar #pagingBarResponsive
                           [pageLinkCount]="(media.registerQuery('md') | async) ? 0 : 5"
                           [firstLast]="media.registerQuery('gt-xs') | async"
-                          [pageSize]="pageSize"
+                          [pageSize]="pageSizeResponsive"
                           [total]="1345"
                           (change)="changeResponsive($event)">
               <span hide-xs>Rows per page:</span>
-              <md-select *ngIf="media.registerQuery('gt-xs') | async" [(ngModel)]="pageSize">
+              <md-select *ngIf="media.registerQuery('gt-xs') | async" [style.width.px]="50" [(ngModel)]="pageSizeResponsive">
                 <md-option *ngFor="let size of [50,100,200,500,1000,2000]" [value]="size">
                   { {size} }
                 </md-option>
@@ -331,6 +331,7 @@
             ...
             export class Demo {
               eventResponsive: IPageChangeEvent;
+              pageSizeResponsive: number = 100;
 
               constructor(private _changeDetectorRef: ChangeDetectorRef,
                           public media: TdMediaService) {}

--- a/src/app/components/components/paging/paging.component.ts
+++ b/src/app/components/components/paging/paging.component.ts
@@ -22,6 +22,7 @@ export class PagingDemoComponent implements AfterViewInit {
   eventInput: IPageChangeEvent;
   eventResponsive: IPageChangeEvent;
   pageSize: number = 100;
+  pageSizeResponsive: number = 100;
   firstLast: boolean = true;
 
   constructor(private _changeDetectorRef: ChangeDetectorRef,

--- a/src/app/components/components/paging/paging.component.ts
+++ b/src/app/components/components/paging/paging.component.ts
@@ -1,4 +1,5 @@
-import { Component, HostBinding } from '@angular/core';
+import { Component, HostBinding, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { TdMediaService } from '../../../../platform/core';
 
 import { slideInDownAnimation } from '../../../app.animations';
 
@@ -10,30 +11,49 @@ import { IPageChangeEvent } from '../../../../platform/core';
   templateUrl: './paging.component.html',
   animations: [slideInDownAnimation],
 })
-export class PagingDemoComponent {
+export class PagingDemoComponent implements AfterViewInit {
 
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
     
-  event1: IPageChangeEvent;
-  event2: IPageChangeEvent;
-  firstLast: boolean = false;
-  pageSizeAll: boolean = false;
+  event: IPageChangeEvent;
+  eventPageSize: IPageChangeEvent;
+  eventLinks: IPageChangeEvent;
+  eventInput: IPageChangeEvent;
+  eventResponsive: IPageChangeEvent;
+  pageSize: number = 100;
+  firstLast: boolean = true;
 
-  change1(event: IPageChangeEvent): void {
-    this.event1 = event;
+  constructor(private _changeDetectorRef: ChangeDetectorRef,
+              public media: TdMediaService) {}
+
+  ngAfterViewInit(): void {
+    this.media.broadcast();
+    this._changeDetectorRef.detectChanges();
   }
 
-  change2(event: IPageChangeEvent): void {
-    this.event2 = event;
+  change(event: IPageChangeEvent): void {
+    this.event = event;
+  }
+
+  changePageSize(event: IPageChangeEvent): void {
+    this.eventPageSize = event;
+  }
+
+  changeLinks(event: IPageChangeEvent): void {
+    this.eventLinks = event;
+  }
+
+  changeInput(event: IPageChangeEvent): void {
+    this.eventInput = event;
+  }
+
+  changeResponsive(event: IPageChangeEvent): void {
+    this.eventResponsive = event;
   }
 
   toggleFirstLast(): void {
     this.firstLast = !this.firstLast;
-  }
-
-  togglePageSizeAll(): void {
-    this.pageSizeAll = !this.pageSizeAll;
   }
 
 }

--- a/src/app/components/style-guide/management-list/management-list.component.html
+++ b/src/app/components/style-guide/management-list/management-list.component.html
@@ -58,8 +58,13 @@
           </ng-template>
         </md-list>
         <md-divider></md-divider>
-        <td-paging-bar #pagingBar [pageSizes]="[5, 10, 15, 20]" total="20">
-          <span td-paging-bar-label hide-xs>Row per page:</span>
+        <td-paging-bar #pagingBar [pageSize]="pageSize" total="20">
+          <span hide-xs>Rows per page:</span>
+          <md-select [(ngModel)]="pageSize">
+            <md-option *ngFor="let size of [5,10,15,20]" [value]="size">
+              {{size}}
+            </md-option>
+          </md-select>
           {{pagingBar.range}} <span hide-xs>of {{pagingBar.total}}</span>
         </td-paging-bar>
       </md-card>
@@ -124,8 +129,13 @@
             </ng-template>
           </md-list>
           <md-divider></md-divider>
-          <td-paging-bar #pagingBar [pageSizes]="[5, 10, 15, 20]" total="20">
-            <span td-paging-bar-label hide-xs>Row per page:</span>
+          <td-paging-bar #pagingBar [pageSize]="pageSize" total="20">
+            <span hide-xs>Rows per page:</span>
+            <md-select [(ngModel)]="pageSize">
+              <md-option *ngFor="let size of [5,10,15,20]" [value]="size">
+                { {size} }
+              </md-option>
+            </md-select>
             { {pagingBar.range} } <span hide-xs>of { {pagingBar.total} }</span>
           </td-paging-bar>
         </md-card>
@@ -146,6 +156,7 @@
           }];
           sortKey: string = this.columnOptions[0].value;
           headers: IHeaders = {};
+          pageSize: number = 5;
 
           ngOnInit(): void {
             this.columnOptions.forEach((option: any) => {

--- a/src/app/components/style-guide/management-list/management-list.component.html
+++ b/src/app/components/style-guide/management-list/management-list.component.html
@@ -60,7 +60,7 @@
         <md-divider></md-divider>
         <td-paging-bar #pagingBar [pageSize]="pageSize" total="20">
           <span hide-xs>Rows per page:</span>
-          <md-select [(ngModel)]="pageSize">
+          <md-select [style.width.px]="50" [(ngModel)]="pageSize">
             <md-option *ngFor="let size of [5,10,15,20]" [value]="size">
               {{size}}
             </md-option>
@@ -131,7 +131,7 @@
           <md-divider></md-divider>
           <td-paging-bar #pagingBar [pageSize]="pageSize" total="20">
             <span hide-xs>Rows per page:</span>
-            <md-select [(ngModel)]="pageSize">
+            <md-select [style.width.px]="50" [(ngModel)]="pageSize">
               <md-option *ngFor="let size of [5,10,15,20]" [value]="size">
                 { {size} }
               </md-option>

--- a/src/app/components/style-guide/management-list/management-list.component.ts
+++ b/src/app/components/style-guide/management-list/management-list.component.ts
@@ -57,6 +57,7 @@ export class ManagementListComponent implements OnInit {
   }];
   sortKey: string = this.columnOptions[0].value;
   headers: IHeaders = {};
+  pageSize: number = 5;
 
   ngOnInit(): void {
     this.columnOptions.forEach((option: any) => {

--- a/src/platform/core/paging/README.md
+++ b/src/platform/core/paging/README.md
@@ -21,12 +21,10 @@ Properties:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `initialPage` | `number` | Sets starting page for the paging bar. Defaults to '1'
-| `pageSizes?` | `number[]` | Array that populates page size menu. Defaults to [50, 100, 200, 500, 1000].
-| `pageSize?` | `number` | Selected page size for the pagination. Defaults to first element of the [pageSizes] array.
+| `initialPage` | `number` | Sets starting page for the paging bar. Defaults to 1.
+| `pageLinkCount?` | `number` | Amount of page navigation links for the paging bar. Defaults to 0.
 | `firstLast?` | `boolean` | Shows or hides the first and last page buttons of the paging bar. Defaults to 'false'
-| `pageSizeAll?` | `boolean` | Shows or hides the 'all' menu item in the page size menu. Defaults to 'false'
-| `pageSizeAllText?` | `string` | Text for the 'all' menu item in the page size menu. Defaults to 'All'
+| `pageSize?` | `number` | Selected page size for the pagination. Defaults to 50.
 | `total` | `number` | Total rows for the pagination.
 | `change` | `function($event: IPageChangeEvent)` | Method to be executed when page size changes or any button is clicked in the paging bar.
 | `navigateToPage` | `function(page: number): boolean` | Navigates to a specific valid page. Returns 'true' if page is valid, else 'false'.
@@ -49,35 +47,42 @@ export class MyModule {}
 
 ## Usage
 
-Example for HTML usage:
+Example with page links for navigation:
 
 ```html
 <td-paging-bar #pagingBar
-                pageSizeAllText="allText"
-                [firstLast]="true"
-                [pageSizeAll]="true"
-                [pageSizes]="[100,200,500,1000,2000]"
-                [initialPage]="1"
+                [pageLinkCount]="5"
                 [pageSize]="100"
                 [total]="1345"
                 (change)="change($event)">
-  <span td-paging-bar-label hide-xs>Row per page:</span>
   {{pagingBar.range}} <span hide-xs>of {{pagingBar.total}}</span>
 </td-paging-bar>
 ```
 
-Example with material input for `Go to` usage: 
+Example with material select for dynamic page sizes:
 
 ```html
 <td-paging-bar #pagingBar
-                [pageSizes]="[50,100,200,500]"
-                pageLinkCount="5"
-                [initialPage]="1"
+                [pageSize]="pageSize"
+                [total]="1345"
+                (change)="change($event)">
+  <span hide-xs>Rows per page:</span>
+  <md-select [(ngModel)]="pageSize">
+    <md-option *ngFor="let size of [50,100,200,500,100]" [value]="size">
+      {{size}}
+    </md-option>
+  </md-select>
+  {{pagingBar.range}} <span hide-xs>of {{pagingBar.total}}</span>
+</td-paging-bar>
+```
+
+Example with material input for navigation: 
+
+```html
+<td-paging-bar #pagingBar
                 [pageSize]="100"
                 [total]="1345"
                 (change)="change($event)">
-  <span td-paging-bar-label hide-xs>Row per page:</span>
-  {{pagingBar.range}} <span hide-xs>of {{pagingBar.total}}</span>
   <p hide-xs>Go to:</p>
   <md-input-container>
     <input #goToInput
@@ -89,5 +94,37 @@ Example with material input for `Go to` usage:
             (blur)="goToInput.value = pagingBar.page"
             (keyup.enter)="pagingBar.navigateToPage(goToInput.value); goToInput.value = pagingBar.page"/>
   </md-input-container>
+  {{pagingBar.range}} <span hide-xs>of {{pagingBar.total}}</span>
+  
+</td-paging-bar>
+```
+
+Example with dynamic page sizes, input and page links for navigation:
+
+```html
+<td-paging-bar #pagingBar
+                [firstLast]="true"
+                [pageLinkCount]="5"
+                [pageSize]="pageSize"
+                [total]="1345"
+                (change)="change($event)">
+  <span hide-xs>Rows per page:</span>
+  <md-select [(ngModel)]="pageSize">
+    <md-option *ngFor="let size of [50,100,200,500,100]" [value]="size">
+      {{size}}
+    </md-option>
+  </md-select>
+  <p hide-xs>Go to:</p>
+  <md-input-container>
+    <input #goToInput
+            mdInput
+            type="number"
+            [min]="1"
+            [max]="pagingBar.maxPage"
+            [value]="pagingBar.page"
+            (blur)="goToInput.value = pagingBar.page"
+            (keyup.enter)="pagingBar.navigateToPage(goToInput.value); goToInput.value = pagingBar.page"/>
+  </md-input-container>
+  {{pagingBar.range}} <span hide-xs>of {{pagingBar.total}}</span>
 </td-paging-bar>
 ```

--- a/src/platform/core/paging/README.md
+++ b/src/platform/core/paging/README.md
@@ -67,7 +67,7 @@ Example with material select for dynamic page sizes:
                 [total]="1345"
                 (change)="change($event)">
   <span hide-xs>Rows per page:</span>
-  <md-select [(ngModel)]="pageSize">
+  <md-select [style.width.px]="50" [(ngModel)]="pageSize">
     <md-option *ngFor="let size of [50,100,200,500,100]" [value]="size">
       {{size}}
     </md-option>
@@ -109,7 +109,7 @@ Example with dynamic page sizes, input and page links for navigation:
                 [total]="1345"
                 (change)="change($event)">
   <span hide-xs>Rows per page:</span>
-  <md-select [(ngModel)]="pageSize">
+  <md-select [style.width.px]="50" [(ngModel)]="pageSize">
     <md-option *ngFor="let size of [50,100,200,500,100]" [value]="size">
       {{size}}
     </md-option>

--- a/src/platform/core/paging/paging-bar.component.html
+++ b/src/platform/core/paging/paging-bar.component.html
@@ -1,28 +1,19 @@
 <div layout="row" layout-align="end center" class="md-caption td-paging-bar" (change)="$event.stopPropagation()" >
-  <ng-content select="[td-paging-bar-label]"></ng-content>
-  <md-select [(ngModel)]="pageSize">
-    <ng-template let-size ngFor [ngForOf]="pageSizes">
-      <md-option [value]="size">
-        {{size}}
-      </md-option>
-    </ng-template>
-    <md-option *ngIf="pageSizeAll" [value]="total">{{pageSizeAllText}}</md-option>
-  </md-select>
   <ng-content></ng-content>
   <div class="td-paging-bar-navigation">
-    <button [id]="'td-paging-bar-' + id + '-first-page'" md-icon-button type="button" *ngIf="firstLast" [disabled]="isMinPage()" (click)="firstPage()">
+    <button md-icon-button class="td-paging-bar-first-page" type="button" *ngIf="firstLast" [disabled]="isMinPage()" (click)="firstPage()">
       <md-icon>{{ isRTL ? 'skip_next' : 'skip_previous' }}</md-icon>
     </button>
-    <button md-icon-button type="button" [disabled]="isMinPage()" (click)="prevPage()">
+    <button md-icon-button class="td-paging-bar-prev-page" type="button" [disabled]="isMinPage()" (click)="prevPage()">
       <md-icon>{{ isRTL ? 'navigate_next' : 'navigate_before' }}</md-icon>
     </button>
     <ng-template *ngIf="pageLinkCount > 0" let-link let-index="index" ngFor [ngForOf]="pageLinks">
-      <button [id]="'td-paging-bar-' + id + '-page-link-' + index" md-icon-button type="button" [color]="page === link ? 'accent' : ''" (click)="navigateToPage(link)">{{link}}</button>
+      <button class="td-paging-bar-link-page" md-icon-button type="button" [color]="page === link ? 'accent' : ''" (click)="navigateToPage(link)">{{link}}</button>
     </ng-template>
-    <button md-icon-button type="button" [disabled]="isMaxPage()" (click)="nextPage()">
+    <button md-icon-button class="td-paging-bar-next-page" type="button" [disabled]="isMaxPage()" (click)="nextPage()">
       <md-icon>{{ isRTL ? 'navigate_before' : 'navigate_next' }}</md-icon>
     </button>
-    <button [id]="'td-paging-bar-' + id + '-last-page'" md-icon-button type="button" *ngIf="firstLast" [disabled]="isMaxPage()" (click)="lastPage()">
+    <button md-icon-button class="td-paging-bar-last-page" type="button" *ngIf="firstLast" [disabled]="isMaxPage()" (click)="lastPage()">
       <md-icon>{{ isRTL ? 'skip_previous' : 'skip_next' }}</md-icon>
     </button>
   </div>

--- a/src/platform/core/paging/paging-bar.component.scss
+++ b/src/platform/core/paging/paging-bar.component.scss
@@ -11,8 +11,8 @@
   font-size: 12px;
   font-weight: normal;
 }
-md-select { 
-  & /deep/ {
+/deep/ md-select { 
+  & {
     .mat-select-trigger {
       min-width: 44px;
       font-size: 12px;

--- a/src/platform/core/paging/paging-bar.component.spec.ts
+++ b/src/platform/core/paging/paging-bar.component.spec.ts
@@ -23,9 +23,8 @@ describe('Component: PagingBar', () => {
         CovalentPagingModule,
       ],
       declarations: [
-        TestpageSizeAllTextComponent,
         TestInitialPageComponent,
-        TestPageSizesComponent,
+        TestPageSizeComponent,
         TestFirstLastComponent,
         TestPageLinkCountComponent,
         TestGoToComponent,
@@ -34,143 +33,95 @@ describe('Component: PagingBar', () => {
     TestBed.compileComponents();
   }));
 
-  it('should create the component', (done: DoneFn) => {
-    let fixture: ComponentFixture<any> = TestBed.createComponent(TestpageSizeAllTextComponent);
-    let component: TestpageSizeAllTextComponent = fixture.debugElement.componentInstance;
-
+  it('should set [pageSize] dynamically', (done: DoneFn) => {
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TestPageSizeComponent);
+    let component: TestPageSizeComponent = fixture.debugElement.componentInstance;
+    let pagingComponent: DebugElement = fixture.debugElement.query(By.directive(TdPagingBarComponent));
+    
+    component.pageSize = 100;
     fixture.detectChanges();
     fixture.whenStable().then(() => {
-      expect(component).toBeTruthy();
-      done();
-    });
-  });
-
-  it('should set pageSizeAllText, pageSizeAll and see it in markup', (done: DoneFn) => {
-    let fixture: ComponentFixture<any> = TestBed.createComponent(TestpageSizeAllTextComponent);
-    let component: TestpageSizeAllTextComponent = fixture.debugElement.componentInstance;
-
-    fixture.detectChanges();
-    fixture.whenStable().then(() => {
+      expect(pagingComponent.componentInstance.pageSize).toBe(100);
+      component.pageSize = 40;
       fixture.detectChanges();
       fixture.whenStable().then(() => {
-        let pageSizeAllText: string = fixture.debugElement.query(By.directive(TdPagingBarComponent)).componentInstance.pageSizeAllText;
-        expect(pageSizeAllText).toBe('SomeOtherText');
-
-        component.pageSizeAllText = 'aDifferentText';
+        expect(pagingComponent.componentInstance.pageSize).toBe(40);
+        component.pageSize = 56;
         fixture.detectChanges();
         fixture.whenStable().then(() => {
-          pageSizeAllText = fixture.debugElement.query(By.directive(TdPagingBarComponent)).componentInstance.pageSizeAllText;
-          expect(pageSizeAllText).toBe('aDifferentText');
-
-          let pageSizeAll: boolean = fixture.debugElement.query(By.directive(TdPagingBarComponent)).componentInstance.pageSizeAll;
-          expect(pageSizeAll).toBe(true);
-
-          component.pageSizeAll = false;
-          fixture.detectChanges();
-          fixture.whenStable().then(() => {
-            pageSizeAll = fixture.debugElement.query(By.directive(TdPagingBarComponent)).componentInstance.pageSizeAll;
-            expect(pageSizeAll).toBe(false);
-            done();
-          });
-        });
-      });
-    });
-  });
-
-  it('should set pageSizes and then component instantiate with that pageSize', (done: DoneFn) => {
-    let fixture: ComponentFixture<any> = TestBed.createComponent(TestPageSizesComponent);
-    let component: TestPageSizesComponent = fixture.debugElement.componentInstance;
-
-    fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        let pageSize: number = fixture.debugElement.query(By.directive(TdPagingBarComponent)).componentInstance.pageSize;
-        expect(pageSize).toBe(37);
-
-        component.pageSizes = [55, 77];
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          pageSize = fixture.debugElement.query(By.directive(TdPagingBarComponent)).componentInstance.pageSize;
-          expect(pageSize).toBe(55);
+          expect(pagingComponent.componentInstance.pageSize).toBe(56);
           done();
         });
       });
     });
   });
 
-  it('should set intialPage and then component instantiate with that page', (done: DoneFn) => {
+  it('should set [initialPage] and instanciate the paging bar at that page', (done: DoneFn) => {
     let fixture: ComponentFixture<any> = TestBed.createComponent(TestInitialPageComponent);
     let component: TestInitialPageComponent = fixture.debugElement.componentInstance;
 
     fixture.detectChanges();
     fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        let page: number = fixture.debugElement.query(By.directive(TdPagingBarComponent)).componentInstance.page;
-        expect(page).toBe(3);
-        done();
-      });
+      let page: number = fixture.debugElement.query(By.directive(TdPagingBarComponent)).componentInstance.page;
+      expect(page).toBe(3);
+      done();
     });
   });
 
-  it('should set firstLast and then see buttons in markup', (done: DoneFn) => {
+  it('should render first/last buttons and then remove them when setting [firstLast] to false', (done: DoneFn) => {
     let fixture: ComponentFixture<any> = TestBed.createComponent(TestFirstLastComponent);
     let component: TestFirstLastComponent = fixture.debugElement.componentInstance;
 
     fixture.detectChanges();
     fixture.whenStable().then(() => {
+      expect(fixture.debugElement.query(By.css('.td-paging-bar-first-page'))).toBeTruthy();
+      expect(fixture.debugElement.query(By.css('.td-paging-bar-last-page'))).toBeTruthy();
+
+      component.firstLast = false;
       fixture.detectChanges();
       fixture.whenStable().then(() => {
-        let id: string = fixture.debugElement.query(By.directive(TdPagingBarComponent)).componentInstance.id;
-        expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-first-page'))).toBeTruthy();
-        expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-last-page'))).toBeTruthy();
-
-        component.firstLast = false;
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          id = fixture.debugElement.query(By.directive(TdPagingBarComponent)).componentInstance.id;
-          expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-first-page'))).toBeFalsy();
-          expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-last-page'))).toBeFalsy();
-          done();
-        });
+        expect(fixture.debugElement.query(By.css('.td-paging-bar-first-page'))).toBeFalsy();
+        expect(fixture.debugElement.query(By.css('.td-paging-bar-last-page'))).toBeFalsy();
+        done();
       });
     });
   });
 
-  it('should set pageLinkCount and then see buttons in markup', (done: DoneFn) => {
+  it('should set [pageLinkCount] and then see buttons in markup and then change count', (done: DoneFn) => {
     let fixture: ComponentFixture<any> = TestBed.createComponent(TestPageLinkCountComponent);
     let component: TestPageLinkCountComponent = fixture.debugElement.componentInstance;
-
+    component.pageLinkCount = 6;
     fixture.detectChanges();
     fixture.whenStable().then(() => {
+      expect(fixture.debugElement.queryAll(By.css('.td-paging-bar-link-page')).length).toBe(6);
+
+      component.pageLinkCount = 4;
+      component.pageSize = 50;
       fixture.detectChanges();
       fixture.whenStable().then(() => {
-        let id: string = fixture.debugElement.query(By.directive(TdPagingBarComponent)).componentInstance.id;
-        expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-0'))).toBeTruthy();
-        expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-1'))).toBeTruthy();
-        expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-2'))).toBeTruthy();
-        expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-3'))).toBeTruthy();
-        expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-4'))).toBeTruthy();
-        expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-5'))).toBeTruthy();
-        expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-6'))).toBeTruthy();
+        expect(fixture.debugElement.queryAll(By.css('.td-paging-bar-link-page')).length).toBe(4);
+        done();
+      });
+    });
+  });
 
-        component.pageLinkCount = 4;
-        component.pageSize = 50;
+  it('should navigate to page link 5 and then 3', (done: DoneFn) => {
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TestPageLinkCountComponent);
+    let component: TestPageLinkCountComponent = fixture.debugElement.componentInstance;
+    let pagingComponent: DebugElement = fixture.debugElement.query(By.directive(TdPagingBarComponent));
+    component.pageLinkCount = 5;
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      expect(pagingComponent.componentInstance.page).toBe(1);
+      fixture.debugElement.queryAll(By.css('.td-paging-bar-link-page'))[4].nativeElement.click();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(pagingComponent.componentInstance.page).toBe(5);
+        fixture.debugElement.queryAll(By.css('.td-paging-bar-link-page'))[0].nativeElement.click();
         fixture.detectChanges();
         fixture.whenStable().then(() => {
-          fixture.detectChanges();
-          fixture.whenStable().then(() => {
-            id = fixture.debugElement.query(By.directive(TdPagingBarComponent)).componentInstance.id;
-            expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-0'))).toBeTruthy();
-            expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-1'))).toBeTruthy();
-            expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-2'))).toBeTruthy();
-            expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-3'))).toBeTruthy();
-            expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-4'))).toBeFalsy();
-            expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-5'))).toBeFalsy();
-            expect(fixture.debugElement.query(By.css('#td-paging-bar-' + id + '-page-link-6'))).toBeFalsy();
-            done();
-          });
+          expect(pagingComponent.componentInstance.page).toBe(3);
+          done();
         });
       });
     });
@@ -255,27 +206,16 @@ describe('Component: PagingBar', () => {
 
 @Component({
   template: `
-    <td-paging-bar [pageSizeAllText]="pageSizeAllText" [pageSizeAll]="pageSizeAll" 
-      [pageSizes]="[50,100,200,500,1000,2000]" [total]="9215"></td-paging-bar>`,
+    <td-paging-bar [pageSize]="pageSize" [total]="9215">
+    </td-paging-bar>`,
 })
-class TestpageSizeAllTextComponent {
-  pageSizeAllText: string = 'SomeOtherText';
-  pageSizeAll: boolean = true;
+class TestPageSizeComponent {
+  pageSize: number = 37;
 }
 
 @Component({
   template: `
-    <td-paging-bar pageSizeAllText="SomeOtherText" [pageSizeAll]="true" 
-      [pageSizes]="pageSizes" [total]="9215"></td-paging-bar>`,
-})
-class TestPageSizesComponent {
-  pageSizes: number[] = [37, 48];
-}
-
-@Component({
-  template: `
-    <td-paging-bar pageSizeAllText="SomeOtherText" [pageSizeAll]="true" 
-      [initialPage]="initialPage" [pageSizes]="[50,100,200,500,1000,2000]" [total]="9215"></td-paging-bar>`,
+    <td-paging-bar [initialPage]="initialPage" [total]="9215"></td-paging-bar>`,
 })
 class TestInitialPageComponent {
   initialPage: number = 3;
@@ -283,8 +223,7 @@ class TestInitialPageComponent {
 
 @Component({
   template: `
-    <td-paging-bar pageSizeAllText="All" [pageSizeAll]="true" [pageSizes]="[50,100,200,500,1000,2000]"
-      [initialPage]="1" [firstLast]="firstLast" [pageSize]="100" [total]="9333"></td-paging-bar>`,
+    <td-paging-bar [firstLast]="firstLast" [total]="9333"></td-paging-bar>`,
 })
 class TestFirstLastComponent {
   firstLast: boolean = true;
@@ -292,8 +231,7 @@ class TestFirstLastComponent {
 
 @Component({
   template: `
-    <td-paging-bar pageSizeAllText="All" [pageSizeAll]="true" [pageSizes]="[50,100,200,500,1000,2000]" [pageLinkCount]="pageLinkCount"
-      [initialPage]="1" [firstLast]="true" [pageSize]="pageSize" [total]="1345"></td-paging-bar>`,
+    <td-paging-bar [pageLinkCount]="pageLinkCount" [pageSize]="pageSize" [total]="1345"></td-paging-bar>`,
 })
 class TestPageLinkCountComponent {
   pageLinkCount: number = 7;
@@ -302,7 +240,7 @@ class TestPageLinkCountComponent {
 
 @Component({
   template: `
-    <td-paging-bar #pagingBar [pageSizes]="[50,100,200,500,1000,2000]" [pageSize]="100" [total]="650">
+    <td-paging-bar #pagingBar [pageSize]="100" [total]="650">
       <p>Go to:</p>
       <md-input-container>
         <input #goToInput

--- a/src/platform/core/paging/paging-bar.component.ts
+++ b/src/platform/core/paging/paging-bar.component.ts
@@ -17,7 +17,6 @@ export interface IPageChangeEvent {
 })
 export class TdPagingBarComponent implements OnInit {
 
-  private _pageSizes: number[] = [50, 100, 200, 500, 1000];
   private _pageSize: number = 50;
   private _total: number = 0;
   private _page: number = 1;
@@ -26,23 +25,10 @@ export class TdPagingBarComponent implements OnInit {
   private _initialized: boolean = false;
   private _pageLinks: number[] = [];
   private _pageLinkCount: number = 0;
-  private _id: string;
   // special case when 2 pageLinks, detect when hit end of pages so can lead in correct direction
   private _hitEnd: boolean = false;
     // special case when 2 pageLinks, detect when hit start of pages so can lead in correct direction
   private _hitStart: boolean = false;
-
-  /**
-   * pageSizeAll?: boolean
-   * Shows or hides the 'all' menu item in the page size menu. Defaults to 'false'
-   */
-  @Input('pageSizeAll') pageSizeAll: boolean = false;
-
-  /**
-   * pageSizeAllText?: string
-   * Text for the 'all' menu item in the page size menu. Defaults to 'All'
-   */
-  @Input('pageSizeAllText') pageSizeAllText: string = 'All';
 
   /**
    * firstLast?: boolean
@@ -58,11 +44,11 @@ export class TdPagingBarComponent implements OnInit {
 
   /**
    * pageLinkCount?: number
-   * Amount of page jump to links for the paging bar. Defaults to '0'
+   * Amount of page navigation links for the paging bar. Defaults to '0'
    */
   @Input('pageLinkCount')
   set pageLinkCount(pageLinkCount: number) {
-    this._pageLinkCount = pageLinkCount;
+    this._pageLinkCount = coerceNumberProperty(pageLinkCount);
     this._calculatePageLinks();
   }
   get pageLinkCount(): number {
@@ -70,33 +56,15 @@ export class TdPagingBarComponent implements OnInit {
   }
 
   /**
-   * pageSizes?: number[]
-   * Array that populates page size menu. Defaults to [50, 100, 200, 500, 1000]
-   */
-  @Input('pageSizes')
-  set pageSizes(pageSizes: number[]) {
-    if (!(pageSizes instanceof Array)) {
-      throw new Error('[pageSizes] needs to be an number array.');
-    }
-    this._pageSizes = pageSizes;
-    this._pageSize = this._pageSizes[0];
-  }
-  get pageSizes(): number[] {
-    return this._pageSizes;
-  }
-
-  /**
    * pageSize?: number
-   * Selected page size for the pagination. Defaults to first element of the [pageSizes] array.
+   * Selected page size for the pagination. Defaults 50.
    */
   @Input('pageSize')
   set pageSize(pageSize: number) {
-    if ((this._pageSizes.indexOf(pageSize) > -1 || this.total === pageSize) && this._pageSize !== pageSize) {
-      this._pageSize = pageSize;
-      this._page = 1;
-      if (this._initialized) {
-        this._handleOnChange();
-      }
+    this._pageSize = coerceNumberProperty(pageSize);
+    this._page = 1;
+    if (this._initialized) {
+      this._handleOnChange();
     }
   }
   get pageSize(): number {
@@ -109,7 +77,7 @@ export class TdPagingBarComponent implements OnInit {
    */
   @Input('total')
   set total(total: number) {
-    this._total = total;
+    this._total = coerceNumberProperty(total);
     this._calculateRows();
     this._calculatePageLinks();
   }
@@ -150,14 +118,6 @@ export class TdPagingBarComponent implements OnInit {
   }
 
   /**
-   * id: string
-   * Returns the guid id for this paginator
-   */
-  get id(): string {
-    return this._id;
-  }
-
-  /**
    * change?: function
    * Method to be executed when page size changes or any button is clicked in the paging bar.
    * Emits an [IPageChangeEvent] implemented object.
@@ -171,9 +131,7 @@ export class TdPagingBarComponent implements OnInit {
     return false;
   }
 
-  constructor(@Optional() private _dir: Dir) {
-    this._id = this.guid();
-  }
+  constructor(@Optional() private _dir: Dir) {}
 
   ngOnInit(): void {
     this._page = coerceNumberProperty(this.initialPage);
@@ -298,18 +256,6 @@ export class TdPagingBarComponent implements OnInit {
       toRow: this._toRow,
     };
     this.onChange.emit(event);
-  }
-
-  /**
-   * guid?: function
-   * Returns RFC4122 random ("version 4") GUIDs
-   */
-  private guid(): string {
-    return this.s4() + this.s4() + '-' + this.s4() + '-' + this.s4() + '-' + this.s4() + '-' + this.s4() + this.s4() + this.s4();
-  }
-
-  private s4(): string {
-    return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
   }
 
 }

--- a/src/platform/core/paging/paging.module.ts
+++ b/src/platform/core/paging/paging.module.ts
@@ -1,9 +1,8 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { NgModule } from '@angular/core';
 
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
 
-import { MdIconModule, MdSelectModule, MdButtonModule } from '@angular/material';
+import { MdIconModule, MdButtonModule } from '@angular/material';
 
 import { TdPagingBarComponent } from './paging-bar.component';
 
@@ -11,10 +10,8 @@ export { TdPagingBarComponent, IPageChangeEvent } from './paging-bar.component';
 
 @NgModule({
   imports: [
-    FormsModule,
     CommonModule,
     MdIconModule,
-    MdSelectModule,
     MdButtonModule,
   ],
   declarations: [


### PR DESCRIPTION
instead of having the paging bar render the `md-select` from material, we are gonna abstract it and add tons of examples on how people can leverage the paging-bar API to add a page size `md-select`, or `md-input` `go to` navigation + other examples. 

This will allow the module to be more lightweight, plus be flexible enough to allow anything in the bar without binding it to certain components nor wrapping them and letting users provide their own translation strings for the content.

This will also allow the paging-bar to be more responsive and the user can pick and choose what to show/hide depending on screen size https://github.com/Teradata/covalent/issues/533

Will also take care of https://github.com/Teradata/covalent/issues/520 since now it's up to the user to show/hide the `md-select` when needed and devs can access its events.

### What's included?

- Remove `md-select` from `td-paging-bar` and add demo examples on how to add your own
- Remove `pageSizes`, ` pageSizeAll` and `pageSizeAllText` inputs since they arent needed anymore
- Remove `td-paging-bar-label` since its not needed anymore
- Add demo for `md-select` page size usage
- Add demo for responsiveness
- Add demo for page links
- Update unit tests and add more cases

#### Usage

Before:

```html
<td-paging-bar #pagingBar
                       [pageSizes]="[50,100,200,500,1000]"
                       [pageSize]="pageSize"
                       [total]="1345"
                       (change)="change($event)">
  <span td-paging-bar-label hide-xs>Rows per page:</span>
  <span>{{pagingBar.range}} <span hide-xs>of {{pagingBar.total}}</span></span>
</td-paging-bar>
```

After:

```html
<td-paging-bar #pagingBar
                       [pageSize]="pageSize"
                       [total]="1345"
                       (change)="change($event)">
  <span hide-xs>Rows per page:</span>
  <md-select [(ngModel)]="pageSize">
    <md-option *ngFor="let size of [50,100,200,500,1000]" [value]="size">
      {{size}}
    </md-option>
  </md-select>
  <span>{{pagingBar.range}} <span hide-xs>of {{pagingBar.total}}</span></span>
</td-paging-bar>
```

#### Test Steps

- [ ] `ng serve`
- [ ] Go to http://localhost:4200/components/paging
- [ ] See new demos and new flexible usage of `td-paging-bar`

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

*BREAKING CHANGE* closes #520 and closes #533