### PR TITLE
docs(loader): fix link to * syntax docs

### DIFF
--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -390,7 +390,7 @@
     <h2><code>tdLoading</code></h2>
     <p>Simply add the <code>tdLoading</code> attibute with a "name" value to the element you want to mask.</p>
     <p>Dont forget to add the asterisk syntax before the <code>tdLoading</code> directive if its not used in a <code><![CDATA[<ng-template>]]></code> element.</p>
-    <p>More info on the asterisk (*) syntax <a target="_blank" href="https://angular.io/docs/ts/latest/guide/template-syntax.html#!#star-template">here</a></p>
+    <p>More info on the asterisk (*) syntax <a target="_blank" href="https://angular.io/guide/structural-directives#asterisk">here</a></p>
     <h3>Properties:</h3>
     <p>The <code>tdLoading</code> directive has {{loadingAttrs.length}} properties:</p>
     <md-list>
@@ -419,7 +419,7 @@
           { {item} }
         </div>
       ]]>
-    </td-highlight>  
+    </td-highlight>
     <p>HTML <![CDATA[<ng-template>]]> syntax</p>
     <td-highlight lang="html">
       <![CDATA[


### PR DESCRIPTION
## Description

Fix link to asterisk syntax

### What's included?

Update url to correct documentation. 

#### Test Steps

This is only a change in documentation.