### PR TITLE
feat(layout): stop depending on layout.scss

### DIFF
--- a/src/platform/core/layout/layout-card-over/layout-card-over.component.html
+++ b/src/platform/core/layout/layout-card-over/layout-card-over.component.html
@@ -1,7 +1,11 @@
 <mat-toolbar [color]="color">
 </mat-toolbar>
-<div class="margin" layout-gt-xs="row" layout-align-gt-xs="center start" layout-fill>
-  <div [attr.flex-gt-xs]="cardWidth">
+<div class="td-layout-card-over-wrapper">
+  <div class="td-layout-card-over"
+        [style.max-width.%]="cardWidth"
+        [style.flex]="'1 1 ' + cardWidth + '%'"
+        [style.-ms-flex]="'1 1 ' + cardWidth + '%'"
+        [style.-webkit-box-flex]="1">
     <mat-card>
       <mat-card-title *ngIf="cardTitle">{{cardTitle}}</mat-card-title>
       <mat-card-subtitle *ngIf="cardSubtitle">{{cardSubtitle}}</mat-card-subtitle>

--- a/src/platform/core/layout/layout-card-over/layout-card-over.component.scss
+++ b/src/platform/core/layout/layout-card-over/layout-card-over.component.scss
@@ -1,3 +1,5 @@
+@import '../../common/styles/variables';
+
 :host {
   position: relative;
   display: block;
@@ -9,6 +11,32 @@
     display: block;
   }
 }
-.margin {
-  margin-top: -64px;
+.td-layout-card-over-wrapper {
+  margin: -64px;
+  margin-left: 0;
+  margin-right: 0;
+  // [layout-fill]
+  width: 100%;
+  min-height: 100%;
+  height: 100%;
+  @media (min-width: $layout-breakpoint-xs) {
+    // [layout="row"]
+    flex-direction: row;
+    // [layout]
+    box-sizing: border-box;
+    display: flex;
+    // [layout-align]="center start"
+    align-items: flex-start;
+    align-content: flex-start;
+    justify-content: center;
+    .td-layout-card-over {
+      max-height: 100%;
+      box-sizing: border-box;
+    }
+  }
+  @media (max-width: $layout-breakpoint-xs - 1) {
+    .td-layout-card-over {
+      max-width: 100% !important;
+    }
+  }
 }

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.html
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.html
@@ -1,4 +1,4 @@
-<mat-sidenav-container fullscreen class="td-layout-manage-list md-content" flex layout="row">
+<mat-sidenav-container fullscreen class="td-layout-manage-list">
   <mat-sidenav #sidenav
               position="start"
               [mode]="mode"
@@ -6,17 +6,15 @@
               [disableClose]="disableClose"
               [style.max-width]="sidenavWidth"
               [style.min-width]="sidenavWidth"
-              layout="column"
-              layout-fill
               class="md-whiteframe-z1">
     <ng-content select="mat-toolbar[td-sidenav-content]"></ng-content>
-    <div flex class="list md-content" cdkScrollable>
+    <div class="td-layout-manage-list-sidenav" cdkScrollable>
       <ng-content select="[td-sidenav-content]"></ng-content>
     </div>
   </mat-sidenav>
-  <div layout="column" layout-fill class="md-content">
+  <div class="td-layout-manage-list-main">
     <ng-content select="mat-toolbar"></ng-content>
-    <div class="md-content" flex cdkScrollable>
+    <div class="td-layout-manage-list-content" cdkScrollable>
       <ng-content></ng-content>
     </div>
     <ng-content select="td-layout-footer-inner"></ng-content>

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.scss
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.scss
@@ -1,3 +1,5 @@
+@import '../../common/styles/whiteframe';
+
 :host {
   display: flex;
   margin: 0;
@@ -6,6 +8,11 @@
   height: 100%;
   overflow: hidden;
   mat-sidenav-container.td-layout-manage-list {
+    // [md-content]
+    display: block;
+    position: relative;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
     & > mat-sidenav {
       &.mat-drawer-opened,
       &.mat-drawer-opening,
@@ -15,8 +22,36 @@
       }
     }
   }
-  .list {
+  .td-layout-manage-list-sidenav {
     text-align: start;
+    // [flex]
+    flex: 1;
+    // [md-content]
+    display: block;
+    position: relative;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .td-layout-manage-list-main {
+    margin: 0;
+    width: 100%;
+    min-height: 100%;
+    height: 100%;
+    position: relative;
+    overflow: auto;
+    // [layout="column"]
+    flex-direction: column;
+    box-sizing: border-box;
+    display: flex;
+    .td-layout-manage-list-content {
+      // [md-content]
+      display: block;
+      position: relative;
+      overflow: auto;
+      -webkit-overflow-scrolling: touch;
+      // [flex]
+      flex: 1;
+    }
   }
 }
 :host /deep/ {

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
@@ -1,43 +1,38 @@
-<div layout="column" layout-fill>
-  <div flex layout="column" class="content md-content">
-    <mat-sidenav-container fullscreen class="td-layout-nav-list" layout="row" flex>
-      <mat-sidenav #sidenav
-                  position="start"
-                  [mode]="mode"
-                  [opened]="opened"
-                  [disableClose]="disableClose"
-                  [style.max-width]="sidenavWidth"
-                  [style.min-width]="sidenavWidth"
-                  layout="column" 
-                  layout-fill
-                  class="md-whiteframe-z1">
-        <mat-toolbar [color]="color" class="md-whiteframe-z1">
-          <ng-content select="[td-menu-button]"></ng-content>
-          <span *ngIf="icon || logo || toolbarTitle"
-                [class.cursor-pointer]="routerEnabled"
-                (click)="handleNavigationClick()"
-                layout="row"
-                layout-align="start center">
-            <mat-icon *ngIf="icon">{{icon}}</mat-icon>
-            <mat-icon *ngIf="logo && !icon" class="mat-icon-logo" [svgIcon]="logo"></mat-icon>
-            <span *ngIf="toolbarTitle">{{toolbarTitle}}</span>
-          </span>
-          <ng-content select="[td-sidenav-toolbar-content]"></ng-content>
-        </mat-toolbar>
-        <div flex class="list md-content" cdkScrollable>
-          <ng-content select="[td-sidenav-content]"></ng-content>
-        </div>
-      </mat-sidenav>
-      <div layout="column" layout-fill class="md-content">
-        <mat-toolbar [color]="color" class="md-whiteframe-z1">
-          <ng-content select="[td-toolbar-content]"></ng-content>
-        </mat-toolbar>
-        <div class="md-content" flex cdkScrollable>
-          <ng-content></ng-content>
-        </div>
-        <ng-content select="td-layout-footer-inner"></ng-content>
+<div class="td-layout-nav-list-wrapper">
+  <mat-sidenav-container fullscreen class="td-layout-nav-list">
+    <mat-sidenav #sidenav
+                position="start"
+                [mode]="mode"
+                [opened]="opened"
+                [disableClose]="disableClose"
+                [style.max-width]="sidenavWidth"
+                [style.min-width]="sidenavWidth"
+                class="md-whiteframe-z1">
+      <mat-toolbar [color]="color" class="md-whiteframe-z1">
+        <ng-content select="[td-menu-button]"></ng-content>
+        <span *ngIf="icon || logo || toolbarTitle"
+              class="td-layout-nav-list-toolbar-content"
+              [class.cursor-pointer]="routerEnabled"
+              (click)="handleNavigationClick()">
+          <mat-icon *ngIf="icon">{{icon}}</mat-icon>
+          <mat-icon *ngIf="logo && !icon" class="mat-icon-logo" [svgIcon]="logo"></mat-icon>
+          <span *ngIf="toolbarTitle">{{toolbarTitle}}</span>
+        </span>
+        <ng-content select="[td-sidenav-toolbar-content]"></ng-content>
+      </mat-toolbar>
+      <div class="td-layout-nav-list-content" cdkScrollable>
+        <ng-content select="[td-sidenav-content]"></ng-content>
       </div>
-    </mat-sidenav-container>
-  </div>
-  <ng-content select="td-layout-footer"></ng-content>
+    </mat-sidenav>
+    <div class="td-layout-nav-list-main">
+      <mat-toolbar [color]="color" class="md-whiteframe-z1">
+        <ng-content select="[td-toolbar-content]"></ng-content>
+      </mat-toolbar>
+      <div class="td-layout-nav-list-content" cdkScrollable>
+        <ng-content></ng-content>
+      </div>
+      <ng-content select="td-layout-footer-inner"></ng-content>
+    </div>
+  </mat-sidenav-container>
 </div>
+<ng-content select="td-layout-footer"></ng-content>

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.scss
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.scss
@@ -1,22 +1,85 @@
+@import '../../common/styles/whiteframe';
+
 :host {
   display: flex;
+  // [layout-fill]
   margin: 0;
   width: 100%;
   min-height: 100%;
   height: 100%;
   overflow: hidden;
-  mat-sidenav-container.td-layout-nav-list {
-    & > mat-sidenav {
-      &.mat-drawer-opened,
-      &.mat-drawer-opening,
-      &.mat-drawer-closed,
-      &.mat-drawer-closing {
-        box-shadow: none;
+  // [layout="column"]
+  flex-direction: column;
+  box-sizing: border-box;
+  display: flex;
+  // [flex]
+  flex: 1;
+  .td-layout-nav-list-wrapper {
+    // [layout="column"]
+    flex-direction: column;
+    box-sizing: border-box;
+    display: flex;
+    // [flex]
+    flex: 1;
+    // [md-content]
+    position: relative;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    .td-layout-nav-list-toolbar-content {
+      // [layout="row"]
+      flex-direction: row;
+      box-sizing: border-box;
+      display: flex;
+      // [layout-align="start center"]
+      align-items: center;
+      align-content: center;
+      max-width: 100%;
+      justify-content: start;
+    }
+    .td-layout-nav-list-content {
+      text-align: start;
+      // [flex]
+      flex: 1;
+      // [md-content]
+      display: block;
+      position: relative;
+      overflow: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+    .td-layout-nav-list-main {
+      // [layout="column"]
+      flex-direction: column;
+      box-sizing: border-box;
+      display: flex;
+      // [layout-fill]
+      margin: 0;
+      width: 100%;
+      min-height: 100%;
+      height: 100%;
+      position: relative;
+      overflow: auto;
+      .td-layout-nav-list-content {
+        // [md-content]
+        display: block;
+        position: relative;
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
+        // [flex]
+        flex: 1;
       }
     }
-  }
-  .list {
-    text-align: start;
+    mat-sidenav-container.td-layout-nav-list {
+      // [flex]
+      flex: 1;
+      & > mat-sidenav {
+        &.mat-drawer-opened,
+        &.mat-drawer-opening,
+        &.mat-drawer-closed,
+        &.mat-drawer-closing {
+          box-shadow: none;
+        }
+      }
+    }
   }
 }
 :host /deep/ {

--- a/src/platform/core/layout/layout-nav/layout-nav.component.html
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.html
@@ -1,18 +1,17 @@
-<div layout="column" layout-fill>
+<div class="td-layout-nav-wrapper">
   <mat-toolbar [color]="color">
     <ng-content select="[td-menu-button]"></ng-content>
     <span *ngIf="icon || logo || toolbarTitle"
           [class.cursor-pointer]="routerEnabled"
           (click)="handleNavigationClick()"
-          layout="row"
-          layout-align="start center">
+          class="td-layout-nav-toolbar-content">
       <mat-icon *ngIf="icon">{{icon}}</mat-icon>
       <mat-icon *ngIf="logo && !icon" class="mat-icon-logo" [svgIcon]="logo"></mat-icon>
       <span *ngIf="toolbarTitle">{{toolbarTitle}}</span>
     </span>
     <ng-content select="[td-toolbar-content]"></ng-content>
   </mat-toolbar>
-  <div flex layout="column" class="content md-content" cdkScrollable>
+  <div class="td-layout-nav-content" cdkScrollable>
     <ng-content></ng-content>
   </div>
   <ng-content select="td-layout-footer"></ng-content>

--- a/src/platform/core/layout/layout-nav/layout-nav.component.scss
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.scss
@@ -13,4 +13,38 @@
   min-height: 100%;
   height: 100%;
   overflow: hidden;
+  .td-layout-nav-wrapper {
+    // [layout="column"]
+    flex-direction: column;
+    box-sizing: border-box;
+    display: flex;
+    // [layout-fill]
+    margin: 0;
+    width: 100%;
+    min-height: 100%;
+    height: 100%;
+    .td-layout-nav-toolbar-content {
+      // [layout="row"]
+      flex-direction: row;
+      box-sizing: border-box;
+      display: flex;
+      // [layout-align="start center"]
+      align-items: center;
+      align-content: center;
+      max-width: 100%;
+      justify-content: start;
+    }
+    .td-layout-nav-content {
+      // [layout="column"]
+      flex-direction: column;
+      box-sizing: border-box;
+      display: flex;
+      // [flex]
+      flex: 1;
+      // [md-content]
+      position: relative;
+      overflow: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+  }
 }

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.html
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.html
@@ -3,10 +3,9 @@
     <ng-content select="[td-navigation-drawer-toolbar]"></ng-content>
     <ng-container *ngIf="!isCustomToolbar">
       <span *ngIf="icon || logo || sidenavTitle"
+            class="td-navigation-drawer-toolbar-content"
             [class.cursor-pointer]="routerEnabled"
-            (click)="handleNavigationClick()"
-            layout="row"
-            layout-align="start center">
+            (click)="handleNavigationClick()">
         <mat-icon *ngIf="icon">{{icon}}</mat-icon>
         <mat-icon *ngIf="logo && !icon" class="mat-icon-logo" [svgIcon]="logo"></mat-icon>
         <span *ngIf="sidenavTitle" class="md-subhead">{{sidenavTitle}}</span>

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.scss
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.scss
@@ -2,6 +2,17 @@
   width: 100%;
   mat-toolbar {
     padding: 16px;
+    .td-navigation-drawer-toolbar-content {
+      // [layout="row"]
+      flex-direction: row;
+      box-sizing: border-box;
+      display: flex;
+      // [layout-align="start center"]
+      align-items: center;
+      align-content: center;
+      max-width: 100%;
+      justify-content: start;
+    }
     &.td-toolbar-background {
       background-repeat: no-repeat;
       background-size: cover;


### PR DESCRIPTION
## Description
In the effort to make all our modules stand alone and not depend on platform.scss.. we will start removing all mentions of `layout`, `typography` and `utility` classes from our modules.

Part of https://github.com/Teradata/covalent/issues/659

### What's included?
- `layouts` wont depend on `_layout.scss` anymore.

#### Test Steps
- [ ] `ng serve`
- [ ] Go to http://localhost:4200/#/components/layouts
- [ ] Go to https://teradata.github.io/covalent/#/components/layouts
- [ ] Open all major browsers
- [ ] Compare away~

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.