### PR TITLE
feat(all): stop depending on layout.scss cleanup

### DIFF
--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.html
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.html
@@ -1,5 +1,4 @@
 <div class="td-data-table-cell-content-wrapper"
-     layout="row"
-     [attr.layout-align]="numeric ? 'end center' : 'start center'">
+     [class.td-data-table-cell-numeric]="numeric">
   <ng-content></ng-content>
 </div>

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.scss
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.scss
@@ -6,6 +6,20 @@
   padding: 0;
   > .td-data-table-cell-content-wrapper {
     padding: 0 28px 0 28px;
+    // [layout]
+    box-sizing: border-box;
+    display: flex;
+    // [layout="row"]
+    flex-direction: row;
+    // [layout-align="start center"]
+    align-items: center;
+    align-content: center;
+    max-width: 100%;
+    justify-content: start;
+    &.td-data-table-cell-numeric {
+      // [layout-align="end center"]
+      justify-content: flex-end;
+    }
   }
 
   &:first-child > .td-data-table-cell-content-wrapper {

--- a/src/platform/core/expansion-panel/expansion-panel.component.html
+++ b/src/platform/core/expansion-panel/expansion-panel.component.html
@@ -17,7 +17,7 @@
       <ng-template [cdkPortalHost]="expansionPanelSublabel"></ng-template>
       <ng-template [ngIf]="!expansionPanelSublabel">{{sublabel}}</ng-template>
     </div>
-    <span flex></span>
+    <span class="td-expansion-panel-spacer"></span>
     <mat-icon class="td-expand-icon" *ngIf="!disabled" [@tdRotate]="expand">keyboard_arrow_down</mat-icon>
   </div>
 </div>

--- a/src/platform/core/expansion-panel/expansion-panel.component.scss
+++ b/src/platform/core/expansion-panel/expansion-panel.component.scss
@@ -22,7 +22,8 @@
       align-items: center;
       align-content: center;
       max-width: 100%;
-      .td-expansion-label {
+      .td-expansion-label,
+      .td-expansion-panel-spacer {
         // flex
         flex: 1;
       }

--- a/src/platform/core/json-formatter/json-formatter.component.html
+++ b/src/platform/core/json-formatter/json-formatter.component.html
@@ -4,8 +4,6 @@
      [class.td-key-leaf]="!hasChildren()"
      [tabIndex]="isObject()? 0 : -1"
      (keydown.enter)="toggle()"
-     layout="row"
-     layout-align="start center"
      (click)="toggle()">
     <mat-icon class="tc-grey-600" *ngIf="hasChildren()">{{open? 'keyboard_arrow_down' : (isRTL ? 'keyboard_arrow_left' : 'keyboard_arrow_right')}}</mat-icon>
     <span *ngIf="key" class="key">{{key}}:</span>

--- a/src/platform/core/json-formatter/json-formatter.component.scss
+++ b/src/platform/core/json-formatter/json-formatter.component.scss
@@ -5,6 +5,16 @@
   padding-top: 2px;
   padding-bottom: 2px;
   .td-key {
+    // [layout]
+    box-sizing: border-box;
+    display: flex;
+    // [layout="row"]
+    flex-direction: row;
+    // [layout-align="start center"]
+    align-items: center;
+    align-content: center;
+    max-width: 100%;
+    justify-content: start;
     &.td-key-node {
       &:hover {
         cursor: pointer;

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.html
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.html
@@ -1,25 +1,26 @@
 <mat-toolbar [color]="color" [style.background-image]="backgroundImage" [class.td-toolbar-background]="!!isBackgroundAvailable">
-  <div flex>
-    <ng-content select="[td-navigation-drawer-toolbar]"></ng-content>
-    <ng-container *ngIf="!isCustomToolbar">
-      <span *ngIf="icon || logo || sidenavTitle"
-            class="td-navigation-drawer-toolbar-content"
-            [class.cursor-pointer]="routerEnabled"
-            (click)="handleNavigationClick()">
-        <mat-icon *ngIf="icon">{{icon}}</mat-icon>
-        <mat-icon *ngIf="logo && !icon" class="mat-icon-logo" [svgIcon]="logo"></mat-icon>
-        <span *ngIf="sidenavTitle" class="md-subhead">{{sidenavTitle}}</span>
-      </span>
-      <div class="md-body-2" *ngIf="email && name">{{name}}</div>
-      <div class="md-body-1" layout="row" href *ngIf="email || name" (click)="toggleMenu()">
-        <span flex>{{email || name}}</span>
-        <button mat-icon-button class="mat-icon-button-mini" *ngIf="isMenuAvailable">
-          <mat-icon *ngIf="!menuToggled">arrow_drop_down</mat-icon>
-          <mat-icon *ngIf="menuToggled">arrow_drop_up</mat-icon>
-        </button>
-      </div>
-    </ng-container>
-  </div>
+  <ng-content select="[td-navigation-drawer-toolbar]"></ng-content>
+  <ng-container *ngIf="!isCustomToolbar">
+    <span *ngIf="icon || logo || sidenavTitle"
+          class="td-navigation-drawer-toolbar-content"
+          [class.cursor-pointer]="routerEnabled"
+          (click)="handleNavigationClick()">
+      <mat-icon *ngIf="icon">{{icon}}</mat-icon>
+      <mat-icon *ngIf="logo && !icon" class="mat-icon-logo" [svgIcon]="logo"></mat-icon>
+      <span *ngIf="sidenavTitle" class="md-subhead">{{sidenavTitle}}</span>
+    </span>
+    <div class="md-body-2" *ngIf="email && name">{{name}}</div>
+    <div class="td-navigation-drawer-menu-toggle md-body-1"
+         href
+         *ngIf="email || name"
+         (click)="toggleMenu()">
+      <span class="td-navigation-drawer-label">{{email || name}}</span>
+      <button mat-icon-button class="mat-icon-button-mini" *ngIf="isMenuAvailable">
+        <mat-icon *ngIf="!menuToggled">arrow_drop_down</mat-icon>
+        <mat-icon *ngIf="menuToggled">arrow_drop_up</mat-icon>
+      </button>
+    </div>
+  </ng-container>
 </mat-toolbar>
 <div [@tdCollapse]="menuToggled">
   <ng-content></ng-content>

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.scss
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.scss
@@ -2,6 +2,10 @@
   width: 100%;
   mat-toolbar {
     padding: 16px;
+    &.td-toolbar-background {
+      background-repeat: no-repeat;
+      background-size: cover;
+    }
     .td-navigation-drawer-toolbar-content {
       // [layout="row"]
       flex-direction: row;
@@ -13,9 +17,15 @@
       max-width: 100%;
       justify-content: start;
     }
-    &.td-toolbar-background {
-      background-repeat: no-repeat;
-      background-size: cover;
+    .td-navigation-drawer-menu-toggle {
+      // [layout="row"]
+      flex-direction: row;
+      box-sizing: border-box;
+      display: flex;
+      .td-navigation-drawer-label{
+        // [flex]
+        flex: 1;
+      }
     }
     /deep/ > .mat-toolbar-layout > mat-toolbar-row {
       height: auto !important;

--- a/src/platform/core/menu/menu.component.html
+++ b/src/platform/core/menu/menu.component.html
@@ -1,9 +1,7 @@
-<div layout="column">
-  <ng-content select="[td-menu-header]"></ng-content>
-  <mat-divider></mat-divider>
-  <div class="td-menu-content">
-    <ng-content></ng-content>
-  </div>
-  <mat-divider></mat-divider>
-  <ng-content select="[td-menu-footer]"></ng-content>
+<ng-content select="[td-menu-header]"></ng-content>
+<mat-divider></mat-divider>
+<div class="td-menu-content">
+  <ng-content></ng-content>
 </div>
+<mat-divider></mat-divider>
+<ng-content select="[td-menu-footer]"></ng-content>

--- a/src/platform/core/menu/menu.component.scss
+++ b/src/platform/core/menu/menu.component.scss
@@ -3,6 +3,11 @@ $td-menu-spacing: 8px !default;
   display: block;
   margin-top: -$td-menu-spacing;
   margin-bottom: -$td-menu-spacing;
+  // [layout]
+  box-sizing: border-box;
+  display: flex;
+  // [layout="column"]
+  flex-direction: column;
 }
 :host /deep/ {
   [td-menu-header] {

--- a/src/platform/core/message/message.component.html
+++ b/src/platform/core/message/message.component.html
@@ -1,14 +1,11 @@
 <div tdMessageContainer></div>
 <ng-template>
-  <div layout="column">
-    <div class="pad-top-sm pad-right pad-bottom-sm pad-left td-message-wrapper" layout="row" layout-align="center center">
-      <mat-icon class="push-right">{{icon}}</mat-icon>
-      <div>
-        <div *ngIf="label" class="td-message-label md-body-2">{{label}}</div>
-        <div *ngIf="sublabel" class="td-message-sublabel md-body-1">{{sublabel}}</div>
-      </div>
-      <span flex></span>
-      <ng-content select="[td-message-actions]"></ng-content>
+  <div class="pad-top-sm pad-right pad-bottom-sm pad-left td-message-wrapper">
+    <mat-icon class="push-right">{{icon}}</mat-icon>
+    <div class="td-message-labels">
+      <div *ngIf="label" class="td-message-label md-body-2">{{label}}</div>
+      <div *ngIf="sublabel" class="td-message-sublabel md-body-1">{{sublabel}}</div>
     </div>
+    <ng-content select="[td-message-actions]"></ng-content>
   </div>
 </ng-template>

--- a/src/platform/core/message/message.component.scss
+++ b/src/platform/core/message/message.component.scss
@@ -2,5 +2,19 @@
   display: block;
   .td-message-wrapper {
     min-height: 52px;
+    // [layout]
+    box-sizing: border-box;
+    display: flex;
+    // [layout="row"]
+    flex-direction: row;
+    // [layout-align="start center"]
+    align-items: center;
+    align-content: center;
+    max-width: 100%;
+    justify-content: start;
+    .td-message-labels {
+      // [flex]
+      flex: 1;
+    }
   }
 }

--- a/src/platform/core/paging/paging-bar.component.html
+++ b/src/platform/core/paging/paging-bar.component.html
@@ -1,4 +1,4 @@
-<div layout="row" layout-align="end center" class="md-caption td-paging-bar" (change)="$event.stopPropagation()" >
+<div class="md-caption td-paging-bar" (change)="$event.stopPropagation()" >
   <ng-content></ng-content>
   <div class="td-paging-bar-navigation">
     <button mat-icon-button class="td-paging-bar-first-page" type="button" *ngIf="firstLast" [disabled]="isMinPage()" (click)="firstPage()">

--- a/src/platform/core/paging/paging-bar.component.scss
+++ b/src/platform/core/paging/paging-bar.component.scss
@@ -2,6 +2,16 @@
   display: block;
   .td-paging-bar {
     height: 48px;
+    // [layout]
+    box-sizing: border-box;
+    display: flex;
+    // [layout="row"]
+    flex-direction: row;
+    // [layout-align="end center"]
+    align-items: center;
+    align-content: center;
+    max-width: 100%;
+    justify-content: flex-end;
     /deep/ > * {
       margin: 0 10px;
     }

--- a/src/platform/core/search/search-box/search-box.component.html
+++ b/src/platform/core/search/search-box/search-box.component.html
@@ -1,5 +1,5 @@
-<div class="td-search-box" layout="row" layout-align="end center">
-  <button mat-icon-button type="button" class="td-search-icon" flex="none" (click)="searchClicked()">
+<div class="td-search-box">
+  <button mat-icon-button type="button" class="td-search-icon" (click)="searchClicked()">
     <mat-icon *ngIf="searchVisible && !alwaysVisible">{{backIcon}}</mat-icon>
     <mat-icon *ngIf="!searchVisible || alwaysVisible">{{searchIcon}}</mat-icon>
   </button>

--- a/src/platform/core/search/search-box/search-box.component.scss
+++ b/src/platform/core/search/search-box/search-box.component.scss
@@ -2,6 +2,20 @@
   display: block;
 }
 .td-search-box {
+  // [layout]
+  box-sizing: border-box;
+  display: flex;
+  // [layout="row"]
+  flex-direction: row;
+  // [layout-align="end center"]
+  align-items: center;
+  align-content: center;
+  max-width: 100%;
+  justify-content: flex-end;
+  .td-search-icon {
+    // [flex="none"]
+    flex: 0 0 auto;
+  }
   td-search-input {
     margin-left: 12px;
     /deep/ [dir='rtl'] & { 

--- a/src/platform/core/search/search-input/search-input.component.html
+++ b/src/platform/core/search/search-input/search-input.component.html
@@ -1,5 +1,7 @@
-<div class="td-search-input" layout="row" layout-align="end center">
-  <mat-form-field [class.mat-hide-underline]="!showUnderline" floatPlaceholder="never" flex>
+<div class="td-search-input">
+  <mat-form-field class="td-search-input-field"
+                  [class.mat-hide-underline]="!showUnderline"
+                  floatPlaceholder="never">
     <input matInput
             #searchElement
             type="search"
@@ -10,10 +12,10 @@
             (keyup.enter)="handleSearch($event)"/>
   </mat-form-field>
   <button mat-icon-button
+          class="td-search-input-clear"
           type="button"
           [@searchState]="(searchElement.value ?  'show' : (isRTL ? 'hide-left' : 'hide-right'))"
-          (click)="clearSearch()"
-          flex="none">
+          (click)="clearSearch()">
     <mat-icon>{{clearIcon}}</mat-icon>
   </button>
 </div>

--- a/src/platform/core/search/search-input/search-input.component.scss
+++ b/src/platform/core/search/search-input/search-input.component.scss
@@ -1,8 +1,25 @@
 .td-search-input {
   overflow-x: hidden;
+  // [layout]
+  box-sizing: border-box;
+  display: flex;
+  // [layout="row"]
+  flex-direction: row;
+  // [layout-align="end center"]
+  align-items: center;
+  align-content: center;
+  max-width: 100%;
+  justify-content: flex-end;
+  .td-search-input-field {
+    flex: 1;
+  }
   /deep/ mat-form-field.mat-hide-underline {
     .mat-form-field-underline {
       display: none;
     }
+  }
+  .td-search-input-clear {
+    // [flex="none"]
+    flex: 0 0 auto;
   }
 }


### PR DESCRIPTION
## Description
In the effort to make all our modules stand alone and not depend on platform.scss.. we will start removing all mentions of `layout`, `typography` and `utility` classes from our modules.

Part of https://github.com/Teradata/covalent/issues/659

### What's included?
- no modules will depend on `_layout.scss` anymore.

#### Test Steps
- [x] `ng serve`
- [x] Go to http://localhost:4200/#/components
- [x] Go to https://teradata.github.io/covalent/#/components
- [ ] Open all major browsers
- [ ] Compare away~

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.