### PR TITLE
feat(animations): add rotate animation utility function and documentation

### DIFF
--- a/src/app/components/components/animations/animations.component.html
+++ b/src/app/components/components/animations/animations.component.html
@@ -53,7 +53,7 @@
           <button [@myAnchor]="triggerState" (click)="triggerState = !triggerState" md-raised-button>Rotate</button>
         ]]>
     </td-highlight>
-    <h3>Method Options:</h3>
+    <h3>Method Details:</h3>
     <p>TdRotateAnimation(anchor: string, duration: number, degrees: number)</p>
     <md-list>
       <md-list-item>

--- a/src/app/components/components/animations/animations.component.html
+++ b/src/app/components/components/animations/animations.component.html
@@ -68,7 +68,7 @@
       <md-divider></md-divider>
       <md-list-item>
         <h3 md-line>degrees</h3>
-        <p md-line> Degrees of rotation that the dom object will animation. Defaults to 180 degrees. </p>
+        <p md-line> Degrees of rotation the dom object will animation. A negative value will cause the animation to initially rotate counter-clockwise. Defaults to 180 degrees. </p>
       </md-list-item>
       <md-divider></md-divider>
     </md-list>

--- a/src/app/components/components/animations/animations.component.html
+++ b/src/app/components/components/animations/animations.component.html
@@ -3,22 +3,24 @@
   <md-card-subtitle>Core Covalent animation utilities</md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
-    <p>Utilities to help add simple animations. For custom and complex animations look into the Angular animations docs.</p>
+    <p>Utilities to help add simple animations. For custom and complex animations look into the Angular animations doc.</p>
 
     <h3>Setup:</h3>
-    <p>Import individual animation utilities needed into the component that will contain the elements you want to animate (ex: TdRotateAnimation).</p>
+    <p>Import individual animation utilities as needed into the component that will contain the elements you want to animate.</p>
+    <p>Replace the "TdAnimationUtility" stub variable in code setup below with the respective animation utilities you decide to equip.</p>
     <p>Invoke the utility functions with a required anchor name and optional configs in the component's metadata. The anchor name is used to attach the animation to an arbitrary element in the template.</p>
     <td-highlight lang="typescript">
       <![CDATA[
+        // my-component.component.ts
         import {
-          TdRotateAnimation
+          TdAnimationUtility
         } from '@covalent/core/common/animations';
 
         @Component({
           ...
           templateUrl: './my-component.component.html',
           animations: [
-            TdRotateAnimation('myAnchor'),
+            TdAnimationUtility('myAnchor'),
           ],
         })
         export class MyComponent {
@@ -39,38 +41,80 @@
   <md-divider></md-divider>
   <md-card-content>
     <p class="md-body-1">Use <code>TdRotateAnimation</code> to rotate any element based on a boolean state.</p>
+      <div>
+        <h3>Demo 1:</h3>
 
-    <div layout="row">
-      <button md-raised-button [@rotateExample180]="rotateState1" class="push-left-xs" (click)="rotateState1 = !rotateState1" color="accent">Rotate 180&deg;<md-icon>mood</md-icon></button>
-      <button md-raised-button [@rotateExample360]="rotateState2" class="push-left-xs" (click)="rotateState2 = !rotateState2" color="accent">Rotate 360&deg;<md-icon>mood</md-icon></button>
-      <button md-raised-button [@rotateExample540]="rotateState3" class="push-left-xs" (click)="rotateState3 = !rotateState3" color="accent">Rotate 540&deg;<md-icon>mood</md-icon></button>
-      <button md-raised-button class="push-left-md" (click)="rotateState1 = !rotateState1; rotateState2 = !rotateState2; rotateState3 = !rotateState3;" color="accent">Rotate All</button>
+        <button md-raised-button [@rotate1Example180]="rotateState1" class="push-left-xs" (click)="rotateState1 = !rotateState1" color="accent">Rotate 180&deg;<md-icon>mood</md-icon></button>
+
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+            <![CDATA[
+              // my-component.component.ts
+              TdRotateAnimation('myAnchor')
+              ...
+              triggerState: boolean = false;
+            ]]>
+        </td-highlight>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+            <![CDATA[
+              <!-- my-component.component.html -->
+              <button [@myAnchor]="triggerState" (click)="triggerState = !triggerState" md-raised-button>Rotate</button>
+            ]]>
+        </td-highlight>
+      </div>
+
+      <hr>
+
+      <div>
+        <h3>Demo 2:</h3>
+        <button md-raised-button [@rotate2Example180]="rotateState2" class="push-left-xs" (click)="rotateState2 = !rotateState2" color="accent">Rotate -180&deg;<md-icon>mood</md-icon></button>
+        <button md-raised-button [@rotate2Example360]="rotateState3" class="push-left-xs" (click)="rotateState3 = !rotateState3" color="accent">Rotate 360&deg;<md-icon>mood</md-icon></button>
+
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+            <![CDATA[
+              // my-component.component.ts
+              TdRotateAnimation('myAnchor1', 1000, -180),
+              TdRotateAnimation('myAnchor2', 500, 360)
+              ...
+              triggerState1: boolean = false;
+              triggerState2: boolean = false;
+            ]]>
+        </td-highlight>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+            <![CDATA[
+              <!-- my-component.component.html -->
+              <button [@myAnchor1]="triggerState1" (click)="triggerState1 = !triggerState1" md-raised-button>Rotate</button>
+              <button [@myAnchor2]="triggerState2" (click)="triggerState2 = !triggerState2" md-raised-button>Rotate</button>
+            ]]>
+        </td-highlight>
+      </div>
+
+    <hr>
+
+    <div>
+      <h2>Method Details:</h2>
+      <p>TdRotateAnimation(anchor: string, duration: number, degrees: number)</p>
+      <md-list>
+        <md-list-item>
+          <h3 md-line>anchor</h3>
+          <p md-line> The anchor name is used to attach the animation to an arbitrary element in the template. </p>
+        </md-list-item>
+        <md-divider></md-divider>
+        <md-list-item>
+          <h3 md-line>duration</h3>
+          <p md-line> Duration the animation will run in miliseconds. Defaults to 250 ms. </p>
+        </md-list-item>
+        <md-divider></md-divider>
+        <md-list-item>
+          <h3 md-line>degrees</h3>
+          <p md-line> Degrees of rotation the dom object will animation. A negative value will cause the animation to initially rotate counter-clockwise. Defaults to 180 degrees. </p>
+        </md-list-item>
+        <md-divider></md-divider>
+      </md-list>
     </div>
-    <p>HTML:</p>
-    <td-highlight lang="html">
-        <![CDATA[
-          <!-- my-component.component.html -->
-          <button [@myAnchor]="triggerState" (click)="triggerState = !triggerState" md-raised-button>Rotate</button>
-        ]]>
-    </td-highlight>
-    <h3>Method Details:</h3>
-    <p>TdRotateAnimation(anchor: string, duration: number, degrees: number)</p>
-    <md-list>
-      <md-list-item>
-        <h3 md-line>anchor</h3>
-        <p md-line> The anchor name is used to attach the animation to an arbitrary element in the template. </p>
-      </md-list-item>
-      <md-divider></md-divider>
-      <md-list-item>
-        <h3 md-line>duration</h3>
-        <p md-line> Duration the animation will run in miliseconds. Defaults to 250 ms. </p>
-      </md-list-item>
-      <md-divider></md-divider>
-      <md-list-item>
-        <h3 md-line>degrees</h3>
-        <p md-line> Degrees of rotation the dom object will animation. A negative value will cause the animation to initially rotate counter-clockwise. Defaults to 180 degrees. </p>
-      </md-list-item>
-      <md-divider></md-divider>
-    </md-list>
+
   </md-card-content>
 </md-card>

--- a/src/app/components/components/animations/animations.component.html
+++ b/src/app/components/components/animations/animations.component.html
@@ -11,14 +11,10 @@
     <p>Invoke the utility functions with a required anchor name and optional configs in the component's metadata. The anchor name is used to attach the animation to an arbitrary element in the template.</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        // my-component.component.ts
-        import {
-          TdAnimationUtility
-        } from '@covalent/core/common/animations';
+        import { TdAnimationUtility } from '@covalent/core';
 
         @Component({
           ...
-          templateUrl: './my-component.component.html',
           animations: [
             TdAnimationUtility('myAnchor'),
           ],
@@ -41,75 +37,85 @@
   <md-divider></md-divider>
   <md-card-content>
     <p class="md-body-1">Use <code>TdRotateAnimation</code> to rotate any element based on a boolean state.</p>
-      <div>
-        <h3>Demo 1:</h3>
+    <div>
+      <h3>Demo 1:</h3>
 
-        <button md-raised-button [@rotate1Example180]="rotateState1" class="push-left-xs" (click)="rotateState1 = !rotateState1" color="accent">Rotate 180&deg;<md-icon>mood</md-icon></button>
+      <button md-raised-button [@tdRotate]="rotateState1" (click)="rotateState1 = !rotateState1" color="accent">
+        Rotate 180&deg;<md-icon>mood</md-icon>
+      </button>
 
-        <p>Typescript:</p>
-        <td-highlight lang="typescript">
-            <![CDATA[
-              // my-component.component.ts
-              TdRotateAnimation('myAnchor')
-              ...
-              triggerState: boolean = false;
-            ]]>
-        </td-highlight>
-        <p>HTML:</p>
-        <td-highlight lang="html">
-            <![CDATA[
-              <!-- my-component.component.html -->
-              <button [@myAnchor]="triggerState" (click)="triggerState = !triggerState" md-raised-button>Rotate</button>
-            ]]>
-        </td-highlight>
-      </div>
+      <p>Typescript:</p>
+      <td-highlight lang="typescript">
+        <![CDATA[
+          import { TdRotateAnimation } from '@covalent/core';
+          ...
+          animations: [
+            TdRotateAnimation('tdRotate'),
+          ],
+          ...
+          class MyDemo {
+            triggerState: boolean = false;
+          }
+        ]]>
+      </td-highlight>
+      <p>HTML:</p>
+      <td-highlight lang="html">
+        <![CDATA[
+          <button md-raised-button [@tdRotate]="triggerState" (click)="triggerState = !triggerState" color="accent">
+            Rotate 180&deg;<md-icon>mood</md-icon>
+          </button>
+        ]]>
+      </td-highlight>
+    </div>
 
-      <hr>
-
-      <div>
-        <h3>Demo 2:</h3>
-        <button md-raised-button [@rotate2Example180]="rotateState2" class="push-left-xs" (click)="rotateState2 = !rotateState2" color="accent">Rotate -180&deg;<md-icon>mood</md-icon></button>
-        <button md-raised-button [@rotate2Example360]="rotateState3" class="push-left-xs" (click)="rotateState3 = !rotateState3" color="accent">Rotate 360&deg;<md-icon>mood</md-icon></button>
-
-        <p>Typescript:</p>
-        <td-highlight lang="typescript">
-            <![CDATA[
-              // my-component.component.ts
-              TdRotateAnimation('myAnchor1', 1000, -180),
-              TdRotateAnimation('myAnchor2', 500, 360)
-              ...
-              triggerState1: boolean = false;
-              triggerState2: boolean = false;
-            ]]>
-        </td-highlight>
-        <p>HTML:</p>
-        <td-highlight lang="html">
-            <![CDATA[
-              <!-- my-component.component.html -->
-              <button [@myAnchor1]="triggerState1" (click)="triggerState1 = !triggerState1" md-raised-button>Rotate</button>
-              <button [@myAnchor2]="triggerState2" (click)="triggerState2 = !triggerState2" md-raised-button>Rotate</button>
-            ]]>
-        </td-highlight>
-      </div>
-
-    <hr>
+    <md-divider></md-divider>
 
     <div>
-      <h2>Method Details:</h2>
-      <p>TdRotateAnimation(anchor: string, duration: number, degrees: number)</p>
+      <h3>Demo 2:</h3>
+      <button md-raised-button [@tdRotateNeg180]="rotateState2" (click)="rotateState2 = !rotateState2" color="accent">
+        Rotate -180&deg;<md-icon [@tdRotate180]="rotateState2">mood</md-icon>
+      </button>
+
+      <p>Typescript:</p>
+      <td-highlight lang="typescript">
+        <![CDATA[
+          import { TdRotateAnimation } from '@covalent/core';
+          ...
+          animations: [
+            TdRotateAnimation('tdRotate180', 500, 180),
+            TdRotateAnimation('tdRotateNeg180', 500, -180)
+          ],
+          ...
+          class MyDemo {
+            triggerState: boolean = false;
+          }
+        ]]>
+      </td-highlight>
+      <p>HTML:</p>
+      <td-highlight lang="html">
+        <![CDATA[
+          <button md-raised-button [@tdRotateNeg180]="triggerState" (click)="triggerState = !triggerState" color="accent">
+            Rotate -180&deg;<md-icon [@tdRotate180]="triggerState">mood</md-icon>
+          </button>
+        ]]>
+      </td-highlight>
+    </div>
+    <md-divider></md-divider>
+    <div>
+      <h2>API:</h2>
       <md-list>
         <md-list-item>
-          <h3 md-line>anchor</h3>
+          <h3 md-line>anchor: string</h3>
           <p md-line> The anchor name is used to attach the animation to an arbitrary element in the template. </p>
         </md-list-item>
         <md-divider></md-divider>
         <md-list-item>
-          <h3 md-line>duration</h3>
+          <h3 md-line>duration?: number</h3>
           <p md-line> Duration the animation will run in miliseconds. Defaults to 250 ms. </p>
         </md-list-item>
         <md-divider></md-divider>
         <md-list-item>
-          <h3 md-line>degrees</h3>
+          <h3 md-line>degrees?: number</h3>
           <p md-line> Degrees of rotation the dom object will animation. A negative value will cause the animation to initially rotate counter-clockwise. Defaults to 180 degrees. </p>
         </md-list-item>
         <md-divider></md-divider>

--- a/src/app/components/components/animations/animations.component.html
+++ b/src/app/components/components/animations/animations.component.html
@@ -1,0 +1,76 @@
+<md-card>
+  <md-card-title>Animations</md-card-title>
+  <md-card-subtitle>Core Covalent animation utilities</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p>Utilities to help add simple animations. For custom and complex animations look into the Angular animations docs.</p>
+
+    <h3>Setup:</h3>
+    <p>Import individual animation utilities needed into the component that will contain the elements you want to animate (ex: TdRotateAnimation).</p>
+    <p>Invoke the utility functions with a required anchor name and optional configs in the component's metadata. The anchor name is used to attach the animation to an arbitrary element in the template.</p>
+    <td-highlight lang="typescript">
+      <![CDATA[
+        import {
+          TdRotateAnimation
+        } from '@covalent/core/common/animations';
+
+        @Component({
+          ...
+          templateUrl: './my-component.component.html',
+          animations: [
+            TdRotateAnimation('myAnchor'),
+          ],
+        })
+        export class MyComponent {
+          triggerState: boolean = false;
+          ...
+        }
+      ]]>
+    </td-highlight>
+  </md-card-content>
+  <md-divider></md-divider>
+  <md-card-actions>
+    <a md-button color="primary" href="https://angular.io/guide/animations" target="_blank" class="text-upper">Animations Docs</a>
+  </md-card-actions>
+</md-card>
+
+<md-card>
+  <md-card-title>Rotate Animation</md-card-title>
+  <md-divider></md-divider>
+  <md-card-content>
+    <p class="md-body-1">Use <code>TdRotateAnimation</code> to rotate any element based on a boolean state.</p>
+
+    <div layout="row">
+      <button md-raised-button [@rotateExample180]="rotateState1" class="push-left-xs" (click)="rotateState1 = !rotateState1" color="accent">Rotate 180&deg;<md-icon>mood</md-icon></button>
+      <button md-raised-button [@rotateExample360]="rotateState2" class="push-left-xs" (click)="rotateState2 = !rotateState2" color="accent">Rotate 360&deg;<md-icon>mood</md-icon></button>
+      <button md-raised-button [@rotateExample540]="rotateState3" class="push-left-xs" (click)="rotateState3 = !rotateState3" color="accent">Rotate 540&deg;<md-icon>mood</md-icon></button>
+      <button md-raised-button class="push-left-md" (click)="rotateState1 = !rotateState1; rotateState2 = !rotateState2; rotateState3 = !rotateState3;" color="accent">Rotate All</button>
+    </div>
+    <p>HTML:</p>
+    <td-highlight lang="html">
+        <![CDATA[
+          <!-- my-component.component.html -->
+          <button [@myAnchor]="triggerState" (click)="triggerState = !triggerState" md-raised-button>Rotate</button>
+        ]]>
+    </td-highlight>
+    <h3>Method Options:</h3>
+    <p>TdRotateAnimation(anchor: string, duration: number, degrees: number)</p>
+    <md-list>
+      <md-list-item>
+        <h3 md-line>anchor</h3>
+        <p md-line> The anchor name is used to attach the animation to an arbitrary element in the template. </p>
+      </md-list-item>
+      <md-divider></md-divider>
+      <md-list-item>
+        <h3 md-line>duration</h3>
+        <p md-line> Duration the animation will run in miliseconds. Defaults to 250 ms. </p>
+      </md-list-item>
+      <md-divider></md-divider>
+      <md-list-item>
+        <h3 md-line>degrees</h3>
+        <p md-line> Degrees of rotation that the dom object will animation. Defaults to 180 degrees. </p>
+      </md-list-item>
+      <md-divider></md-divider>
+    </md-list>
+  </md-card-content>
+</md-card>

--- a/src/app/components/components/animations/animations.component.ts
+++ b/src/app/components/components/animations/animations.component.ts
@@ -9,9 +9,9 @@ import { TdRotateAnimation } from '../../../../platform/core/common/animations/r
   templateUrl: './animations.component.html',
   animations: [
     slideInDownAnimation,
-    TdRotateAnimation('rotateExample180'),
-    TdRotateAnimation('rotateExample360', 500, 360),
-    TdRotateAnimation('rotateExample540', 1000, 540),
+    TdRotateAnimation('rotate1Example180'),
+    TdRotateAnimation('rotate2Example180', 1000, -180),
+    TdRotateAnimation('rotate2Example360', 500, 360),
   ],
 })
 export class AnimationsComponent {

--- a/src/app/components/components/animations/animations.component.ts
+++ b/src/app/components/components/animations/animations.component.ts
@@ -9,9 +9,9 @@ import { TdRotateAnimation } from '../../../../platform/core/common/animations/r
   templateUrl: './animations.component.html',
   animations: [
     slideInDownAnimation,
-    TdRotateAnimation('rotate1Example180'),
-    TdRotateAnimation('rotate2Example180', 1000, -180),
-    TdRotateAnimation('rotate2Example360', 500, 360),
+    TdRotateAnimation('tdRotate'),
+    TdRotateAnimation('tdRotate180', 500, 180),
+    TdRotateAnimation('tdRotateNeg180', 500, -180),
   ],
 })
 export class AnimationsComponent {
@@ -21,6 +21,5 @@ export class AnimationsComponent {
 
   rotateState1: boolean = false;
   rotateState2: boolean = false;
-  rotateState3: boolean = false;
 
 }

--- a/src/app/components/components/animations/animations.component.ts
+++ b/src/app/components/components/animations/animations.component.ts
@@ -1,0 +1,26 @@
+import { Component, HostBinding } from '@angular/core';
+
+import { slideInDownAnimation } from '../../../app.animations';
+import { TdRotateAnimation } from '../../../../platform/core/common/animations/rotate/rotate.animation';
+
+@Component({
+  selector: 'animations-demo',
+  styleUrls: ['./animations.component.scss' ],
+  templateUrl: './animations.component.html',
+  animations: [
+    slideInDownAnimation,
+    TdRotateAnimation('rotateExample180'),
+    TdRotateAnimation('rotateExample360', 500, 360),
+    TdRotateAnimation('rotateExample540', 1000, 540),
+  ],
+})
+export class AnimationsComponent {
+
+  @HostBinding('@routeAnimation') routeAnimation: boolean = true;
+  @HostBinding('class.td-route-animation') classAnimation: boolean = true;
+
+  rotateState1: boolean = false;
+  rotateState2: boolean = false;
+  rotateState3: boolean = false;
+
+}

--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -100,6 +100,11 @@ export class ComponentsComponent implements AfterViewInit {
     icon: 'filter_list',
     route: 'pipes',
     title: 'Pipes',
+  }, {
+    description: 'Custom Angular animation utilities',
+    icon: 'theaters',
+    route: 'animations',
+    title: 'Animations',
   }];
 
   optional: Object[] = [{

--- a/src/app/components/components/components.module.ts
+++ b/src/app/components/components/components.module.ts
@@ -21,6 +21,7 @@ import { ChipsDemoComponent } from './chips/chips.component';
 import { DialogsDemoComponent } from './dialogs/dialogs.component';
 import { DirectivesComponent } from './directives/directives.component';
 import { PipesComponent } from './pipes/pipes.component';
+import { AnimationsComponent } from './animations/animations.component';
 import { DataTableDemoComponent } from './data-table/data-table.component';
 import { PagingDemoComponent } from './paging/paging.component';
 import { SearchDemoComponent } from './search/search.component';
@@ -72,6 +73,7 @@ import { ToolbarModule } from '../../components/toolbar/toolbar.module';
     DialogsDemoComponent,
     DirectivesComponent,
     PipesComponent,
+    AnimationsComponent,
     DataTableDemoComponent,
     PagingDemoComponent,
     SearchDemoComponent,

--- a/src/app/components/components/components.routes.ts
+++ b/src/app/components/components/components.routes.ts
@@ -17,6 +17,7 @@ import { ChipsDemoComponent } from './chips/chips.component';
 import { DialogsDemoComponent } from './dialogs/dialogs.component';
 import { DirectivesComponent } from './directives/directives.component';
 import { PipesComponent } from './pipes/pipes.component';
+import { AnimationsComponent } from './animations/animations.component';
 import { DataTableDemoComponent } from './data-table/data-table.component';
 import { PagingDemoComponent } from './paging/paging.component';
 import { SearchDemoComponent } from './search/search.component';
@@ -79,6 +80,9 @@ const routes: Routes = [{
     }, {
       component: PipesComponent,
       path: 'pipes',
+    }, {
+      component: AnimationsComponent,
+      path: 'animations',
     }, {
       component: DataTableDemoComponent,
       path: 'data-table',

--- a/src/app/components/components/overview/overview.component.ts
+++ b/src/app/components/components/overview/overview.component.ts
@@ -94,6 +94,12 @@ export class ComponentsOverviewComponent {
       route: 'pipes',
       title: 'Pipes',
     },
+    {
+      color: 'amber-A700',
+      icon: 'theaters',
+      route: 'animations',
+      title: 'Animations',
+    },
   ];
   optional: Object[] = [{
       color: 'pink-A700',

--- a/src/platform/core/common/animations/index.ts
+++ b/src/platform/core/common/animations/index.ts
@@ -1,0 +1,1 @@
+export { TdRotateAnimation } from './rotate/rotate.animation';

--- a/src/platform/core/common/animations/index.ts
+++ b/src/platform/core/common/animations/index.ts
@@ -1,4 +1,3 @@
-// AnimationTriggerMetadata
 export { TdRotateAnimation } from './rotate/rotate.animation';
 export { TdCollapseAnimation } from './collapse/collapse.animation';
 export { TdFadeInOutAnimation } from './fade/fadeInOut.animation';

--- a/src/platform/core/common/animations/index.ts
+++ b/src/platform/core/common/animations/index.ts
@@ -1,1 +1,4 @@
+// AnimationTriggerMetadata
 export { TdRotateAnimation } from './rotate/rotate.animation';
+export { TdCollapseAnimation } from './collapse/collapse.animation';
+export { TdFadeInOutAnimation } from './fade/fadeInOut.animation';

--- a/src/platform/core/common/animations/rotate/rotate.animation.ts
+++ b/src/platform/core/common/animations/rotate/rotate.animation.ts
@@ -1,0 +1,27 @@
+import { trigger, state, style, transition, animate, AnimationTriggerMetadata, AUTO_STYLE } from '@angular/animations';
+
+/**
+ * Function TdRotateAnimation
+ *
+ * params:
+ * * anchor: Name of the anchor that will attach to a dom element in the components template that will contain the animation.
+ * * duration: Duration the animation will run in miliseconds. Defaults to 250 ms.
+ * * degrees: Degrees of rotation that the dom object will animation. Defaults to 180 degrees.
+ *
+ * Returns an [AnimationTriggerMetadata] object with states for a boolean trigger based rotation animation.
+ *
+ * usage: [@myAnchorName]="true|false"
+ */
+export function TdRotateAnimation(anchor: string, duration: number = 250, degrees: number = 180): AnimationTriggerMetadata {
+  return trigger(anchor, [
+    state('0', style({
+      transform: 'rotate(0deg)',
+    })),
+    state('1',  style({
+      transform: 'rotate(' + degrees + 'deg)',
+    })),
+    transition('0 <=> 1', [
+      animate(duration + 'ms ease-in'),
+    ]),
+  ]);
+}

--- a/src/platform/core/common/animations/rotate/rotate.animation.ts
+++ b/src/platform/core/common/animations/rotate/rotate.animation.ts
@@ -21,7 +21,7 @@ export function TdRotateAnimation(anchor: string, duration: number = 250, degree
       transform: 'rotate(' + degrees + 'deg)',
     })),
     transition('0 <=> 1', [
-      animate(duration + 'ms ease-in'),
+      animate(duration + 'ms ease-out'),
     ]),
   ]);
 }

--- a/src/platform/core/common/animations/rotate/rotate.animation.ts
+++ b/src/platform/core/common/animations/rotate/rotate.animation.ts
@@ -6,7 +6,8 @@ import { trigger, state, style, transition, animate, AnimationTriggerMetadata, A
  * params:
  * * anchor: Name of the anchor that will attach to a dom element in the components template that will contain the animation.
  * * duration: Duration the animation will run in miliseconds. Defaults to 250 ms.
- * * degrees: Degrees of rotation that the dom object will animation. Defaults to 180 degrees.
+ * * degrees: Degrees of rotation that the dom object will animation. A negative value will cause the animation to initially rotate counter-clockwise.
+ * Defaults to 180 degrees.
  *
  * Returns an [AnimationTriggerMetadata] object with states for a boolean trigger based rotation animation.
  *

--- a/src/platform/core/common/common.module.ts
+++ b/src/platform/core/common/common.module.ts
@@ -8,6 +8,7 @@ import { FormsModule } from '@angular/forms';
  * ANIMATIONS
  */
 
+// Directives
 import { TdToggleDirective } from './animations/toggle/toggle.directive';
 import { TdFadeDirective } from './animations/fade/fade.directive';
 
@@ -15,10 +16,10 @@ const TD_ANIMATIONS: Type<any>[] = [
   TdToggleDirective,
   TdFadeDirective,
 ];
-
 export { TdToggleDirective, TdFadeDirective };
-export { TdCollapseAnimation } from './animations/collapse/collapse.animation';
-export { TdFadeInOutAnimation } from './animations/fade/fadeInOut.animation';
+
+// Utility functions
+export * from './animations';
 
 /**
  * BEHAVIORS

--- a/src/platform/core/common/common.module.ts
+++ b/src/platform/core/common/common.module.ts
@@ -19,7 +19,6 @@ const TD_ANIMATIONS: Type<any>[] = [
 export { TdToggleDirective, TdFadeDirective };
 export { TdCollapseAnimation } from './animations/collapse/collapse.animation';
 export { TdFadeInOutAnimation } from './animations/fade/fadeInOut.animation';
-export { TdRotateAnimation } from './animations/rotate/rotate.animation';
 
 /**
  * BEHAVIORS

--- a/src/platform/core/common/common.module.ts
+++ b/src/platform/core/common/common.module.ts
@@ -19,6 +19,7 @@ const TD_ANIMATIONS: Type<any>[] = [
 export { TdToggleDirective, TdFadeDirective };
 export { TdCollapseAnimation } from './animations/collapse/collapse.animation';
 export { TdFadeInOutAnimation } from './animations/fade/fadeInOut.animation';
+export { TdRotateAnimation } from './animations/rotate/rotate.animation';
 
 /**
  * BEHAVIORS

--- a/src/platform/core/expansion-panel/expansion-panel.component.html
+++ b/src/platform/core/expansion-panel/expansion-panel.component.html
@@ -9,8 +9,8 @@
   <div class="td-expansion-panel-header-content"
         [class.mat-disabled]="disabled"
         *ngIf="!expansionPanelHeader"
-        layout="row" 
-        layout-align="start center" 
+        layout="row"
+        layout-align="start center"
         flex>
     <div *ngIf="label || expansionPanelLabel" class="md-subhead td-expansion-label" [attr.flex-gt-xs]="(sublabel || expansionPanelSublabel) ? 40 : null">
       <ng-template [cdkPortalHost]="expansionPanelLabel"></ng-template>
@@ -21,8 +21,7 @@
       <ng-template [ngIf]="!expansionPanelSublabel">{{sublabel}}</ng-template>
     </div>
     <span flex></span>
-    <md-icon class="td-expand-icon" *ngIf="!expand && !disabled">keyboard_arrow_down</md-icon>
-    <md-icon class="td-expand-icon" *ngIf="expand">keyboard_arrow_up</md-icon>
+    <md-icon class="td-expand-icon" *ngIf="!disabled" [@tdRotate]="expand">keyboard_arrow_down</md-icon>
   </div>
 </div>
 <div class="td-expansion-content"

--- a/src/platform/core/expansion-panel/expansion-panel.component.ts
+++ b/src/platform/core/expansion-panel/expansion-panel.component.ts
@@ -3,7 +3,7 @@ import { Component, Directive, Input, Output, TemplateRef, ViewContainerRef, Con
 import { EventEmitter } from '@angular/core';
 import { coerceBooleanProperty, TemplatePortalDirective } from '@angular/cdk';
 
-import { TdCollapseAnimation, ICanDisable, mixinDisabled, ICanDisableRipple, mixinDisableRipple } from '../common/common.module';
+import { TdCollapseAnimation, TdRotateAnimation, ICanDisable, mixinDisabled, ICanDisableRipple, mixinDisableRipple } from '../common/common.module';
 
 @Directive({
   selector: '[td-expansion-panel-header]ng-template',
@@ -50,6 +50,7 @@ export const _TdExpansionPanelMixinBase = mixinDisableRipple(mixinDisabled(TdExp
   inputs: ['disabled', 'disableRipple'],
   animations: [
     TdCollapseAnimation(),
+    TdRotateAnimation('tdRotate'),
   ],
 })
 export class TdExpansionPanelComponent extends _TdExpansionPanelMixinBase implements ICanDisable, ICanDisableRipple {

--- a/src/platform/core/expansion-panel/expansion-panel.component.ts
+++ b/src/platform/core/expansion-panel/expansion-panel.component.ts
@@ -3,7 +3,8 @@ import { Component, Directive, Input, Output, TemplateRef, ViewContainerRef, Con
 import { EventEmitter } from '@angular/core';
 import { coerceBooleanProperty, TemplatePortalDirective } from '@angular/cdk';
 
-import { TdCollapseAnimation, TdRotateAnimation, ICanDisable, mixinDisabled, ICanDisableRipple, mixinDisableRipple } from '../common/common.module';
+import { TdCollapseAnimation, ICanDisable, mixinDisabled, ICanDisableRipple, mixinDisableRipple } from '../common/common.module';
+import { TdRotateAnimation } from '../common/animations';
 
 @Directive({
   selector: '[td-expansion-panel-header]ng-template',


### PR DESCRIPTION
## Description

Stepping stone for animation utilities to be consumable publicly. This PoC contains both implementation and documentation for the first of the utilities, rotate animation utility. This lays a general structure for future animation utilities to build upon.

I applied the rotate animation utility internally to the covalent expansion panel as an example use case. When opening and closing the expansion panel the `keyboard_arrow_down` icon will rotate accordingly. 

The plan is to start off by delivering many pre-canned modular animations utilities (commonly used animations) that can be easily applied to any template element. Next is to have many pre-canned route animations. Far beyond that we plan to research ways to make it easier to create custom/complex Angular based animations. 

### What's included?

- Rotate animation utility implementation in: 
`src/platform/core/common/animations/rotate/rotate.animation.ts`


- Initial animation documentation w/ rotate animation utility doc included in: 
`src/app/components/components/animations/animations.component.html`
`src/app/components/components/animations/animations.component.ts`


- Example use case of rotate animation utility in: 
`src/platform/core/expansion-panel/expansion-panel.component.ts`
`src/platform/core/expansion-panel/expansion-panel.component.html`

#### Test Steps

- [ ] `npm run reinstall`
- [ ] `ng serve`
- [ ] Navigate to `/#/components/expansion-panel`
- [ ] Verify that the expansion panel icon rotates when opening/closing.
- [ ] Navigate to `/#/components/animations`
- [ ] Play/use the rotate animation utility as specified in the animations docs on some other code in the Covalent repo.
  - [ ] Do the docs operate okay? feedback?
- [ ] Does the file/folder structure of the code look okay for future animation utilities to live in/build upon? 

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![rec](https://user-images.githubusercontent.com/24550592/29389400-b6681c4c-829e-11e7-9095-51bc9119943f.gif)


Example use of rotate animation utility within expansion-panel: 
![rec1](https://user-images.githubusercontent.com/24550592/29235279-74f781fc-7eb2-11e7-8fe0-8cbef72a48fd.gif)
