### PR TITLE
docs(angular-material): fix broken URL

### DIFF
--- a/src/app/components/docs/angular-material/angular-material.component.html
+++ b/src/app/components/docs/angular-material/angular-material.component.html
@@ -38,7 +38,7 @@
       <span matLine>Angular Material Docs Site</span>
     </a>
     <mat-divider></mat-divider>
-    <a mat-list-item href="https://github.com/angular/material2#feature-status" target="_blank">
+    <a mat-list-item href="https://github.com/angular/material2#available-features" target="_blank">
       <mat-icon>launch</mat-icon>
       <span matLine>Angular Material Feature Status</span>
     </a>


### PR DESCRIPTION
## Description
Fix broken URL in Angular Material docs page.

### What's included?
- `#feature-status` -> `#available-features`

#### Test Steps
Click the link and verify that it brings you to the section of the docs related to features.

#### General Tests for Every PR
- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
N/A