### PR TITLE
chore(): URLs to pages that no longer exist in style-guide/colors doc

### DIFF
--- a/src/app/components/style-guide/colors/colors.component.html
+++ b/src/app/components/style-guide/colors/colors.component.html
@@ -324,11 +324,6 @@
       <span mdLine>Material Design Dark Color Palette</span>
     </a>
     <md-divider></md-divider>
-    <a md-list-item href="http://www.dadapixel.com/blog/2014/12/2/download-googles-expanded-material-design-palette-for-the-osx-system-color-picker" target="_blank">
-      <md-icon>launch</md-icon>
-      <span mdLine>OSX Material Design System Color Picker</span>
-    </a>
-    <md-divider></md-divider>
     <a md-list-item href="https://github.com/romannurik/MaterialColorsApp" target="_blank">
       <md-icon>launch</md-icon>
       <span mdLine>Material Colors OSX Desktop App</span>


### PR DESCRIPTION
## Description
Removing links to pages that no longer exist.

### What's included?
- Removal of OSX Material Design System Color Picker link

#### Test Steps
- [ ] navigate to style-guide/colors
- [ ] bad link no longer exists
- [ ] huzzah

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
