### PR TITLE
feat(): upgrade to rxjs@5.5.0 and switch to lettable operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "d3": "^4.4.0",
     "hammerjs": "^2.0.8",
     "highlight.js": "9.11.0",
-    "rxjs": "^5.2.0",
+    "rxjs": "^5.5.2",
     "showdown": "1.6.4",
     "tslib": "^1.7.1",
     "web-animations-js": "2.3.1",

--- a/scripts/rollup.js
+++ b/scripts/rollup.js
@@ -40,7 +40,6 @@ gulp.task('rollup-code', '', function() {
     '@angular/cdk/keycodes': 'ng.cdk.keycodes',
     '@angular/cdk/bidi': 'ng.cdk.bidi',
     '@angular/cdk/coercion': 'ng.cdk.coercion',
-    '@angular/cdk/rxjs': 'ng.cdk.rxjs',
     '@angular/cdk/scrolling': 'ng.cdk.scrolling',
 
     // Rxjs dependencies
@@ -49,17 +48,14 @@ gulp.task('rollup-code', '', function() {
     'rxjs/observable/forkJoin': 'Rx.Observable',
     'rxjs/observable/of': 'Rx.Observable',
     'rxjs/observable/timer': 'Rx.Observable',
-    'rxjs/operator/pairwise': 'Rx.Observable.prototype',
+    'rxjs/observable/fromEvent': 'Rx.Observable',
     'rxjs/operator/toPromise': 'Rx.Observable.prototype',
-    'rxjs/operator/map': 'Rx.Observable.prototype',
-    'rxjs/operator/filter': 'Rx.Observable.prototype',
-    'rxjs/observable/fromEvent': 'Rx.Observable.prototype',
-    'rxjs/operator/do': 'Rx.Observable.prototype',
-    'rxjs/operator/share': 'Rx.Observable.prototype',
-    'rxjs/operator/finally': 'Rx.Observable.prototype',
-    'rxjs/operator/catch': 'Rx.Observable.prototype',
-    'rxjs/operator/debounceTime': 'Rx.Observable.prototype',
-    'rxjs/operator/skip': 'Rx.Observable.prototype',
+    'rxjs/operators/pairwise': 'Rx.Observable',
+    'rxjs/operators/map': 'Rx.Observable',
+    'rxjs/operators/filter': 'Rx.Observable',
+    'rxjs/operators/catchError': 'Rx.Observable',
+    'rxjs/operators/debounceTime': 'Rx.Observable',
+    'rxjs/operators/skip': 'Rx.Observable',
     'rxjs/Observable': 'Rx',
 
     // Covalent

--- a/src/platform/core/chips/chips.component.ts
+++ b/src/platform/core/chips/chips.component.ts
@@ -754,15 +754,17 @@ export class TdChipsComponent extends _TdChipsMixinBase implements ControlValueA
         fromEvent(this._document, 'click'),
         fromEvent(this._document, 'touchend'),
       ).pipe(
-        filter((event: MouseEvent) => {
-        const clickTarget: HTMLElement = <HTMLElement>event.target;
-        setTimeout(() => {
-          this._internalClick = false;
-        });
-        return this.focused &&
-               (clickTarget !== this._elementRef.nativeElement) &&
-               !this._elementRef.nativeElement.contains(clickTarget) && !this._internalClick;
-        })
+        filter(
+          (event: MouseEvent) => {
+            const clickTarget: HTMLElement = <HTMLElement>event.target;
+            setTimeout(() => {
+              this._internalClick = false;
+            });
+            return this.focused &&
+                  (clickTarget !== this._elementRef.nativeElement) &&
+                  !this._elementRef.nativeElement.contains(clickTarget) && !this._internalClick;
+          },
+        ),
       ).subscribe(() => { 
         if (this.focused) {
           this._autocompleteTrigger.closePanel();

--- a/src/platform/core/chips/chips.component.ts
+++ b/src/platform/core/chips/chips.component.ts
@@ -355,10 +355,11 @@ export class TdChipsComponent extends _TdChipsMixinBase implements ControlValueA
   }
 
   ngOnInit(): void {
-    this.inputControl.valueChanges.pipe(debounceTime(this.debounce))
-      .subscribe((value: string) => {
-        this.onInputChange.emit(value ? value : '');
-      });
+    this.inputControl.valueChanges.pipe(
+      debounceTime(this.debounce),
+    ).subscribe((value: string) => {
+      this.onInputChange.emit(value ? value : '');
+    });
     this._changeDetectorRef.markForCheck();
   }
 

--- a/src/platform/core/common/services/router-path.service.ts
+++ b/src/platform/core/common/services/router-path.service.ts
@@ -1,15 +1,16 @@
 import { Injectable } from '@angular/core';
 import { Router, RoutesRecognized } from '@angular/router';
 
-import { filter } from 'rxjs/operator/filter';
-import { pairwise } from 'rxjs/operator/pairwise';
+import { filter } from 'rxjs/operators/filter';
+import { pairwise } from 'rxjs/operators/pairwise';
 
 @Injectable()
 export class RouterPathService {
 private static _previousRoute: string = '/';
   constructor(private _router: Router) {
-    pairwise.call(
-      filter.call(this._router.events, (e: any) => e instanceof RoutesRecognized),
+    this._router.events.pipe(
+      filter((e: any) => e instanceof RoutesRecognized),
+      pairwise(),
     ).subscribe((e: any[]) => {
       RouterPathService._previousRoute = e[0].urlAfterRedirects;
     });

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -12,7 +12,7 @@ import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { Subject } from 'rxjs/Subject';
 
-import { debounceTime } from 'rxjs/operator/debounceTime';
+import { debounceTime } from 'rxjs/operators/debounceTime';
 
 import { TdDataTableRowComponent } from './data-table-row/data-table-row.component';
 import { ITdDataTableSortChangeEvent, TdDataTableColumnComponent } from './data-table-column/data-table-column.component';
@@ -493,7 +493,9 @@ export class TdDataTableComponent implements ControlValueAccessor, OnInit, After
    * so we can start calculating the widths
    */
   ngAfterViewInit(): void {
-    this._rowsChangedSubs = debounceTime.call(this._rows.changes, 0).subscribe(() => {
+    this._rowsChangedSubs = this._rows.changes.pipe(
+      debounceTime(0)
+    ).subscribe(() => {
       this._onResize.next();
     });
     this._calculateVirtualRows();

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -494,7 +494,7 @@ export class TdDataTableComponent implements ControlValueAccessor, OnInit, After
    */
   ngAfterViewInit(): void {
     this._rowsChangedSubs = this._rows.changes.pipe(
-      debounceTime(0)
+      debounceTime(0),
     ).subscribe(() => {
       this._onResize.next();
     });

--- a/src/platform/core/loading/directives/loading.directive.spec.ts
+++ b/src/platform/core/loading/directives/loading.directive.spec.ts
@@ -11,7 +11,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
 import { CovalentLoadingModule, LoadingMode, LoadingType, LoadingStrategy, TdLoadingService } from '../loading.module';
 import { of } from 'rxjs/observable/of';
-import { _catch } from 'rxjs/operator/catch';
+import { catchError } from 'rxjs/operators/catchError';
 
 describe('Directive: Loading', () => {
 
@@ -382,10 +382,12 @@ class TdLoadingNamedErrorStarUntilAsyncTestComponent {
   constructor(private _loadingService: TdLoadingService) {}
 
   createObservable(): void {
-    this.observable = _catch.call(this._subject.asObservable(), () => {
-      this._loadingService.resolveAll('name1');
-      return of(undefined);
-    });
+    this.observable = this._subject.asObservable().pipe(
+      catchError(() => {
+        this._loadingService.resolveAll('name1');
+        return of(undefined);
+      }),
+    );
   }
 
   sendError(error: any): void {

--- a/src/platform/core/search/search-input/search-input.component.ts
+++ b/src/platform/core/search/search-input/search-input.component.ts
@@ -3,8 +3,9 @@ import { trigger, state, style, transition, animate } from '@angular/animations'
 import { FormControl } from '@angular/forms';
 import { Dir } from '@angular/cdk/bidi';
 import { MatInput } from '@angular/material';
-import { debounceTime } from 'rxjs/operator/debounceTime';
-import { skip } from 'rxjs/operator/skip';
+
+import { debounceTime } from 'rxjs/operators/debounceTime';
+import { skip } from 'rxjs/operators/skip';
 
 @Component({
   selector: 'td-search-input',
@@ -95,12 +96,12 @@ export class TdSearchInputComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    debounceTime.call(
-      skip.call(this._input.ngControl.valueChanges, 1), // skip first change when value is set to undefined
-      this.debounce)
-      .subscribe((value: string) => {
-        this._searchTermChanged(value);
-      });
+    this._input.ngControl.valueChanges.pipe(
+      skip(1), // skip first change when value is set to undefined
+      debounceTime(this.debounce),
+    ).subscribe((value: string) => {
+      this._searchTermChanged(value);
+    });
   }
 
   /**

--- a/src/platform/http/http-rest.service.ts
+++ b/src/platform/http/http-rest.service.ts
@@ -1,8 +1,8 @@
 import { Headers, RequestOptionsArgs, Response, Request } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
-import { map } from 'rxjs/operator/map';
-import { _catch } from 'rxjs/operator/catch';
+import { map } from 'rxjs/operators/map';
+import { catchError } from 'rxjs/operators/catchError';
 
 export interface IRestTransform {
   (response: Response): any;
@@ -51,106 +51,121 @@ export abstract class RESTService<T> {
 
   public query(query?: IRestQuery, transform?: IRestTransform): Observable<any> {
     let request: Observable<Response> = this.http.get(this.buildUrl(undefined, query), this.buildRequestOptions());
-    return _catch.call(map.call(request, (res: Response) => {
-      if (transform) {
-        return transform(res);
-      }
-      return this.transform(res);
-    }), (error: Response) => {
-      return new Observable<any>((subscriber: Subscriber<any>) => {
-        try {
-          subscriber.error(this.transform(error));
-        } catch (err) {
-          subscriber.error(error);
+    return request.pipe(
+      catchError((error: Response) => {
+        return new Observable<any>((subscriber: Subscriber<any>) => {
+          try {
+            subscriber.error(this.transform(error));
+          } catch (err) {
+            subscriber.error(error);
+          }
+        });
+      }),
+      map((res: Response) => {
+        if (transform) {
+          return transform(res);
         }
-      });
-    });
+        return this.transform(res);
+      }),
+    );
   }
 
   public get(id: string | number, transform?: IRestTransform): Observable<any> {
     let request: Observable<Response> = this.http.get(this.buildUrl(id), this.buildRequestOptions());
-    return _catch.call(map.call(request, (res: Response) => {
-      if (transform) {
-        return transform(res);
-      }
-      return this.transform(res);
-    }), (error: Response) => {
-      return new Observable<any>((subscriber: Subscriber<any>) => {
-        try {
-          subscriber.error(this.transform(error));
-        } catch (err) {
-          subscriber.error(error);
+    return request.pipe(
+      catchError((error: Response) => {
+        return new Observable<any>((subscriber: Subscriber<any>) => {
+          try {
+            subscriber.error(this.transform(error));
+          } catch (err) {
+            subscriber.error(error);
+          }
+        });
+      }),
+      map((res: Response) => {
+        if (transform) {
+          return transform(res);
         }
-      });
-    });
+        return this.transform(res);
+      }),
+    );
   }
 
   public create(obj: T, transform?: IRestTransform): Observable<any> {
     let requestOptions: RequestOptionsArgs = this.buildRequestOptions();
     let request: Observable<Response> = this.http.post(this.buildUrl(), obj, requestOptions);
-    return _catch.call(map.call(request, (res: Response) => {
-      if (res.status === 201) {
-        if (transform) {
-          return transform(res);
+    return request.pipe(
+      catchError((error: Response) => {
+        return new Observable<any>((subscriber: Subscriber<any>) => {
+          try {
+            subscriber.error(this.transform(error));
+          } catch (err) {
+            subscriber.error(error);
+          }
+        });
+      }),
+      map((res: Response) => {
+        if (res.status === 201) {
+          if (transform) {
+            return transform(res);
+          }
+          return this.transform(res);
+        } else {
+          return res;
         }
-        return this.transform(res);
-      } else {
-        return res;
-      }
-    }), (error: Response) => {
-      return new Observable<any>((subscriber: Subscriber<any>) => {
-        try {
-          subscriber.error(this.transform(error));
-        } catch (err) {
-          subscriber.error(error);
-        }
-      });
-    });
+      }),
+    );
   }
 
   public update(id: string | number, obj: T, transform?: IRestTransform): Observable<any> {
     let requestOptions: RequestOptionsArgs = this.buildRequestOptions();
     let request: Observable<Response> = this.http.patch(this.buildUrl(id), obj, requestOptions);
-    return _catch.call(map.call(request, (res: Response) => {
-      if (res.status === 200) {
-        if (transform) {
-          return transform(res);
+    return request.pipe(
+      catchError((error: Response) => {
+        return new Observable<any>((subscriber: Subscriber<any>) => {
+          try {
+            subscriber.error(this.transform(error));
+          } catch (err) {
+            subscriber.error(error);
+          }
+        });
+      }),
+      map((res: Response) => {
+        if (res.status === 200) {
+          if (transform) {
+            return transform(res);
+          }
+          return this.transform(res);
+        } else {
+          return res;
         }
-        return this.transform(res);
-      } else {
-        return res;
-      }
-    }), (error: Response) => {
-      return new Observable<any>((subscriber: Subscriber<any>) => {
-        try {
-          subscriber.error(this.transform(error));
-        } catch (err) {
-          subscriber.error(error);
-        }
-      });
-    });
+      }),
+    );
   }
 
   public delete(id: string | number, transform?: IRestTransform): Observable<any> {
     let request: Observable<Response> = this.http.delete(this.buildUrl(id), this.buildRequestOptions());
-    return _catch.call(map.call(request, (res: Response) => {
-      if (res.status === 200) {
-        if (transform) {
-          return transform(res);
+    return request.pipe(
+      catchError((error: Response) => {
+        return new Observable<any>((subscriber: Subscriber<any>) => {
+          try {
+            subscriber.error(this.transform(error));
+          } catch (err) {
+            subscriber.error(error);
+          }
+        });
+      }),
+      map((res: Response) => {
+        if (res.status === 200) {
+          if (transform) {
+            return transform(res);
+          }
+          return this.transform(res);
+        } else {
+          return res;
         }
-        return this.transform(res);
-      } else {
-        return res;
-      }
-    }), (error: Response) => {
-      return new Observable<any>((subscriber: Subscriber<any>) => {
-        try {
-          subscriber.error(this.transform(error));
-        } catch (err) {
-          subscriber.error(error);
-        }
-      });
-    });
+      }),
+    );
   }
 
   protected buildRequestOptions(): RequestOptionsArgs {

--- a/src/platform/http/interceptors/http-interceptor.service.spec.ts
+++ b/src/platform/http/interceptors/http-interceptor.service.spec.ts
@@ -10,7 +10,7 @@ import { MockBackend, MockConnection } from '@angular/http/testing';
 import { HttpModule, Http } from '@angular/http';
 import { HttpInterceptorService, HttpConfig, CovalentHttpModule, IHttpInterceptor } from '../';
 import { URLRegExpInterceptorMatcher } from './url-regexp-interceptor-matcher.class';
-import { map } from 'rxjs/operator/map';
+import { map } from 'rxjs/operators/map';
 import { toPromise } from 'rxjs/operator/toPromise';
 import { forkJoin } from 'rxjs/observable/forkJoin';
 
@@ -109,16 +109,19 @@ describe('Service: HttpInterceptor', () => {
             body: JSON.stringify('success')},
         )));
       });
-
-      map.call(service.patch('http://www.test.com/recovery/id/id2/fromerror', {}),
-        (res: Response) => res.json()).subscribe((data: string) => {
+      service.patch('http://www.test.com/recovery/id/id2/fromerror', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
           expect(data).toBe('success', '/error/*/fromerror was intercepted');
         });
-
-      map.call(service.patch('http://www.test.com/recovery/id/fromerror', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBe('recovered', '/error/*/fromerror was not intercepted');
-      });
+ 
+      service.patch('http://www.test.com/recovery/id/fromerror', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('recovered', '/error/*/fromerror was not intercepted');
+        });
     }),
   ));
 
@@ -131,8 +134,10 @@ describe('Service: HttpInterceptor', () => {
         )));
       });
 
-      map.call(service.patch('http://www.test.com/error', {}),
-        (res: Response) => res.json()).subscribe((data: string) => {
+      service.patch('http://www.test.com/error', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
           expect(data).toBeUndefined('/error was not intercepted so request didnt fail');
         }, (error: Error) => {
           expect(error.message).toBe('error');
@@ -150,45 +155,61 @@ describe('Service: HttpInterceptor', () => {
         )));
       });
 
-      map.call(service.post('http://www.test.com/url/with/any-path/another-path?query=1&query=2', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBeTruthy();
-      });
+      service.post('http://www.test.com/url/with/any-path/another-path?query=1&query=2', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
 
-      map.call(service.post('http://www.test.com/any_path?query=1&query=2', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBeTruthy();
-      });
+      service.post('http://www.test.com/any_path?query=1&query=2', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
 
-      map.call(service.get('http://www.test.com/url/any-path/111'),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBeTruthy();
-      });
+      service.get('http://www.test.com/url/any-path/111').pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
 
-      map.call(service.get('http://www.test.com/anypath/url'),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBeTruthy();
-      });
+      service.get('http://www.test.com/anypath/url').pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
 
-      map.call(service.delete('http://www.test.com/any_path?', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBeTruthy();
-      });
+      service.delete('http://www.test.com/any_path?', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
 
-      map.call(service.delete('http://www.test.com', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBeTruthy();
-      });
+      service.delete('http://www.test.com', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
 
-      map.call(service.patch('http://www.test.com/any_path/111/url/another_path', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBeTruthy();
-      });
+      service.patch('http://www.test.com/any_path/111/url/another_path', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
 
-      map.call(service.patch('http://www.test.com/any-path/111/another_path/', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBeTruthy();
-      });
+      service.patch('http://www.test.com/any-path/111/another_path/', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
     }),
   ));
 
@@ -201,45 +222,61 @@ describe('Service: HttpInterceptor', () => {
         )));
       });
 
-      map.call(service.post('http://www.test.com/url/with/any-path/another-path?query=1&query=2', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBe('override', 'didnt intercept url with `/url`');
-      });
+      service.post('http://www.test.com/url/with/any-path/another-path?query=1&query=2', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('override', 'didnt intercept url with `/url`');
+        });
 
-      map.call(service.post('http://www.test.com/any_path?query=1&query=2', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
+      service.post('http://www.test.com/any_path?query=1&query=2', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
         expect(data).toBe('success', 'intercepted url without `/url`');
       });
 
-      map.call(service.get('http://www.test.com/url/any-path/111'),
-      (res: Response) => res.json()).subscribe((data: string) => {
+      service.get('http://www.test.com/url/any-path/111').pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
         expect(data).toBe('override', 'didnt intercept url with `/url`');
       });
 
-      map.call(service.get('http://www.test.com/anypath/url'),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBe('override', 'didnt intercept url with `/url`');
-      });
+      service.get('http://www.test.com/anypath/url').pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('override', 'didnt intercept url with `/url`');
+        });
 
-      map.call(service.delete('http://www.test.com/any_path?', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBe('success', 'intercepted url without `/url`');
-      });
+      service.delete('http://www.test.com/any_path?', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('success', 'intercepted url without `/url`');
+        });
 
-      map.call(service.delete('http://www.test.com', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBe('success', 'intercepted url without `/url`');
-      });
+      service.delete('http://www.test.com', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('success', 'intercepted url without `/url`');
+        });
 
-      map.call(service.patch('http://www.test.com/any_path/111/url/another_path', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBe('override', 'didnt intercept url with `/url`');
-      });
+      service.patch('http://www.test.com/any_path/111/url/another_path', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('override', 'didnt intercept url with `/url`');
+        });
 
-      map.call(service.patch('http://www.test.com/any-path/111/another_path/', {}),
-      (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBe('success', 'intercepted url without `/url`');
-      });
+      service.patch('http://www.test.com/any-path/111/another_path/', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('success', 'intercepted url without `/url`');
+        });
     }),
   ));
 
@@ -307,14 +344,17 @@ describe('Service: HttpInterceptor', () => {
       let success: boolean = false;
       let error: boolean = false;
       let complete: boolean = false;
-      map.call(service.post('testurl', {}), (res: Response) => res.json()).subscribe((data: string) => {
-        expect(data).toBe('success');
-        success = true;
-      }, () => {
-        error = true;
-      }, () => {
-        complete = true;
-      });
+      service.post('testurl', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('success');
+          success = true;
+        }, () => {
+          error = true;
+        }, () => {
+          complete = true;
+        });
       expect(success).toBe(true, 'on success didnt execute with observables');
       expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
       expect(complete).toBe(true, 'on complete didnt execute with observables');
@@ -329,14 +369,17 @@ describe('Service: HttpInterceptor', () => {
       let success: boolean = false;
       let error: boolean = false;
       let complete: boolean = false;
-      map.call(service.post('testurl', {}), (res: Response) => res.json()).subscribe(() => {
-        success = true;
-      }, (err: Error) => {
-        expect(err.message).toBe('error');
-        error = true;
-      }, () => {
-        complete = true;
-      });
+      service.post('testurl', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe(() => {
+          success = true;
+        }, (err: Error) => {
+          expect(err.message).toBe('error');
+          error = true;
+        }, () => {
+          complete = true;
+        });
       expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
       expect(error).toBe(true, 'on error didnt execute with observables');
       expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
@@ -353,12 +396,15 @@ describe('Service: HttpInterceptor', () => {
       });
       let success: boolean = false;
       let error: boolean = false;
-      toPromise.call(map.call(service.post('testurl', {}), (res: Response) => res.json())).then((data: string) => {
-        expect(data).toBe('success');
-        success = true;
-      }, () => {
-        error = true;
-      });
+      toPromise.call(service.post('testurl', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        ))).then((data: string) => {
+          expect(data).toBe('success');
+          success = true;
+        }, () => {
+          error = true;
+        });
       setTimeout(() => {
         expect(success).toBe(true, 'on success didnt execute with promises');
         expect(error).toBe(false, 'on error executed when it shouldnt have with promises');
@@ -373,12 +419,15 @@ describe('Service: HttpInterceptor', () => {
       });
       let success: boolean = false;
       let error: boolean = false;
-      toPromise.call(map.call(service.post('testurl', {}), (res: Response) => res.json())).then(() => {
-        success = true;
-      }, (err: Error) => {
-        expect(err.message).toBe('error');
-        error = true;
-      });
+      toPromise.call(service.post('testurl', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        ))).then(() => {
+          success = true;
+        }, (err: Error) => {
+          expect(err.message).toBe('error');
+          error = true;
+        });
       setTimeout(() => {
         expect(success).toBe(false, 'on success execute when it shouldnt have with promises');
         expect(error).toBe(true, 'on error didnt execute with promises');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5938,9 +5938,15 @@ rw@1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
 
-rxjs@^5.2.0, rxjs@^5.4.2:
+rxjs@^5.4.2:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.3.tgz#0758cddee6033d68e0fd53676f0f3596ce3d483f"
+  dependencies:
+    symbol-observable "^1.0.1"
+
+rxjs@^5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.2.tgz#28d403f0071121967f18ad665563255d54236ac3"
   dependencies:
     symbol-observable "^1.0.1"
 


### PR DESCRIPTION
## Description
Since we had a small dependency to the `cdk/rxjs` module of material, this would allow us to do replace `RxChain` and leverage `pipe()` to pipe operations with observables.

This will also make us follow the same standards as material, and prepare for their next release as they removed the `cdk/rxjs` module in favor of `rxjs/operators`

### What's included?
<!-- List features included in this PR -->
- Upgrade to `rxjs@5.5.0`
- Switch to lettable operators
- Leverage `pipe()` when possible
- Stop depending on `cdk/rxjs`

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `ng serve`
- [ ] Test components to see they still work (chips, search-input and data-table)

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
