### PR TITLE
perf(data-table): make checkbox state check more performant

### DIFF
--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -365,8 +365,14 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
         if (this.isRowSelected(row)) {
           toggledRows.push(row);
         }
+        row = this._value.filter((val: any) => {
+            return this.compareWith(row, val);
+          })[0];
+        let index: number = this._value.indexOf(row);
+        if (index > -1) {
+          this._value.splice(index, 1);
+        }
       });
-      this.clearModel();
       this._allSelected = false;
       this._indeterminate = false;
     }
@@ -597,7 +603,7 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
       }
     }
     this._calculateCheckboxState();
-    this.onRowSelect.emit({row: row, selected: this.isRowSelected(row)});
+    this.onRowSelect.emit({row: row, selected: !wasSelected});
     this.onChange(this._value);
   }
 
@@ -605,30 +611,15 @@ export class TdDataTableComponent implements ControlValueAccessor, AfterContentI
    * Calculate all the state of all checkboxes
    */
   private _calculateCheckboxState(): void {
-    this._calculateAllSelected();
-    this._calculateIndeterminate();
-  }
-
-  /**
-   * Checks if all visible rows are selected.
-   */
-  private _calculateAllSelected(): void {
-    const match: string =
-      this._data ? this._data.find((d: any) => !this.isRowSelected(d)) : true;
-    this._allSelected = typeof match === 'undefined';
-  }
-
-  /**
-   * Checks if all visible rows are selected.
-   */
-  private _calculateIndeterminate(): void {
-    this._indeterminate = false;
     if (this._data) {
+      this._allSelected = typeof this._data.find((d: any) => !this.isRowSelected(d)) === 'undefined';
+      this._indeterminate = false;
       for (let row of this._data) {
         if (!this.isRowSelected(row)) {
           continue;
         }
         this._indeterminate = true;
+        break;
       }
     }
   }


### PR DESCRIPTION
also, when clicking on uncheck all, we only uncheck the items that are in the current data array

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.