### PR TITLE
fix(virtual-scroll): re-render rows with proper height when replacing the data input

### DIFF
--- a/src/platform/core/virtual-scroll/virtual-scroll-container.component.spec.ts
+++ b/src/platform/core/virtual-scroll/virtual-scroll-container.component.spec.ts
@@ -77,6 +77,36 @@ describe('Component: VirtualScrollContainer', () => {
       });
     });
   });
+
+  it('should render rows, clear them and render them again', (done: DoneFn) => {
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TestBasicVirtualScrollComponent);
+    let component: TestBasicVirtualScrollComponent = fixture.debugElement.componentInstance;
+    let virtualScrollComponent: DebugElement = fixture.debugElement.query(By.directive(TdVirtualScrollContainerComponent));
+
+    component.height = 100;
+    let data: any[] = component.data;
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(virtualScrollComponent.componentInstance.fromRow).toBe(0);
+        expect(virtualScrollComponent.componentInstance.virtualData.length).toBe(6);
+        component.data = [];
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(virtualScrollComponent.componentInstance.fromRow).toBe(0);
+          expect(virtualScrollComponent.componentInstance.virtualData.length).toBe(0);
+          component.data = data;
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(virtualScrollComponent.componentInstance.fromRow).toBe(0);
+            expect(virtualScrollComponent.componentInstance.virtualData.length).toBe(6);
+            done();
+          });
+        });
+      });
+    });
+  });
 });
 
 @Component({

--- a/src/platform/core/virtual-scroll/virtual-scroll-container.component.ts
+++ b/src/platform/core/virtual-scroll/virtual-scroll-container.component.ts
@@ -1,6 +1,6 @@
 import { Component, Directive, Input, Output, EventEmitter, ContentChild, AfterViewInit, ViewChild,
          ChangeDetectionStrategy, ChangeDetectorRef, QueryList, ViewChildren, ElementRef, HostListener,
-         Renderer2, AfterViewChecked } from '@angular/core';
+         Renderer2, AfterViewChecked, OnDestroy } from '@angular/core';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
 
 import { Subscription } from 'rxjs/Subscription';
@@ -15,8 +15,9 @@ const TD_VIRTUAL_OFFSET: number = 2;
   templateUrl: './virtual-scroll-container.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TdVirtualScrollContainerComponent implements AfterViewInit, AfterViewChecked {
+export class TdVirtualScrollContainerComponent implements AfterViewInit, AfterViewChecked, OnDestroy {
 
+  private _rowChangeSubs: Subscription;
   private _initialized: boolean = false;
 
   private _totalHeight: number = 0;
@@ -83,8 +84,7 @@ export class TdVirtualScrollContainerComponent implements AfterViewInit, AfterVi
               private _changeDetectorRef: ChangeDetectorRef) {}
 
   ngAfterViewInit(): void {
-    let subs: Subscription = this._rows.changes.subscribe(() => {
-      subs.unsubscribe();
+    this._rowChangeSubs = this._rows.changes.subscribe(() => {
       this._calculateVirtualRows();
     });
     this._initialized = true;
@@ -98,6 +98,12 @@ export class TdVirtualScrollContainerComponent implements AfterViewInit, AfterVi
       if (this._initialized) {
         this._calculateVirtualRows();
       }
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this._rowChangeSubs) {
+      this._rowChangeSubs.unsubscribe();
     }
   }
 


### PR DESCRIPTION

## Description
After the `data` input was cleared and then populated, the pseudo height was improperly calculated 

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] Render rows properly after `data` input is replaced
- [ ] Unit test to prove it

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle

closes https://github.com/Teradata/covalent/issues/878
