### PR TITLE
feat(virtual-scroll): initial implementation of virtual scroll component

### DIFF
--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -61,6 +61,11 @@ export class ComponentsComponent implements AfterViewInit {
     route: 'data-table',
     title: 'Data Table',
   }, {
+    description: 'Scroll virtually on a set of items',
+    icon: 'format_line_spacing',
+    route: 'virtual-scroll',
+    title: 'Virtual Scroll',
+  }, {
     description: 'JSON object tree with collapsible nodes',
     icon: 'format_indent_increase',
     route: 'json-formatter',

--- a/src/app/components/components/components.module.ts
+++ b/src/app/components/components/components.module.ts
@@ -29,6 +29,7 @@ import { DynamicFormsDemoComponent } from './dynamic-forms/dynamic-forms.compone
 import { CodeEditorDemoComponent } from './code-editor/code-editor.component';
 import { TextEditorDemoComponent } from './text-editor/text-editor.component';
 import { NotificationsDemoComponent } from './notifications/notifications.component';
+import { VirtualScrollDemoComponent } from './virtual-scroll/virtual-scroll.component';
 import { NgxChartsDemoComponent } from './ngx-charts/ngx-charts.component';
 import { NgxTranslateDemoComponent } from './ngx-translate/ngx-translate.component';
 
@@ -43,7 +44,7 @@ import { MdButtonModule, MdListModule, MdIconModule, MdCardModule, MdMenuModule,
 import { CovalentCommonModule, CovalentLayoutModule, CovalentMediaModule, CovalentExpansionPanelModule, CovalentFileModule,
          CovalentStepsModule, CovalentLoadingModule, CovalentDialogsModule, CovalentSearchModule, CovalentPagingModule,
          CovalentNotificationsModule, CovalentMenuModule, CovalentChipsModule, CovalentDataTableModule, CovalentJsonFormatterModule,
-         CovalentMessageModule } from '../../../platform/core';
+         CovalentMessageModule, CovalentVirtualScrollModule } from '../../../platform/core';
 import { CovalentHighlightModule } from '../../../platform/highlight';
 import { CovalentMarkdownModule } from '../../../platform/markdown';
 import { CovalentDynamicFormsModule } from '../../../platform/dynamic-forms';
@@ -81,6 +82,7 @@ import { ToolbarModule } from '../../components/toolbar/toolbar.module';
     CodeEditorDemoComponent,
     TextEditorDemoComponent,
     NotificationsDemoComponent,
+    VirtualScrollDemoComponent,
     // External Dependencies
     NgxChartsDemoComponent,
     NgxTranslateDemoComponent,
@@ -125,6 +127,7 @@ import { ToolbarModule } from '../../components/toolbar/toolbar.module';
     CovalentMarkdownModule,
     CovalentDynamicFormsModule,
     CovalentMessageModule,
+    CovalentVirtualScrollModule,
     CovalentCodeEditorModule,
     CovalentTextEditorModule,
     DocumentationToolsModule,

--- a/src/app/components/components/components.routes.ts
+++ b/src/app/components/components/components.routes.ts
@@ -25,6 +25,7 @@ import { DynamicFormsDemoComponent } from './dynamic-forms/dynamic-forms.compone
 import { CodeEditorDemoComponent } from './code-editor/code-editor.component';
 import { TextEditorDemoComponent } from './text-editor/text-editor.component';
 import { NotificationsDemoComponent } from './notifications/notifications.component';
+import { VirtualScrollDemoComponent } from './virtual-scroll/virtual-scroll.component';
 import { NgxChartsDemoComponent } from './ngx-charts/ngx-charts.component';
 import { NgxTranslateDemoComponent } from './ngx-translate/ngx-translate.component';
 
@@ -92,6 +93,9 @@ const routes: Routes = [{
     }, {
       component: NotificationsDemoComponent,
       path: 'notifications',
+    }, {
+      component: VirtualScrollDemoComponent,
+      path: 'virtual-scroll',
     }, {
       component: DynamicFormsDemoComponent,
       path: 'dynamic-forms',

--- a/src/app/components/components/overview/overview.component.ts
+++ b/src/app/components/components/overview/overview.component.ts
@@ -54,6 +54,11 @@ export class ComponentsOverviewComponent {
       route: 'data-table',
       title: 'Data Table',
     }, {
+      color: 'orange-A700',
+      icon: 'format_line_spacing',
+      route: 'virtual-scroll',
+      title: 'Virtual Scroll',
+    }, {
       color: 'teal-A700',
       icon: 'format_indent_increase',
       route: 'json-formatter',

--- a/src/app/components/components/virtual-scroll/virtual-scroll.component.html
+++ b/src/app/components/components/virtual-scroll/virtual-scroll.component.html
@@ -3,7 +3,7 @@
     <span flex></span>
     <button md-icon-button
             mdTooltip="View Source"
-            (click)="toggleDemoCode1 = !toggleDemoCode1">
+            (click)="toggleDemoCode = !toggleDemoCode">
       <md-icon class="tc-grey-700">code</md-icon>
     </button>
   </div>
@@ -13,7 +13,7 @@
   </md-card-subtitle>
   <md-divider></md-divider>
   <md-card-content>
-    <div [tdToggle]="!toggleDemoCode1">
+    <div [tdToggle]="!toggleDemoCode">
       <md-tab-group md-stretch-tabs dynamicHeight>
         <md-tab>
           <ng-template mdTabLabel>HTML</ng-template>
@@ -46,7 +46,6 @@
               ...
               export class Demo implements OnInit {
               
-                toggleDemoCode1: boolean = false;
                 data: any[] = [];
               
                 ngOnInit(): void {

--- a/src/app/components/components/virtual-scroll/virtual-scroll.component.html
+++ b/src/app/components/components/virtual-scroll/virtual-scroll.component.html
@@ -1,16 +1,17 @@
 <md-card>
+  <div class="pad-left pad-right bgc-grey-100" layout="row" layout-align="start center">
+    <span flex></span>
+    <button md-icon-button
+            mdTooltip="View Source"
+            (click)="toggleDemoCode1 = !toggleDemoCode1">
+      <md-icon class="tc-grey-700">code</md-icon>
+    </button>
+  </div>
   <md-card-title>Virtual Scroll</md-card-title>
-  <md-card-subtitle class="bgc-grey-100">
-    <div layout="row" layout-align="start center">
-      <span>Scroll virtually on a set of items</span>
-      <span flex></span>
-      <button md-icon-button
-              mdTooltip="View Source"
-              (click)="toggleDemoCode1 = !toggleDemoCode1">
-        <md-icon class="tc-grey-700">code</md-icon>
-      </button>
-    </div>
+  <md-card-subtitle>
+    Scroll virtually on a set of items
   </md-card-subtitle>
+  <md-divider></md-divider>
   <md-card-content>
     <div [tdToggle]="!toggleDemoCode1">
       <md-tab-group md-stretch-tabs dynamicHeight>
@@ -22,6 +23,7 @@
                 <md-list-item>
                   Column Header
                 </md-list-item>
+                <md-divider></md-divider>
                 <td-virtual-scroll-container #virtualScroll [style.height.px]="400" [data]="data">
                   <ng-template let-row="row" let-last="last" tdVirtualScrollRow>
                     <md-list-item>
@@ -29,7 +31,7 @@
                       <h4 md-line>{ {row.name} }</h4>
                       <p md-line>Row: { {row.index} }</p>
                     </md-list-item>
-                    <md-divider *ngIf="!last"></md-divider>
+                    <md-divider *ngIf="!last" md-inset></md-divider>
                   </ng-template>
                 </td-virtual-scroll-container>
               </md-list>
@@ -63,6 +65,7 @@
       <md-list-item>
         Column Header
       </md-list-item>
+      <md-divider></md-divider>
       <td-virtual-scroll-container #virtualScroll [style.height.px]="400" [data]="data">
         <ng-template let-row="row" let-last="last" tdVirtualScrollRow>
           <md-list-item>
@@ -70,7 +73,7 @@
             <h4 md-line>{{row.name}}</h4>
             <p md-line>Row: {{row.index}}</p>
           </md-list-item>
-          <md-divider *ngIf="!last"></md-divider>
+          <md-divider *ngIf="!last" md-inset></md-divider>
         </ng-template>
       </td-virtual-scroll-container>
     </md-list>

--- a/src/app/components/components/virtual-scroll/virtual-scroll.component.html
+++ b/src/app/components/components/virtual-scroll/virtual-scroll.component.html
@@ -1,44 +1,92 @@
 <md-card>
   <md-card-title>Virtual Scroll</md-card-title>
-  <md-card-subtitle>Scroll virtually on a set of items</md-card-subtitle>
-  <md-divider></md-divider>
+  <md-card-subtitle class="bgc-grey-100">
+    <div layout="row" layout-align="start center">
+      <span>Scroll virtually on a set of items</span>
+      <span flex></span>
+      <button md-icon-button
+              mdTooltip="View Source"
+              (click)="toggleDemoCode1 = !toggleDemoCode1">
+        <md-icon class="tc-grey-700">code</md-icon>
+      </button>
+    </div>
+  </md-card-subtitle>
   <md-card-content>
-    <h3 class="md-title">Virtual List</h3>
-    <h4 class="md-subhead">iterate over 10000 md-list item's</h4>
-    <md-divider></md-divider>
-    <md-tab-group md-stretch-tabs>
-      <md-tab>
-        <ng-template mdTabLabel>Demo</ng-template>
-        <md-list>
-          <td-virtual-scroll-container [style.height.px]="400" [data]="randomData">
-            <ng-template let-row="row" let-last="last" tdVirtualScrollRow>
-              <md-list-item>
-                <md-icon mdListAvatar>person</md-icon>
-                <h4 md-line>{{row.name}}</h4>
-                <p md-line>Row: {{row.index}}</p>
-              </md-list-item>
-              <md-divider *ngIf="!last"></md-divider>
-            </ng-template>
-          </td-virtual-scroll-container>
-        </md-list>
-      </md-tab>
-      <md-tab>
-        <ng-template mdTabLabel>Code</ng-template>
-        <p>HTML:</p>
-        <td-highlight lang="html">
-          <![CDATA[
-            
-          ]]>
-        </td-highlight>
-        <p>Typescript:</p>
-        <td-highlight lang="typescript">
-          <![CDATA[
-            
-          ]]>
-        </td-highlight>
-      </md-tab>
-    </md-tab-group>
+    <div [tdToggle]="!toggleDemoCode1">
+      <md-tab-group md-stretch-tabs dynamicHeight>
+        <md-tab>
+          <ng-template mdTabLabel>HTML</ng-template>
+          <td-highlight lang="html">
+            <![CDATA[
+              <md-list>
+                <md-list-item>
+                  Column Header
+                </md-list-item>
+                <td-virtual-scroll-container #virtualScroll [style.height.px]="400" [data]="data">
+                  <ng-template let-row="row" let-last="last" tdVirtualScrollRow>
+                    <md-list-item>
+                      <md-icon mdListAvatar>person</md-icon>
+                      <h4 md-line>{ {row.name} }</h4>
+                      <p md-line>Row: { {row.index} }</p>
+                    </md-list-item>
+                    <md-divider *ngIf="!last"></md-divider>
+                  </ng-template>
+                </td-virtual-scroll-container>
+              </md-list>
+            ]]>
+          </td-highlight>
+        </md-tab>
+        <md-tab>
+          <ng-template mdTabLabel>TS</ng-template>
+          <td-highlight lang="typescript">
+            <![CDATA[
+              import { Component, OnInit } from '@angular/core';
+              ...
+              export class Demo implements OnInit {
+              
+                toggleDemoCode1: boolean = false;
+                data: any[] = [];
+              
+                ngOnInit(): void {
+                  for (let index: number = 1; index <= 1500; index++) {
+                    this.data.push({index: index, name: 'element-' + index});
+                  }
+                }
+              }
+            ]]>
+          </td-highlight>
+        </md-tab>
+      </md-tab-group>
+      <md-divider></md-divider>
+    </div>
+    <md-list>
+      <md-list-item>
+        Column Header
+      </md-list-item>
+      <td-virtual-scroll-container #virtualScroll [style.height.px]="400" [data]="data">
+        <ng-template let-row="row" let-last="last" tdVirtualScrollRow>
+          <md-list-item>
+            <md-icon mdListAvatar>person</md-icon>
+            <h4 md-line>{{row.name}}</h4>
+            <p md-line>Row: {{row.index}}</p>
+          </md-list-item>
+          <md-divider *ngIf="!last"></md-divider>
+        </ng-template>
+      </td-virtual-scroll-container>
+    </md-list>
   </md-card-content>
+  <md-divider></md-divider>
+  <md-card-actions>
+    <button md-button class="text-upper" (click)="virtualScroll.scrollToStart()">
+      Scroll to first
+    </button>
+    <button md-button class="text-upper" (click)="virtualScroll.scrollToEnd()">
+      Scroll to last
+    </button>
+    <button md-button class="text-upper" (click)="virtualScroll.scrollTo(400)">
+      Scroll to 400th row
+    </button>
+  </md-card-actions>
 </md-card>
 
 <td-readme-loader resourceUrl="platform/core/virtual-scroll/README.md"></td-readme-loader>

--- a/src/app/components/components/virtual-scroll/virtual-scroll.component.html
+++ b/src/app/components/components/virtual-scroll/virtual-scroll.component.html
@@ -1,0 +1,44 @@
+<md-card>
+  <md-card-title>Virtual Scroll</md-card-title>
+  <md-card-subtitle>Scroll virtually on a set of items</md-card-subtitle>
+  <md-divider></md-divider>
+  <md-card-content>
+    <h3 class="md-title">Virtual List</h3>
+    <h4 class="md-subhead">iterate over 10000 md-list item's</h4>
+    <md-divider></md-divider>
+    <md-tab-group md-stretch-tabs>
+      <md-tab>
+        <ng-template mdTabLabel>Demo</ng-template>
+        <md-list>
+          <td-virtual-scroll-container [style.height.px]="400" [data]="randomData">
+            <ng-template let-row="row" let-last="last" tdVirtualScrollRow>
+              <md-list-item>
+                <md-icon mdListAvatar>person</md-icon>
+                <h4 md-line>{{row.name}}</h4>
+                <p md-line>Row: {{row.index}}</p>
+              </md-list-item>
+              <md-divider *ngIf="!last"></md-divider>
+            </ng-template>
+          </td-virtual-scroll-container>
+        </md-list>
+      </md-tab>
+      <md-tab>
+        <ng-template mdTabLabel>Code</ng-template>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            
+          ]]>
+        </td-highlight>
+      </md-tab>
+    </md-tab-group>
+  </md-card-content>
+</md-card>
+
+<td-readme-loader resourceUrl="platform/core/virtual-scroll/README.md"></td-readme-loader>

--- a/src/app/components/components/virtual-scroll/virtual-scroll.component.ts
+++ b/src/app/components/components/virtual-scroll/virtual-scroll.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit, HostBinding, ChangeDetectionStrategy } from '@angular/core';
+
+import { slideInDownAnimation } from '../../../app.animations';
+
+import { } from '../../../../platform/core';
+
+@Component({
+  selector: 'virtual-scroll-demo',
+  styleUrls: ['./virtual-scroll.component.scss'],
+  templateUrl: './virtual-scroll.component.html',
+  animations: [slideInDownAnimation],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class VirtualScrollDemoComponent implements OnInit {
+
+  @HostBinding('@routeAnimation') routeAnimation: boolean = true;
+  @HostBinding('class.td-route-animation') classAnimation: boolean = true;
+
+  randomData: any[] = [];
+
+  ngOnInit(): void {
+    for (let index: number = 1; index <= 10000; index++) {
+      this.randomData.push({index: index, name: 'element-' + index});
+    }
+  }
+
+}

--- a/src/app/components/components/virtual-scroll/virtual-scroll.component.ts
+++ b/src/app/components/components/virtual-scroll/virtual-scroll.component.ts
@@ -2,8 +2,6 @@ import { Component, OnInit, HostBinding, ChangeDetectionStrategy } from '@angula
 
 import { slideInDownAnimation } from '../../../app.animations';
 
-import { } from '../../../../platform/core';
-
 @Component({
   selector: 'virtual-scroll-demo',
   styleUrls: ['./virtual-scroll.component.scss'],
@@ -16,11 +14,12 @@ export class VirtualScrollDemoComponent implements OnInit {
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
 
-  randomData: any[] = [];
+  toggleDemoCode1: boolean = false;
+  data: any[] = [];
 
   ngOnInit(): void {
-    for (let index: number = 1; index <= 10000; index++) {
-      this.randomData.push({index: index, name: 'element-' + index});
+    for (let index: number = 1; index <= 1200; index++) {
+      this.data.push({index: index, name: 'element-' + index});
     }
   }
 

--- a/src/app/components/components/virtual-scroll/virtual-scroll.component.ts
+++ b/src/app/components/components/virtual-scroll/virtual-scroll.component.ts
@@ -14,7 +14,7 @@ export class VirtualScrollDemoComponent implements OnInit {
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
 
-  toggleDemoCode1: boolean = false;
+  toggleDemoCode: boolean = false;
   data: any[] = [];
 
   ngOnInit(): void {

--- a/src/platform/core/index.ts
+++ b/src/platform/core/index.ts
@@ -115,3 +115,10 @@ export * from './search/search.module';
 
 import { CovalentStepsModule } from './steps/steps.module';
 export * from './steps/steps.module';
+
+/**
+ * VIRTUAL SCROLL
+ */
+
+import { CovalentVirtualScrollModule } from './virtual-scroll/virtual-scroll.module';
+export * from './virtual-scroll/virtual-scroll.module';

--- a/src/platform/core/virtual-scroll/README.md
+++ b/src/platform/core/virtual-scroll/README.md
@@ -1,0 +1,52 @@
+# td-virtual-scroll-container
+
+`td-virtual-scroll-container` element calcules the items that fit in the viewport and only renders those, improving resource efficiency in long lists.
+
+**NOTE:** every row has to have the same height, since there are some calculations assumed for the total scroll height.
+
+## API Summary
+
+Properties:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `data` | `any[]` | List of items to virtually iterate on.
+| `trackBy?` | `TrackByFunction` | This accepts the same trackBy function [ngFor] does. https://angular.io/api/core/TrackByFunction
+| `refresh` | `function()` | Method to refresh and recalculate the virtual rows
+| `scrollTo` | `function(row)` | Method to scroll to a specific row of the list.
+| `scrollToStart` | `function()` | Method to scroll to the start of the list.
+| `scrollToEnd?` | `function()` | Method to scroll to the end of the list.
+
+## Setup
+
+Import the [CovalentVirtualScrollModule] in your NgModule:
+
+```typescript
+import { CovalentVirtualScrollModule } from '@covalent/core';
+@NgModule({
+  imports: [
+    CovalentVirtualScrollModule,
+    ...
+  ],
+  ...
+})
+export class MyModule {}
+```
+
+## Usage
+
+Example for HTML usage:
+
+```html
+<td-virtual-scroll-container [style.height.px]="400" [data]="data" [trackBy]="trackByFn">
+  <ng-template let-row="row"
+               let-index="index"
+               let-first="first"
+               let-last="last"
+               let-odd="odd"
+               let-even="even"
+               tdVirtualScrollRow>
+    {{row}}
+  </ng-template>
+</td-virtual-scroll-container>
+```

--- a/src/platform/core/virtual-scroll/README.md
+++ b/src/platform/core/virtual-scroll/README.md
@@ -1,6 +1,6 @@
 # td-virtual-scroll-container
 
-`td-virtual-scroll-container` element calcules the items that fit in the viewport and only renders those, improving resource efficiency in long lists.
+`td-virtual-scroll-container` element calculates the items that fit in the viewport and only renders those, improving resource efficiency in long lists.
 
 **NOTE:** every row has to have the same height, since there are some calculations assumed for the total scroll height.
 

--- a/src/platform/core/virtual-scroll/README.md
+++ b/src/platform/core/virtual-scroll/README.md
@@ -15,7 +15,7 @@ Properties:
 | `refresh` | `function()` | Method to refresh and recalculate the virtual rows
 | `scrollTo` | `function(row)` | Method to scroll to a specific row of the list.
 | `scrollToStart` | `function()` | Method to scroll to the start of the list.
-| `scrollToEnd?` | `function()` | Method to scroll to the end of the list.
+| `scrollToEnd` | `function()` | Method to scroll to the end of the list.
 
 ## Setup
 

--- a/src/platform/core/virtual-scroll/virtual-scroll-container.component.html
+++ b/src/platform/core/virtual-scroll/virtual-scroll-container.component.html
@@ -1,0 +1,22 @@
+<div [style.height.px]="totalHeight"></div>
+<div [style.transform]="offsetTransform"
+      [style.position]="'absolute'"
+      [style.min-width.%]="100">
+  <ng-template let-row
+                let-index="index"
+                ngFor
+                [ngForOf]="virtualData"
+                [ngForTrackBy]="trackBy">
+    <div #rowElement>
+      <ng-template *ngIf="_rowTemplate"
+                  [ngTemplateOutlet]="_rowTemplate.templateRef"
+                  [ngOutletContext]="{row: row,
+                                      index: (fromRow + index),
+                                      first: (fromRow + index) === 0,
+                                      last: (fromRow + index) === (data.length - 1),
+                                      odd: ((fromRow + index + 1) % 2) === 1,
+                                      even: ((fromRow + index + 1) % 2) === 0}">
+      </ng-template>
+    </div>
+  </ng-template>
+</div>

--- a/src/platform/core/virtual-scroll/virtual-scroll-container.component.scss
+++ b/src/platform/core/virtual-scroll/virtual-scroll-container.component.scss
@@ -1,0 +1,7 @@
+:host {
+  display: block;
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+  position: relative;
+}

--- a/src/platform/core/virtual-scroll/virtual-scroll-container.component.spec.ts
+++ b/src/platform/core/virtual-scroll/virtual-scroll-container.component.spec.ts
@@ -1,0 +1,117 @@
+import {
+  TestBed,
+  inject,
+  async,
+  ComponentFixture,
+} from '@angular/core/testing';
+import 'hammerjs';
+import { Component } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { TdVirtualScrollContainerComponent } from './virtual-scroll-container.component';
+import { CovalentVirtualScrollModule } from './virtual-scroll.module';
+import { MdListModule } from '@angular/material';
+import { NgModule, DebugElement } from '@angular/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Component: VirtualScrollContainer', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule,
+        MdListModule,
+        CovalentVirtualScrollModule,
+      ],
+      declarations: [
+        TestBasicVirtualScrollComponent,
+      ],
+    });
+    TestBed.compileComponents();
+  }));
+
+  it('should render only what fits the viewport', (done: DoneFn) => {
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TestBasicVirtualScrollComponent);
+    let component: TestBasicVirtualScrollComponent = fixture.debugElement.componentInstance;
+    let virtualScrollComponent: DebugElement = fixture.debugElement.query(By.directive(TdVirtualScrollContainerComponent));
+    
+    component.height = 200;
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(virtualScrollComponent.componentInstance.fromRow).toBe(0);
+        expect(virtualScrollComponent.componentInstance.virtualData.length).toBe(8);
+        component.height = 400;
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(virtualScrollComponent.componentInstance.fromRow).toBe(0);
+          expect(virtualScrollComponent.componentInstance.virtualData.length).toBe(12);
+          component.height = 300;
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(virtualScrollComponent.componentInstance.fromRow).toBe(0);
+            expect(virtualScrollComponent.componentInstance.virtualData.length).toBe(10);
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  it('should render rows and scroll to 2th row', (done: DoneFn) => {
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TestBasicVirtualScrollComponent);
+    let component: TestBasicVirtualScrollComponent = fixture.debugElement.componentInstance;
+    let virtualScrollComponent: DebugElement = fixture.debugElement.query(By.directive(TdVirtualScrollContainerComponent));
+
+    component.height = 100;
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(virtualScrollComponent.componentInstance.fromRow).toBe(0);
+        expect(virtualScrollComponent.componentInstance.virtualData.length).toBe(6);
+        fixture.detectChanges();
+        virtualScrollComponent.componentInstance.scrollTo(2);
+        expect(virtualScrollComponent.nativeElement.scrollTop).toBe(virtualScrollComponent.componentInstance.rowHeight * 2);
+        done();
+      });
+    });
+  });
+});
+
+@Component({
+  template: `
+    <md-list>
+      <td-virtual-scroll-container [style.height.px]="height" [data]="data">
+        <ng-template let-row="row" let-last="last" tdVirtualScrollRow>
+          <md-list-item>
+            <h4 md-line>{{row}}</h4>
+          </md-list-item>
+          <md-divider *ngIf="!last"></md-divider>
+        </ng-template>
+      </td-virtual-scroll-container>
+    </md-list>`,
+})
+class TestBasicVirtualScrollComponent {
+  height: number = 200;
+  data: any[] = [
+    'Pizza',
+    'Burger',
+    'Tacos',
+    'Sushi',
+    'Wings',
+    'Salad',
+    'Fries',
+    'Nuggets',
+    'Quesadilla',
+    'Steak',
+    'Hot Dog',
+    'Torta',
+    'Rice',
+    'Sandwich',
+    'Tuna',
+    'Milk',
+    'Soda',
+    'Tea',
+  ];
+}

--- a/src/platform/core/virtual-scroll/virtual-scroll-container.component.ts
+++ b/src/platform/core/virtual-scroll/virtual-scroll-container.component.ts
@@ -1,0 +1,158 @@
+import { Component, Directive, Input, Output, EventEmitter, ContentChild, AfterContentInit, ViewChild,
+         ChangeDetectionStrategy, ChangeDetectorRef, QueryList, ViewChildren, ElementRef, HostListener,
+         Renderer2, AfterContentChecked } from '@angular/core';
+import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
+
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
+import { Subject } from 'rxjs/Subject';
+
+import { TdVirtualScrollRowDirective } from './virtual-scroll-row.directive';
+
+const TD_VIRTUAL_OFFSET: number = 2;
+
+@Component({
+  selector: 'td-virtual-scroll-container',
+  styleUrls: ['./virtual-scroll-container.component.scss' ],
+  templateUrl: './virtual-scroll-container.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TdVirtualScrollContainerComponent implements AfterContentInit, AfterContentChecked {
+
+  private _initialized: boolean = false;
+
+  private _totalHeight: number = 0;
+  private _hostHeight: number = 0;
+  private _scrollVerticalOffset: number = 0;
+  private _offsetTransform: SafeStyle;
+
+  private _fromRow: number = 0;
+  private _toRow: number = 0;
+  
+  private _data: any[];
+  private _virtualData: any[];
+
+  @Input('data')
+  set data(data: any[]) {
+    this._data = data;
+    if (this._initialized) {
+      this._calculateVirtualRows();
+    }
+    this._changeDetectorRef.markForCheck();
+  }
+  get data(): any[] {
+    return this._data;
+  }
+
+  get virtualData(): any[] {
+    return this._virtualData;
+  }
+
+  @ViewChildren('rowElement') _rows: QueryList<ElementRef>;
+
+  @ContentChild(TdVirtualScrollRowDirective) _rowTemplate: TdVirtualScrollRowDirective;
+
+  get rowHeight(): number {
+    if (this._rows && this._rows.toArray()[0]) {
+      return this._rows.toArray()[0].nativeElement.getBoundingClientRect().height;
+    }
+    return 0;
+  }
+
+  get totalHeight(): number {
+    return this._totalHeight;
+  }
+
+  get fromRow(): number {
+    return this._fromRow;
+  }
+
+  get toRow(): number {
+    return this._toRow;
+  }
+
+  get offsetTransform(): SafeStyle {
+    return this._offsetTransform;
+  }
+
+  constructor(private _elementRef: ElementRef,
+              private _domSanitizer: DomSanitizer,
+              private _renderer: Renderer2,
+              private _changeDetectorRef: ChangeDetectorRef) {}
+
+  ngAfterContentInit(): void {
+    setTimeout(() => {
+      this._calculateVirtualRows();
+    });
+  }
+
+  ngAfterContentChecked(): void {
+    let newHostHeight: number = this._elementRef.nativeElement.getBoundingClientRect().height;
+    if (this._hostHeight !== newHostHeight) {
+      this._hostHeight = newHostHeight;
+      if (this._initialized) {
+        this._calculateVirtualRows();
+      }
+    }
+  }
+
+  @Input('trackBy') trackBy: Function = (row: any) => {
+    return row;
+  }
+
+  @HostListener('scroll', ['$event'])
+  handleScroll(event: Event): void {
+    let element: HTMLElement = (<HTMLElement>event.target);
+    if (element) {
+      let verticalScroll: number = element.scrollTop;
+      if (this._scrollVerticalOffset !== verticalScroll) {
+        this._scrollVerticalOffset = verticalScroll;
+        this._calculateVirtualRows();
+      }
+    }
+  }
+
+  scrollTo(row: number): void {
+    this._elementRef.nativeElement.scrollTop = row * this.rowHeight;
+    this._changeDetectorRef.markForCheck();
+  }
+
+  scrollToStart(): void {
+    this.scrollTo(0);
+    this._changeDetectorRef.markForCheck();
+  }
+
+  scrollToEnd(): void {
+    this.scrollTo(this.totalHeight / this.rowHeight);
+    this._changeDetectorRef.markForCheck();
+  }
+
+  private _calculateVirtualRows(): void {
+    if (this._data) {
+      this._totalHeight = this._data.length * this.rowHeight;
+      let fromRow: number = Math.floor((this._scrollVerticalOffset / this.rowHeight)) - TD_VIRTUAL_OFFSET;
+      this._fromRow = fromRow > 0 ? fromRow : 0;
+      let range: number = Math.floor((this._hostHeight / this.rowHeight)) + (TD_VIRTUAL_OFFSET * 2);
+      let toRow: number = range + this.fromRow;
+      if (toRow > this._data.length) {
+        toRow = this._data.length;
+      }
+      this._toRow = toRow;
+    } else {
+      this._totalHeight = 0;
+      this._fromRow = 0;
+      this._toRow = 0;
+    }
+  
+    let offset: number = 0;
+    if (this._scrollVerticalOffset > (TD_VIRTUAL_OFFSET * this.rowHeight)) {
+      offset = this.fromRow * this.rowHeight;
+    }
+    
+    this._offsetTransform = this._domSanitizer.bypassSecurityTrustStyle('translateY(' + (offset - this.totalHeight) + 'px)');
+
+    this._virtualData = this.data.slice(this.fromRow, this.toRow);
+    this._changeDetectorRef.markForCheck();
+  }
+
+}

--- a/src/platform/core/virtual-scroll/virtual-scroll-container.component.ts
+++ b/src/platform/core/virtual-scroll/virtual-scroll-container.component.ts
@@ -86,6 +86,7 @@ export class TdVirtualScrollContainerComponent implements AfterContentInit, Afte
 
   ngAfterContentInit(): void {
     setTimeout(() => {
+      this._initialized = true;
       this._calculateVirtualRows();
     });
   }

--- a/src/platform/core/virtual-scroll/virtual-scroll-container.component.ts
+++ b/src/platform/core/virtual-scroll/virtual-scroll-container.component.ts
@@ -34,7 +34,7 @@ export class TdVirtualScrollContainerComponent implements AfterContentInit, Afte
 
   /**
    * data: any[]
-   * List of items to iterate on.
+   * List of items to virtually iterate on.
    */
   @Input('data')
   set data(data: any[]) {
@@ -102,11 +102,12 @@ export class TdVirtualScrollContainerComponent implements AfterContentInit, Afte
   }
 
   /**
-   * trackBy?: Function
+   * trackBy?: TrackByFunction
    * This accepts the same trackBy function [ngFor] does.
+   * https://angular.io/api/core/TrackByFunction
    */
-  @Input('trackBy') trackBy: Function = (row: any) => {
-    return row;
+  @Input('trackBy') trackBy: any =  (index: number, item: any) => {
+    return item;
   }
 
   @HostListener('scroll', ['$event'])

--- a/src/platform/core/virtual-scroll/virtual-scroll-container.component.ts
+++ b/src/platform/core/virtual-scroll/virtual-scroll-container.component.ts
@@ -32,6 +32,10 @@ export class TdVirtualScrollContainerComponent implements AfterContentInit, Afte
   private _data: any[];
   private _virtualData: any[];
 
+  /**
+   * data: any[]
+   * List of items to iterate on.
+   */
   @Input('data')
   set data(data: any[]) {
     this._data = data;
@@ -96,6 +100,10 @@ export class TdVirtualScrollContainerComponent implements AfterContentInit, Afte
     }
   }
 
+  /**
+   * trackBy?: Function
+   * This accepts the same trackBy function [ngFor] does.
+   */
   @Input('trackBy') trackBy: Function = (row: any) => {
     return row;
   }
@@ -111,17 +119,34 @@ export class TdVirtualScrollContainerComponent implements AfterContentInit, Afte
       }
     }
   }
+  
+  /**
+   * Method to refresh and recalculate the virtual rows
+   * e.g. after changing the [data] content
+   */
+  refresh(): void {
+    this._calculateVirtualRows();
+  }
 
+  /**
+   * Method to scroll to a specific row of the list.
+   */
   scrollTo(row: number): void {
     this._elementRef.nativeElement.scrollTop = row * this.rowHeight;
     this._changeDetectorRef.markForCheck();
   }
 
+  /**
+   * Method to scroll to the start of the list.
+   */
   scrollToStart(): void {
     this.scrollTo(0);
     this._changeDetectorRef.markForCheck();
   }
 
+  /**
+   * Method to scroll to the end of the list.
+   */
   scrollToEnd(): void {
     this.scrollTo(this.totalHeight / this.rowHeight);
     this._changeDetectorRef.markForCheck();
@@ -148,10 +173,11 @@ export class TdVirtualScrollContainerComponent implements AfterContentInit, Afte
     if (this._scrollVerticalOffset > (TD_VIRTUAL_OFFSET * this.rowHeight)) {
       offset = this.fromRow * this.rowHeight;
     }
-    
-    this._offsetTransform = this._domSanitizer.bypassSecurityTrustStyle('translateY(' + (offset - this.totalHeight) + 'px)');
 
-    this._virtualData = this.data.slice(this.fromRow, this.toRow);
+    this._offsetTransform = this._domSanitizer.bypassSecurityTrustStyle('translateY(' + (offset - this.totalHeight) + 'px)');
+    if (this._data) {
+      this._virtualData = this.data.slice(this.fromRow, this.toRow);
+    }
     this._changeDetectorRef.markForCheck();
   }
 

--- a/src/platform/core/virtual-scroll/virtual-scroll-row.directive.ts
+++ b/src/platform/core/virtual-scroll/virtual-scroll-row.directive.ts
@@ -1,0 +1,12 @@
+import { Directive, TemplateRef, ViewContainerRef } from '@angular/core';
+import { TemplatePortalDirective } from '@angular/cdk/portal';
+
+@Directive({selector: '[tdVirtualScrollRow]'})
+export class TdVirtualScrollRowDirective extends TemplatePortalDirective {
+
+  constructor(templateRef: TemplateRef<any>,
+              viewContainerRef: ViewContainerRef) {
+    super(templateRef, viewContainerRef);
+  }
+  
+}

--- a/src/platform/core/virtual-scroll/virtual-scroll.module.ts
+++ b/src/platform/core/virtual-scroll/virtual-scroll.module.ts
@@ -1,0 +1,27 @@
+import { NgModule, Type } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { TdVirtualScrollRowDirective } from './virtual-scroll-row.directive';
+import { TdVirtualScrollContainerComponent } from './virtual-scroll-container.component';
+
+const TD_VIRTUAL_SCROLL: Type<any>[] = [
+  TdVirtualScrollRowDirective,
+  TdVirtualScrollContainerComponent,
+];
+
+export { TdVirtualScrollRowDirective, TdVirtualScrollContainerComponent };
+
+@NgModule({
+  imports: [
+    CommonModule,
+  ],
+  declarations: [
+    TD_VIRTUAL_SCROLL,
+  ],
+  exports: [
+    TD_VIRTUAL_SCROLL,
+  ],
+})
+export class CovalentVirtualScrollModule {
+
+}


### PR DESCRIPTION
## Description
This is the initial implementation of the virtual-scroll component. The initial use case that this will solve it to be able to render thousands of rows (e.g. md-list) without consuming all browser resources.

### What's included?
- `TdVirtualScrollComponent` and `TdVirtualScrollRow` components.
- `virtual-scroll` demo and docs.
- `virtual-scroll` README

#### Test Steps
- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/virtual-scroll
- [ ] Play around with the demo

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle

![image](https://user-images.githubusercontent.com/5846742/30048692-46d32c22-91cc-11e7-8c43-405a073f4528.png)

![virtual-scroll-md-list](https://user-images.githubusercontent.com/5846742/30048730-6da4ac68-91cc-11e7-931d-6b3366c02013.gif)
