### PR TITLE
feat(theme): Add menu button to switch between dark and light themes

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <td-layout #layout
-            class="{{activeTheme}}"
+            [class]="activeTheme"
             [dir]="dir"
             [mode]="(media.registerQuery('gt-md') | async) ? 'side' : 'over'"
             [sidenavWidth]="(media.registerQuery('gt-md') | async) ? '257px' : '320px'">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,5 @@
 <td-layout #layout
+            class="{{activeTheme}}"
             [dir]="dir"
             [mode]="(media.registerQuery('gt-md') | async) ? 'side' : 'over'"
             [sidenavWidth]="(media.registerQuery('gt-md') | async) ? '257px' : '320px'">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -87,6 +87,13 @@ export class DocsAppComponent implements AfterViewInit {
     this.dir = getDirection();
   }
 
+  get activeTheme(): string {
+    return localStorage.getItem('theme');
+  }
+  theme(theme: string): void {
+    localStorage.setItem('theme', theme);
+  }
+
   ngAfterViewInit(): void {
     // broadcast to all listener observables when loading the page
     setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -48,5 +48,13 @@
         <mat-icon>swap_horiz</mat-icon>
         <span>{{dir.toUpperCase()}}</span>
       </button>
+      <button mat-menu-item *ngIf="activeTheme === 'theme-dark'" (click)="theme('default-theme')">
+        <mat-icon>brightness_high</mat-icon>
+        <span>Light Mode</span>
+      </button>
+      <button mat-menu-item *ngIf="activeTheme != 'theme-dark'" (click)="theme('theme-dark')">
+        <mat-icon>brightness_low</mat-icon>
+        <span>Dark Mode</span>
+      </button>
     </mat-menu>
   </div>

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -37,4 +37,11 @@ export class ToolbarComponent {
     this._dir.dir = dir;
     setDirection(dir);
   }
+
+  get activeTheme(): string {
+    return localStorage.getItem('theme');
+  }
+  theme(theme: string): void {
+    localStorage.setItem('theme', theme);
+  }
 }


### PR DESCRIPTION
## Description
Add toggle button to switch between dark and light themes

### What's included?
- modified:   src/app/app.component.html
- modified:   src/app/app.component.ts
- modified:   src/app/components/toolbar/toolbar.component.html
- modified:   src/app/components/toolbar/toolbar.component.ts

#### Test Steps
- [ ] checkout branch 
- [ ] ng serve
- [ ] go to http://localhost:4200/#/components
- [ ] In top right under 3 dots click on Dark Theme
- [ ] See UI change to dark theme



#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![screen shot 2017-10-20 at 10 15 10 am](https://user-images.githubusercontent.com/10502797/31833491-971ebef4-b57f-11e7-8aa8-b5579e76eb53.png)