### PR TITLE
feat(dynamic-forms): stop depending on layout.scss

### DIFF
--- a/src/platform/core/steps/step-body/step-body.component.html
+++ b/src/platform/core/steps/step-body/step-body.component.html
@@ -5,7 +5,7 @@
     <div #contentRef cdkScrollable [class.td-step-content]="contentRef.children.length || contentRef.textContent.trim()">
       <ng-content select="[td-step-body-content]"></ng-content>
     </div>
-    <div #actionsRef layout="row" [class.td-step-actions]="actionsRef.children.length || actionsRef.textContent.trim()">
+    <div #actionsRef [class.td-step-actions]="actionsRef.children.length || actionsRef.textContent.trim()">
       <ng-content select="[td-step-body-actions]"></ng-content>
     </div>
   </div>

--- a/src/platform/core/steps/step-body/step-body.component.scss
+++ b/src/platform/core/steps/step-body/step-body.component.scss
@@ -12,5 +12,12 @@
     .td-step-content {
       overflow-x: auto; 
     }
+    .td-step-actions {
+      // layout
+      box-sizing: border-box;
+      display: flex;
+      // layout="row"
+      flex-direction: row;
+    }
   }
 }

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-checkbox/dynamic-checkbox.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-checkbox/dynamic-checkbox.component.html
@@ -1,7 +1,6 @@
-<div class="dynamic-checkbox-wrapper">
+<div class="td-dynamic-checkbox-wrapper">
   <mat-checkbox [(ngModel)]="value"
-                [required]="required"
-                flex>
+                [required]="required">
     {{label}}
   </mat-checkbox>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
@@ -1,12 +1,12 @@
-<div class="dynamic-file-input-wrapper" layout="row">
+<div class="td-dynamic-file-input-wrapper">
   <mat-form-field tdFileDrop
-                      floatPlaceholder="never"
-                      (fileDrop)="value = $event"
-                      (click)="fileInput.inputElement.click()"
-                      (keyup.enter)="fileInput.inputElement.click()"
-                      (keyup.delete)="fileInput.clear()"
-                      (keyup.backspace)="fileInput.clear()"
-                      flex>
+                  class="td-dynamic-file-input-field"
+                  floatPlaceholder="never"
+                  (fileDrop)="value = $event"
+                  (click)="fileInput.inputElement.click()"
+                  (keyup.enter)="fileInput.inputElement.click()"
+                  (keyup.delete)="fileInput.clear()"
+                  (keyup.backspace)="fileInput.clear()">
     <input matInput
           [value]="value?.name"
           [placeholder]="label"

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.scss
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.scss
@@ -1,3 +1,15 @@
+.td-dynamic-file-input-wrapper {
+  // [layout="row"]
+  flex-direction: row;
+  // [layout]
+  display: flex;
+  box-sizing: border-box;
+  .td-dynamic-file-input-field {
+    // [flex]
+    flex: 1;
+    box-sizing: border-box;
+  }
+}
 .td-file-input {
   margin-left: 10px;
 }

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.html
@@ -1,5 +1,5 @@
-<div class="dynamic-input-wrapper" layout="row">
-  <mat-form-field flex>
+<div class="td-dynamic-input-wrapper">
+  <mat-form-field class="td-dynamic-input-field">
     <input #elementInput
             matInput
             [(ngModel)]="value"
@@ -10,7 +10,6 @@
             [attr.min]="min"
             [attr.max]="max"
             [attr.minLength]="minLength"
-            [attr.maxLength]="maxLength"
-            flex/>
+            [attr.maxLength]="maxLength"/>
   </mat-form-field>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.scss
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.scss
@@ -1,0 +1,12 @@
+.td-dynamic-input-wrapper {
+  // [layout="row"]
+  flex-direction: row;
+  // [layout]
+  display: flex;
+  box-sizing: border-box;
+  .td-dynamic-input-field {
+    // [flex]
+    flex: 1;
+    box-sizing: border-box;
+  }
+}

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.html
@@ -1,9 +1,8 @@
-<div class="dynamic-select-wrapper" layout="row">
-  <mat-form-field flex="100">
+<div class="td-dynamic-select-wrapper">
+  <mat-form-field class="td-dynamic-select-field">
     <mat-select [(ngModel)]="value"
               [placeholder]="label"
-              [required]="required"
-              flex="100">
+              [required]="required">
       <mat-option *ngFor="let selection of selections" [value]="selection.value || selection">{{selection.label || selection}}</mat-option>
     </mat-select>
   </mat-form-field>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.scss
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.scss
@@ -1,0 +1,12 @@
+.td-dynamic-select-wrapper {
+  // [layout="row"]
+  flex-direction: row;
+  // [layout]
+  display: flex;
+  box-sizing: border-box;
+  .td-dynamic-select-field {
+    // [flex]
+    flex: 1;
+    box-sizing: border-box;
+  }
+}

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-slide-toggle/dynamic-slide-toggle.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-slide-toggle/dynamic-slide-toggle.component.html
@@ -1,7 +1,6 @@
-<div class="dynamic-slide-toggle-wrapper">
+<div class="td-dynamic-slide-toggle-wrapper">
   <mat-slide-toggle [(ngModel)]="value"
-                   [required]="required"
-                   flex>
+                   [required]="required">
     {{label}}
   </mat-slide-toggle>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-slider/dynamic-slider.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-slider/dynamic-slider.component.html
@@ -1,16 +1,17 @@
-<div class="dynamic-slider-wrapper relative push-top-sm">
-  <span class="mat-form-field-placeholder-wrapper">
-    <label class="mat-form-field-placeholder mat-float mat-form-field-float td-slider-label" [class.mat-focused]="slider._isActive"> {{label}} <span *ngIf="required" class="mat-placeholder-required">*</span></label>
-  </span>
-  <div layout="row" layout-align="start center" flex>
+<div class="td-dynamic-slider-wrapper relative push-top-sm">
+  <div class="mat-form-field-placeholder-wrapper mat-form-field-can-float mat-form-field-should-float"
+       [class.mat-focused]="slider._isActive">
+    <label class="mat-form-field-placeholder mat-float mat-form-field-float td-slider-label"> {{label}} <span *ngIf="required" class="mat-placeholder-required">*</span></label>
+  </div>
+  <div class="td-dynamic-slider-field">
     <mat-slider #slider
+               class="td-dynamic-slider"
                [(ngModel)]="value"
                 [min]="min"
                 [max]="max"
                 thumbLabel
                 tickInterval="auto"
-                [required]="required"
-                flex>
+                [required]="required">
     </mat-slider>
   </div>  
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-slider/dynamic-slider.component.scss
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-slider/dynamic-slider.component.scss
@@ -1,0 +1,11 @@
+.td-dynamic-slider-field {
+  // [layout="row"]
+  flex-direction: row;
+  // [layout]
+  display: flex;
+  box-sizing: border-box;
+  .td-dynamic-slider {
+    // [flex]
+    flex: 1;
+  }
+}

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-textarea/dynamic-textarea.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-textarea/dynamic-textarea.component.html
@@ -1,12 +1,11 @@
-<div class="dynamic-textarea-wrapper" layout="row">
-  <mat-form-field flex>
+<div class="td-dynamic-textarea-wrapper">
+  <mat-form-field class="td-dynamic-textarea-field">
     <textarea #elementInput
             matInput
             [(ngModel)]="value"
             [placeholder]="label"
             [required]="required"
-            rows="4"
-            flex>
+            rows="4">
     </textarea>
   </mat-form-field>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-textarea/dynamic-textarea.component.scss
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-textarea/dynamic-textarea.component.scss
@@ -1,0 +1,12 @@
+.td-dynamic-textarea-wrapper {
+  // [layout="row"]
+  flex-direction: row;
+  // [layout]
+  display: flex;
+  box-sizing: border-box;
+  .td-dynamic-textarea-field {
+    // [flex]
+    flex: 1;
+    box-sizing: border-box;
+  }
+}

--- a/src/platform/dynamic-forms/dynamic-forms.component.html
+++ b/src/platform/dynamic-forms/dynamic-forms.component.html
@@ -1,9 +1,12 @@
 <form [formGroup]="dynamicForm" novalidate>
-  <div layout="row"
-       layout-wrap
-       layout-align="start center">
+  <div class="td-dynamic-form-wrapper">
     <ng-template let-element ngFor [ngForOf]="elements">
-      <div class="pad-xs" [style.position]="'relative'" [attr.flex]="element.flex ? element.flex : 100">
+      <div class="pad-xs td-dynamic-element-wrapper"
+          [style.position]="'relative'"
+          [style.max-width.%]="element.flex ? element.flex : 100"
+          [style.flex]="'1 1 ' + (element.flex ? element.flex : 100) + '%'"
+          [style.-ms-flex]="'1 1 ' + (element.flex ? element.flex : 100) + '%'"
+          [style.-webkit-box-flex]="1">
         <td-dynamic-element
           #dynamicElement
           *ngIf="dynamicForm.controls[element.name]"

--- a/src/platform/dynamic-forms/dynamic-forms.component.scss
+++ b/src/platform/dynamic-forms/dynamic-forms.component.scss
@@ -1,0 +1,18 @@
+.td-dynamic-form-wrapper {
+  // [layout-wrap]
+  flex-wrap: wrap;
+  // [layout]
+  box-sizing: border-box;
+  display: flex;
+  // [layout="row"]
+  flex-direction: row;
+  // [layout-align="start center"]
+  align-items: center;
+  align-content: center;
+  max-width: 100%;
+  justify-content: start;
+  .td-dynamic-element-wrapper {
+    max-height: 100%;
+    box-sizing: border-box;
+  }
+}

--- a/src/platform/dynamic-forms/dynamic-forms.component.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.component.ts
@@ -11,6 +11,7 @@ import { toPromise } from 'rxjs/operator/toPromise';
 @Component({
   selector: 'td-dynamic-forms',
   templateUrl: './dynamic-forms.component.html',
+  styleUrls: ['./dynamic-forms.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TdDynamicFormsComponent implements AfterContentInit {


### PR DESCRIPTION
## Description
In the effort to make all our modules stand alone and not depend on platform.scss.. we will start removing all mentions of `layout`, `typography` and `utility` classes from our modules.

Part of https://github.com/Teradata/covalent/issues/659

### What's included?
- `dynamic-forms` wont depend on `_layout.scss` anymore.

#### Test Steps
- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/dynamic-forms
- [ ] Go to https://teradata.github.io/covalent/#/components/dynamic-forms
- [ ] Open all major browsers
- [ ] Compare away~

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.