### PR TITLE
feat(dynamic-forms): dynamic forms select values (#802)

### DIFF
--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
@@ -82,6 +82,15 @@ export class DynamicFormsDemoComponent {
     type: TdDynamicElement.Select,
     selections: ['Test1', 'Test2', 'Test3', 'Test4'],
     required: true,
+  }, {
+    name: 'value-label-select',
+    type: TdDynamicElement.Select,
+    selections: [
+      {label: 'Test1', value: 1},
+      {label: 'Test2', value: 2},
+      {label: 'Test3', value: 3},
+      {label: 'Test4', value: 4}],
+    required: true,
   }];
 
   fileElements: ITdDynamicElementConfig[] = [{

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.html
@@ -3,6 +3,6 @@
              [placeholder]="label"
              [required]="required"
              flex="100">
-    <md-option *ngFor="let selection of selections" [value]="selection">{{selection}}</md-option>
+    <md-option *ngFor="let selection of selections" [value]="selection.value || selection">{{selection.label || selection}}</md-option>
   </md-select>
 </div>

--- a/src/platform/dynamic-forms/services/dynamic-forms.service.ts
+++ b/src/platform/dynamic-forms/services/dynamic-forms.service.ts
@@ -38,7 +38,7 @@ export interface ITdDynamicElementConfig {
   required?: boolean;
   min?: any;
   max?: any;
-  selections?: any[];
+  selections?: string[] | { value: any, label: string }[];
   default?: any;
   flex?: number;
   validators?: ITdDynamicElementValidator[];
@@ -122,7 +122,7 @@ export class TdDynamicFormsService {
 }
 
 export function DYNAMIC_FORMS_PROVIDER_FACTORY(
-    parent: TdDynamicFormsService): TdDynamicFormsService {
+  parent: TdDynamicFormsService): TdDynamicFormsService {
   return parent || new TdDynamicFormsService();
 }
 


### PR DESCRIPTION
* feat(): Select input label and values separated

- Create TdDynamicElement.Select with selections as array of objects eg. {label: "Label", value: "MyValue"}
- As backcompat create TdDynamicElement.Select with selections as array of strings

* docs(dynamic-forms): update docs to reflex new select definition

## Description
Add custom values for select on dynamic forms
Update docs about it

### What's included?
- new way of define collection for select in dynamic forms

#### Test Steps
- [x] add dynamic form config with select and array of selections made up of objects {value: string, label: string}
- [x] add dynamic form config with select and array of selections made up of strings


#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
