### PR TITLE
feat(chips): stop depending on layout.scss

### DIFF
--- a/src/platform/core/chips/chips.component.html
+++ b/src/platform/core/chips/chips.component.html
@@ -7,8 +7,8 @@
                    (keydown)="_chipKeydown($event, index)"
                    (blur)="_handleChipBlur($event, chip)"
                    (focus)="_handleChipFocus($event, chip)">
-      <div class="td-chip" layout="row" [attr.layout-align]="stacked ? 'space-between center' : 'start center'" >
-        <span class="td-chip-content" layout="row" layout-align="start center">
+      <div class="td-chip" [class.td-chip-stacked]="stacked">
+        <span class="td-chip-content">
           <span *ngIf="!_chipTemplate?.templateRef">{{chip}}</span>
           <ng-template
             *ngIf="_chipTemplate?.templateRef"

--- a/src/platform/core/chips/chips.component.scss
+++ b/src/platform/core/chips/chips.component.scss
@@ -14,6 +14,24 @@
       width: 100%;
     }
   }
+  .td-chip {
+    &, > .td-chip-content {
+      // layout
+      box-sizing: border-box;
+      display: flex;
+      // layout row
+      flex-direction: row;
+      // layout-align start center
+      max-width: 100%;
+      align-items: center;
+      align-content: center;
+      justify-content: start;
+      &.td-chip-stacked {
+        // layout-align space-between center
+        justify-content: space-between;
+      }
+    }
+  }
   /deep/ {
     .mat-form-field-wrapper {
       padding-bottom: 2px;


### PR DESCRIPTION
## Description
In the effort to make all our modules stand alone and not depend on platform.scss.. we will start removing all mentions of `layout`, `typography` and `utility` classes from our modules.

Part of https://github.com/Teradata/covalent/issues/659

### What's included?
- `chips` wont depend on `_layout.scss` anymore.

#### Test Steps
- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/chips
- [ ] Go to https://teradata.github.io/covalent/#/components/chips
- [ ] Open all major browsers
- [ ] Compare away~

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.