### PR TITLE
feat(loader): Remove blocking background from linear loader

### DIFF
--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -339,7 +339,7 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-   <h3 class="md-title">Custom [TdLoading] fullscreen mask</h3>
+   <h3 class="md-title">Custom [TdLoading] linear at top of page</h3>
     <h4 class="md-subhead">with indeterminate [mode], linear [type], accent [color]</h4>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>

--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -292,11 +292,11 @@
 <mat-card>
   <mat-card-content>
     <h3 class="md-title">[tdLoading] until template syntax with booleans</h3>
-    <h4 class="md-subhead">with overlay [tdLoadingStrategy]</h4>
+    <h4 class="md-subhead">with overlay [tdLoadingStrategy], linear [tdLoadingType]</h4>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
-        <ng-template tdLoading [tdLoadingUntil]="!loading" tdLoadingStrategy="overlay">
+        <ng-template tdLoading [tdLoadingUntil]="!loading" tdLoadingStrategy="overlay" tdLoadingType="linear">
           <div layout="row">
             <mat-form-field flex>
               <input matInput [(ngModel)]="untilOverlayDemo.name" placeholder="Name"/>
@@ -317,7 +317,7 @@
         <p>HTML:</p>
         <td-highlight lang="html">
           <![CDATA[
-            <ng-template tdLoading [tdLoadingUntil]="!loading" tdLoadingStrategy="overlay">
+            <ng-template tdLoading [tdLoadingUntil]="!loading" tdLoadingStrategy="overlay" tdLoadingType="linear">
               <div layout="row">
                 <mat-form-field flex>
                   <input matInput [(ngModel)]="untilOverlayDemo.name" placeholder="Name"/>

--- a/src/platform/core/loading/loading.component.html
+++ b/src/platform/core/loading/loading.component.html
@@ -1,4 +1,8 @@
-<div class="td-loading-wrapper" [style.min-height]="getHeight()" [class.td-overlay]="isOverlay() || isFullScreen()" [class.td-fullscreen]="isFullScreen()">
+<div class="td-loading-wrapper"
+    [style.min-height]="getHeight()"
+    [class.td-overlay]="isOverlay() || (isFullScreen() && !isLinear())"
+    [class.td-overlay-linear]="isOverlay() || (isFullScreen() && isLinear())" 
+    [class.td-fullscreen]="isFullScreen()">
   <div [@tdFadeInOut]="animation"
      (@tdFadeInOut.done)="animationComplete($event)"
      [style.min-height]="getHeight()"

--- a/src/platform/core/loading/loading.component.html
+++ b/src/platform/core/loading/loading.component.html
@@ -1,7 +1,7 @@
 <div class="td-loading-wrapper"
     [style.min-height]="getHeight()"
-    [class.td-overlay]="isOverlay() || (isFullScreen() && !isLinear())"
-    [class.td-overlay-linear]="isOverlay() || (isFullScreen() && isLinear())" 
+    [class.td-overlay-circular]="(isOverlay() || isFullScreen()) && !isLinear()"
+    [class.td-overlay]="isOverlay() || isFullScreen()" 
     [class.td-fullscreen]="isFullScreen()">
   <div [@tdFadeInOut]="animation"
      (@tdFadeInOut.done)="animationComplete($event)"

--- a/src/platform/core/loading/loading.component.scss
+++ b/src/platform/core/loading/loading.component.scss
@@ -11,7 +11,6 @@
       top: 0;
       left: 0;
       right: 0;
-      bottom: 0;
       z-index: 1000;
       mat-progress-bar {
         position: absolute;
@@ -21,20 +20,9 @@
       }
     }
   }
-  &.td-overlay-linear {
+  &.td-overlay-circular {
     .td-loading {
-      position: absolute;
-      margin: 0;
-      top: 0;
-      left: 0;
-      right: 0;
-      z-index: 1000;
-      mat-progress-bar {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-      }
+      bottom: 0;
     }
   }
 }

--- a/src/platform/core/loading/loading.component.scss
+++ b/src/platform/core/loading/loading.component.scss
@@ -21,4 +21,20 @@
       }
     }
   }
+  &.td-overlay-linear {
+    .td-loading {
+      position: absolute;
+      margin: 0;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 1000;
+      mat-progress-bar {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Description
Remove blocking background from linear loader
closes #823

### What's included?
- modified:   src/app/components/components/loading/loading.component.html
- modified:   src/platform/core/loading/loading.component.html
- modified:   src/platform/core/loading/loading.component.scs

#### Test Steps
- [ ] Checkout branch 
- [ ] ng serve 
- [ ] go to http://localhost:4200/#/components/loading
- [ ] Under the section, "Custom [TdLoading] linear at top of page" click on the "Toggle Loader" button
- [ ] See linear loader at top of page and see you can still click on anything else on page

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
![linear](https://user-images.githubusercontent.com/10502797/31844812-01fca936-b5b0-11e7-8b55-a9c19463dcac.gif)
