### PR TITLE
bugfix(mediaService): Fix for TdMediaService doesn't trigger Portrait or Landscape

### DIFF
--- a/src/app/components/components/media/media.component.html
+++ b/src/app/components/components/media/media.component.html
@@ -5,11 +5,17 @@
   <mat-card-content>
     <p>Media Queries:</p>
     <mat-list>
-      <ng-template let-demo let-last="demo" ngFor [ngForOf]="mediaDemo">
-        <a mat-list-item layout-align="row">
-          <h3 [tdMediaToggle]="demo.query" [mediaStyles]="{color: 'red'}" [mediaAttributes]="{title: 'It matches!!!'}" matLine> {{demo.query}}</h3>
+      <ng-template let-demo let-last="last" ngFor [ngForOf]="mediaDemo">
+        <mat-list-item>
+          <mat-icon [@tdJello]="demo.value" matListAvatar>
+            <span *ngIf="demo.value; else offStateIcon" class="tc-primary">check_circle</span>
+            <ng-template #offStateIcon>
+              <span>highlight_off</span>
+            </ng-template>
+          </mat-icon>
+          <h3 [tdMediaToggle]="demo.query" [mediaClasses]="['tc-primary']" [mediaAttributes]="{title: 'It matches!!!'}" matLine> {{demo.query}}</h3>
           <p matLine> matches: {{demo.value}} </p>
-        </a>
+        </mat-list-item>
         <mat-divider *ngIf="!last"></mat-divider>
       </ng-template>
     </mat-list>    
@@ -26,7 +32,7 @@
       <a href="https://material.google.com/layout/responsive-ui.html" target="_blank">breakpoints</a>:
     </p>
     <mat-list>
-      <ng-template let-bpoint let-last="bpoint" ngFor [ngForOf]="mediaBreakpoints">
+      <ng-template let-bpoint let-last="last" ngFor [ngForOf]="mediaBreakpoints">
         <a mat-list-item layout-align="row">
           <h3 matLine> {{bpoint.breakpoint}}</h3>
           <p matLine> {{bpoint.query}} </p>
@@ -37,7 +43,7 @@
     <h3>Methods:</h3>
     <p>The <code>TdMediaService</code> service has {{mediaServiceMethods.length}} properties:</p>
     <mat-list>
-      <ng-template let-attr let-last="attr" ngFor [ngForOf]="mediaServiceMethods">
+      <ng-template let-attr let-last="last" ngFor [ngForOf]="mediaServiceMethods">
         <a mat-list-item layout-align="row">
           <h3 matLine> {{attr.name}}: <span>{{attr.type}}</span></h3>
           <p matLine> {{attr.description}} </p>

--- a/src/app/components/components/media/media.component.html
+++ b/src/app/components/components/media/media.component.html
@@ -3,7 +3,7 @@
   <mat-card-subtitle>Responsive service & directive (for attributes)</mat-card-subtitle>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p>Media Queries:</p>
+    <p>Resize screen to toggle breakpoints</p>
     <mat-list>
       <ng-template let-demo let-last="last" ngFor [ngForOf]="mediaDemo">
         <mat-list-item>

--- a/src/app/components/components/media/media.component.ts
+++ b/src/app/components/components/media/media.component.ts
@@ -2,13 +2,16 @@ import { Component, OnInit, NgZone, OnDestroy, HostBinding } from '@angular/core
 import { slideInDownAnimation } from '../../../app.animations';
 import { Subscription } from 'rxjs/Subscription';
 
-import { TdMediaService } from '../../../../platform/core';
+import { TdMediaService, TdJelloAnimation } from '../../../../platform/core';
 
 @Component({
   selector: 'media-demo',
   styleUrls: ['./media.component.scss' ],
   templateUrl: './media.component.html',
-  animations: [slideInDownAnimation],
+  animations: [
+    TdJelloAnimation(),
+    slideInDownAnimation,
+  ],
 })
 export class MediaDemoComponent implements OnInit, OnDestroy {
 

--- a/src/platform/core/media/services/media.service.ts
+++ b/src/platform/core/media/services/media.service.ts
@@ -23,8 +23,8 @@ export class TdMediaService {
     this._queryMap.set('lg', '(min-width: 1280px) and (max-width: 1919px)');
     this._queryMap.set('gt-lg', '(min-width: 1920px)');
     this._queryMap.set('xl', '(min-width: 1920px)');
-    this._queryMap.set('landscape', 'landscape');
-    this._queryMap.set('portrait', 'portrait');
+    this._queryMap.set('landscape', '(orientation: landscape)');
+    this._queryMap.set('portrait', '(orientation: portrait)');
     this._queryMap.set('print', 'print');
 
     this._resizing = false;


### PR DESCRIPTION
## Description
Fix for TdMediaService doesn't trigger Portrait or Landscape
closes #922

### What's included?
- modified:   src/platform/core/media/services/media.service.ts

#### Test Steps
- [x] checkout branch
- [x] ng serve
- [x] Go to http://localhost:4200/#/components/media
- [x] Resize browser window back and forth and see portrait and landscape turn red and black

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![landscape](https://user-images.githubusercontent.com/10502797/31799639-1f6501c8-b4f0-11e7-8e9e-f7e90a20007b.gif)
