### PR TITLE
chore(): use comments in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,15 +1,19 @@
+<!--
 This repository's issues are reserved for feature requests and bug reports.
+If you have need support/help you can use the gitter chat to ask the community.
+https://gitter.im/Teradata/covalent
+-->
 
 ### Do you want to request a *feature* or report a *bug*?
 
 #### Feature Request
-
-please first make sure your request falls under the official Material Design spec guidelines https://material.google.com/
+<!-- Requests must fall under the official Material Design spec guidelines https://material.google.com/ -->
 
 #### Bug Report
-
+<!--
 please provide steps to reproduce and if possible screenhots, animated Gifs and/or a Plunker (or similar).
 you can easily create animated Gif with this free PC/OSX App: http://www.cockos.com/licecap/ and a Plunker to help us reproduce it
+-->
 Plunker template: http://plnkr.co/edit/7uZQn4mLNJkL6XN9WSNd
 
 ##### Screenshots or link to CodePen/Plunker/JSfiddle
@@ -24,8 +28,11 @@ Plunker template: http://plnkr.co/edit/7uZQn4mLNJkL6XN9WSNd
 #### Which version of Angular and Material, and which browser and OS does this issue affect?
 
 Did this work in previous versions of Angular / Material?
-Please also test with the latest stable and snapshot versions.
+
+<!-- Please also test with the latest stable and snapshot versions. -->
 
 
 ##### Other information
+<!--
 (e.g. detailed explanation, stacktraces, related issues, suggestions how to fix)
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,14 @@
 ## Description
-
-Talk about the great work you've done!
+<!-- Talk about the great work you've done! -->
 
 ### What's included?
-
+<!-- List features included in this PR -->
 - One
 - Two
 - Three
 
 #### Test Steps
-
+<!-- Add instructions on how to test your changes -->
 - [ ] do this
 - [ ] then this
 - [ ] finally this


### PR DESCRIPTION
## Description
This PR uses comments for instructions within issue templates rather than plain text. This helps clean up how issues are displayed when people don't remove instructions,

### What's included?

- Issue template
- PR template

#### Test Steps

- [x] view parsed markdown to ensure everything is formated