### PR TITLE
feature(dialog): added validation logic to prompt/confirm dialogs

### DIFF
--- a/src/platform/core/dialogs/confirm-dialog/confirm-dialog.component.html
+++ b/src/platform/core/dialogs/confirm-dialog/confirm-dialog.component.html
@@ -4,6 +4,12 @@
   </td-dialog-title>
   <td-dialog-content class="md-subhead tc-grey-700">
     {{message}}
+    <form *ngIf="validatorIsSet" #form="ngForm" layout="row" novalidate flex>
+      <md-input-container flex>
+        <input mdInput (keydown.enter)="$event.preventDefault(); form.valid && valid && accept()"
+          [(ngModel)]="input" name="input" required/>
+      </md-input-container>
+    </form>
   </td-dialog-content>
   <td-dialog-actions>
     <button md-button
@@ -12,6 +18,7 @@
             (click)="cancel()">{{cancelButton}}</button>
     <button md-button
             color="accent"
+            [disabled]="validatorIsSet && !valid"
             #acceptBtn
             (keydown.arrowleft)="closeBtn.focus()"
             (click)="accept()">{{acceptButton}}</button>

--- a/src/platform/core/dialogs/confirm-dialog/confirm-dialog.component.ts
+++ b/src/platform/core/dialogs/confirm-dialog/confirm-dialog.component.ts
@@ -4,15 +4,18 @@ import { MdDialogRef } from '@angular/material';
 @Component({
   selector: 'td-confirm-dialog',
   templateUrl: './confirm-dialog.component.html',
-  styleUrls: ['./confirm-dialog.component.scss' ],
+  styleUrls: ['./confirm-dialog.component.scss'],
 })
 export class TdConfirmDialogComponent {
   title: string;
   message: string;
   cancelButton: string = 'CANCEL';
   acceptButton: string = 'ACCEPT';
+  input: string;
 
-  constructor(private _dialogRef: MdDialogRef<TdConfirmDialogComponent>) {}
+  constructor(private _dialogRef: MdDialogRef<TdConfirmDialogComponent>) { }
+
+  validatorFn = (input: string): boolean => undefined;
 
   cancel(): void {
     this._dialogRef.close(false);
@@ -20,5 +23,13 @@ export class TdConfirmDialogComponent {
 
   accept(): void {
     this._dialogRef.close(true);
+  }
+
+  get validatorIsSet(): boolean {
+    return this.validatorFn !== undefined;
+  }
+
+  get valid(): boolean {
+    return this.validatorFn(this.input);
   }
 }

--- a/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.html
+++ b/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.html
@@ -9,7 +9,7 @@
         <input mdInput
                #input
                (focus)="handleInputFocus()"
-               (keydown.enter)="$event.preventDefault(); form.valid && accept()"
+               (keydown.enter)="$event.preventDefault(); form.valid && valid && accept()"
                [(ngModel)]="value"
                name="value"
                required/>
@@ -25,7 +25,7 @@
             color="accent"
             #acceptBtn
             (keydown.arrowleft)="closeBtn.focus()"
-            [disabled]="!form.valid"
+            [disabled]="!form.valid || !valid"
             (click)="accept()">{{acceptButton}}</button>
   </td-dialog-actions>
 </td-dialog>

--- a/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.ts
+++ b/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.ts
@@ -24,6 +24,10 @@ export class TdPromptDialogComponent implements AfterViewInit {
     });
   }
 
+  validatorFn = (input: string): boolean => {
+    return true;
+  }
+
   /**
    * Method executed when input is focused
    * Selects all text
@@ -38,5 +42,9 @@ export class TdPromptDialogComponent implements AfterViewInit {
 
   accept(): void {
     this._dialogRef.close(this.value);
+  }
+
+  get valid(): boolean {
+    return this.validatorFn(this.value);
   }
 }

--- a/src/platform/core/dialogs/services/dialog.service.ts
+++ b/src/platform/core/dialogs/services/dialog.service.ts
@@ -19,6 +19,7 @@ export interface IAlertConfig extends IDialogConfig {
 export interface IConfirmConfig extends IDialogConfig {
   acceptButton?: string;
   cancelButton?: string;
+  validatorFn?: (input: string) => boolean;
 }
 
 export interface IPromptConfig extends IConfirmConfig {
@@ -28,7 +29,7 @@ export interface IPromptConfig extends IConfirmConfig {
 @Injectable()
 export class TdDialogService {
 
-  constructor(private _dialogService: MdDialog) {}
+  constructor(private _dialogService: MdDialog) { }
 
   /**
    * params:
@@ -82,6 +83,7 @@ export class TdDialogService {
    *     viewContainerRef?: ViewContainerRef;
    *     acceptButton?: string;
    *     cancelButton?: string;
+   *     validatorFn?: (input:string) => boolean;
    * }
    *
    * Opens a confirm dialog with the provided config.
@@ -100,6 +102,9 @@ export class TdDialogService {
     if (config.cancelButton) {
       confirmDialogComponent.cancelButton = config.cancelButton;
     }
+    if (config.validatorFn) {
+      confirmDialogComponent.validatorFn = config.validatorFn;
+    }
     return dialogRef;
   }
 
@@ -112,6 +117,7 @@ export class TdDialogService {
    *     viewContainerRef?: ViewContainerRef;
    *     acceptButton?: string;
    *     cancelButton?: string;
+   *     validatorFn?: (input:string) => boolean;
    * }
    *
    * Opens a prompt dialog with the provided config.
@@ -131,6 +137,9 @@ export class TdDialogService {
     if (config.cancelButton) {
       promptDialogComponent.cancelButton = config.cancelButton;
     }
+    if (config.validatorFn) {
+      promptDialogComponent.validatorFn = config.validatorFn;
+    }
     return dialogRef;
   }
 
@@ -144,7 +153,7 @@ export class TdDialogService {
 }
 
 export function DIALOG_PROVIDER_FACTORY(
-    parent: TdDialogService, dialog: MdDialog): TdDialogService {
+  parent: TdDialogService, dialog: MdDialog): TdDialogService {
   return parent || new TdDialogService(dialog);
 }
 


### PR DESCRIPTION
## Description

Added an extra validation step in the prompt and confirm dialogs.

**Confirm dialog** 

The addition of this allows developers to create an extra validation step before being able to confirm some operation.

_Typical use case_: delete something

If the "something" to be deleted could cause mayor side effects (example: delete a repo in github), to confirm this through a simple click isnt safe enough.  In the case of github, a confirm dialog will be shown, in which the user needs to type in the name of the repo to delete. This can now be archived through this pr.

**Prompt dialog**

Developers can now filter what users type in, before allowing them to click confirm.

_Typical use case_: allow any value, except for the ones in an array.

To get a rough idea of what I tried to archieve, please take a look in the following plnkr:

http://plnkr.co/edit/mxVwIc7qRHinLjY6FEQa

Closes #602 
Closes #660

### What's included?

- Added property to `IConfirmConfig` interface
- Changed `openConfirm` and `openPrompt` methods in dialog service
- Changes to `ConfirmDialog` and `PromptDialog` components

#### Test Steps

Dont apply

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.