### PR TITLE
feat(stepper): stop depending on layout.scss

### DIFF
--- a/src/platform/core/steps/step-body/step-body.component.html
+++ b/src/platform/core/steps/step-body/step-body.component.html
@@ -1,18 +1,16 @@
-<div layout="row" flex>
-  <ng-content></ng-content>
-  <div class="td-step-body" flex>
-    <div class="td-step-content-wrapper"
-         [@tdCollapse]="!active">
-      <div #contentRef cdkScrollable [class.td-step-content]="contentRef.children.length || contentRef.textContent.trim()">
-        <ng-content select="[td-step-body-content]"></ng-content>
-      </div>
-      <div #actionsRef layout="row" [class.td-step-actions]="actionsRef.children.length || actionsRef.textContent.trim()">
-        <ng-content select="[td-step-body-actions]"></ng-content>
-      </div>
+<ng-content></ng-content>
+<div class="td-step-body">
+  <div class="td-step-content-wrapper"
+        [@tdCollapse]="!active">
+    <div #contentRef cdkScrollable [class.td-step-content]="contentRef.children.length || contentRef.textContent.trim()">
+      <ng-content select="[td-step-body-content]"></ng-content>
     </div>
-    <div #summaryRef [@tdCollapse]="active || !isComplete()"
-                     [class.td-step-summary]="summaryRef.children.length || summaryRef.textContent.trim()">
-      <ng-content select="[td-step-body-summary]"></ng-content>
+    <div #actionsRef layout="row" [class.td-step-actions]="actionsRef.children.length || actionsRef.textContent.trim()">
+      <ng-content select="[td-step-body-actions]"></ng-content>
     </div>
+  </div>
+  <div #summaryRef [@tdCollapse]="active || !isComplete()"
+                    [class.td-step-summary]="summaryRef.children.length || summaryRef.textContent.trim()">
+    <ng-content select="[td-step-body-summary]"></ng-content>
   </div>
 </div>

--- a/src/platform/core/steps/step-body/step-body.component.scss
+++ b/src/platform/core/steps/step-body/step-body.component.scss
@@ -1,6 +1,16 @@
-.td-step-body {
-  overflow-x: hidden;
-  .td-step-content {
-    overflow-x: auto; 
+:host {
+  // layout
+  box-sizing: border-box;
+  display: flex;
+  // layout="row"
+  flex-direction: row;
+  .td-step-body {
+    overflow-x: hidden;
+    // flex
+    flex: 1;
+    box-sizing: border-box;
+    .td-step-content {
+      overflow-x: auto; 
+    }
   }
 }

--- a/src/platform/core/steps/step-header/step-header.component.html
+++ b/src/platform/core/steps/step-header/step-header.component.html
@@ -2,37 +2,31 @@
       [class.mat-disabled]="disabled"
       matRipple
       [matRippleDisabled]="disabled || disableRipple"
-      [tabIndex]="disabled ? -1 : 0"
-      flex>
-  <div class="td-step-header-content"
-        layout="row" 
-        layout-align="start center"
-        flex>
-    <div class="td-circle"
-        [class.mat-inactive]="(!active && !isComplete()) || disabled"
-        [class.mat-active]="active && !disabled"
-        *ngIf="!isRequired() && !isComplete()">
-      <span *ngIf="(active || !isComplete())">{{number || ''}}</span>
-    </div>
-    <div class="td-complete" *ngIf="isComplete()">
-      <mat-icon class="mat-complete">check_circle</mat-icon>
-    </div>
-    <div class="td-triangle"
-        [class.bg-muted]="disabled"
-        *ngIf="isRequired()">
-      <mat-icon class="mat-warn">warning</mat-icon>
-    </div>
-    <div class="td-step-label-wrapper"
-          [class.mat-inactive]="(!active && !isComplete()) || disabled"
-          [class.mat-warn]="isRequired() && !disabled">
-      <div class="md-body-2 td-step-label">
-        <ng-content select="[td-step-header-label]"></ng-content>
-      </div>
-      <div class="md-caption td-step-sublabel">
-        <ng-content select="[td-step-header-sublabel]"></ng-content>
-      </div>
-    </div>
-    <span flex></span>
-    <mat-icon class="td-edit-icon" *ngIf="isComplete() && !active && !disabled">mode_edit</mat-icon>
+      [tabIndex]="disabled ? -1 : 0">
+  <div class="td-circle"
+      [class.mat-inactive]="(!active && !isComplete()) || disabled"
+      [class.mat-active]="active && !disabled"
+      *ngIf="!isRequired() && !isComplete()">
+    <span *ngIf="(active || !isComplete())">{{number || ''}}</span>
   </div>
+  <div class="td-complete" *ngIf="isComplete()">
+    <mat-icon class="mat-complete">check_circle</mat-icon>
+  </div>
+  <div class="td-triangle"
+      [class.bg-muted]="disabled"
+      *ngIf="isRequired()">
+    <mat-icon class="mat-warn">warning</mat-icon>
+  </div>
+  <div class="td-step-label-wrapper"
+        [class.mat-inactive]="(!active && !isComplete()) || disabled"
+        [class.mat-warn]="isRequired() && !disabled">
+    <div class="md-body-2 td-step-label">
+      <ng-content select="[td-step-header-label]"></ng-content>
+    </div>
+    <div class="md-caption td-step-sublabel">
+      <ng-content select="[td-step-header-sublabel]"></ng-content>
+    </div>
+  </div>
+  <span class="td-step-header-separator"></span>
+  <mat-icon class="td-edit-icon" *ngIf="isComplete() && !active && !disabled">mode_edit</mat-icon>
 </div>

--- a/src/platform/core/steps/step-header/step-header.component.scss
+++ b/src/platform/core/steps/step-header/step-header.component.scss
@@ -3,11 +3,22 @@ $step-circle: 24px;
 .td-step-header {
   position: relative;
   outline: none;
+  height: 72px;
+  // layout row
+  flex-direction: row;
+  // layout
+  box-sizing: border-box;
+  display: flex;
+  // flex
+  flex: 1;
+  // layout-align start
+  justify-content: start;
+  // layout-align start center
+  align-items: center;
+  align-content: center;
+  max-width: 100%;
   &:hover:not(.mat-disabled) {
     cursor: pointer;
-  }
-  .td-step-header-content {
-    height: 72px;
   }
   mat-icon.td-edit-icon {
     margin: 0 8px;
@@ -74,5 +85,9 @@ $step-circle: 24px;
   .td-step-sublabel {
     line-height: 14px;
     font-weight: normal;
+  }
+  .td-step-header-separator {
+    flex: 1;
+    box-sizing: border-box;
   }
 }

--- a/src/platform/core/steps/steps.component.html
+++ b/src/platform/core/steps/steps.component.html
@@ -1,21 +1,21 @@
-<div *ngIf="isHorizontal()" class="td-steps-header" layout="row" title>
+<div *ngIf="isHorizontal()" class="td-steps-header">
   <ng-template let-step let-index="index" let-last="last" ngFor [ngForOf]="steps">
     <td-step-header class="td-step-horizontal-header"
-                    (keydown.enter)="step.toggle()"
+                    (keydown.enter)="step.open()"
                     [number]="index + 1"
                     [active]="step.active"
                     [disableRipple]="step.disableRipple"
                     [disabled]="step.disabled" 
                     [state]="step.state"
-                    (click)="step.toggle()">
+                    (click)="step.open()">
       <ng-template td-step-header-label [cdkPortalHost]="step.stepLabel"></ng-template>
       <ng-template td-step-header-label [ngIf]="!step.stepLabel">{{step.label}}</ng-template>
       <ng-template td-step-header-sublabel [ngIf]="true">{{step.sublabel | truncate:30}}</ng-template>
     </td-step-header>
-    <span *ngIf="!last" class="td-horizontal-line" flex></span>
+    <span *ngIf="!last" class="td-horizontal-line"></span>
   </ng-template>
 </div>
-<div *ngFor="let step of steps; let index = index; let last = last" class="td-step" layout="column">
+<div *ngFor="let step of steps; let index = index; let last = last" class="td-step">
   <td-step-header class="td-step-vertical-header"
                   (keydown.enter)="step.toggle()"
                   [number]="index + 1"

--- a/src/platform/core/steps/steps.component.scss
+++ b/src/platform/core/steps/steps.component.scss
@@ -3,6 +3,14 @@
   position: relative;
 }
 
+.td-steps-header {
+  // layout
+  box-sizing: border-box;
+  display: flex;
+  // layout="row"
+  flex-direction: row;
+}
+
 .td-line-wrapper {
   width: 24px;
   min-height: 1px;
@@ -23,6 +31,9 @@
     right: -6px;
   }
   min-width: 15px;
+  // flex
+  flex: 1;
+  box-sizing: border-box;
 }
 
 .td-vertical-line {


### PR DESCRIPTION
## Description
In the effort to make all our modules stand alone and not depend on platform.scss.. we will start removing all mentions of `layout`, `typography` and `utility` classes from our modules.

Part of https://github.com/Teradata/covalent/issues/659

### What's included?
- `stepper` wont depend on `_layout.scss` anymore.

#### Test Steps
- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/steps
- [ ] Go to https://teradata.github.io/covalent/#/components/steps
- [ ] Open all major browsers
- [ ] Compare away~

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.