### PR TITLE
 fix(loading): get proper heights for overlay strategy

### DIFF
--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -162,6 +162,67 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
+    <h3 class="md-title">[tdLoading] until usage with icons</h3>
+    <h4 class="md-subhead">using the template syntax</h4>
+    <mat-tab-group mat-stretch-tabs dynamicHeight>
+      <mat-tab>
+        <ng-template matTabLabel>Demo</ng-template>
+        <mat-list>
+          <ng-template let-item let-last="last" ngFor [ngForOf]="itemList">
+            <mat-list-item>
+              <div matListAvatar>
+                <ng-template tdLoading [tdLoadingUntil]="!item.value" tdLoadingStrategy="overlay">
+                  <mat-icon matListAvatar>
+                    settings_backup_restore
+                  </mat-icon>
+                </ng-template>
+              </div>
+              <h3 matLine>{{item.label}}</h3>
+            </mat-list-item>
+            <mat-divider *ngIf="!last"></mat-divider>
+          </ng-template>
+        </mat-list>
+      </mat-tab>
+      <mat-tab>
+        <ng-template matTabLabel>Code</ng-template>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <mat-list>
+              <ng-template let-item let-last="last" ngFor [ngForOf]="itemList">
+                <mat-list-item>
+                  <div matListAvatar>
+                    <ng-template tdLoading [tdLoadingUntil]="!item.value" tdLoadingStrategy="overlay">
+                      <mat-icon matListAvatar>
+                        settings_backup_restore
+                      </mat-icon>
+                    </ng-template>
+                  </div>
+                  <h3 matLine>{ {item.label} }</h3>
+                </mat-list-item>
+                <mat-divider *ngIf="!last"></mat-divider>
+              </ng-template>
+            </mat-list>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            ...
+            export class Demo {
+              items: any[] = [
+                {label: 'Light', value: true},
+                {label: 'Console', value: false},
+                {label: 'T.V.', value: true}];
+            }
+          ]]>
+        </td-highlight>
+      </mat-tab>
+    </mat-tab-group>
+  </mat-card-content>
+</mat-card>
+<mat-card>
+  <mat-card-content>
     <h3 class="md-title">[tdLoading] until star syntax with variable reference and observables</h3>
     <h4 class="md-subhead">with accent [tdLoadingColor]</h4>
     <mat-tab-group mat-stretch-tabs dynamicHeight>

--- a/src/app/components/components/loading/loading.component.ts
+++ b/src/app/components/components/loading/loading.component.ts
@@ -79,6 +79,11 @@ export class LoadingDemoComponent implements OnInit {
     type: 'function(options: ITdLoadingConfig)',
   }];
 
+  itemList: any[] = [
+    {label: 'Light', value: true},
+    {label: 'Console', value: false},
+    {label: 'T.V.', value: true}];
+
   loading: boolean = false;
   listObservable: Observable<any[]>;
 
@@ -113,7 +118,6 @@ export class LoadingDemoComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.toggleDefaultFullscreenDemo();
     this.startDirectives();
   }
 
@@ -166,7 +170,7 @@ export class LoadingDemoComponent implements OnInit {
     this.listObservableDisabled = true;
     this.listObservable = new Observable<any[]>((subscriber: Subscriber<any[]>) => {
       setTimeout(() => {
-        subscriber.next([{label: 'Light', value: true}, {label: 'Console', value: false}, {label: 'T.V.', value: true}]);
+        subscriber.next(this.itemList);
         this.listObservableDisabled = false;
       }, 3000);
     });

--- a/src/platform/core/loading/loading.component.html
+++ b/src/platform/core/loading/loading.component.html
@@ -10,8 +10,8 @@
                         [mode]="mode"
                         [value]="value" 
                         [color]="color" 
-                        [style.height]="getCircleDiameter()"
-                        [style.width]="getCircleDiameter()">
+                        [diameter]="getCircleDiameter()"
+                        [strokeWidth]="getCircleStrokeWidth()">
     </mat-progress-spinner>
     <mat-progress-bar *ngIf="isLinear()" 
                      [mode]="mode"

--- a/src/platform/core/loading/loading.component.ts
+++ b/src/platform/core/loading/loading.component.ts
@@ -27,6 +27,8 @@ export enum LoadingStyle {
 
 import { TdFadeInOutAnimation } from '../common/common.module';
 
+export const TD_CIRCLE_DIAMETER: number = 100;
+
 @Component({
   selector: 'td-loading',
   styleUrls: ['./loading.component.scss' ],
@@ -109,7 +111,8 @@ export class TdLoadingComponent {
   }
 
   getCircleDiameter(): number {
-    let diameter: number = 100;
+    // we set a default diameter of 100 since this is the default in material
+    let diameter: number = TD_CIRCLE_DIAMETER;
     // if height is provided, then we take that as diameter
     if (this.height) {
       diameter = this.height;
@@ -117,14 +120,15 @@ export class TdLoadingComponent {
     } else if (this.height === undefined) {
       diameter = this._hostHeight();
     }
-    // if the diameter is over 100, we return 100
-    if (!!diameter && diameter <= 100) {
+    // if the diameter is over TD_CIRCLE_DIAMETER, we return TD_CIRCLE_DIAMETER
+    if (!!diameter && diameter <= TD_CIRCLE_DIAMETER) {
       return diameter;
     }
-    return 100;
+    return TD_CIRCLE_DIAMETER;
   }
 
   getCircleStrokeWidth(): number {
+    // we calculate the stroke width by setting it as 10% of its diameter
     let strokeWidth: number = this.getCircleDiameter() / 10;
     return Math.abs(strokeWidth);
   }

--- a/src/platform/core/loading/services/loading.factory.ts
+++ b/src/platform/core/loading/services/loading.factory.ts
@@ -70,7 +70,7 @@ export class TdLoadingFactory {
   /**
    * Creates a loading component dynamically and attaches it into the given viewContainerRef.
    * Leverages TemplatePortals from material to inject the template inside of it so it fits
-   * perfecly when overlaying it.
+   * perfectly when overlaying it.
    *
    * Saves a reference in context to be called when registering/resolving the loading element.
    */


### PR DESCRIPTION
## Description

With the latest material changes, the loading component was not setting the heights properly since we need to take into account the `[diameter]` and `[strokeWidth]` inputs now.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `ng serve`
- [ ] Go to the loading demo
- [ ] See the new demo for loading usage in icons

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
