### PR TITLE
feat(loading): stop depending on layout.scss

### DIFF
--- a/src/platform/core/loading/loading.component.html
+++ b/src/platform/core/loading/loading.component.html
@@ -6,10 +6,7 @@
   <div [@tdFadeInOut]="animation"
      (@tdFadeInOut.done)="animationComplete($event)"
      [style.min-height]="getHeight()"
-     class="td-loading"
-     layout="row"
-     layout-align="center center"
-     flex>
+     class="td-loading">
     <mat-progress-spinner *ngIf="isCircular()" 
                         [mode]="mode"
                         [value]="value" 

--- a/src/platform/core/loading/loading.component.scss
+++ b/src/platform/core/loading/loading.component.scss
@@ -4,6 +4,20 @@
   &.td-fullscreen {
     position: inherit;
   }
+  .td-loading {
+    // layout
+    box-sizing: border-box;
+    display: flex;
+    // [layout="row"]
+    flex-direction: row;
+    // [layout-align="center center"]
+    align-items: center;
+    align-content: center;
+    max-width: 100%;
+    justify-content: center;
+    // flex
+    flex: 1;
+  }
   &.td-overlay {
     .td-loading {
       position: absolute;


### PR DESCRIPTION
## Description
In the effort to make all our modules stand alone and not depend on platform.scss.. we will start removing all mentions of `layout`, `typography` and `utility` classes from our modules.

Part of https://github.com/Teradata/covalent/issues/659

### What's included?
- `loading` wont depend on `_layout.scss` anymore.

#### Test Steps
- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/loading
- [ ] Go to https://teradata.github.io/covalent/#/components/loading
- [ ] Open all major browsers
- [ ] Compare away~

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.