### PR TITLE
feat(markdown): make markdown include showdown.js implicitly

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -27,8 +27,7 @@
         "platform/core/common/platform.scss"
       ],
       "scripts": [
-        "../node_modules/hammerjs/hammer.min.js",
-        "../node_modules/showdown/dist/showdown.js"
+        "../node_modules/hammerjs/hammer.min.js"
       ],
       "environmentSource": "environments/environment.ts",
       "environments": {

--- a/src/platform/markdown/README.md
+++ b/src/platform/markdown/README.md
@@ -27,22 +27,6 @@ npm i -save @covalent/markdown
 
 ## Setup
 
-`showdown.js` needs to be added as script in the `.angular-cli.json` OR referenced in `index.html` (installed as a `markdown` dependency).
-
-**.angular-cli.json**:
-
-```json
-"scripts": [
-  "path/to/node_modules/showdown/dist/showdown.js"
-]
-```
-
-**index.html**:
-
-```html
-<script src="path/to/node_modules/showdown/dist/showdown.js"></script>
-```
-
 Then, import the **[CovalentMarkdownModule]** in your NgModule:
 
 ```typescript
@@ -74,12 +58,6 @@ $warn:    mat-palette($mat-red, 600);
 $theme: mat-light-theme($primary, $accent, $warn);
 
 @include markdown-markdown-theme($theme);
-```
-
-Or by loading them in the `index.html` file:
-
-```html
-<link rel="stylesheet" href="/path/to/node_modules/highlight.js/styles/vs.css">
 ```
 
 ## Example

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -1,7 +1,8 @@
 import { Component, AfterViewInit, ElementRef, Input, Output, EventEmitter, Renderer2, SecurityContext } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
-declare var showdown: any;
+/* tslint:disable-next-line */
+let showdown: any = require('showdown/dist/showdown.js');
 
 @Component({
   selector: 'td-markdown',


### PR DESCRIPTION
## Description
The showdown.js lib needed to be included via `index.html` or `.angular-cli.json` file, now it will be pulled from the `node_modules` via `require` like `highlight` does.

#### Test Steps
- [ ] `ng serve`
- [ ] See markdown still works properly without including the `lib` in the `angular-cli.json`

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
