### PR TITLE
chore(data-table): td-data-table missing (rowClick) at "Code" tab

### DIFF
--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -318,6 +318,12 @@
                 this.filter();
               }
 
+              showAlert(event: any): void {
+                this._dialogService.openAlert({
+                  message: JSON.stringify('You clicked on row: ' + event.row.name),
+                });
+              }
+
               filter(): void {
                 let newData: any[] = this.data;
                 let excludedColumns: string[] = this.columns

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -246,6 +246,7 @@
               [(ngModel)]="selectedRows"
               [sortOrder]="sortOrder"
               (sortChange)="sort($event)"
+              (rowClick)="showAlert($event)"
               [style.height.px]="200">
             </td-data-table>
             <div class="md-padding" *ngIf="!dataTable.hasData" layout="row" layout-align="center center">


### PR DESCRIPTION
There is not call to action when a row is clicked at the documentation.

## Description
Just completed the documentation. Included at the td-data-table element the call to action placed at the Code Tab.