### PR TITLE
feat(docs): Add Stackblitz Example to Text Editor Demo

### DIFF
--- a/src/app/components/components/text-editor/text-editor.component.html
+++ b/src/app/components/components/text-editor/text-editor.component.html
@@ -11,9 +11,18 @@
     <a md-button color="accent" href="https://www.npmjs.com/package/@covalent/text-editor" target="_blank" class="text-upper">npm Module</a>
   </md-card-actions>
 </md-card>
-<md-card>
+<md-card class="pad-bottom-lg">
   <md-card-title>Demo</md-card-title>
-  <md-card-subtitle>Edit the markdown in the left editor for a real-time preview</md-card-subtitle>
+    <md-card-subtitle class="bgc-grey-100 push-none">
+        <div layout="row">
+          <p>Edit the markdown in the left editor for a real-time preview</p>
+                <span flex></span>
+                <a class="bgc-grey-100 push-none" md-icon-button mdTooltip="View in Editor" target="_blank" href="https://stackblitz.com/edit/angular-rzw7vp">
+              <md-icon class="tc-grey-700">open_in_new</md-icon>
+          </a>
+        </div>
+    </md-card-subtitle>
+  <md-divider></md-divider>
   <md-divider></md-divider>
   <md-toolbar hide show-gt-md>
     <div layout="row" flex>

--- a/src/app/components/components/text-editor/text-editor.component.html
+++ b/src/app/components/components/text-editor/text-editor.component.html
@@ -13,16 +13,15 @@
 </md-card>
 <md-card class="pad-bottom-lg">
   <md-card-title>Demo</md-card-title>
-    <md-card-subtitle class="bgc-grey-100 push-none">
-        <div layout="row">
-          <p>Edit the markdown in the left editor for a real-time preview</p>
-                <span flex></span>
-                <a class="bgc-grey-100 push-none" md-icon-button mdTooltip="View in Editor" target="_blank" href="https://stackblitz.com/edit/angular-rzw7vp">
-              <md-icon class="tc-grey-700">open_in_new</md-icon>
-          </a>
-        </div>
-    </md-card-subtitle>
-  <md-divider></md-divider>
+  <md-card-subtitle class="bgc-grey-100 push-none">
+      <div layout="row">
+        <p>Edit the markdown in the left editor for a real-time preview</p>
+              <span flex></span>
+              <a class="bgc-grey-100 push-none" md-icon-button mdTooltip="View in Editor" target="_blank" href="https://stackblitz.com/edit/angular-rzw7vp">
+            <md-icon class="tc-grey-700">open_in_new</md-icon>
+        </a>
+      </div>
+  </md-card-subtitle>
   <md-divider></md-divider>
   <md-toolbar hide show-gt-md>
     <div layout="row" flex>

--- a/src/app/components/components/text-editor/text-editor.component.html
+++ b/src/app/components/components/text-editor/text-editor.component.html
@@ -14,13 +14,13 @@
 <md-card class="pad-bottom-lg">
   <md-card-title>Demo</md-card-title>
   <md-card-subtitle class="bgc-grey-100 push-none">
-      <div layout="row">
-        <p>Edit the markdown in the left editor for a real-time preview</p>
-              <span flex></span>
-              <a class="bgc-grey-100 push-none" md-icon-button mdTooltip="View in Editor" target="_blank" href="https://stackblitz.com/edit/angular-rzw7vp">
-            <md-icon class="tc-grey-700">open_in_new</md-icon>
-        </a>
-      </div>
+    <div layout="row">
+      <p>Edit the markdown in the left editor for a real-time preview</p>
+      <span flex></span>
+      <a class="bgc-grey-100 push-none" md-icon-button mdTooltip="View in Editor" target="_blank" href="https://stackblitz.com/edit/angular-rzw7vp">
+        <md-icon class="tc-grey-700">open_in_new</md-icon>
+      </a>
+    </div>
   </md-card-subtitle>
   <md-divider></md-divider>
   <md-toolbar hide show-gt-md>


### PR DESCRIPTION
## Description

Add a link to the Text Editor Demo that opens a Stackblitz example

### What's included?

- modified:   src/app/components/components/text-editor/text-editor.component.html

#### Test Steps

- [ ] Checkout branch
- [ ] ng serve
- [ ] go to http://localhost:4200/#/components/text-editor
- [ ] Click on `View in Editor` button to launch you to Stackblitz example

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
<img width="1406" alt="screen shot 2017-08-11 at 11 26 53 am" src="https://user-images.githubusercontent.com/10502797/29226748-053eeec4-7e88-11e7-8755-ce6db6465bf1.png">
