### PR TITLE
fix(layout): fix proper width for manage-list layout

### DIFF
--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.scss
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.scss
@@ -8,11 +8,8 @@
   height: 100%;
   overflow: hidden;
   mat-sidenav-container.td-layout-manage-list {
-    // [md-content]
-    display: block;
-    position: relative;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
+    // [flex]
+    flex: 1;
     & > mat-sidenav {
       &.mat-drawer-opened,
       &.mat-drawer-opening,


### PR DESCRIPTION
## Description
Since we removed the layout.scss styles from the layout module, adding some styles by default actually introduced errors, in this case the rules for `md-content` were getting in the way.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.