### PR TITLE
feat(): change /deep/ in favor of ::ng-deep

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,6 +1,6 @@
 // Applies Shadow DOM styles to the root app component
 
-// :host /deep/ lets you travel down the Shadow DOM tree to change web component styles
-:host /deep/ {
+// :host ::ng-deep lets you travel down the Shadow DOM tree to change web component styles
+:host ::ng-deep {
 
 }

--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.scss
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.scss
@@ -1,3 +1,3 @@
-/deep/ .mat-input-infix.mat-form-field-infix {
+::ng-deep .mat-input-infix.mat-form-field-infix {
   width: 100%;
 }

--- a/src/app/components/components/file-input/file-input.component.html
+++ b/src/app/components/components/file-input/file-input.component.html
@@ -77,7 +77,7 @@
           <![CDATA[
             .drop-zone {
               font-weight: 600;
-              /deep/ * {
+              ::ng-deep * {
                 pointer-events: none; //added to fix bug that re-throws dragleave/dragenter by child elements
               }
             }

--- a/src/app/components/components/file-input/file-input.component.scss
+++ b/src/app/components/components/file-input/file-input.component.scss
@@ -1,6 +1,6 @@
 .drop-zone {
   font-weight: 600;
-  /deep/ * {
+  ::ng-deep * {
     pointer-events: none; //added to fix bug that re-throws dragleave/dragenter by child elements
   }
 }

--- a/src/app/components/design-patterns/navigation-drawer/navigation-drawer.component.scss
+++ b/src/app/components/design-patterns/navigation-drawer/navigation-drawer.component.scss
@@ -1,4 +1,4 @@
-:host /deep/ {
+:host ::ng-deep {
   .mat-drawer-container[fullscreen] {
     position: static;
     width: 100%;

--- a/src/app/components/layouts/card-over/card-over.component.scss
+++ b/src/app/components/layouts/card-over/card-over.component.scss
@@ -1,4 +1,4 @@
-:host /deep/ {
+:host ::ng-deep {
   .mat-drawer-container[fullscreen] {
     position: static;
     width: 100%;

--- a/src/app/components/layouts/manage-list/manage-list.component.scss
+++ b/src/app/components/layouts/manage-list/manage-list.component.scss
@@ -1,4 +1,4 @@
-:host /deep/ {
+:host ::ng-deep {
   .mat-drawer-container[fullscreen] {
     position: static;
     width: 100%;

--- a/src/app/components/layouts/nav-list/nav-list.component.html
+++ b/src/app/components/layouts/nav-list/nav-list.component.html
@@ -2,14 +2,14 @@
   <mat-card-title>Minimum Demo</mat-card-title>
   <mat-card-subtitle>Minimum code for this layout with no wrapper</mat-card-subtitle>
   <mat-divider></mat-divider>
-  <mat-card-content [style.height]="'400px'" class="relative pad-none">
+  <div [style.height]="'400px'" class="relative">
     <td-layout-nav-list logo="assets:teradata" toolbarTitle="Covalent" navigationRoute="/" opened="true" mode="side">
       <div td-sidenav-content>
         Sidenav content here
       </div>
       Content goes here
     </td-layout-nav-list>
-  </mat-card-content>
+  </div>
   <mat-divider></mat-divider>
   <mat-card-content>
     <td-highlight lang="html">

--- a/src/app/components/layouts/nav-list/nav-list.component.scss
+++ b/src/app/components/layouts/nav-list/nav-list.component.scss
@@ -1,4 +1,4 @@
-:host /deep/ {
+:host ::ng-deep {
   .mat-drawer-container[fullscreen] {
     position: static;
     width: 100%;

--- a/src/app/components/layouts/nav-view/nav-view.component.scss
+++ b/src/app/components/layouts/nav-view/nav-view.component.scss
@@ -1,4 +1,4 @@
-:host /deep/ {
+:host ::ng-deep {
   .mat-drawer-container[fullscreen] {
     position: static;
     width: 100%;

--- a/src/app/components/style-guide/logo/logo.component.scss
+++ b/src/app/components/style-guide/logo/logo.component.scss
@@ -1,4 +1,4 @@
-:host /deep/ {
+:host ::ng-deep {
   .mat-drawer-container[fullscreen] {
     position: static;
     width: 100%;

--- a/src/app/components/templates/templates.component.scss
+++ b/src/app/components/templates/templates.component.scss
@@ -1,4 +1,4 @@
-:host /deep/ {
+:host ::ng-deep {
     mat-grid-tile img {
         width: 100%;
         height: auto;

--- a/src/app/documentation-tools/pretty-markdown/pretty-markdown.component.scss
+++ b/src/app/documentation-tools/pretty-markdown/pretty-markdown.component.scss
@@ -1,7 +1,7 @@
 @import '~@angular/material/theming';
 $code-font: Menlo, Monaco, "Andale Mono", "lucida console", "Courier New", monospace;
 
-:host /deep/ {
+:host ::ng-deep {
   td-markdown:first-of-type > div:first-of-type {
     &  > h1:first-of-type,
     &  > h2:first-of-type {

--- a/src/platform/core/chips/chips.component.scss
+++ b/src/platform/core/chips/chips.component.scss
@@ -32,7 +32,7 @@
       }
     }
   }
-  /deep/ {
+  ::ng-deep {
     .mat-form-field-wrapper {
       padding-bottom: 2px;
     }
@@ -107,7 +107,7 @@
 }
 
 :host {
-   /deep/ mat-form-field {
+   ::ng-deep mat-form-field {
     .mat-form-field-underline {
       display: none;
     }

--- a/src/platform/core/data-table/data-table.component.scss
+++ b/src/platform/core/data-table/data-table.component.scss
@@ -44,13 +44,13 @@ table.td-data-table {
     mat-pseudo-checkbox {
       width: $checkbox-size;
       height: $checkbox-size;
-      /deep/ &.mat-pseudo-checkbox-checked::after {
+      ::ng-deep &.mat-pseudo-checkbox-checked::after {
         width: 11px !important;
         height: 4px !important;
       }
     }
     mat-checkbox {
-      /deep/ .mat-checkbox-inner-container {
+      ::ng-deep .mat-checkbox-inner-container {
         width: $checkbox-size;
         height: $checkbox-size;
         margin: 0;

--- a/src/platform/core/dialogs/dialog.component.scss
+++ b/src/platform/core/dialogs/dialog.component.scss
@@ -11,7 +11,7 @@
   position: relative;
   top: 16px;
   left: 16px;
-  /deep/ [dir='rtl'] & { 
+  ::ng-deep [dir='rtl'] & { 
     right: 16px;
     left: auto;
   }
@@ -28,7 +28,7 @@
       // flex
       flex: 1;
     }
-    /deep/ button {
+    ::ng-deep button {
       text-transform: uppercase;
       margin-left: 8px;
       [dir='rtl'] & { 

--- a/src/platform/core/expansion-panel/expansion-panel.component.scss
+++ b/src/platform/core/expansion-panel/expansion-panel.component.scss
@@ -37,7 +37,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   margin-right: 5px;
-  /deep/ [dir='rtl'] & { 
+  ::ng-deep [dir='rtl'] & { 
     margin-left: 5px;
     margin-right: inherit;
   }

--- a/src/platform/core/file/file-upload/file-upload.component.scss
+++ b/src/platform/core/file/file-upload/file-upload.component.scss
@@ -8,7 +8,7 @@
   position: relative;
   top: 24px;
   left: -12px;
-  /deep/ [dir='rtl'] & {
+  ::ng-deep [dir='rtl'] & {
     right: -12px;
     left: 0;
   }

--- a/src/platform/core/json-formatter/json-formatter.component.scss
+++ b/src/platform/core/json-formatter/json-formatter.component.scss
@@ -25,13 +25,13 @@
     & .td-key,
     & .td-object-children {
       padding-left: 24px;
-      /deep/ [dir='rtl'] & {
+      ::ng-deep [dir='rtl'] & {
         padding-right: 24px;
         padding-left: 0;
       }
       &.td-key-leaf {
         padding-left: 48px;
-        /deep/ [dir='rtl'] & {
+        ::ng-deep [dir='rtl'] & {
           padding-right: 48px;
           padding-left: 0;
         }
@@ -40,7 +40,7 @@
   }
   .value {
     margin-left: 5px;
-    /deep/ [dir='rtl'] & {
+    ::ng-deep [dir='rtl'] & {
       padding-right: 5px;
       padding-left: 0;
     }

--- a/src/platform/core/layout/_layout-theme.scss
+++ b/src/platform/core/layout/_layout-theme.scss
@@ -14,7 +14,7 @@
 
   [mat-icon-button].td-layout-menu-button {
     margin-left: 0px;
-    /deep/ [dir='rtl'] & { 
+    ::ng-deep [dir='rtl'] & { 
       margin-right: 0px;
       margin-left: 6px;
     }

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.scss
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.scss
@@ -51,7 +51,7 @@
     }
   }
 }
-:host /deep/ {
+:host ::ng-deep {
   mat-sidenav-container.td-layout-manage-list {
     & > .mat-drawer-content {
       flex-grow: 1;

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.scss
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.scss
@@ -82,7 +82,7 @@
     }
   }
 }
-:host /deep/ {
+:host ::ng-deep {
   mat-sidenav-container.td-layout-nav-list {
     & > .mat-drawer-content {
       flex-grow: 1;

--- a/src/platform/core/layout/layout-nav/layout-nav.component.scss
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.scss
@@ -1,6 +1,6 @@
 .td-menu-button {
   margin-left: 0px;
-  /deep/ [dir='rtl'] & { 
+  ::ng-deep [dir='rtl'] & { 
     margin-right: 0px;
     margin-left: 6px;
   }

--- a/src/platform/core/layout/layout.component.scss
+++ b/src/platform/core/layout/layout.component.scss
@@ -6,7 +6,7 @@
   height: 100%;
   overflow: hidden;
 
-  /deep/ {
+  ::ng-deep {
     // Ensuring sidenav content has flex column properties
     & > mat-sidenav-container > mat-sidenav {
       display: -webkit-box;

--- a/src/platform/core/menu/menu.component.scss
+++ b/src/platform/core/menu/menu.component.scss
@@ -9,7 +9,7 @@ $td-menu-spacing: 8px !default;
   // [layout="column"]
   flex-direction: column;
 }
-:host /deep/ {
+:host ::ng-deep {
   [td-menu-header] {
     padding: $td-menu-spacing;
     text-align: center;

--- a/src/platform/core/notifications/notification-count.component.scss
+++ b/src/platform/core/notifications/notification-count.component.scss
@@ -60,7 +60,7 @@ $td-notification-content-size: 40px !default;
       right: 8px;
     }
   }
-  /deep/ [dir='rtl'] & {
+  ::ng-deep [dir='rtl'] & {
     &.td-notification-before {
       right: 0px;
       left: auto;
@@ -83,7 +83,7 @@ $td-notification-content-size: 40px !default;
 }
 
 .td-notification-content {
-  &, /deep/ > * {
+  &, ::ng-deep > * {
     line-height: $td-notification-content-size;
   }
 }

--- a/src/platform/core/paging/paging-bar.component.scss
+++ b/src/platform/core/paging/paging-bar.component.scss
@@ -12,7 +12,7 @@
     align-content: center;
     max-width: 100%;
     justify-content: flex-end;
-    /deep/ > * {
+    ::ng-deep > * {
       margin: 0 10px;
     }
     [mat-icon-button] {

--- a/src/platform/core/search/search-box/search-box.component.scss
+++ b/src/platform/core/search/search-box/search-box.component.scss
@@ -18,7 +18,7 @@
   }
   td-search-input {
     margin-left: 12px;
-    /deep/ [dir='rtl'] & { 
+    ::ng-deep [dir='rtl'] & { 
       margin-right: 12px;
       margin-left: 0px !important;
     }

--- a/src/platform/core/search/search-input/search-input.component.scss
+++ b/src/platform/core/search/search-input/search-input.component.scss
@@ -13,7 +13,7 @@
   .td-search-input-field {
     flex: 1;
   }
-  /deep/ mat-form-field.mat-hide-underline {
+  ::ng-deep mat-form-field.mat-hide-underline {
     .mat-form-field-underline {
       display: none;
     }

--- a/src/platform/core/steps/step-header/step-header.component.scss
+++ b/src/platform/core/steps/step-header/step-header.component.scss
@@ -61,13 +61,13 @@ $step-circle: 24px;
   .td-circle,
   .td-triangle,
   .td-complete {
-    /deep/ :not([dir='rtl']) & {
+    ::ng-deep :not([dir='rtl']) & {
       margin: {
         left: 8px;
         right: 0px;
       }
     }
-    /deep/ [dir='rtl'] & {
+    ::ng-deep [dir='rtl'] & {
       margin: {
         left: 0px;
         right: 8px;

--- a/src/platform/core/steps/steps.component.scss
+++ b/src/platform/core/steps/steps.component.scss
@@ -22,11 +22,11 @@
   height: 1px;
   position: relative;
   top: 36px;
-  /deep/ :not([dir='rtl']) & {
+  ::ng-deep :not([dir='rtl']) & {
     left: -6px;
     right: -3px;
   }
-  /deep/ [dir='rtl'] & {
+  ::ng-deep [dir='rtl'] & {
     left: -3px;
     right: -6px;
   }
@@ -38,11 +38,11 @@
 
 .td-vertical-line {
   position: absolute;
-  /deep/ :not([dir='rtl']) & {
+  ::ng-deep :not([dir='rtl']) & {
     left: 20px;
     right: auto;
   }
-  /deep/ [dir='rtl'] & {
+  ::ng-deep [dir='rtl'] & {
     left: auto;
     right: 20px;
   }

--- a/src/platform/highlight/highlight.component.scss
+++ b/src/platform/highlight/highlight.component.scss
@@ -1,7 +1,7 @@
 $code-font: Menlo, Monaco, "Andale Mono", "lucida console", "Courier New", monospace;
 $padding: 16px;
 
-:host /deep/ {
+:host ::ng-deep {
   display: block;
   overflow-x: auto;
   padding: $padding;

--- a/src/platform/markdown/markdown.component.scss
+++ b/src/platform/markdown/markdown.component.scss
@@ -1,4 +1,4 @@
-:host /deep/ {
+:host ::ng-deep {
 
   @font-face {
     font-family: octicons-link;


### PR DESCRIPTION
## Description
Since `/deep/` was deprecated a while back, angular@4.3.x and up support an alternative which is `::ng-deep`. 

This PR focus on replacing `/deep/` with `::ng-deep`


#### Test Steps
- [ ] `ng serve`
- [ ] See docs and components working fine

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
