### PR TITLE
chore(patterns): use routerLink

### DIFF
--- a/src/app/components/design-patterns/alerts/alerts.component.html
+++ b/src/app/components/design-patterns/alerts/alerts.component.html
@@ -39,7 +39,7 @@
         <span mdLine>Angular Material Snackbars</span>
       </a>
       <md-divider></md-divider>
-      <a md-list-item href="/#/components/dialogs" target="_blank">
+      <a md-list-item [routerLink]="['/components', 'dialogs']" target="_blank">
         <md-icon>launch</md-icon>
         <span mdLine>Covalent Dialogs</span>
       </a>

--- a/src/app/components/design-patterns/cards/cards.component.html
+++ b/src/app/components/design-patterns/cards/cards.component.html
@@ -118,7 +118,7 @@
         <md-card-title>Login Card</md-card-title>
         <md-card-subtitle>Card with form</md-card-subtitle>
         <md-card-content>
-          <p>In special cases, cards may contain form elements, like the login card.  However, in most sitautions, we recommend using the <a href="/#/layouts/card-over" target="_blank">Card Over</a> full page layout for forms.</p>
+          <p>In special cases, cards may contain form elements, like the login card.  However, in most sitautions, we recommend using the <a [routerLink]="['/layouts', 'card-over']" target="_blank">Card Over</a> full page layout for forms.</p>
         </md-card-content>
       </div>
       <div flex>
@@ -219,7 +219,7 @@
         <md-card-title>Metadata List Card</md-card-title>
         <md-card-subtitle>Card with metadata for an item detail</md-card-subtitle>
         <md-card-content>
-          <p>Cards support many rich components, including our <a href="/#/style-guide/management-list" target="_blank">management list</a>.  When adding multiple lists to a card, seperate them using md-divider and consider adding md-subheader.</p>
+          <p>Cards support many rich components, including our <a [routerLink]="['/design-patterns', 'management-list']" target="_blank">management list</a>.  When adding multiple lists to a card, seperate them using md-divider and consider adding md-subheader.</p>
         </md-card-content>
       </div> 
       <div flex>
@@ -333,7 +333,7 @@
         <md-card-title>CRUD Manage List Card</md-card-title>
         <md-card-subtitle>Card with faux-columns & search</md-card-subtitle>
         <md-card-content>
-          <p>In this example, notice the <a href="/#/components/search" target="_blank">search component</a> in the top left.  Also, using the flex model, you can simulate columns by using the same layout on each row.  See the <a href="/#/style-guide/management-list" target="_blank">management list</a> for more implementation details.</p>
+          <p>In this example, notice the <a [routerLink]="['/components', 'search']" target="_blank">search component</a> in the top left.  Also, using the flex model, you can simulate columns by using the same layout on each row.  See the <a [routerLink]="['/design-patterns', 'management-list']" target="_blank">management list</a> for more implementation details.</p>
         </md-card-content>
       </div>
       <div flex>

--- a/src/app/components/design-patterns/management-list/management-list.component.html
+++ b/src/app/components/design-patterns/management-list/management-list.component.html
@@ -42,13 +42,13 @@
         <md-card-content>
           <p>This example contains a variety of components including:</p>
           <md-nav-list>
-            <a md-list-item href="/#/components/search" target="_blank">
+            <a md-list-item [routerLink]="['/components', 'search']" target="_blank">
               <md-icon>launch</md-icon>
               <span mdLine>Covalent Search</span>
               <p mdLine>td-search</p>
             </a>
             <md-divider></md-divider>
-            <a md-list-item href="/#/components/paging" target="_blank">
+            <a md-list-item [routerLink]="['/components', 'paging']" target="_blank">
               <md-icon>launch</md-icon>
               <span mdLine>Covalent Paging</span>
               <p mdLine>td-paging-bar</p>


### PR DESCRIPTION
- replace all href elements with routerLink in all patterns pages

## Description
Currently using href for links.  Replace with routerLink using the format: 
<a [routerLink]="['path', 'path']>Text</a>

### What's included?
- Fixes for all current patterns
- Point to design-patterns for management-list (currently, points to removed page in style section)

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] navigate to docs > design patterns
- [ ] verify links work

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![patternslinks](https://user-images.githubusercontent.com/17860952/30558083-2882ab28-9c65-11e7-99dd-4a007f7393cf.gif)
