### PR TITLE
fix(virtual-scroll): fix issue with virtual scroll not respecting the parent's width

### DIFF
--- a/src/platform/core/virtual-scroll/virtual-scroll-container.component.html
+++ b/src/platform/core/virtual-scroll/virtual-scroll-container.component.html
@@ -1,13 +1,14 @@
 <div [style.height.px]="totalHeight"></div>
 <div [style.transform]="offsetTransform"
       [style.position]="'absolute'"
-      [style.min-width.%]="100">
+      [style.width.%]="100">
   <ng-template let-row
                 let-index="index"
                 ngFor
                 [ngForOf]="virtualData"
                 [ngForTrackBy]="trackBy">
-    <div #rowElement>
+    <div #rowElement
+         [style.width.%]="100">
       <ng-template *ngIf="_rowTemplate"
                   [ngTemplateOutlet]="_rowTemplate.templateRef"
                   [ngTemplateOutletContext]="{row: row,


### PR DESCRIPTION
When using virtual scroll in a narrow area, the elements inside it had a bigger width than expected.

This is fixed by setting the virtual scroll width to 100%.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to CodePen/Plunker/JSfiddle
