### PR TITLE
feat(media): change to BehaviorSubject to stop the use of broadcast method on page load

### DIFF
--- a/scripts/rollup.js
+++ b/scripts/rollup.js
@@ -44,6 +44,7 @@ gulp.task('rollup-code', '', function() {
 
     // Rxjs dependencies
     'rxjs/Subject': 'Rx',
+    'rxjs/BehaviorSubject': 'Rx.BehaviorSubject',
     'rxjs/observable/merge': 'Rx.Observable',
     'rxjs/observable/forkJoin': 'Rx.Observable',
     'rxjs/observable/of': 'Rx.Observable',

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { Component, ChangeDetectorRef } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { Dir } from '@angular/cdk/bidi';
 import { MatIconRegistry } from '@angular/material';
@@ -13,7 +13,7 @@ import { getDirection } from './utilities/direction';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class DocsAppComponent implements AfterViewInit {
+export class DocsAppComponent {
 
   routes: Object[] = [{
       icon: 'library_books',
@@ -92,14 +92,6 @@ export class DocsAppComponent implements AfterViewInit {
   }
   theme(theme: string): void {
     localStorage.setItem('theme', theme);
-  }
-
-  ngAfterViewInit(): void {
-    // broadcast to all listener observables when loading the page
-    setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining
-      this.media.broadcast();
-      this._changeDetectorRef.detectChanges();
-    });
   }
 
 }

--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, ChangeDetectorRef, AfterViewInit } from '@angular/core';
+import { Component, HostBinding, ChangeDetectorRef } from '@angular/core';
 
 import { TdMediaService } from '@covalent/core';
 
@@ -10,7 +10,7 @@ import { fadeAnimation } from '../../app.animations';
   templateUrl: './components.component.html',
   animations: [fadeAnimation],
 })
-export class ComponentsComponent implements AfterViewInit {
+export class ComponentsComponent {
 
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
@@ -158,12 +158,4 @@ export class ComponentsComponent implements AfterViewInit {
 
   constructor(private _changeDetectorRef: ChangeDetectorRef,
               public media: TdMediaService) {}
-
-  ngAfterViewInit(): void {
-    // broadcast to all listener observables when loading the page
-    setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining
-      this.media.broadcast();
-      this._changeDetectorRef.detectChanges();
-    });
-  }
 }

--- a/src/app/components/components/paging/paging.component.html
+++ b/src/app/components/components/paging/paging.component.html
@@ -333,16 +333,7 @@
               eventResponsive: IPageChangeEvent;
               pageSizeResponsive: number = 100;
 
-              constructor(private _changeDetectorRef: ChangeDetectorRef,
-                          public media: TdMediaService) {}
-
-              ngAfterViewInit(): void {
-                // broadcast to all listener observables when loading the page
-                setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining
-                  this.media.broadcast();
-                  this._changeDetectorRef.detectChanges();
-                });
-              }
+              constructor(public media: TdMediaService) {}
 
               changeResponsive(event: IPageChangeEvent): void {
                 this.eventResponsive = event;

--- a/src/app/components/components/paging/paging.component.ts
+++ b/src/app/components/components/paging/paging.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { Component, HostBinding, ChangeDetectorRef } from '@angular/core';
 import { TdMediaService } from '../../../../platform/core';
 
 import { slideInDownAnimation } from '../../../app.animations';
@@ -11,7 +11,7 @@ import { IPageChangeEvent } from '../../../../platform/core';
   templateUrl: './paging.component.html',
   animations: [slideInDownAnimation],
 })
-export class PagingDemoComponent implements AfterViewInit {
+export class PagingDemoComponent {
 
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
@@ -27,14 +27,6 @@ export class PagingDemoComponent implements AfterViewInit {
 
   constructor(private _changeDetectorRef: ChangeDetectorRef,
               public media: TdMediaService) {}
-
-  ngAfterViewInit(): void {
-    // broadcast to all listener observables when loading the page
-    setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining
-      this.media.broadcast();
-      this._changeDetectorRef.detectChanges();
-    });
-  }
 
   change(event: IPageChangeEvent): void {
     this.event = event;

--- a/src/app/components/design-patterns/design-patterns.component.ts
+++ b/src/app/components/design-patterns/design-patterns.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { Component, HostBinding, ChangeDetectorRef } from '@angular/core';
 import { TdMediaService } from '@covalent/core';
 
 import { fadeAnimation } from '../../app.animations';
@@ -9,7 +9,7 @@ import { fadeAnimation } from '../../app.animations';
   templateUrl: './design-patterns.component.html',
   animations: [fadeAnimation],
 })
-export class DesignPatternsComponent implements AfterViewInit {
+export class DesignPatternsComponent {
 
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
@@ -38,12 +38,4 @@ export class DesignPatternsComponent implements AfterViewInit {
 
   constructor(private _changeDetectorRef: ChangeDetectorRef,
               public media: TdMediaService) {}
-
-  ngAfterViewInit(): void {
-    // broadcast to all listener observables when loading the page
-    setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining
-      this.media.broadcast();
-      this._changeDetectorRef.detectChanges();
-    });
-  }
 }

--- a/src/app/components/docs/docs.component.ts
+++ b/src/app/components/docs/docs.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { Component, HostBinding, ChangeDetectorRef } from '@angular/core';
 import { TdMediaService } from '@covalent/core';
 
 import { fadeAnimation } from '../../app.animations';
@@ -9,7 +9,7 @@ import { fadeAnimation } from '../../app.animations';
   templateUrl: './docs.component.html',
   animations: [fadeAnimation],
 })
-export class DocsComponent implements AfterViewInit {
+export class DocsComponent {
 
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
@@ -78,13 +78,5 @@ export class DocsComponent implements AfterViewInit {
 
   constructor(private _changeDetectorRef: ChangeDetectorRef,
               public media: TdMediaService) {}
-
-  ngAfterViewInit(): void {
-    // broadcast to all listener observables when loading the page
-    setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining
-      this.media.broadcast();
-      this._changeDetectorRef.detectChanges();
-    });
-  }
 
 }

--- a/src/app/components/layouts/manage-list/manage-list.component.html
+++ b/src/app/components/layouts/manage-list/manage-list.component.html
@@ -355,7 +355,7 @@
     <h3 class="md-title">TypeScript:</h3>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { Component, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+        import { Component, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
         import { TdMediaService } from '@covalent/core';
 
         @Component({
@@ -365,7 +365,7 @@
           templateUrl: './manage-list.component.html',
           animations: [fadeAnimation],
         })
-        export class ManageListComponent implements AfterViewInit {
+        export class ManageListComponent {
 
           routes: Object[] = [{
               icon: 'home',
@@ -431,16 +431,7 @@
             },
           ];
 
-          constructor(private _changeDetectorRef: ChangeDetectorRef,
-                      public media: TdMediaService) {}
-
-          ngAfterViewInit(): void {
-            // broadcast to all listener observables when loading the page
-            setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining
-              this.media.broadcast();
-              this._changeDetectorRef.detectChanges();
-            });
-          }
+          constructor(public media: TdMediaService) {}
 
         }
 

--- a/src/app/components/layouts/manage-list/manage-list.component.ts
+++ b/src/app/components/layouts/manage-list/manage-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, HostBinding, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { TdMediaService } from '@covalent/core';
 
 import { fadeAnimation } from '../../../app.animations';
@@ -10,7 +10,7 @@ import { fadeAnimation } from '../../../app.animations';
   templateUrl: './manage-list.component.html',
   animations: [fadeAnimation],
 })
-export class ManageListComponent implements AfterViewInit {
+export class ManageListComponent {
 
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
@@ -81,13 +81,5 @@ export class ManageListComponent implements AfterViewInit {
 
   constructor(private _changeDetectorRef: ChangeDetectorRef,
               public media: TdMediaService) {}
-
-  ngAfterViewInit(): void {
-    // broadcast to all listener observables when loading the page
-    setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining
-      this.media.broadcast();
-      this._changeDetectorRef.detectChanges();
-    });
-  }
 
 }

--- a/src/app/components/layouts/nav-list/nav-list.component.html
+++ b/src/app/components/layouts/nav-list/nav-list.component.html
@@ -241,7 +241,7 @@
     <h3 class="md-title">TypeScript:</h3>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { Component, HostBinding, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+        import { Component, HostBinding, ChangeDetectionStrategy } from '@angular/core';
         import { TdMediaService } from '@covalent/core';
 
         @Component({
@@ -250,7 +250,7 @@
           styleUrls: ['./nav-list.component.scss'],
           templateUrl: './nav-list.component.html',
         })
-        export class NavListComponent implements AfterViewInit {
+        export class NavListComponent {
 
           routes: Object[] = [{
               icon: 'home',
@@ -316,16 +316,7 @@
             },
           ];
 
-          constructor(private _changeDetectorRef: ChangeDetectorRef,
-                      public media: TdMediaService) {}
-
-          ngAfterViewInit(): void {
-            // broadcast to all listener observables when loading the page
-            setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining
-              this.media.broadcast();
-              this._changeDetectorRef.detectChanges();
-            });
-          }
+          constructor(public media: TdMediaService) {}
 
         }
       ]]>

--- a/src/app/components/layouts/nav-list/nav-list.component.ts
+++ b/src/app/components/layouts/nav-list/nav-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, HostBinding, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { TdMediaService } from '@covalent/core';
 
 import { fadeAnimation } from '../../../app.animations';
@@ -10,7 +10,7 @@ import { fadeAnimation } from '../../../app.animations';
   templateUrl: './nav-list.component.html',
   animations: [fadeAnimation],
 })
-export class NavListComponent implements AfterViewInit {
+export class NavListComponent {
 
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
@@ -81,13 +81,5 @@ export class NavListComponent implements AfterViewInit {
 
   constructor(private _changeDetectorRef: ChangeDetectorRef,
               public media: TdMediaService) {}
-
-  ngAfterViewInit(): void {
-    // broadcast to all listener observables when loading the page
-    setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining
-      this.media.broadcast();
-      this._changeDetectorRef.detectChanges();
-    });
-  }
 
 }

--- a/src/app/components/style-guide/style-guide.component.ts
+++ b/src/app/components/style-guide/style-guide.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { Component, HostBinding, ChangeDetectorRef } from '@angular/core';
 import { TdMediaService } from '@covalent/core';
 
 import { fadeAnimation } from '../../app.animations';
@@ -9,7 +9,7 @@ import { fadeAnimation } from '../../app.animations';
   templateUrl: './style-guide.component.html',
   animations: [fadeAnimation],
 })
-export class StyleGuideComponent implements AfterViewInit {
+export class StyleGuideComponent {
 
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
@@ -74,12 +74,4 @@ export class StyleGuideComponent implements AfterViewInit {
 
   constructor(private _changeDetectorRef: ChangeDetectorRef,
               public media: TdMediaService) {}
-
-  ngAfterViewInit(): void {
-    // broadcast to all listener observables when loading the page
-    setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining
-      this.media.broadcast();
-      this._changeDetectorRef.detectChanges();
-    });
-  }
 }

--- a/src/app/components/templates/templates.component.ts
+++ b/src/app/components/templates/templates.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { Component, HostBinding, ChangeDetectorRef } from '@angular/core';
 import { TdMediaService } from '@covalent/core';
 import { fadeAnimation } from '../../app.animations';
 
@@ -12,7 +12,7 @@ import { InternalDocsService, ITemplate } from '../../services';
   templateUrl: './templates.component.html',
   animations: [fadeAnimation],
 })
-export class TemplatesComponent implements AfterViewInit {
+export class TemplatesComponent {
 
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
@@ -23,13 +23,5 @@ export class TemplatesComponent implements AfterViewInit {
               private _changeDetectorRef: ChangeDetectorRef,
               private _internalDocsService: InternalDocsService) {
     this.templatesObs = this._internalDocsService.queryTemplates();
-  }
-
-  ngAfterViewInit(): void {
-    // broadcast to all listener observables when loading the page
-    setTimeout(() => { // workaround since MatSidenav has issues redrawing at the beggining
-      this.media.broadcast();
-      this._changeDetectorRef.detectChanges();
-    });
   }
 }

--- a/src/platform/core/layout/layout-toggle.class.ts
+++ b/src/platform/core/layout/layout-toggle.class.ts
@@ -7,6 +7,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { merge } from 'rxjs/observable/merge';
 
 export interface ILayoutTogglable {
+  opened: boolean;
   sidenav: MatSidenav;
   toggle(): Promise<MatDrawerToggleResult>;
   open(): Promise<MatDrawerToggleResult>;
@@ -52,6 +53,11 @@ export abstract class LayoutToggle implements AfterViewInit, OnDestroy {
     // execute toggleVisibility since the onOpenStart and onCloseStart
     // methods might not be executed always when the element is rendered
     this._toggleVisibility();
+    // Force the view to be toggled again since the animation may not be triggered
+    // properly if its a child route
+    Promise.resolve().then(() => {
+      this._layout.sidenav.toggle(this._layout.opened);
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/platform/core/media/services/media.service.ts
+++ b/src/platform/core/media/services/media.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NgZone, SkipSelf, Optional, Provider } from '@angular/core';
-import { Subject } from 'rxjs/Subject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { fromEvent } from 'rxjs/observable/fromEvent';
@@ -10,7 +10,7 @@ export class TdMediaService {
   private _resizing: boolean = false;
   private _globalSubscription: Subscription;
   private _queryMap: Map<string, string> = new Map<string, string>();
-  private _querySources: {[key: string]: Subject<boolean>} = {};
+  private _querySources: { [key: string]: BehaviorSubject<boolean>} = {};
   private _queryObservables: {[key: string]: Observable<boolean>} = {};
 
   constructor(private _ngZone: NgZone) {
@@ -77,7 +77,7 @@ export class TdMediaService {
       query = this._queryMap.get(query.toLowerCase());
     }
     if (!this._querySources[query]) {
-      this._querySources[query] = new Subject<boolean>();
+      this._querySources[query] = new BehaviorSubject<boolean>(matchMedia(query).matches);
       this._queryObservables[query] = this._querySources[query].asObservable();
     }
     return this._queryObservables[query];


### PR DESCRIPTION
## Description
To avoid the use of broadcast on every page load, the media service Subjects will change to leverage BehaviorSubject's so the value is read upon subscription.

### What's included?
- fix(layout): issue when layouts are rendered for the first time in opened mode
- chore(rollup): add BehaviorSubject to rollup build
- fix(docs): remove `changeDetection` and broadcast on ngAfterViewInit

#### Test Steps
- [ ] `ng serve`
- [ ] See docs work the same way without broadcasting the media events

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.