### PR TITLE
feat(expansion-panel): stop depending on layout.scss

### DIFF
--- a/src/platform/core/expansion-panel/expansion-panel.component.html
+++ b/src/platform/core/expansion-panel/expansion-panel.component.html
@@ -8,11 +8,8 @@
   <ng-template [cdkPortalHost]="expansionPanelHeader"></ng-template>
   <div class="td-expansion-panel-header-content"
         [class.mat-disabled]="disabled"
-        *ngIf="!expansionPanelHeader"
-        layout="row"
-        layout-align="start center"
-        flex>
-    <div *ngIf="label || expansionPanelLabel" class="md-subhead td-expansion-label" [attr.flex-gt-xs]="(sublabel || expansionPanelSublabel) ? 40 : null">
+        *ngIf="!expansionPanelHeader">
+    <div *ngIf="label || expansionPanelLabel" class="md-subhead td-expansion-label">
       <ng-template [cdkPortalHost]="expansionPanelLabel"></ng-template>
       <ng-template [ngIf]="!expansionPanelLabel">{{label}}</ng-template>
     </div>

--- a/src/platform/core/expansion-panel/expansion-panel.component.scss
+++ b/src/platform/core/expansion-panel/expansion-panel.component.scss
@@ -10,6 +10,22 @@
     .td-expansion-panel-header-content {
       height: 48px;
       padding: 0 16px;
+      // layout
+      box-sizing: border-box;
+      display: flex;
+      // layout row
+      flex-direction: row;
+      // flex
+      flex: 1;
+      // layout-align start center
+      justify-content: start;
+      align-items: center;
+      align-content: center;
+      max-width: 100%;
+      .td-expansion-label {
+        // flex
+        flex: 1;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
In the effort to make all our modules stand alone and not depend on platform.scss.. we will start removing all mentions of `layout`, `typography` and `utility` classes from our modules.

Part of https://github.com/Teradata/covalent/issues/659

### What's included?
- `expansion-panel` wont depend on `_layout.scss` anymore.

#### Test Steps
- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/expansion-panel
- [ ] Go to https://teradata.github.io/covalent/#/components/expansion-panel
- [ ] Open all major browsers
- [ ] Compare away~

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.