### PR TITLE
fix(data-table): replace hardcoded 100px min width with projected width

### DIFF
--- a/src/platform/core/data-table/data-table-column/data-table-column.component.html
+++ b/src/platform/core/data-table/data-table-column/data-table-column.component.html
@@ -1,4 +1,4 @@
-<span class="td-data-table-heading">
+<span #columnContent class="td-data-table-heading">
   <md-icon 
     class="td-data-table-sort-icon" 
     *ngIf="sortable && numeric"

--- a/src/platform/core/data-table/data-table-column/data-table-column.component.ts
+++ b/src/platform/core/data-table/data-table-column/data-table-column.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, Renderer2, ElementRef, HostBinding, HostListener } from '@angular/core';
+import { Component, Input, Output, EventEmitter, Renderer2, ElementRef, HostBinding, HostListener, ViewChild } from '@angular/core';
 
 import { TdDataTableSortingOrder } from '../data-table.component';
 
@@ -16,6 +16,15 @@ export interface ITdDataTableSortChangeEvent {
 export class TdDataTableColumnComponent {
 
   private _sortOrder: TdDataTableSortingOrder = TdDataTableSortingOrder.Ascending;
+
+  @ViewChild('columnContent', {read: ElementRef}) _columnContent: ElementRef;
+
+  get projectedWidth(): number {
+    if (this._columnContent && this._columnContent.nativeElement) {
+      return (<HTMLElement>this._columnContent.nativeElement).getBoundingClientRect().width;
+    }
+    return 100;
+  }
 
   /**
    * name?: string

--- a/src/platform/core/data-table/data-table.component.html
+++ b/src/platform/core/data-table/data-table.component.html
@@ -63,8 +63,8 @@
           [numeric]="column.numeric"
           [hidden]="column.hidden"
           *ngFor="let column of columns; let i = index"
-          [style.min-width.px]="getWidth(i)"
-          [style.max-width.px]="getWidth(i)">
+          [style.min-width.px]="getColumnWidth(i)"
+          [style.max-width.px]="getColumnWidth(i)">
         <span class="md-body-1" *ngIf="!getTemplateRef(column.name)">{{column.format ? column.format(getCellValue(column, row)) : getCellValue(column, row)}}</span>
         <ng-template
           *ngIf="getTemplateRef(column.name)"

--- a/src/platform/core/data-table/data-table.component.scss
+++ b/src/platform/core/data-table/data-table.component.scss
@@ -38,6 +38,7 @@ table.td-data-table {
 
   td.mat-checkbox-cell,
   th.mat-checkbox-column {
+    min-width: 42px;
     width: 42px;
     font-size: 0 !important;
     md-pseudo-checkbox {

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -939,11 +939,15 @@ export class TdDataTableComponent implements ControlValueAccessor, OnInit, After
       min: false,
       max: false,
     };
+    // flag to see if we need to skip the min width projection
+    // depending if a width or min width has been provided
+    let skipMinWidthProjection: boolean = false;
     if (this.columns[index]) {
       // if the provided width has min/max, then we check to see if we need to set it
       if (typeof this.columns[index].width === 'object') {
         let widthOpts: ITdDataTableColumnWidth = <ITdDataTableColumnWidth>this.columns[index].width;
         // if the column width is less than the configured min, we override it
+        skipMinWidthProjection = (widthOpts && !!widthOpts.min);
         if (widthOpts && widthOpts.min >= this._widths[index].value) {
           this._widths[index].value = widthOpts.min;
           this._widths[index].min = true;
@@ -955,12 +959,11 @@ export class TdDataTableComponent implements ControlValueAccessor, OnInit, After
       // if it has a fixed width, then we just set it
       } else if (typeof this.columns[index].width === 'number') {
         this._widths[index].value = <number>this.columns[index].width;
-        this._widths[index].limit = true;
+        skipMinWidthProjection = this._widths[index].limit = true;
       }
     }
-    // if there wasnt any width or min width provided, we set a min to what the column width min should be
-    if (!this._widths[index].limit &&
-        !(this.columns[index].width && (<ITdDataTableColumnWidth>this.columns[index].width).min) &&
+    // if there wasn't any width or min width provided, we set a min to what the column width min should be
+    if (!skipMinWidthProjection &&
         this._widths[index].value < this._colElements.toArray()[index].projectedWidth) {
       this._widths[index].value = this._colElements.toArray()[index].projectedWidth;
       this._widths[index].min = true;


### PR DESCRIPTION
Also add possibility to override projected min width via configuration

closes https://github.com/Teradata/covalent/issues/891

### What's included?
- `ng serve`
- See that now the projected min width per column isnt 100px, but whatever the column header width is at a minimum
- Override it via column configuration

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] do this
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
