### PR TITLE
Feature/minor doc fixes

### DIFF
--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.html
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.html
@@ -196,8 +196,10 @@
     <md-tab-group md-stretch-tabs dynamicHeight>
       <md-tab>
         <ng-template mdTabLabel>Demo</ng-template>
-        <td-dynamic-forms [elements]="booleanElements">
-        </td-dynamic-forms>
+        <div class="pad-sm">
+          <td-dynamic-forms [elements]="booleanElements">
+          </td-dynamic-forms>
+        </div>
       </md-tab>
       <md-tab>
         <ng-template mdTabLabel>Code</ng-template>

--- a/src/app/components/components/paging/paging.component.html
+++ b/src/app/components/components/paging/paging.component.html
@@ -266,7 +266,7 @@
         </md-card-content>
         <md-divider></md-divider>
         <td-paging-bar #pagingBarResponsive
-                       [pageLinkCount]="(media.registerQuery('md') | async) ? 0 : 5"
+                       [pageLinkCount]="(media.registerQuery('sm') | async) ? 0 : 3"
                        [firstLast]="media.registerQuery('gt-xs') | async"
                        [pageSize]="pageSizeResponsive"
                        [total]="1345"

--- a/src/app/components/components/paging/paging.component.html
+++ b/src/app/components/components/paging/paging.component.html
@@ -278,7 +278,7 @@
             </md-option>
           </md-select>
           <p hide-xs hide-sm hide-md>Go to:</p>
-          <md-form-field [style.width.px]="30" *ngIf="media.registerQuery('gt-sm') | async">
+          <md-form-field [style.width.px]="30" *ngIf="media.registerQuery('gt-xs') | async">
             <input #goToResponsive
                     mdInput
                     type="number"

--- a/src/app/components/components/paging/paging.component.scss
+++ b/src/app/components/components/paging/paging.component.scss
@@ -1,0 +1,4 @@
+/* Set margin on all elements in td-paging-bar to 5px to prevent wrapping in examples */
+.td-paging-bar * {
+    margin: 0 5px; 
+}

--- a/src/app/components/components/paging/paging.component.scss
+++ b/src/app/components/components/paging/paging.component.scss
@@ -1,4 +1,0 @@
-/* Set margin on all elements in td-paging-bar to 5px to prevent wrapping in examples */
-.td-paging-bar * {
-    margin: 0 5px; 
-}

--- a/src/app/components/design-patterns/alerts/alerts.component.html
+++ b/src/app/components/design-patterns/alerts/alerts.component.html
@@ -95,16 +95,16 @@
                           openAlert(): void {
                             this._dialogService.openAlert({
                               message: 'You don\'t have the required permissions to view this item! Contact an administrator!',
-                              title: '401 Permissions Error!',
-                              closeButton: 'Dismiss',
+                              title: '401 Permissions Error',
+                              closeButton: 'Ok',
                             });
                           }
                           openConfirm(): void {
                             this._dialogService.openConfirm({
                               message: 'Are you sure you want to delete this item? It\'s used on other items.',
                               title: 'Confirm',
-                              cancelButton: 'No, Cancel',
-                              acceptButton: 'Yes, Delete',
+                              cancelButton: 'Cancel',
+                              acceptButton: 'Delete',
                             }).afterClosed().subscribe((accept: boolean) => {
                               if (accept) {
                                 // DO SOMETHING
@@ -168,7 +168,7 @@
                           constructor(private _snackBarService: MdSnackBar) {
                           }
                           showSnackBar(): void {
-                            this._snackBarService.open('Toast here!', 'Dismiss', { duration: 3000 });
+                            this._snackBarService.open('Connection timed out.  Showing limited messages.', 'Retry', { duration: 3000 });
                           }
                         }
                       ]]>

--- a/src/app/components/design-patterns/alerts/alerts.component.ts
+++ b/src/app/components/design-patterns/alerts/alerts.component.ts
@@ -32,7 +32,7 @@ export class AlertsComponent {
 
   showSnackBar(): void {
     this._snackBarService
-      .open('Connection timed out.  Showing limited messages.', 'Retry',{ duration: 3000 });
+      .open('Connection timed out.  Showing limited messages.', 'Retry', { duration: 3000 });
   }
   openAlert(): void {
     this._dialogService.openAlert({

--- a/src/app/components/design-patterns/alerts/alerts.component.ts
+++ b/src/app/components/design-patterns/alerts/alerts.component.ts
@@ -32,22 +32,22 @@ export class AlertsComponent {
 
   showSnackBar(): void {
     this._snackBarService
-      .open('Toast here', 'Dismiss', { duration: 3000 });
+      .open('Connection timed out.  Showing limited messages.', 'Retry',{ duration: 3000 });
   }
   openAlert(): void {
     this._dialogService.openAlert({
       message: 'You don\'t have the required permissions to view this item! Contact an administrator!',
       disableClose: true,
       title: '401 Permissions Error!',
-      closeButton: 'Dismiss',
+      closeButton: 'Ok',
     });
   }
   openConfirm(): void {
     this._dialogService.openConfirm({
       message: 'Are you sure you want to delete this item? It\'s used on other items.',
       title: 'Confirm',
-      cancelButton: 'No, Cancel',
-      acceptButton: 'Yes, Delete',
+      cancelButton: 'Cancel',
+      acceptButton: 'Delete',
     }).afterClosed().subscribe((accept: boolean) => {
       if (accept) {
         this.confirmDelete();
@@ -57,7 +57,7 @@ export class AlertsComponent {
     });
   }
   confirmDelete(): void {
-    this._snackBarService.open('Item deleted!', 'Ok', { duration: 3000 });
+    this._snackBarService.open('Item deleted', '', { duration: 3000 });
   }
   openPrompt(): void {
     this._dialogService.openPrompt({


### PR DESCRIPTION
## Description
Fix minor margin, padding, and text issues in Covalent Docs examples.

### What's included?
- Do not use "Dismiss" per Material Design
> Reworked snackbars and alert in Design Patterns > Alerts
> Use "Ok" on alert and single word confirmation on other dialogs
- In Componets> Dynamic Forms > Dynamic Booleans example, effects cut off in the corner
> Add margin to td-dynamic-forms
- In Components > Paging > Paging with everything demo, prevent wrapping on resize
> Reduce default margin in paging component SCSS

#### Test Steps
- Verify items above

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Design Patterns > Alerts examples
![covalent_alert](https://user-images.githubusercontent.com/17860952/30220863-0066b1a8-9476-11e7-9c16-e86ccd6fcb4b.gif)

##### Components > Dynamic Forms > Dyamic Boolean Elements example
![covalent_boolean](https://user-images.githubusercontent.com/17860952/30220830-e33f8d48-9475-11e7-87ae-344b2645d2e4.gif)


##### Components > Paging
![covalent_paging](https://user-images.githubusercontent.com/17860952/30220884-1b4c92f8-9476-11e7-9edf-755fa105271c.gif)