### PR TITLE
fix(scss): missing scss variables for scss compilation (closes #851)

### DIFF
--- a/src/platform/core/common/styles/_variables.scss
+++ b/src/platform/core/common/styles/_variables.scss
@@ -75,9 +75,9 @@ $z-index-progress-circular: 2 !default; // Used to fix animation bug in Chrome
 // Easing Curves
 
 // The default animation curves used by material design.
-$md-linear-out-slow-in-timing-function: cubic-bezier(0.0, 0.0, 0.2, 0.1) !default;
-$md-fast-out-slow-in-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1) !default;
-$md-fast-out-linear-in-timing-function: cubic-bezier(0.4, 0.0, 1, 1) !default;
+$mat-linear-out-slow-in-timing-function: cubic-bezier(0.0, 0.0, 0.2, 0.1) !default;
+$mat-fast-out-slow-in-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !default;
+$mat-fast-out-linear-in-timing-function: cubic-bezier(0.4, 0.0, 1, 1) !default;
 
 $ease-in-out-curve-function: cubic-bezier(0.35, 0, 0.25, 1) !default;
 


### PR DESCRIPTION
## Description
Following https://github.com/Teradata/covalent/issues/851 there was a variable usage that was renamed with the `mat` preffix.. and the variable was preffixed with `md` on its definition.

### What's included?
- Added missing variable to `_elevation.scss`

#### Test Steps
- [ ] `npm run build`

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle

closes https://github.com/Teradata/covalent/issues/851