### PR TITLE
feat(data-table): allow dynamic row heights in data table even when using its virtual scroll

### DIFF
--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -13,24 +13,24 @@
           <table td-data-table>
             <thead>
               <tr td-data-table-column-row>
-                <th td-data-table-column>
-                  <md-icon>comment</md-icon>
-                  <span>Comments</span>
-                </th>
                 <th td-data-table-column
                     *ngFor="let column of columns"
                     [numeric]="column.numeric">
                   {{column.label}}
                 </th>
+                <th td-data-table-column>
+                  <md-icon>comment</md-icon>
+                  <span>Comments</span>
+                </th>
               </tr>
             </thead>
             <tbody>
               <tr td-data-table-row *ngFor="let row of basicData">
-                <td td-data-table-cell (click)="openPrompt(row, 'comments')">
-                  <button md-button [class.mat-accent]="!row['comments']">{{row['comments'] || 'Add Comment'}}</button>
-                </td>
                 <td td-data-table-cell *ngFor="let column of columns" [numeric]="column.numeric">
                   {{column.format ? column.format(row[column.name]) : row[column.name]}}
+                </td>
+                <td td-data-table-cell (click)="openPrompt(row, 'comments')">
+                  <button md-button [class.mat-accent]="!row['comments']">{{row['comments'] || 'Add Comment'}}</button>
                 </td>
               </tr>
             </tbody>
@@ -45,24 +45,24 @@
             <table td-data-table>
               <thead>
                 <tr td-data-table-column-row>
-                  <th td-data-table-column>
-                    <md-icon>comment</md-icon>
-                    <span>Comments</span>
-                  </th>
                   <th td-data-table-column
                       *ngFor="let column of columns"
                       [numeric]="column.numeric">
                     { {column.label}}
                   </th>
+                  <th td-data-table-column>
+                    <md-icon>comment</md-icon>
+                    <span>Comments</span>
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 <tr td-data-table-row *ngFor="let row of basicData">
-                  <td td-data-table-cell (click)="openPrompt(row, 'comments')">
-                    <button md-button [class.mat-accent]="!row['comments']">{ {row['comments'] || 'Add Comment'}}</button>
-                  </td>
                   <td td-data-table-cell *ngFor="let column of columns" [numeric]="column.numeric">
                     { {column.format ? column.format(row[column.name]) : row[column.name]}}
+                  </td>
+                  <td td-data-table-cell (click)="openPrompt(row, 'comments')">
+                    <button md-button [class.mat-accent]="!row['comments']">{ {row['comments'] || 'Add Comment'}}</button>
                   </td>
                 </tr>
               </tbody>
@@ -75,69 +75,19 @@
             import { ITdDataTableColumn } from '@covalent/core';
             import { TdDialogService } from '@covalent/core';
             ...
-            const NUMBER_FORMAT: (v: any) => any = (v: number) => v;
             const DECIMAL_FORMAT: (v: any) => any = (v: number) => v.toFixed(2);
             ...
             })
             export class Demo {
               columns: ITdDataTableColumn[] = [
-                { name: 'name',  label: 'Dessert (100g serving)' },
-                { name: 'type', label: 'Type', filter: true },
-                { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT },
-                { name: 'fat', label: 'Fat (g)', numeric: true, format: DECIMAL_FORMAT },
-                { name: 'carbs', label: 'Carbs (g)', numeric: true, format: NUMBER_FORMAT },
-                { name: 'protein', label: 'Protein (g)', numeric: true, format: DECIMAL_FORMAT },
-                { name: 'sodium', label: 'Sodium (mg)', numeric: true, format: NUMBER_FORMAT },
-                { name: 'calcium', label: 'Calcium (%)', numeric: true, format: NUMBER_FORMAT },
-                { name: 'iron', label: 'Iron (%)', numeric: true, format: NUMBER_FORMAT },
+                { name: 'first_name',  label: 'First Name' },
+                { name: 'last_name', label: 'Last Name' },
+                { name: 'gender', label: 'Gender' },
+                { name: 'email', label: 'Email' },
+                { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },
               ];
 
-              data: any[] = {
-                'id': 1,
-                'name': 'Frozen yogurt',
-                'type': 'Ice cream',
-                'calories': 159.0,
-                'fat': 6.0,
-                'carbs': 24.0,
-                'protein': 4.0,
-                'sodium': 87.0,
-                'calcium': 14.0,
-                'iron': 1.0,
-                'comments': 'I love froyo!',
-              }, {
-                'id': 2,
-                'name': 'Ice cream sandwich',
-                'type': 'Ice cream',
-                'calories': 237.0,
-                'fat': 9.0,
-                'carbs': 37.0,
-                'protein': 4.3,
-                'sodium': 129.0,
-                'calcium': 8.0,
-                'iron': 1.0,
-              }, {
-                'id': 3,
-                'name': 'Eclair',
-                'type': 'Pastry',
-                'calories':  262.0,
-                'fat': 16.0,
-                'carbs': 24.0,
-                'protein':  6.0,
-                'sodium': 337.0,
-                'calcium':  6.0,
-                'iron': 7.0,
-              }, {
-                'id': 4,
-                'name': 'Cupcake',
-                'type': 'Pastry',
-                'calories':  305.0,
-                'fat': 3.7,
-                'carbs': 67.0,
-                'protein': 4.3,
-                'sodium': 413.0,
-                'calcium': 3.0,
-                'iron': 8.0,
-              }];
+              basicData: any[] = [...]; // see data json
 
               constructor(private _dialogService: TdDialogService) {}
 
@@ -154,6 +104,9 @@
             }
           ]]>
         </td-highlight>
+        <p>Data:</p>
+        <td-highlight lang="json" [content]="basicData | json">
+        </td-highlight>
       </md-tab>
     </md-tab-group>
   </md-card-content>
@@ -161,7 +114,7 @@
 <md-card>
   <md-card-content>
     <h3 class="md-title">Basic Data Table</h3>
-    <h4 class="md-subhead">with nested data, formatting, configurable width columns and templates</h4>
+    <h4 class="md-subhead">with formatting, configurable width columns and templates</h4>
     <md-divider></md-divider>
     <md-tab-group md-stretch-tabs>
       <md-tab>
@@ -169,12 +122,8 @@
         <td-data-table
           [data]="basicData"
           [columns]="configWidthColumns">
-          <ng-template tdDataTableTemplate="type" let-value="value" let-row="row" let-column="column">
-            <div layout="row">
-              <span>{{value}}</span>
-              <span flex></span>
-              <md-icon>star</md-icon>
-            </div>
+          <ng-template tdDataTableTemplate="img" let-value="value">
+            <img [src]="value"/>
           </ng-template>
         </td-data-table>
       </md-tab>
@@ -186,12 +135,8 @@
             <td-data-table
               [data]="basicData"
               [columns]="configWidthColumns">
-              <ng-template tdDataTableTemplate="type" let-value="value" let-row="row" let-column="column">
-                <div layout="row">
-                  <span>{ {value}}</span> // or <span flex>{ {row[column]}}</span>
-                  <span flex></span>
-                  <md-icon>star</md-icon>
-                </div>
+              <ng-template tdDataTableTemplate="img" let-value="value">
+                <img [src]="value"/>
               </ng-template>
             </td-data-table>
           ]]>
@@ -201,55 +146,24 @@
           <![CDATA[
             import { ITdDataTableColumn } from '@covalent/core';
             ...
-            const NUMBER_FORMAT: (v: any) => any = (v: number) => v;
             const DECIMAL_FORMAT: (v: any) => any = (v: number) => v.toFixed(2);
             ...
             })
-            export class Demo {
+            export class Demo implements OnInit {
               configWidthColumns: ITdDataTableColumn[] = [
-                { name: 'name',  label: 'Dessert (100g serving)', width: 300 },
-                { name: 'type', label: 'Type', width: { min: 150, max: 250 } },
-                { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT},
-                { name: 'fat', label: 'Fat (g)', numeric: true, format: DECIMAL_FORMAT},
+                { name: 'first_name',  label: 'First name', width: 150 },
+                { name: 'last_name', label: 'Last name', width: { min: 150, max: 250 } },
+                { name: 'gender', label: 'Gender'},
+                { name: 'email', label: 'Email', width: 250},
+                { name: 'img', label: 'Avatar', width: 50},
               ];
 
-              basicData: any[] = [
-                  {
-                    'id': 1,
-                    'food': {
-                      'name': 'Frozen yogurt',
-                      'type': 'Ice cream',
-                    },
-                    'calories': 159.0,
-                    'fat': 6.0,
-                  }, {
-                    'id': 2,
-                    'food': {
-                      'name': 'Ice cream sandwich',
-                      'type': 'Ice cream',
-                    },
-                    'calories': 237.0,
-                    'fat': 9.0,
-                  }, {
-                    'id': 3,
-                    'food': {
-                      'name': 'Eclair',
-                      'type': 'Pastry',
-                    },
-                    'calories':  262.0,
-                    'fat': 16.0,
-                  }, {
-                    'id': 4,
-                    'food': {
-                      'name': 'Cupcake',
-                      'type': 'Pastry',
-                    },
-                    'calories':  305.0,
-                    'fat': 3.7,
-                  }
-                ];
+              basicData: any[] = [...]; // see data json
             }
           ]]>
+        </td-highlight>
+        <p>Data:</p>
+        <td-highlight lang="json" [content]="basicData | json">
         </td-highlight>
       </md-tab>
     </md-tab-group>
@@ -296,7 +210,7 @@
         <td-paging-bar #pagingBar [pageSize]="pageSize" [total]="filteredTotal" (change)="page($event)">
           <span hide-xs>Rows per page:</span>
           <md-select [style.width.px]="50" [(ngModel)]="pageSize">
-            <md-option *ngFor="let size of [5,10,15,20]" [value]="size">
+            <md-option *ngFor="let size of [50,100,200,500]" [value]="size">
               {{size}}
             </md-option>
           </md-select>
@@ -340,7 +254,7 @@
             <td-paging-bar #pagingBar [pageSize]="pageSize" [total]="filteredTotal" (change)="page($event)">
               <span hide-xs>Rows per page:</span>
               <md-select [style.width.px]="50" [(ngModel)]="pageSize">
-                <md-option *ngFor="let size of [5,10,15,20]" [value]="size">
+                <md-option *ngFor="let size of [50,100,200,500]" [value]="size">
                   { {size} }
                 </md-option>
               </md-select>
@@ -354,148 +268,19 @@
             import { TdDataTableService, TdDataTableSortingOrder, ITdDataTableSortChangeEvent, ITdDataTableColumn } from '@covalent/core';
             import { IPageChangeEvent } from '@covalent/core';
             ...
-            const NUMBER_FORMAT: (v: any) => any = (v: number) => v;
             const DECIMAL_FORMAT: (v: any) => any = (v: number) => v.toFixed(2);
             ...
             })
             export class Demo {
               columns: ITdDataTableColumn[] = [
-                { name: 'name',  label: 'Dessert (100g serving)', sortable: true, width: 200 },
-                { name: 'type', label: 'Type', filter: true },
-                { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT, sortable: true, hidden: false },
-                { name: 'fat', label: 'Fat (g)', numeric: true, format: DECIMAL_FORMAT, sortable: true },
-                { name: 'carbs', label: 'Carbs (g)', numeric: true, format: NUMBER_FORMAT },
-                { name: 'protein', label: 'Protein (g)', numeric: true, format: DECIMAL_FORMAT },
-                { name: 'sodium', label: 'Sodium (mg)', numeric: true, format: NUMBER_FORMAT },
-                { name: 'calcium', label: 'Calcium (%)', numeric: true, format: NUMBER_FORMAT },
-                { name: 'iron', label: 'Iron (%)', numeric: true, format: NUMBER_FORMAT },
+                { name: 'first_name',  label: 'First Name', sortable: true, width: 150 },
+                { name: 'last_name', label: 'Last Name', filter: true },
+                { name: 'gender', label: 'Gender', hidden: false },
+                { name: 'email', label: 'Email', sortable: true, width: 250 },
+                { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },
               ];
           
-              data: any[] = [
-                {
-                  'id': 1,
-                  'name': 'Frozen yogurt',
-                  'type': 'Ice cream',
-                  'calories': 159.0,
-                  'fat': 6.0,
-                  'carbs': 24.0,
-                  'protein': 4.0,
-                  'sodium': 87.0,
-                  'calcium': 14.0,
-                  'iron': 1.0,
-                  'comments': 'I love froyo!',
-                }, {
-                  'id': 2,
-                  'name': 'Ice cream sandwich',
-                  'type': 'Ice cream',
-                  'calories': 237.0,
-                  'fat': 9.0,
-                  'carbs': 37.0,
-                  'protein': 4.3,
-                  'sodium': 129.0,
-                  'calcium': 8.0,
-                  'iron': 1.0,
-                }, {
-                  'id': 3,
-                  'name': 'Eclair',
-                  'type': 'Pastry',
-                  'calories':  262.0,
-                  'fat': 16.0,
-                  'carbs': 24.0,
-                  'protein':  6.0,
-                  'sodium': 337.0,
-                  'calcium':  6.0,
-                  'iron': 7.0,
-                }, {
-                  'id': 4,
-                  'name': 'Cupcake',
-                  'type': 'Pastry',
-                  'calories':  305.0,
-                  'fat': 3.7,
-                  'carbs': 67.0,
-                  'protein': 4.3,
-                  'sodium': 413.0,
-                  'calcium': 3.0,
-                  'iron': 8.0,
-                }, {
-                  'id': 5,
-                  'name': 'Jelly bean',
-                  'type': 'Candy',
-                  'calories':  375.0,
-                  'fat': 0.0,
-                  'carbs': 94.0,
-                  'protein': 0.0,
-                  'sodium': 50.0,
-                  'calcium': 0.0,
-                  'iron': 0.0,
-                }, {
-                  'id': 6,
-                  'name': 'Lollipop',
-                  'type': 'Candy',
-                  'calories': 392.0,
-                  'fat': 0.2,
-                  'carbs': 98.0,
-                  'protein': 0.0,
-                  'sodium': 38.0,
-                  'calcium': 0.0,
-                  'iron': 2.0,
-                }, {
-                  'id': 7,
-                  'name': 'Honeycomb',
-                  'type': 'Other',
-                  'calories': 408.0,
-                  'fat': 3.2,
-                  'carbs': 87.0,
-                  'protein': 6.5,
-                  'sodium': 562.0,
-                  'calcium': 0.0,
-                  'iron': 45.0,
-                }, {
-                  'id': 8,
-                  'name': 'Donut',
-                  'type': 'Pastry',
-                  'calories': 452.0,
-                  'fat': 25.0,
-                  'carbs': 51.0,
-                  'protein': 4.9,
-                  'sodium': 326.0,
-                  'calcium': 2.0,
-                  'iron': 22.0,
-                }, {
-                  'id': 9,
-                  'name': 'KitKat',
-                  'type': 'Candy',
-                  'calories': 518.0,
-                  'fat': 26.0,
-                  'carbs': 65.0,
-                  'protein': 7.0,
-                  'sodium': 54.0,
-                  'calcium': 12.0,
-                  'iron': 6.0,
-                }, {
-                  'id': 10,
-                  'name': 'Chocolate',
-                  'type': 'Candy',
-                  'calories': 518.0,
-                  'fat': 26.0,
-                  'carbs': 65.0,
-                  'protein': 7.0,
-                  'sodium': 54.0,
-                  'calcium': 12.0,
-                  'iron': 6.0,
-                }, {
-                  'id': 11,
-                  'name': 'Chamoy',
-                  'type': 'Candy',
-                  'calories': 518.0,
-                  'fat': 26.0,
-                  'carbs': 65.0,
-                  'protein': 7.0,
-                  'sodium': 54.0,
-                  'calcium': 12.0,
-                  'iron': 6.0,
-                },
-              ];
+              data: any[] = [...]; // see json data
 
               filteredData: any[] = this.data;
               filteredTotal: number = this.data.length;
@@ -503,8 +288,8 @@
               searchTerm: string = '';
               fromRow: number = 1;
               currentPage: number = 1;
-              pageSize: number = 10;
-              sortBy: string = 'name';
+              pageSize: number = 50;
+              sortBy: string = 'first_name';
               selectedRows: any[] = [];
               sortOrder: TdDataTableSortingOrder = TdDataTableSortingOrder.Descending;
 
@@ -550,6 +335,9 @@
             }
           ]]>
         </td-highlight>
+        <p>Data:</p>
+        <td-highlight lang="json" [content]="basicData | json">
+        </td-highlight>
       </md-tab>
     </md-tab-group>
   </md-card-content>
@@ -575,10 +363,10 @@
     <md-divider></md-divider>
     <div class="pad-sm">
       <md-slide-toggle color="accent" [(ngModel)]="columns[2].hidden" (ngModelChange)="dataTable.refresh()">
-        Hide calories
+        Hide gender
       </md-slide-toggle>
       <md-slide-toggle color="accent" [(ngModel)]="columns[1].filter">
-        Type column is searchable (search for <code>candy</code>)
+        Type column is searchable (search for <code>lifsey</code>)
       </md-slide-toggle>
     </div>
   </md-card-actions>

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -7,6 +7,10 @@ import { TdDataTableSortingOrder, TdDataTableService, TdDataTableComponent,
 import { IPageChangeEvent } from '../../../../platform/core';
 import { TdDialogService } from '../../../../platform/core';
 
+import { InternalDocsService } from '../../../services';
+
+import { toPromise } from 'rxjs/operator/toPromise';
+
 const NUMBER_FORMAT: (v: any) => any = (v: number) => v;
 const DECIMAL_FORMAT: (v: any) => any = (v: number) => v.toFixed(2);
 
@@ -78,167 +82,41 @@ export class DataTableDemoComponent implements OnInit {
   }];
 
   configWidthColumns: ITdDataTableColumn[] = [
-    { name: 'name',  label: 'Dessert (100g serving)', width: 300 },
-    { name: 'type', label: 'Type', width: { min: 150, max: 250 } },
-    { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT},
-    { name: 'fat', label: 'Fat (g)', numeric: true, format: DECIMAL_FORMAT},
+    { name: 'first_name',  label: 'First name', width: 150 },
+    { name: 'last_name', label: 'Last name', width: { min: 150, max: 250 } },
+    { name: 'gender', label: 'Gender'},
+    { name: 'email', label: 'Email', width: 250},
+    { name: 'img', label: 'Avatar', width: 50},
   ];
 
   columns: ITdDataTableColumn[] = [
-    { name: 'name',  label: 'Dessert (100g serving)', sortable: true, width: 200 },
-    { name: 'type', label: 'Type', filter: true },
-    { name: 'calories', label: 'Calories', numeric: true, format: NUMBER_FORMAT, sortable: true, hidden: false },
-    { name: 'fat', label: 'Fat (g)', numeric: true, format: DECIMAL_FORMAT, sortable: true },
-    { name: 'carbs', label: 'Carbs (g)', numeric: true, format: NUMBER_FORMAT },
-    { name: 'protein', label: 'Protein (g)', numeric: true, format: DECIMAL_FORMAT },
-    { name: 'sodium', label: 'Sodium (mg)', numeric: true, format: NUMBER_FORMAT },
-    { name: 'calcium', label: 'Calcium (%)', numeric: true, format: NUMBER_FORMAT },
-    { name: 'iron', label: 'Iron (%)', numeric: true, format: NUMBER_FORMAT },
+    { name: 'first_name',  label: 'First Name', sortable: true, width: 150 },
+    { name: 'last_name', label: 'Last Name', filter: true },
+    { name: 'gender', label: 'Gender', hidden: false },
+    { name: 'email', label: 'Email', sortable: true, width: 250 },
+    { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },
   ];
 
-  data: any[] = [
-    {
-        'id': 1,
-        'name': 'Frozen yogurt',
-        'type': 'Ice cream',
-        'calories': 159.0,
-        'fat': 6.0,
-        'carbs': 24.0,
-        'protein': 4.0,
-        'sodium': 87.0,
-        'calcium': 14.0,
-        'iron': 1.0,
-        'comments': 'I love froyo!',
-      }, {
-        'id': 2,
-        'name': 'Ice cream sandwich',
-        'type': 'Ice cream',
-        'calories': 237.0,
-        'fat': 9.0,
-        'carbs': 37.0,
-        'protein': 4.3,
-        'sodium': 129.0,
-        'calcium': 8.0,
-        'iron': 1.0,
-      }, {
-        'id': 3,
-        'name': 'Eclair',
-        'type': 'Pastry',
-        'calories':  262.0,
-        'fat': 16.0,
-        'carbs': 24.0,
-        'protein':  6.0,
-        'sodium': 337.0,
-        'calcium':  6.0,
-        'iron': 7.0,
-      }, {
-        'id': 4,
-        'name': 'Cupcake',
-        'type': 'Pastry',
-        'calories':  305.0,
-        'fat': 3.7,
-        'carbs': 67.0,
-        'protein': 4.3,
-        'sodium': 413.0,
-        'calcium': 3.0,
-        'iron': 8.0,
-      }, {
-        'id': 5,
-        'name': 'Jelly bean',
-        'type': 'Candy',
-        'calories':  375.0,
-        'fat': 0.0,
-        'carbs': 94.0,
-        'protein': 0.0,
-        'sodium': 50.0,
-        'calcium': 0.0,
-        'iron': 0.0,
-      }, {
-        'id': 6,
-        'name': 'Lollipop',
-        'type': 'Candy',
-        'calories': 392.0,
-        'fat': 0.2,
-        'carbs': 98.0,
-        'protein': 0.0,
-        'sodium': 38.0,
-        'calcium': 0.0,
-        'iron': 2.0,
-      }, {
-        'id': 7,
-        'name': 'Honeycomb',
-        'type': 'Other',
-        'calories': 408.0,
-        'fat': 3.2,
-        'carbs': 87.0,
-        'protein': 6.5,
-        'sodium': 562.0,
-        'calcium': 0.0,
-        'iron': 45.0,
-      }, {
-        'id': 8,
-        'name': 'Donut',
-        'type': 'Pastry',
-        'calories': 452.0,
-        'fat': 25.0,
-        'carbs': 51.0,
-        'protein': 4.9,
-        'sodium': 326.0,
-        'calcium': 2.0,
-        'iron': 22.0,
-      }, {
-        'id': 9,
-        'name': 'KitKat',
-        'type': 'Candy',
-        'calories': 518.0,
-        'fat': 26.0,
-        'carbs': 65.0,
-        'protein': 7.0,
-        'sodium': 54.0,
-        'calcium': 12.0,
-        'iron': 6.0,
-      }, {
-        'id': 10,
-        'name': 'Chocolate',
-        'type': 'Candy',
-        'calories': 518.0,
-        'fat': 26.0,
-        'carbs': 65.0,
-        'protein': 7.0,
-        'sodium': 54.0,
-        'calcium': 12.0,
-        'iron': 6.0,
-      }, {
-        'id': 11,
-        'name': 'Chamoy',
-        'type': 'Candy',
-        'calories': 518.0,
-        'fat': 26.0,
-        'carbs': 65.0,
-        'protein': 7.0,
-        'sodium': 54.0,
-        'calcium': 12.0,
-        'iron': 6.0,
-      },
-    ];
-  basicData: any[] = this.data.slice(0, 4);
+  data: any[];
+  basicData: any[];
   selectable: boolean = true;
   clickable: boolean = false;
   multiple: boolean = true;
   filterColumn: boolean = true;
 
-  filteredData: any[] = this.data;
-  filteredTotal: number = this.data.length;
+  filteredData: any[];
+  filteredTotal: number ;
   selectedRows: any[] = [];
 
   searchTerm: string = '';
   fromRow: number = 1;
   currentPage: number = 1;
-  pageSize: number = 10;
-  sortBy: string = 'name';
+  pageSize: number = 50;
+  sortBy: string = 'first_name';
   sortOrder: TdDataTableSortingOrder = TdDataTableSortingOrder.Descending;
 
   constructor(private _dataTableService: TdDataTableService,
+              private _internalDocsService: InternalDocsService,
               private _dialogService: TdDialogService) {}
 
   openPrompt(row: any, name: string): void {
@@ -252,7 +130,9 @@ export class DataTableDemoComponent implements OnInit {
     });
   }
 
-  ngOnInit(): void {
+  async ngOnInit(): Promise<void> {
+    this.data = await toPromise.call(this._internalDocsService.queryData());
+    this.basicData = this.data.slice(0, 10);
     this.filter();
   }
 

--- a/src/app/services/internal-docs.service.ts
+++ b/src/app/services/internal-docs.service.ts
@@ -41,4 +41,22 @@ export class InternalDocsService {
     });
   }
 
+  queryData(): Observable<any[]> {
+    return new Observable<ITemplate[]>((subscriber: Subscriber<ITemplate[]>) => {
+      this._http.get(INTERNAL_DOCS_URL + '/data.json').subscribe((response: Response) => {
+        let data: ITemplate[];
+        try {
+          data = response.json();
+        } catch (e) {
+          data = [];
+          subscriber.error();
+        }
+        subscriber.next(data);
+        subscriber.complete();
+      }, (error: any) => {
+        subscriber.error();
+      });
+    });
+  }
+
 }

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.scss
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.scss
@@ -6,7 +6,6 @@
   padding: 0;
   > .td-data-table-cell-content-wrapper {
     padding: 0 28px 0 28px;
-    height: 48px;
   }
 
   &:first-child > .td-data-table-cell-content-wrapper {

--- a/src/platform/core/data-table/data-table-row/data-table-row.component.ts
+++ b/src/platform/core/data-table/data-table-row/data-table-row.component.ts
@@ -40,6 +40,14 @@ export class TdDataTableRowComponent {
     return this._selected;
   }
 
+  get height(): number {
+    let height: number = 48;
+    if (this._elementRef.nativeElement) {
+      height = (<HTMLElement>this._elementRef.nativeElement).getBoundingClientRect().height;
+    }
+    return height;
+  }
+
   constructor(private _elementRef: ElementRef, private _renderer: Renderer2) {
     this._renderer.addClass(this._elementRef.nativeElement, 'td-data-table-row');
   }

--- a/src/platform/core/data-table/data-table.component.html
+++ b/src/platform/core/data-table/data-table.component.html
@@ -43,7 +43,7 @@
         #dtRow
         [tabIndex]="selectable ? 0 : -1"
         [selected]="(clickable || selectable) && isRowSelected(row)"
-        *ngFor="let row of data | slice:fromRow:toRow; let rowIndex = index"
+        *ngFor="let row of virtualData; let rowIndex = index"
         (click)="handleRowClick(row, $event)"
         (keyup)="selectable && _rowKeyup($event, row, rowIndex)"
         (keydown.space)="blockEvent($event)"


### PR DESCRIPTION
## Description

now we will cache the height of every row and recalculate the height as we keep scrolling


#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/data-table
- [ ] See new demos and play around with them

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
