### PR TITLE
fix(json-formatter): represent array of arrays properly

### DIFF
--- a/src/app/components/components/json-formatter/json-formatter.component.ts
+++ b/src/app/components/components/json-formatter/json-formatter.component.ts
@@ -37,6 +37,10 @@ export class JsonFormatterDemoComponent {
     'numberProperty': 10000,
     'booleanProperty': true,
     'numberArray': [1, 2, 3, 4, 5, 6],
+    'arrayOfArrays': [
+      [1, [2, 3]],
+      [3, 4],
+    ],
     'objectArray': [{
         'prop': undefined,
       }, {

--- a/src/platform/core/json-formatter/json-formatter.component.ts
+++ b/src/platform/core/json-formatter/json-formatter.component.ts
@@ -137,6 +137,8 @@ export class TdJsonFormatterComponent {
       return value.toString()
           .replace(/[\r\n]/g, '')
           .replace(/\{.*\}/, '') + '{…}';
+    } else if (Array.isArray(value)) {
+      return this.getObjectName() + ' [' + value.length + ']';
     }
     return value;
   }
@@ -149,6 +151,9 @@ export class TdJsonFormatterComponent {
     if (typeof object === 'object') {
       if (!object) {
         return 'null';
+      }
+      if (Array.isArray(object)) {
+        return 'object';
       }
       let date: Date = new Date(object);
       if (Object.prototype.toString.call(date) === '[object Date]') {


### PR DESCRIPTION
## Description

Tuples and array of arrays were presented improperly in the json formatter.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/json-formatter
- [ ] See array of arrays working fine now

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

#### Screenshots

![image](https://user-images.githubusercontent.com/5846742/31052885-034319d0-a645-11e7-85be-b47a1f0d1756.png)


closes https://github.com/Teradata/covalent/issues/852
