### PR TITLE
Prioritize column setting for sortable

### DIFF
--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -274,7 +274,7 @@
             export class Demo {
               columns: ITdDataTableColumn[] = [
                 { name: 'first_name',  label: 'First Name', sortable: true, width: 150 },
-                { name: 'last_name', label: 'Last Name', filter: true },
+                { name: 'last_name', label: 'Last Name', filter: true, sortable: false },
                 { name: 'gender', label: 'Gender', hidden: false },
                 { name: 'email', label: 'Email', sortable: true, width: 250 },
                 { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -91,7 +91,7 @@ export class DataTableDemoComponent implements OnInit {
 
   columns: ITdDataTableColumn[] = [
     { name: 'first_name',  label: 'First Name', sortable: true, width: 150 },
-    { name: 'last_name', label: 'Last Name', filter: true },
+    { name: 'last_name', label: 'Last Name', filter: true, sortable: false },
     { name: 'gender', label: 'Gender', hidden: false },
     { name: 'email', label: 'Email', sortable: true, width: 250 },
     { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },

--- a/src/platform/core/data-table/data-table.component.html
+++ b/src/platform/core/data-table/data-table.component.html
@@ -23,7 +23,7 @@
         [name]="column.name"
         [numeric]="column.numeric"
         [active]="(column.sortable || sortable) && column === sortByColumn"
-        [sortable]="column.sortable || sortable"
+        [sortable]="column.sortable || (sortable && column.sortable !== false)"
         [sortOrder]="sortOrderEnum"
         [hidden]="column.hidden"
         (sortChange)="handleSort(column)">


### PR DESCRIPTION
## Description
Change the behavior of sortable in the data-table as described in #933
closes #933

### What's included?
- Prioritize per column setting of sortable (allow override)

#### Test Steps
- [x] Set sortable on data table to true
- [x] Set sortable on one column to false
- [x] Check if sortable is disabled on the one specific column

#### General Tests for Every PR
- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.