### PR TITLE
feat(docs): Covalent Text/Markdown Editor Demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@angular/platform-server": "^4.2.0",
     "@angular/router": "^4.2.0",
     "@covalent/code-editor": "^1.0.0-alpha.6-7",
+    "@covalent/text-editor": "^1.0.0-alpha.1",
     "@ngx-translate/core": "7.0.0",
     "@ngx-translate/http-loader": "0.1.0",
     "@swimlane/ngx-charts": "5.3.1",

--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -123,6 +123,11 @@ export class ComponentsComponent implements AfterViewInit {
     route: 'code-editor',
     title: 'Code Editor',
   }, {
+    description: 'Text and Markdown editor component',
+    icon: 'vertical_align_bottom',
+    route: 'text-editor',
+    title: 'Text Editor',
+  }, {
     description: 'Http wrappers and helpers',
     icon: 'http',
     route: 'http',

--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -111,7 +111,7 @@ export class ComponentsComponent implements AfterViewInit {
     description: 'Parse markdown code',
     icon: 'chrome_reader_mode',
     route: 'markdown',
-    title: 'Markdown',
+    title: 'Markdown Parser',
   }, {
     description: 'Build forms from a JS object',
     icon: 'format_align_center',
@@ -124,9 +124,9 @@ export class ComponentsComponent implements AfterViewInit {
     title: 'Code Editor',
   }, {
     description: 'Text and Markdown editor component',
-    icon: 'vertical_align_bottom',
+    icon: 'keyboard',
     route: 'text-editor',
-    title: 'Text Editor',
+    title: 'Markdown Text Editor',
   }, {
     description: 'Http wrappers and helpers',
     icon: 'http',

--- a/src/app/components/components/components.module.ts
+++ b/src/app/components/components/components.module.ts
@@ -26,6 +26,7 @@ import { PagingDemoComponent } from './paging/paging.component';
 import { SearchDemoComponent } from './search/search.component';
 import { DynamicFormsDemoComponent } from './dynamic-forms/dynamic-forms.component';
 import { CodeEditorDemoComponent } from './code-editor/code-editor.component';
+import { TextEditorDemoComponent } from './text-editor/text-editor.component';
 import { NotificationsDemoComponent } from './notifications/notifications.component';
 import { NgxChartsDemoComponent } from './ngx-charts/ngx-charts.component';
 import { NgxTranslateDemoComponent } from './ngx-translate/ngx-translate.component';
@@ -46,6 +47,7 @@ import { CovalentHighlightModule } from '../../../platform/highlight';
 import { CovalentMarkdownModule } from '../../../platform/markdown';
 import { CovalentDynamicFormsModule } from '../../../platform/dynamic-forms';
 import { CovalentCodeEditorModule } from '../../../../node_modules/@covalent/code-editor';
+import { CovalentTextEditorModule } from '../../../../node_modules/@covalent/text-editor';
 
 import { DocumentationToolsModule } from '../../documentation-tools';
 
@@ -75,6 +77,7 @@ import { ToolbarModule } from '../../components/toolbar/toolbar.module';
     SearchDemoComponent,
     DynamicFormsDemoComponent,
     CodeEditorDemoComponent,
+    TextEditorDemoComponent,
     NotificationsDemoComponent,
     // External Dependencies
     NgxChartsDemoComponent,
@@ -121,6 +124,7 @@ import { ToolbarModule } from '../../components/toolbar/toolbar.module';
     CovalentDynamicFormsModule,
     CovalentMessageModule,
     CovalentCodeEditorModule,
+    CovalentTextEditorModule,
     DocumentationToolsModule,
     NgxChartsModule,
     TranslateModule,

--- a/src/app/components/components/components.routes.ts
+++ b/src/app/components/components/components.routes.ts
@@ -22,6 +22,7 @@ import { PagingDemoComponent } from './paging/paging.component';
 import { SearchDemoComponent } from './search/search.component';
 import { DynamicFormsDemoComponent } from './dynamic-forms/dynamic-forms.component';
 import { CodeEditorDemoComponent } from './code-editor/code-editor.component';
+import { TextEditorDemoComponent } from './text-editor/text-editor.component';
 import { NotificationsDemoComponent } from './notifications/notifications.component';
 import { NgxChartsDemoComponent } from './ngx-charts/ngx-charts.component';
 import { NgxTranslateDemoComponent } from './ngx-translate/ngx-translate.component';
@@ -93,6 +94,9 @@ const routes: Routes = [{
     }, {
       component: CodeEditorDemoComponent,
       path: 'code-editor',
+    }, {
+      component: TextEditorDemoComponent,
+      path: 'text-editor',
     }, {
       component: NgxChartsDemoComponent,
       path: 'ngx-charts',

--- a/src/app/components/components/overview/overview.component.ts
+++ b/src/app/components/components/overview/overview.component.ts
@@ -104,7 +104,7 @@ export class ComponentsOverviewComponent {
       color: 'orange-A700',
       icon: 'chrome_reader_mode',
       route: 'markdown',
-      title: 'Markdown',
+      title: 'Markdown Parser',
     }, {
       color: 'green-A700',
       icon: 'format_align_center',
@@ -116,10 +116,10 @@ export class ComponentsOverviewComponent {
       route: 'code-editor',
       title: 'Code Editor',
     }, {
-      color: 'purple-A700',
-      icon: 'vertical_align_bottom',
+      color: 'cyan-A700',
+      icon: 'keyboard',
       route: 'text-editor',
-      title: 'Text/Markdown Editor',
+      title: 'Markdown Text Editor',
     }, {
       color: 'indigo-A700',
       icon: 'http',

--- a/src/app/components/components/overview/overview.component.ts
+++ b/src/app/components/components/overview/overview.component.ts
@@ -116,6 +116,11 @@ export class ComponentsOverviewComponent {
       route: 'code-editor',
       title: 'Code Editor',
     }, {
+      color: 'purple-A700',
+      icon: 'vertical_align_bottom',
+      route: 'text-editor',
+      title: 'Text/Markdown Editor',
+    }, {
       color: 'indigo-A700',
       icon: 'http',
       route: 'http',

--- a/src/app/components/components/text-editor/text-editor.component.html
+++ b/src/app/components/components/text-editor/text-editor.component.html
@@ -1,6 +1,6 @@
 <md-card>
-  <md-card-title>Text Editor</md-card-title>
-  <md-card-subtitle>Text and Markdown editor component</md-card-subtitle>
+  <md-card-title>Markdown Text Editor</md-card-title>
+  <md-card-subtitle>Simple markdown text editor component</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
     <p>With this component you can utilize SimpleMDE as an Angular Component.</p>
@@ -12,19 +12,24 @@
   </md-card-actions>
 </md-card>
 <md-card>
-  <md-card-title>Basic example</md-card-title>
-  <md-card-subtitle>Markdown editor running in browser</md-card-subtitle>
+  <md-card-title>Demo</md-card-title>
+  <md-card-subtitle>Edit the markdown in the left editor for a real-time preview</md-card-subtitle>
   <md-divider></md-divider>
-  <md-card-content>
-    <div layout="row" layout-align="start center">
-      <td-text-editor [(ngModel)]="editorVal"></td-text-editor>
+  <md-toolbar hide show-gt-md>
+    <div layout="row" flex>
+      <span flex="55">Editor</span>
+      <span flex="45">Preview</span>
     </div>
-    <h3 class="md-title">Editor Output:</h3>
-    <div layout="row" layout-align="start center">
-      <td-markdown [content]="editorVal"></td-markdown>
+  </md-toolbar>
+  <md-divider hide show-gt-md></md-divider>
+  <div layout-gt-md="row" class="bgc-grey-50" tdMediaToggle="gt-md" [mediaStyles]="{height: '650px'}">
+    <div flex-gt-md="55" layout-gt-md="column" class="pad-sm">
+      <td-text-editor flex-gt-md [(ngModel)]="editorVal"></td-text-editor>
     </div>
-  </md-card-content>
-  <md-divider></md-divider>
+    <div flex-gt-md="45" layout-gt-md="column" class="md-content pad-sm">
+      <td-markdown flex-gt-md [content]="editorVal"></td-markdown>
+    </div>
+  </div>
 </md-card>
 
 <td-readme-loader resourceUrl="https://raw.githubusercontent.com/Teradata/covalent-text-editor/master/docs/API.md">

--- a/src/app/components/components/text-editor/text-editor.component.html
+++ b/src/app/components/components/text-editor/text-editor.component.html
@@ -1,0 +1,34 @@
+<md-card>
+  <md-card-title>Text Editor</md-card-title>
+  <md-card-subtitle>Text and Markdown editor component</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p>With this component you can utilize SimpleMDE as an Angular Component.</p>
+  </md-card-content>
+  <md-divider></md-divider>
+  <md-card-actions>
+    <a md-button color="accent" href="https://github.com/Teradata/covalent-text-editor" target="_blank" class="text-upper">Github Repo</a>
+    <a md-button color="accent" href="https://www.npmjs.com/package/@covalent/text-editor" target="_blank" class="text-upper">npm Module</a>
+  </md-card-actions>
+</md-card>
+<md-card>
+  <md-card-title>Basic example</md-card-title>
+  <md-card-subtitle>Markdown editor running in browser</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <div layout="row" layout-align="start center">
+      <td-text-editor [(ngModel)]="editorVal"></td-text-editor>
+    </div>
+    <h3 class="md-title">Editor Output:</h3>
+    <div layout="row" layout-align="start center">
+      <td-markdown [content]="editorVal"></td-markdown>
+    </div>
+  </md-card-content>
+  <md-divider></md-divider>
+</md-card>
+
+<td-readme-loader resourceUrl="https://raw.githubusercontent.com/Teradata/covalent-text-editor/master/docs/API.md">
+</td-readme-loader>
+
+<td-readme-loader resourceUrl="https://raw.githubusercontent.com/Teradata/covalent-text-editor/master/docs/SETUP.md">
+</td-readme-loader>

--- a/src/app/components/components/text-editor/text-editor.component.scss
+++ b/src/app/components/components/text-editor/text-editor.component.scss
@@ -1,0 +1,3 @@
+.editor {
+    height: 200px;
+}

--- a/src/app/components/components/text-editor/text-editor.component.ts
+++ b/src/app/components/components/text-editor/text-editor.component.ts
@@ -1,0 +1,37 @@
+import { Component, HostBinding, ViewChild } from '@angular/core';
+import { slideInDownAnimation } from '../../../app.animations';
+import { TdTextEditorComponent } from '@covalent/text-editor';
+
+@Component({
+  selector: 'text-editor-demo',
+  styleUrls: [ './text-editor.component.scss' ],
+  templateUrl: './text-editor.component.html',
+  animations: [slideInDownAnimation],
+})
+export class TextEditorDemoComponent {
+
+  @ViewChild('editor') private _tdEditor: TdTextEditorComponent;
+  @HostBinding('@routeAnimation') routeAnimation: boolean = true;
+  @HostBinding('class.td-route-animation') classAnimation: boolean = true;
+
+  editorVal: string = `# Intro
+Go ahead, play around with the editor! Be sure to check out **bold** and *italic* styling, or even [links](https://google.com).
+You can type the Markdown syntax, use the toolbar, or use shortcuts like 'cmd-b' or 'ctrl-b'.
+
+## Lists
+Ordered lists can be started by typing '1. '.
+
+#### Unordered
+* Lists are a piece of cake
+* They even auto continue as you type
+* A double enter will end them
+* Tabs and shift-tabs work too
+
+#### Ordered
+1. Numbered lists...
+2. ...work too!
+
+## What about images?
+![Yes](https://i.imgur.com/sZlktY7.png)
+`;
+}

--- a/src/app/components/components/text-editor/text-editor.component.ts
+++ b/src/app/components/components/text-editor/text-editor.component.ts
@@ -19,7 +19,6 @@ Go ahead, play around with the editor! Be sure to check out **bold** and *italic
 You can type the Markdown syntax, use the toolbar, or use shortcuts like 'cmd-b' or 'ctrl-b'.
 
 ## Lists
-## Lists
 Unordered lists can be started using the toolbar or by typing '* ', '- ', or '+ '. Ordered lists can be started by typing '1. '.
 
 #### Unordered

--- a/src/app/components/components/text-editor/text-editor.component.ts
+++ b/src/app/components/components/text-editor/text-editor.component.ts
@@ -19,7 +19,8 @@ Go ahead, play around with the editor! Be sure to check out **bold** and *italic
 You can type the Markdown syntax, use the toolbar, or use shortcuts like 'cmd-b' or 'ctrl-b'.
 
 ## Lists
-Ordered lists can be started by typing '1. '.
+## Lists
+Unordered lists can be started using the toolbar or by typing '* ', '- ', or '+ '. Ordered lists can be started by typing '1. '.
 
 #### Unordered
 * Lists are a piece of cake

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -36,6 +36,11 @@ export class ToolbarComponent {
       icon: 'featured_play_list',
       route: '/components/code-editor',
       title: 'New component',
+    }, {
+      description: 'introducing covalent/text-editor',
+      icon: 'vertical_align_bottom',
+      route: '/components/text-editor',
+      title: 'New component',
     },
   ];
 


### PR DESCRIPTION
## Description

Added demo for Covalent Text/Markdown Editor into Covalent Docs

### What's included?

- new file:   src/app/components/components/text-editor/text-editor.component.html
- new file:   src/app/components/components/text-editor/text-editor.component.scss
- new file:   src/app/components/components/text-editor/text-editor.component.ts
- modified:   package.json
- modified:   src/app/components/components/components.component.ts
- modified:   src/app/components/components/components.module.ts
- modified:   src/app/components/components/components.routes.ts
- modified:   src/app/components/components/overview/overview.component.ts
- modified:   src/app/components/toolbar/toolbar.component.ts

#### Test Steps

- [ ] checkout branch
- [ ] rm -rf node_modules
- [ ] npm i
- [ ] ng serve
- [ ] go to http://localhost:4200/#/components
- [ ] Click on Text/Markdown Editor under optional components
- [ ] Try out editor and see output

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![screen shot 2017-08-08 at 3 44 03 pm](https://user-images.githubusercontent.com/10502797/29097776-757993b8-7c50-11e7-9725-45c768cd2602.png)
