### PR TITLE
fix(paging): stop css bleed to all md-selects from paging scss

### DIFF
--- a/src/platform/core/paging/paging-bar.component.scss
+++ b/src/platform/core/paging/paging-bar.component.scss
@@ -1,27 +1,27 @@
 :host {
   display: block;
-}
-.td-paging-bar {
-  height: 48px;
-  /deep/ > * {
-    margin: 0 10px;
-  }
-}
-[md-icon-button] {
-  font-size: 12px;
-  font-weight: normal;
-}
-/deep/ md-select { 
-  &.mat-select {
-    padding-top: 0px;
-  }
-  & {  
-    .mat-select-trigger {
-      min-width: 44px;
-      font-size: 12px;
+  .td-paging-bar {
+    height: 48px;
+    /deep/ > * {
+      margin: 0 10px;
     }
-    .mat-select-underline {
-      display: none;
+  }
+  [md-icon-button] {
+    font-size: 12px;
+    font-weight: normal;
+  }
+  /deep/ md-select { 
+    &.mat-select {
+      padding-top: 0px;
+    }
+    & {  
+      .mat-select-trigger {
+        min-width: 44px;
+        font-size: 12px;
+      }
+      .mat-select-underline {
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

There was some scss bleeding because of the use of `/deep/` in the paging scss, which should only affect the md/mat select components directly under the paging bar.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `ng serve`
- [ ] Use an md-select anywhere
- [ ] See styles not being bled

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

closes https://github.com/Teradata/covalent/issues/872