### PR TITLE
feat(search): Make icons of 'Search Box' and 'Search Input' customizable

### DIFF
--- a/src/app/components/components/search/search.component.html
+++ b/src/app/components/components/search/search.component.html
@@ -95,7 +95,7 @@
     <h3>Properties:</h3>
     <p>The <code><![CDATA[<td-search-box>]]></code> component has {{searchBoxAttrs.length}} properties:</p>
     <mat-list>
-      <ng-template let-attr let-last="attr" ngFor [ngForOf]="searchBoxAttrs">
+      <ng-template let-attr let-last="last" ngFor [ngForOf]="searchBoxAttrs">
         <a mat-list-item layout-align="row">
           <h3 matLine> {{attr.name}}: <span>{{attr.type}}</span></h3>
           <p matLine> {{attr.description}} </p>

--- a/src/app/components/components/search/search.component.ts
+++ b/src/app/components/components/search/search.component.ts
@@ -34,6 +34,10 @@ export class SearchDemoComponent {
     name: 'search',
     type: 'function($event)',
   }, {
+    description: `The icon used to clear the search input. Defaults to 'cancel' icon.`,
+    name: 'clearIcon?',
+    type: 'string',
+  }, {
     description: `Event emitted after the clear icon has been clicked.`,
     name: 'clear',
     type: 'function($event)',
@@ -51,6 +55,15 @@ export class SearchDemoComponent {
     description: `The icon used to close the search toggle, only shown when [alwaysVisible] is false.
                   Defaults to 'search' icon.`,
     name: 'backIcon?',
+    type: 'string',
+  }, {
+    description: `The icon used to open the search toggle, only shown when [searchVisible] is false or [alwaysVisible] is true.
+                  Defaults to 'search' icon.`,
+    name: 'searchIcon?',
+    type: 'string',
+  }, {
+    description: `The icon used to clear the search input. Defaults to 'cancel' icon.`,
+    name: 'clearIcon?',
     type: 'string',
   }, {
     description: `Sets if the input underline should be visible. Defaults to 'false'.`,

--- a/src/app/components/components/search/search.component.ts
+++ b/src/app/components/components/search/search.component.ts
@@ -57,7 +57,7 @@ export class SearchDemoComponent {
     name: 'backIcon?',
     type: 'string',
   }, {
-    description: `The icon used to open the search toggle, only shown when [searchVisible] is false or [alwaysVisible] is true.
+    description: `The icon used to open/focus the search toggle.
                   Defaults to 'search' icon.`,
     name: 'searchIcon?',
     type: 'string',

--- a/src/platform/core/search/search-box/search-box.component.html
+++ b/src/platform/core/search/search-box/search-box.component.html
@@ -1,13 +1,14 @@
 <div class="td-search-box" layout="row" layout-align="end center">
   <button mat-icon-button type="button" class="td-search-icon" flex="none" (click)="searchClicked()">
     <mat-icon *ngIf="searchVisible && !alwaysVisible">{{backIcon}}</mat-icon>
-    <mat-icon *ngIf="!searchVisible || alwaysVisible">search</mat-icon>
+    <mat-icon *ngIf="!searchVisible || alwaysVisible">{{searchIcon}}</mat-icon>
   </button>
   <td-search-input #searchInput
                    [@inputState]="alwaysVisible || searchVisible"
                    [debounce]="debounce"
                    [showUnderline]="showUnderline"
                    [placeholder]="placeholder"
+                   [clearIcon]="clearIcon"
                    (searchDebounce)="handleSearchDebounce($event)"
                    (search)="handleSearch($event)"
                    (clear)="handleClear(); toggleVisibility()">

--- a/src/platform/core/search/search-box/search-box.component.ts
+++ b/src/platform/core/search/search-box/search-box.component.ts
@@ -47,7 +47,7 @@ export class TdSearchBoxComponent {
 
   /**
    * searchIcon?: string
-   * The icon used to open the search toggle, only shown when [searchVisible] is false or [alwaysVisible] is true.
+   * The icon used to open/focus the search toggle.
    * Defaults to 'search' icon.
    */
   @Input('searchIcon') searchIcon: string = 'search';

--- a/src/platform/core/search/search-box/search-box.component.ts
+++ b/src/platform/core/search/search-box/search-box.component.ts
@@ -70,6 +70,20 @@ export class TdSearchBoxComponent {
   @Input('placeholder') placeholder: string;
 
   /**
+   * searchIcon?: string
+   * The icon used to open the search toggle, only shown when [searchVisible] is false or [alwaysVisible] is true.
+   * Defaults to 'search' icon.
+   */
+  @Input('searchIcon') searchIcon: string = 'search';
+
+  /**
+   * clearIcon?: string
+   * The icon used to clear the search input.
+   * Defaults to 'cancel' icon.
+   */
+  @Input('clearIcon') clearIcon: string = 'cancel';
+
+  /**
    * searchDebounce: function($event)
    * Event emitted after the [debounce] timeout.
    */

--- a/src/platform/core/search/search-box/search-box.component.ts
+++ b/src/platform/core/search/search-box/search-box.component.ts
@@ -46,6 +46,20 @@ export class TdSearchBoxComponent {
   @Input('backIcon') backIcon: string = 'search';
 
   /**
+   * searchIcon?: string
+   * The icon used to open the search toggle, only shown when [searchVisible] is false or [alwaysVisible] is true.
+   * Defaults to 'search' icon.
+   */
+  @Input('searchIcon') searchIcon: string = 'search';
+
+  /**
+   * clearIcon?: string
+   * The icon used to clear the search input.
+   * Defaults to 'cancel' icon.
+   */
+  @Input('clearIcon') clearIcon: string = 'cancel';
+  
+  /**
    * showUnderline?: boolean
    * Sets if the input underline should be visible. Defaults to 'false'.
    */
@@ -68,20 +82,6 @@ export class TdSearchBoxComponent {
    * Placeholder for the underlying input component.
    */
   @Input('placeholder') placeholder: string;
-
-  /**
-   * searchIcon?: string
-   * The icon used to open the search toggle, only shown when [searchVisible] is false or [alwaysVisible] is true.
-   * Defaults to 'search' icon.
-   */
-  @Input('searchIcon') searchIcon: string = 'search';
-
-  /**
-   * clearIcon?: string
-   * The icon used to clear the search input.
-   * Defaults to 'cancel' icon.
-   */
-  @Input('clearIcon') clearIcon: string = 'cancel';
 
   /**
    * searchDebounce: function($event)

--- a/src/platform/core/search/search-input/search-input.component.html
+++ b/src/platform/core/search/search-input/search-input.component.html
@@ -14,6 +14,6 @@
           [@searchState]="(searchElement.value ?  'show' : (isRTL ? 'hide-left' : 'hide-right'))"
           (click)="clearSearch()"
           flex="none">
-    <mat-icon>cancel</mat-icon>
+    <mat-icon>{{clearIcon}}</mat-icon>
   </button>
 </div>

--- a/src/platform/core/search/search-input/search-input.component.ts
+++ b/src/platform/core/search/search-input/search-input.component.ts
@@ -54,6 +54,13 @@ export class TdSearchInputComponent implements OnInit {
   @Input('placeholder') placeholder: string;
 
   /**
+   * clearIcon?: string
+   * The icon used to clear the search input.
+   * Defaults to 'cancel' icon.
+   */
+  @Input('clearIcon') clearIcon: string = 'cancel';
+
+  /**
    * searchDebounce: function($event)
    * Event emitted after the [debounce] timeout.
    */


### PR DESCRIPTION
## Description
Make icons of 'Search Box' and 'Search Input' customizable
closes #420

### What's included?
- modified:   src/app/components/components/search/search.component.ts
- modified:   src/platform/core/search/search-box/search-box.component.html
- modified:   src/platform/core/search/search-box/search-box.component.ts
- modified:   src/platform/core/search/search-input/search-input.component.html
- modified:   src/platform/core/search/search-input/search-input.component.ts

#### Test Steps
- [ ] checkout branch
- [ ] ng serve 
- [ ] modify src/app/components/components/search/search.component.html on line 28 change to:
```
<td-search-box clearIcon="swap_horiz" searchIcon="info_outline" backIcon="info_outline" *ngIf="!debounce" placeholder="Search here" [alwaysVisible]="alwaysVisible" (search)="searchBoxTerm = $event" (clear)="searchBoxTerm = ''" flex></td-search-box>

```
- [ ] See icons change for search and clear

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![icons](https://user-images.githubusercontent.com/10502797/31836162-2273de22-b589-11e7-8a99-fb57b4cad279.gif)