### PR TITLE
feat(dialog): stop depending on layout.scss

### DIFF
--- a/src/platform/core/dialogs/dialog.component.html
+++ b/src/platform/core/dialogs/dialog.component.html
@@ -5,8 +5,8 @@
   <div class="td-dialog-content" *ngIf="dialogContent.length > 0">
     <ng-content select="td-dialog-content"></ng-content>
   </div>
-  <div class="td-dialog-actions" *ngIf="dialogActions.length > 0" layout="row">
-    <span flex></span>
+  <div class="td-dialog-actions" *ngIf="dialogActions.length > 0">
+    <span class="td-dialog-spacer"></span>
     <ng-content select="td-dialog-actions"></ng-content>
   </div>
 </div>

--- a/src/platform/core/dialogs/dialog.component.scss
+++ b/src/platform/core/dialogs/dialog.component.scss
@@ -20,6 +20,14 @@
 :host {
   display: block;
   .td-dialog-actions {
+    // [layout="row"]
+    flex-direction: row;
+    box-sizing: border-box;
+    display: flex;
+    .td-dialog-spacer {
+      // flex
+      flex: 1;
+    }
     /deep/ button {
       text-transform: uppercase;
       margin-left: 8px;

--- a/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.html
+++ b/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.html
@@ -5,8 +5,8 @@
   <td-dialog-content class="md-subhead tc-grey-700">
     {{message}}
     <form #form="ngForm" novalidate>
-      <div layout="row">
-        <mat-form-field flex>
+      <div class="td-dialog-input-wrapper">
+        <mat-form-field class="td-dialog-input">
           <input matInput
                 #input
                 (focus)="handleInputFocus()"

--- a/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.scss
+++ b/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.scss
@@ -8,3 +8,14 @@
     width: 250px;
   }
 }
+.td-dialog-input-wrapper {
+  // layout row
+  flex-direction: row;
+  box-sizing: border-box;
+  display: flex;
+  .td-dialog-input {
+    // flex
+    flex: 1;
+    box-sizing: border-box;
+  }
+}


### PR DESCRIPTION
## Description
In the effort to make all our modules stand alone and not depend on platform.scss.. we will start removing all mentions of `layout`, `typography` and `utility` classes from our modules.

Part of https://github.com/Teradata/covalent/issues/659

### What's included?
- `dialogs` wont depend on `_layout.scss` anymore.

#### Test Steps
- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/dialogs
- [ ] Go to https://teradata.github.io/covalent/#/components/dialogs
- [ ] Open all major browsers
- [ ] Compare away~

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.