### PR TITLE
feat(dynamic-form): Added dynamic file input

### DIFF
--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.html
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.html
@@ -110,6 +110,33 @@
   </md-card-content>
 </md-card>
 <md-card>
+  <md-card-content>
+    <h3 class="md-title">Dynamic File Input Element</h3>
+    <md-divider></md-divider>
+    <md-tab-group md-stretch-tabs>
+      <md-tab>
+        <ng-template md-tab-label>Demo</ng-template>
+        <td-dynamic-forms [elements]="fileElements">
+        </td-dynamic-forms>
+      </md-tab>
+      <md-tab>
+        <ng-template md-tab-label>Code</ng-template>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-dynamic-forms [elements]="fileElements">
+            </td-dynamic-forms>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          {{fileElements | json}}
+        </td-highlight>
+      </md-tab>
+    </md-tab-group>
+  </md-card-content>
+</md-card>
+<md-card>
   <md-card-title>TdDynamicFormsComponent</md-card-title>
   <md-card-subtitle>How to use this component</md-card-subtitle>
   <md-divider></md-divider>

--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
@@ -104,4 +104,9 @@ export class DynamicFormsDemoComponent {
     selections: ['Test1', 'Test2', 'Test3', 'Test4'],
     required: true,
   }];
+
+  fileElements: ITdDynamicElementConfig[] = [{
+    name: 'file-input',
+    type: TdDynamicElement.FileInput,
+  }];
 }

--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
@@ -107,6 +107,7 @@ export class DynamicFormsDemoComponent {
 
   fileElements: ITdDynamicElementConfig[] = [{
     name: 'file-input',
+    label: 'Browse a file',
     type: TdDynamicElement.FileInput,
   }];
 }

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
@@ -1,0 +1,24 @@
+<div class="dynamic-file-input-wrapper" layout="row">
+  <md-input-container tdFileDrop
+                      (fileDrop)="value = $event"
+                      (click)="fileInput.inputElement.click()"
+                      (keyup.enter)="fileInput.inputElement.click()"
+                      (keyup.delete)="fileInput.clear()"
+                      (keyup.backspace)="fileInput.clear()"
+                      flex>
+    <input mdInput
+          [value]="value?.length ? (value?.length + ' files') : value?.name"
+          [placeholder]="label"
+          readonly/>
+  </md-input-container>
+  <button md-icon-button *ngIf="value" (click)="fileInput.clear()" (keyup.enter)="fileInput.clear()">
+    <md-icon>cancel</md-icon>
+  </button>
+  <td-file-input class="push-left-sm push-right-sm" #fileInput [(ngModel)]="value" multiple>
+    <md-icon>folder</md-icon>
+    <span class="text-upper">Browse</span>
+  </td-file-input>
+  <span>
+    <button md-raised-button color="accent" [disabled]="!value" class="text-upper">Submit</button>
+  </span>
+</div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
@@ -7,18 +7,15 @@
                       (keyup.backspace)="fileInput.clear()"
                       flex>
     <input mdInput
-          [value]="value?.length ? (value?.length + ' files') : value?.name"
+          [value]="value?.name"
           [placeholder]="label"
           readonly/>
   </md-input-container>
   <button md-icon-button *ngIf="value" (click)="fileInput.clear()" (keyup.enter)="fileInput.clear()">
     <md-icon>cancel</md-icon>
   </button>
-  <td-file-input class="push-left-sm push-right-sm" #fileInput [(ngModel)]="value" multiple>
+  <td-file-input class="push-left-sm push-right-sm" #fileInput [(ngModel)]="value">
     <md-icon>folder</md-icon>
-    <span class="text-upper">Browse</span>
+    <span>{{ label }}</span>
   </td-file-input>
-  <span>
-    <button md-raised-button color="accent" [disabled]="!value" class="text-upper">Submit</button>
-  </span>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
@@ -1,5 +1,6 @@
 <div class="dynamic-file-input-wrapper" layout="row">
   <md-input-container tdFileDrop
+                      floatPlaceholder="never"
                       (fileDrop)="value = $event"
                       (click)="fileInput.inputElement.click()"
                       (keyup.enter)="fileInput.inputElement.click()"
@@ -14,7 +15,7 @@
   <button md-icon-button *ngIf="value" (click)="fileInput.clear()" (keyup.enter)="fileInput.clear()">
     <md-icon>cancel</md-icon>
   </button>
-  <td-file-input class="push-left-sm push-right-sm" #fileInput [(ngModel)]="value">
+  <td-file-input class="td-file-input" #fileInput [(ngModel)]="value">
     <md-icon>folder</md-icon>
     <span>{{ label }}</span>
   </td-file-input>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.scss
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.scss
@@ -1,0 +1,3 @@
+.td-file-input {
+  margin-left: 10px;
+}

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.ts
@@ -1,0 +1,28 @@
+import { Component, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR, ControlValueAccessor, FormControl } from '@angular/forms';
+
+import { AbstractControlValueAccessor } from '../abstract-control-value-accesor';
+
+export const UPLOAD_INPUT_CONTROL_VALUE_ACCESSOR: any = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => TdDynamicFileInputComponent),
+  multi: true,
+};
+
+@Component({
+  providers: [ UPLOAD_INPUT_CONTROL_VALUE_ACCESSOR ],
+  selector: 'td-dynamic-file-input',
+  styleUrls: [ './dynamic-file-input.component.scss' ],
+  templateUrl: './dynamic-file-input.component.html',
+})
+export class TdDynamicFileInputComponent extends AbstractControlValueAccessor implements ControlValueAccessor {
+
+  control: FormControl;
+
+  type: string = undefined;
+
+  required: boolean = undefined;
+
+  label: string = '';
+
+}

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.ts
@@ -19,8 +19,6 @@ export class TdDynamicFileInputComponent extends AbstractControlValueAccessor im
 
   control: FormControl;
 
-  type: string = undefined;
-
   required: boolean = undefined;
 
   label: string = '';

--- a/src/platform/dynamic-forms/dynamic-forms.module.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.module.ts
@@ -2,15 +2,18 @@ import { NgModule, Type, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 
-import { MdInputModule, MdSelectModule, MdCheckboxModule, MdSliderModule, MdSlideToggleModule } from '@angular/material';
+import { MdInputModule, MdSelectModule, MdCheckboxModule, MdSliderModule, MdSlideToggleModule, MdIconModule,
+   MdButtonModule } from '@angular/material';
 
 import { CovalentCommonModule } from '../core';
+import { CovalentFileModule } from '../core';
 
 import { TdDynamicFormsComponent } from './dynamic-forms.component';
 import { TdDynamicElementComponent, TdDynamicElementDirective } from './dynamic-element.component';
 import { TdDynamicFormsService, DYNAMIC_FORMS_PROVIDER } from './services/dynamic-forms.service';
 
 import { TdDynamicInputComponent } from './dynamic-elements/dynamic-input/dynamic-input.component';
+import { TdDynamicFileInputComponent } from './dynamic-elements/dynamic-file-input/dynamic-file-input.component';
 import { TdDynamicTextareaComponent } from './dynamic-elements/dynamic-textarea/dynamic-textarea.component';
 import {
   TdDynamicSlideToggleComponent,
@@ -29,6 +32,7 @@ const TD_DYNAMIC_FORMS: Type<any>[] = [
 
 const TD_DYNAMIC_FORMS_ENTRY_COMPONENTS: Type<any>[] = [
   TdDynamicInputComponent,
+  TdDynamicFileInputComponent,
   TdDynamicTextareaComponent,
   TdDynamicSlideToggleComponent,
   TdDynamicCheckboxComponent,
@@ -49,7 +53,10 @@ const TD_DYNAMIC_FORMS_ENTRY_COMPONENTS: Type<any>[] = [
     MdCheckboxModule,
     MdSliderModule,
     MdSlideToggleModule,
+    MdIconModule,
+    MdButtonModule,
     CovalentCommonModule,
+    CovalentFileModule,
   ],
   exports: [
     TD_DYNAMIC_FORMS,

--- a/src/platform/dynamic-forms/index.ts
+++ b/src/platform/dynamic-forms/index.ts
@@ -4,6 +4,7 @@ export { ITdDynamicElementConfig, TdDynamicType,
 export { TdDynamicElementComponent } from './dynamic-element.component';
 export { TdDynamicFormsComponent } from './dynamic-forms.component';
 export { TdDynamicInputComponent } from './dynamic-elements/dynamic-input/dynamic-input.component';
+export { TdDynamicFileInputComponent } from './dynamic-elements/dynamic-file-input/dynamic-file-input.component';
 export { TdDynamicTextareaComponent } from './dynamic-elements/dynamic-textarea/dynamic-textarea.component';
 export {
   TdDynamicSlideToggleComponent,

--- a/src/platform/dynamic-forms/services/dynamic-forms.service.ts
+++ b/src/platform/dynamic-forms/services/dynamic-forms.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Provider, SkipSelf, Optional } from '@angular/core';
 import { Validators, ValidatorFn, FormControl } from '@angular/forms';
 
 import { TdDynamicInputComponent } from '../dynamic-elements/dynamic-input/dynamic-input.component';
+import { TdDynamicFileInputComponent } from '../dynamic-elements/dynamic-file-input/dynamic-file-input.component';
 import { TdDynamicTextareaComponent } from '../dynamic-elements/dynamic-textarea/dynamic-textarea.component';
 import { TdDynamicSlideToggleComponent } from '../dynamic-elements/dynamic-slide-toggle/dynamic-slide-toggle.component';
 import { TdDynamicCheckboxComponent } from '../dynamic-elements/dynamic-checkbox/dynamic-checkbox.component';
@@ -23,6 +24,7 @@ export enum TdDynamicElement {
   SlideToggle = <any>'slide-toggle',
   Checkbox = <any>'checkbox',
   Select = <any>'select',
+  FileInput = <any>'file-input',
 }
 
 export interface ITdDynamicElementConfig {
@@ -74,6 +76,8 @@ export class TdDynamicFormsService {
       case TdDynamicType.Array:
       case TdDynamicElement.Select:
         return TdDynamicSelectComponent;
+      case TdDynamicElement.FileInput:
+        return TdDynamicFileInputComponent;
       default:
         throw new Error(`Error: type ${element} does not exist or not supported.`);
     }
@@ -91,6 +95,7 @@ export class TdDynamicFormsService {
       case TdDynamicElement.Input:
       case TdDynamicElement.Password:
       case TdDynamicType.Array:
+      case TdDynamicElement.FileInput:
       case TdDynamicElement.Select:
         return 45;
       case TdDynamicElement.Textarea:


### PR DESCRIPTION
## Description

Upstreamed Dynamic File Input from AppCenter. Modified the name from `upload` to `file-input`.

### What's included?

- Added new file input into dynamic forms
- Added docs & demo on http://localhost:4200/#/components/dynamic-forms

#### Test Steps

- [ ] Navigate to http://localhost:4200/#/components/dynamic-forms & check demo & docs section for `Dynamic File Input Element`

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle