### PR TITLE
feat(docs): migrate to material typography

### DIFF
--- a/src/app/components/components/animations/animations.component.html
+++ b/src/app/components/components/animations/animations.component.html
@@ -42,7 +42,7 @@
   <mat-card-title>Rotate Animation</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">Use <code>TdRotateAnimation</code> to rotate any element based on a boolean state.</p>
+    <p class="mat-body-1">Use <code>TdRotateAnimation</code> to rotate any element based on a boolean state.</p>
     <div>
       <h3>Demo 1:</h3>
 
@@ -145,7 +145,7 @@
   <mat-card-title>Collapse Animation</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">Use <code>TdCollapseAnimation</code> to collapse any element based on a boolean state.</p>
+    <p class="mat-body-1">Use <code>TdCollapseAnimation</code> to collapse any element based on a boolean state.</p>
     <div>
       <h3>Demo 1:</h3>
 
@@ -225,7 +225,7 @@
   <mat-card-title>Fade in/out Animation</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">Use <code>TdFadeInOutAnimation</code> to fade in/out any element based on a boolean state.</p>
+    <p class="mat-body-1">Use <code>TdFadeInOutAnimation</code> to fade in/out any element based on a boolean state.</p>
     <div>
       <h3>Demo 1:</h3>
 

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -6,7 +6,7 @@
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <div class="push">
-        <div class="md-body-1">Type and select a preset option or press enter:</div>
+        <div class="mat-body-1">Type and select a preset option or press enter:</div>
         <td-chips [chipAddition]="chipAddition"
                   [chipRemoval]="chipRemoval"
                   [items]="filteredStrings"
@@ -111,7 +111,7 @@
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <div class="push">
-        <div class="md-body-1">Type and select a preset option or press enter:</div>
+        <div class="mat-body-1">Type and select a preset option or press enter:</div>
         <td-chips color="accent"
                   [items]="filteredObjects"
                   [(ngModel)]="objectsModel"
@@ -198,7 +198,7 @@
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <div class="push">
-        <div class="md-body-1">Type and see how it will load items async:</div>
+        <div class="mat-body-1">Type and see how it will load items async:</div>
         <td-chips [items]="filteredAsync"
                   [debounce]="500"
                   [(ngModel)]="asyncModel"
@@ -285,7 +285,7 @@
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <div class="push">
-        <div class="md-body-1">Type and select option or enter custom text and press enter:</div>
+        <div class="mat-body-1">Type and select option or enter custom text and press enter:</div>
         <td-chips [items]="filteredStackedStrings"
                   [(ngModel)]="stackedStringsModel"
                   placeholder="Enter any string"
@@ -359,7 +359,7 @@
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <div class="push">
-        <div class="md-body-1">Type any test and press enter:</div>
+        <div class="mat-body-1">Type any test and press enter:</div>
         <td-chips color="warn" placeholder="Enter any string"></td-chips>
       </div>
     </mat-tab>
@@ -392,7 +392,7 @@
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <div class="push">
-        <div class="md-body-1">Type and select a preset option or press enter:</div>
+        <div class="mat-body-1">Type and select a preset option or press enter:</div>
         <td-chips [items]="filteredStrings"
                   [(ngModel)]="stringsModel"
                   placeholder="Enter autocomplete strings"

--- a/src/app/components/components/code-editor/code-editor.component.html
+++ b/src/app/components/components/code-editor/code-editor.component.html
@@ -27,7 +27,7 @@
   <mat-divider></mat-divider>
   <mat-card-actions>
     <div layout="row" layout-align="start center" class="pad-sm">
-      <span flex="none" hide-xs class="push-right md-body-1">Editor Language</span>
+      <span flex="none" hide-xs class="push-right mat-body-1">Editor Language</span>
       <mat-form-field floatPlaceholder="never">
         <mat-select [(ngModel)]="editorLanguage" (change)="changeLanguage()" placeholder="Editor Language">
           <mat-option value="sql">SQL</mat-option>
@@ -38,7 +38,7 @@
     </div>
     <mat-divider></mat-divider>
     <div layout="row" layout-align="start center" class="pad-sm">
-      <span flex="none" hide-xs class="push-right md-body-1">Editor Theme</span>
+      <span flex="none" hide-xs class="push-right mat-body-1">Editor Theme</span>
       <mat-form-field floatPlaceholder="never">
         <mat-select [(ngModel)]="editorTheme" (change)="changeTheme()" placeholder="Editor Theme">
           <mat-option value="vs">Light</mat-option>

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -3,8 +3,8 @@
   <mat-card-subtitle>Display sets of raw data</mat-card-subtitle>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <h3 class="md-title">Custom Data Table</h3>
-    <h4 class="md-subhead">with custom headings, columns, and inline editing</h4>
+    <h3 class="mat-title">Custom Data Table</h3>
+    <h4 class="mat-subheading-2">with custom headings, columns, and inline editing</h4>
     <mat-divider></mat-divider>
     <mat-tab-group mat-stretch-tabs>
       <mat-tab>
@@ -113,8 +113,8 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">Basic Data Table</h3>
-    <h4 class="md-subhead">with formatting, configurable width columns and templates</h4>
+    <h3 class="mat-title">Basic Data Table</h3>
+    <h4 class="mat-subheading-2">with formatting, configurable width columns and templates</h4>
     <mat-divider></mat-divider>
     <mat-tab-group mat-stretch-tabs>
       <mat-tab>
@@ -171,16 +171,16 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">Data Table with components</h3>
-    <h4 class="md-subhead">Paging Bar / Search Box / Sortable components</h4>
+    <h3 class="mat-title">Data Table with components</h3>
+    <h4 class="mat-subheading-2">Paging Bar / Search Box / Sortable components</h4>
     <mat-divider></mat-divider>
     <mat-tab-group mat-stretch-tabs>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
         <div layout="row" layout-align="start center" class="pad-left-sm pad-right-sm" [class.mat-selected-title]="selectedRows.length && selectable">
           <span *ngIf="!searchBox.searchVisible" class="push-left-sm">
-            <span *ngIf="(selectable && !selectedRows.length) || !selectable" class="md-title">Title here</span>
-            <span *ngIf="selectedRows.length && selectable" class="md-body-1">{{selectedRows.length}} item(s) selected</span>
+            <span *ngIf="(selectable && !selectedRows.length) || !selectable" class="mat-title">Title here</span>
+            <span *ngIf="selectedRows.length && selectable" class="mat-body-1">{{selectedRows.length}} item(s) selected</span>
           </span>
           <td-search-box #searchBox backIcon="arrow_back" class="push-right-sm" placeholder="Search here" (searchDebounce)="search($event)" flex>
           </td-search-box>
@@ -224,11 +224,11 @@
           <![CDATA[
             <div layout="row" layout-align="start center" class="pad-left-sm pad-right-sm">
               <span *ngIf="!searchBox.searchVisible" class="push-left-sm">
-                <span class="md-title">Title here</span>
+                <span class="mat-title">Title here</span>
               </span>
               <span *ngIf="!searchBox.searchVisible" class="push-left-sm">
-                <span *ngIf="(selectable && !selectedRows.length) || !selectable" class="md-title">Title here</span>
-                <span *ngIf="selectedRows.length && selectable" class="md-body-1">{{selectedRows.length}} item(s) selected</span>
+                <span *ngIf="(selectable && !selectedRows.length) || !selectable" class="mat-title">Title here</span>
+                <span *ngIf="selectedRows.length && selectable" class="mat-body-1">{{selectedRows.length}} item(s) selected</span>
               </span>
               <td-search-box #searchBox backIcon="arrow_back" class="push-right-sm" placeholder="Search here" (searchDebounce)="search($event)" flex>
               </td-search-box>

--- a/src/app/components/components/directives/directives.component.html
+++ b/src/app/components/components/directives/directives.component.html
@@ -33,7 +33,7 @@
   <mat-card-title>Autotrim directive</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">Use <code>tdAutoTrim</code> on an input to automatically trim the characters.</p>
+    <p class="mat-body-1">Use <code>tdAutoTrim</code> on an input to automatically trim the characters.</p>
     <p>Try entering white spaces before or after a word this input:</p>
     <div layout="row">
       <mat-form-field flex>
@@ -55,7 +55,7 @@
   <mat-card-title>Toggle directive</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">Use <code>[tdToggle]="variable"</code> on an element to toggle it open or closed (used in Stepper &amp; Expansion Panels).</p>
+    <p class="mat-body-1">Use <code>[tdToggle]="variable"</code> on an element to toggle it open or closed (used in Stepper &amp; Expansion Panels).</p>
     <p>Click on this to open a div:</p>
     <button mat-raised-button color="accent" (click)="toggle()" class="text-upper">Toggle</button>
     <div [tdToggle]="toggleDiv">
@@ -89,7 +89,7 @@
   <mat-card-title>Fade directive</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">Use <code>[tdFade]="variable"</code> on an element to fade it in and out.</p>
+    <p class="mat-body-1">Use <code>[tdFade]="variable"</code> on an element to fade it in and out.</p>
     <p>Click on this to open a div:</p>
     <button mat-raised-button color="accent" (click)="fade()" class="text-upper">Fade</button>
     <div [tdFade]="fadeDiv">

--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.html
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.html
@@ -141,7 +141,7 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">Dynamic Text Elements</h3>
+    <h3 class="mat-title">Dynamic Text Elements</h3>
     <mat-divider></mat-divider>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
@@ -184,7 +184,7 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">Dynamic Number Elements</h3>
+    <h3 class="mat-title">Dynamic Number Elements</h3>
     <mat-divider></mat-divider>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
@@ -227,7 +227,7 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">Dynamic Boolean Elements</h3>
+    <h3 class="mat-title">Dynamic Boolean Elements</h3>
     <mat-divider></mat-divider>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
@@ -256,7 +256,7 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">Dynamic Array Elements</h3>
+    <h3 class="mat-title">Dynamic Array Elements</h3>
     <mat-divider></mat-divider>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
@@ -284,7 +284,7 @@
 
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">Dynamic File Input Element</h3>
+    <h3 class="mat-title">Dynamic File Input Element</h3>
     <mat-divider></mat-divider>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
@@ -312,7 +312,7 @@
 
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">Custom Validation</h3>
+    <h3 class="mat-title">Custom Validation</h3>
     <h4>Using custom validator functions to create your own</h4>
     <mat-divider></mat-divider>
     <mat-tab-group mat-stretch-tabs>

--- a/src/app/components/components/expansion-panel/expansion-panel.component.html
+++ b/src/app/components/components/expansion-panel/expansion-panel.component.html
@@ -7,7 +7,7 @@
       <ng-template matTabLabel>Demo</ng-template>
       <td-expansion-panel label="Label goes here" sublabel="sublabel goes here" [disabled]="disabled">
         <div class="md-padding">
-          <h3 class="md-subhead">md-padding class</h3>
+          <h3 class="mat-subheading-2">md-padding class</h3>
           <div>Demo 1</div>
           <div>Demo 2</div>
           <div>Demo 3</div>
@@ -16,7 +16,7 @@
       </td-expansion-panel>
       <td-expansion-panel label="Another label goes here" [disabled]="disabled">
         <div class="md-padding">
-          <h3 class="md-subhead">md-padding class</h3>
+          <h3 class="mat-subheading-2">md-padding class</h3>
           <div>Demo 5</div>
           <div>Demo 6</div>
           <div>Demo 7</div>
@@ -32,7 +32,7 @@
           <![CDATA[
             <td-expansion-panel label="Label goes here" sublabel="sublabel goes here" [disabled]="disabled">
               <div class="md-padding">
-                <h3 class="md-subhead">md-padding class</h3>
+                <h3 class="mat-subheading-2">md-padding class</h3>
                 <div>Demo 1</div>
                 <div>Demo 2</div>
                 <div>Demo 3</div>
@@ -41,7 +41,7 @@
             </td-expansion-panel>
             <td-expansion-panel label="Another label goes here" [disabled]="disabled">
               <div class="md-padding">
-                <h3 class="md-subhead">md-padding class</h3>
+                <h3 class="mat-subheading-2">md-padding class</h3>
                 <div>Demo 5</div>
                 <div>Demo 6</div>
                 <div>Demo 7</div>
@@ -81,17 +81,17 @@
       <td-expansion-panel-group>
         <td-expansion-panel label="Label goes here">
           <div class="md-padding">
-            <h3 class="md-subhead">md-padding class</h3>
+            <h3 class="mat-subheading-2">md-padding class</h3>
           </div>
         </td-expansion-panel>
         <td-expansion-panel label="Another label goes here">
           <div class="md-padding">
-            <h3 class="md-subhead">md-padding class</h3>
+            <h3 class="mat-subheading-2">md-padding class</h3>
           </div>
         </td-expansion-panel>
         <td-expansion-panel label="Yet another label goes here">
           <div class="md-padding">
-            <h3 class="md-subhead">md-padding class</h3>
+            <h3 class="mat-subheading-2">md-padding class</h3>
           </div>
         </td-expansion-panel>
       </td-expansion-panel-group>
@@ -105,17 +105,17 @@
             <td-expansion-panel-group>
               <td-expansion-panel label="Label goes here">
                 <div class="md-padding">
-                  <h3 class="md-subhead">md-padding class</h3>
+                  <h3 class="mat-subheading-2">md-padding class</h3>
                 </div>
               </td-expansion-panel>
               <td-expansion-panel label="Another label goes here">
                 <div class="md-padding">
-                  <h3 class="md-subhead">md-padding class</h3>
+                  <h3 class="mat-subheading-2">md-padding class</h3>
                 </div>
               </td-expansion-panel>
               <td-expansion-panel label="Yet another label goes here">
                 <div class="md-padding">
-                  <h3 class="md-subhead">md-padding class</h3>
+                  <h3 class="mat-subheading-2">md-padding class</h3>
                 </div>
               </td-expansion-panel>
             </td-expansion-panel-group>
@@ -239,12 +239,12 @@
           <td-expansion-summary>
             <div class="md-padding">
               <div flex layout-gt-xs="row" layout-align="start center">
-                <span flex="30" class="md-subhead">Owner</span>
+                <span flex="30" class="mat-subheading-2">Owner</span>
                 <span flex="5" hide-xs><mat-icon class="tc-grey-500">chevron_right</mat-icon></span>
                 <span flex>John Jameson</span>
               </div>
               <div flex layout-gt-xs="row" layout-align="start center">
-                <span flex="30" class="md-subhead">API Key</span>
+                <span flex="30" class="mat-subheading-2">API Key</span>
                 <span flex="5" hide-xs><mat-icon class="tc-grey-500">chevron_right</mat-icon></span>
                 <span flex>1141e8e8-8d24-4956-93c2</span>
               </div>
@@ -287,12 +287,12 @@
               <td-expansion-summary>
                 <div class="md-padding">
                   <div flex layout-gt-xs="row" layout-align="start center">
-                    <span flex="30" class="md-subhead">Owner</span>
+                    <span flex="30" class="mat-subheading-2">Owner</span>
                     <span flex="5" hide-xs><mat-icon class="tc-grey-500">chevron_right</mat-icon></span>
                     <span flex>John Jameson</span>
                   </div>
                   <div flex layout-gt-xs="row" layout-align="start center">
-                    <span flex="30" class="md-subhead">API Key</span>
+                    <span flex="30" class="mat-subheading-2">API Key</span>
                     <span flex="5" hide-xs><mat-icon class="tc-grey-500">chevron_right</mat-icon></span>
                     <span flex>1141e8e8-8d24-4956-93c2</span>
                   </div>

--- a/src/app/components/components/file-upload/file-upload.component.html
+++ b/src/app/components/components/file-upload/file-upload.component.html
@@ -6,7 +6,7 @@
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <mat-card-content>
-        <h3 class="md-title">Single file selection or drop:</h3>
+        <h3 class="mat-title">Single file selection or drop:</h3>
         <p>Select Event: {{fileSelectMsg}}</p>
         <p>Upload Event: {{fileUploadMsg}}</p>
         <td-file-upload #singleFileUpload [(ngModel)]="files" (select)="selectEvent($event)" (upload)="uploadEvent($event)" (cancel)="cancelEvent()" [disabled]="disabled" required>
@@ -83,7 +83,7 @@
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <mat-card-content>
-        <h3 class="md-title">Multiple selection/drop for only .sql files and custom color palette:</h3>
+        <h3 class="mat-title">Multiple selection/drop for only .sql files and custom color palette:</h3>
         <p>Select Event: {{fileSelectMultipleMsg}}</p>
         <p>Upload Event: {{fileUploadMultipleMsg}}</p>
         <td-file-upload #fileMultipleUpload (select)="selectMultipleEvent($event)" (upload)="uploadMultipleEvent($event)" (cancel)="cancelMultipleEvent()"

--- a/src/app/components/components/json-formatter/json-formatter.component.html
+++ b/src/app/components/components/json-formatter/json-formatter.component.html
@@ -3,11 +3,11 @@
   <mat-card-subtitle>JSON object tree with collapsible nodes</mat-card-subtitle>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <h3 class="md-title">Object using JSON Formatting:</h3>
+    <h3 class="mat-title">Object using JSON Formatting:</h3>
     <p>(Use mouse or keyboard to expand/collapse nodes)</p>
     <td-json-formatter [data]="data" [levelsOpen]="2"></td-json-formatter>
     <mat-divider class="push-top"></mat-divider>
-    <h3 class="md-title">Original JSON Object:</h3>
+    <h3 class="mat-title">Original JSON Object:</h3>
     <td-highlight lang="json">
       {{data | json}}
     </td-highlight>

--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -3,8 +3,8 @@
   <mat-card-subtitle>Circular or linear progress loader</mat-card-subtitle>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <h3 class="md-title">[tdLoading] directive with (*) syntax</h3>
-    <h4 class="md-subhead">with indetederminate [tdLoadingMode], circular [tdLoadingType], overlay [tdLoadingStrategy], accent [tdLoadingColor]</h4>
+    <h3 class="mat-title">[tdLoading] directive with (*) syntax</h3>
+    <h4 class="mat-subheading-2">with indetederminate [tdLoadingMode], circular [tdLoadingType], overlay [tdLoadingStrategy], accent [tdLoadingColor]</h4>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
@@ -82,8 +82,8 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">[tdLoading] directive with template syntax</h3>
-    <h4 class="md-subhead">with determinate [tdLoadingMode], linear [tdLoadingType], replace [tdLoadingStrategy], warn [tdLoadingColor]</h4>
+    <h3 class="mat-title">[tdLoading] directive with template syntax</h3>
+    <h4 class="mat-subheading-2">with determinate [tdLoadingMode], linear [tdLoadingType], replace [tdLoadingStrategy], warn [tdLoadingColor]</h4>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
@@ -162,8 +162,8 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">[tdLoading] until usage with icons</h3>
-    <h4 class="md-subhead">using the template syntax</h4>
+    <h3 class="mat-title">[tdLoading] until usage with icons</h3>
+    <h4 class="mat-subheading-2">using the template syntax</h4>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
@@ -223,8 +223,8 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">[tdLoading] until star syntax with variable reference and observables</h3>
-    <h4 class="md-subhead">with accent [tdLoadingColor]</h4>
+    <h3 class="mat-title">[tdLoading] until star syntax with variable reference and observables</h3>
+    <h4 class="mat-subheading-2">with accent [tdLoadingColor]</h4>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
@@ -291,8 +291,8 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">[tdLoading] until template syntax with booleans</h3>
-    <h4 class="md-subhead">with overlay [tdLoadingStrategy], linear [tdLoadingType]</h4>
+    <h3 class="mat-title">[tdLoading] until template syntax with booleans</h3>
+    <h4 class="mat-subheading-2">with overlay [tdLoadingStrategy], linear [tdLoadingType]</h4>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
@@ -354,8 +354,8 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">Preloaded [TdLoading] fullscreen mask</h3>
-    <h4 class="md-subhead">with indeterminate [mode], circular [type], primary [color] by default</h4>
+    <h3 class="mat-title">Preloaded [TdLoading] fullscreen mask</h3>
+    <h4 class="mat-subheading-2">with indeterminate [mode], circular [type], primary [color] by default</h4>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
@@ -400,8 +400,8 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-   <h3 class="md-title">Custom [TdLoading] linear at top of page</h3>
-    <h4 class="md-subhead">with indeterminate [mode], linear [type], accent [color]</h4>
+   <h3 class="mat-title">Custom [TdLoading] linear at top of page</h3>
+    <h4 class="mat-subheading-2">with indeterminate [mode], linear [type], accent [color]</h4>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>

--- a/src/app/components/components/message/message.component.html
+++ b/src/app/components/components/message/message.component.html
@@ -6,15 +6,15 @@
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <mat-card-content>
-        <p class="md-body-1">Standalone message:</p>
+        <p class="mat-body-1">Standalone message:</p>
         <td-message label="Error!" sublabel="You did something wrong!" color="warn" icon="error"></td-message>
-        <p class="md-body-1">Message in a card with action</p>
+        <p class="mat-body-1">Message in a card with action</p>
         <mat-card>
           <td-message label="Warning!" sublabel="Your probably shouldn't do that!" color="primary" icon="warning">
             <button td-message-actions mat-button>VIEW MORE</button>
           </td-message>
         </mat-card>
-        <p class="md-body-1">Message in a card content:</p>
+        <p class="mat-body-1">Message in a card content:</p>
         <mat-card>
           <mat-card-title>Card title</mat-card-title>
           <mat-divider></mat-divider>
@@ -23,7 +23,7 @@
             content
           </mat-card-content>
         </mat-card>
-        <p class="md-body-1">Toggle visibility:</p>
+        <p class="mat-body-1">Toggle visibility:</p>
         <td-message #messageDemo color="primary" class="pad-sm" label="Hide me!" sublabel="You can toggle my visibility & add a class!">
           <button td-message-actions mat-icon-button (click)="messageDemo.close()"><mat-icon>cancel</mat-icon></button>
         </td-message>
@@ -35,15 +35,15 @@
         <p>HTML:</p>
         <td-highlight lang="html">
           <![CDATA[
-            <p class="md-body-1">Standalone message:</p>
+            <p class="mat-body-1">Standalone message:</p>
             <td-message label="Error!" sublabel="You did something wrong!" color="warn" icon="error"></td-message>
-            <p class="md-body-1">Message in a card with action</p>
+            <p class="mat-body-1">Message in a card with action</p>
             <mat-card>
               <td-message label="Warning!" sublabel="Your probably shouldn't do that!" color="primary" icon="warning">
                 <button td-message-actions mat-button>VIEW MORE</button>
               </td-message>
             </mat-card>
-            <p class="md-body-1">Message in a card content:</p>
+            <p class="mat-body-1">Message in a card content:</p>
             <mat-card>
               <mat-card-title>Card title</mat-card-title>
               <mat-divider></mat-divider>
@@ -52,7 +52,7 @@
                 content
               </mat-card-content>
             </mat-card>
-            <p class="md-body-1">Toggle visibility:</p>
+            <p class="mat-body-1">Toggle visibility:</p>
             <td-message #messageDemo color="primary" class="pad-sm" label="Hide me!" sublabel="You can toggle my visibility & add a class!">
               <button td-message-actions mat-icon-button (click)="messageDemo.close()"><mat-icon>cancel</mat-icon></button>
             </td-message>
@@ -79,11 +79,11 @@
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <mat-card-content>
-        <p class="md-body-1">Using <code>color</code>:</p>
+        <p class="mat-body-1">Using <code>color</code>:</p>
         <td-message label="Purple!" sublabel="Simply add color=blah" color="purple" icon="error">
           <button td-message-actions mat-button>VIEW MORE</button>
         </td-message>
-        <p class="md-body-1">Using <code>class</code>:</p>
+        <p class="mat-body-1">Using <code>class</code>:</p>
         <td-message label="Cyan!" sublabel="Reference the Covalent style guide" class="bgc-cyan-800 tc-cyan-100" icon="error">
           <button td-message-actions mat-button>VIEW MORE</button>
         </td-message>
@@ -95,11 +95,11 @@
         <p>HTML:</p>
         <td-highlight lang="html">
           <![CDATA[
-            <p class="md-body-1">Using <code>color</code>:</p>
+            <p class="mat-body-1">Using <code>color</code>:</p>
             <td-message label="Purple!" sublabel="Simply add color=blah" color="purple" icon="error">
               <button td-message-actions mat-button>VIEW MORE</button>
             </td-message>
-            <p class="md-body-1">Using <code>class</code>:</p>
+            <p class="mat-body-1">Using <code>class</code>:</p>
             <td-message label="Cyan!" sublabel="Reference the Covalent style guide" class="bgc-cyan-800 tc-cyan-100" icon="error">
               <button td-message-actions mat-button>VIEW MORE</button>
             </td-message>

--- a/src/app/components/components/ngx-charts/ngx-charts.component.html
+++ b/src/app/components/components/ngx-charts/ngx-charts.component.html
@@ -458,7 +458,7 @@
   <mat-divider></mat-divider>
   <mat-card-content>
     <p>Since our apps largely span from Orange / Blue / Grey families, here's some recommended palettes:</p>
-    <h3 class="md-title">Blues</h3>
+    <h3 class="mat-title">Blues</h3>
     <div layout="row" class="push-bottom-sm">
       <span class="bgc-blue-900 pad-md"></span>
       <span class="bgc-blue-700 pad-md"></span>
@@ -475,7 +475,7 @@
       ]]>
     </td-highlight>
     <mat-divider></mat-divider>
-    <h3 class="md-title">Oranges</h3>
+    <h3 class="mat-title">Oranges</h3>
     <div layout="row" class="push-bottom-sm">
       <span class="bgc-deep-orange-900 pad-md"></span>
       <span class="bgc-orange-800 pad-md"></span>
@@ -492,7 +492,7 @@
       ]]>
     </td-highlight>
     <mat-divider></mat-divider>
-    <h3 class="md-title">Blue to Orange</h3>
+    <h3 class="mat-title">Blue to Orange</h3>
     <div layout="row" class="push-bottom-sm">
       <span class="bgc-blue-900 pad-md"></span>
       <span class="bgc-light-blue-900 pad-md"></span>

--- a/src/app/components/components/notifications/notifications.component.html
+++ b/src/app/components/components/notifications/notifications.component.html
@@ -3,7 +3,7 @@
   <mat-card-subtitle>Notification count &amp; menu for toolbar</mat-card-subtitle>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <h3 class="md-title">Toolbar notification &amp; menu</h3>
+    <h3 class="mat-title">Toolbar notification &amp; menu</h3>
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
@@ -26,7 +26,7 @@
           </button>
           <mat-menu #notificationsMenu="matMenu" [overlapTrigger]="false">
             <td-menu>
-              <div td-menu-header class="md-subhead">Notifications</div>
+              <div td-menu-header class="mat-subheading-2">Notifications</div>
               <mat-nav-list dense>
                 <ng-template let-last="last" ngFor [ngForOf]="[0,1,2,3,4,5,6,7,8,9]">
                   <a mat-list-item>
@@ -79,7 +79,7 @@
               </button>
               <mat-menu #notificationsMenu="matMenu" [overlapTrigger]="false">
                 <td-menu>
-                  <div td-menu-header class="md-subhead">Notifications</div>
+                  <div td-menu-header class="mat-subheading-2">Notifications</div>
                   <mat-nav-list dense>
                     <ng-template let-last="last" ngFor [ngForOf]="[0,1,2,3,4,5,6,7,8,9]">
                       <a mat-list-item>
@@ -115,7 +115,7 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">Tabs notification</h3>
+    <h3 class="mat-title">Tabs notification</h3>
     <mat-tab-group mat-stretch-tabs>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
@@ -191,7 +191,7 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">List item notification</h3>
+    <h3 class="mat-title">List item notification</h3>
     <mat-tab-group mat-stretch-tabs>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>

--- a/src/app/components/components/overview/overview.component.html
+++ b/src/app/components/components/overview/overview.component.html
@@ -12,7 +12,7 @@
               </mat-toolbar>
               <mat-card-content>
                 <div layout="column" layout-padding>
-                  <div class="md-subhead">{{item.title}}</div>
+                  <div class="mat-subheading-2">{{item.title}}</div>
                 </div>
               </mat-card-content>
             </mat-card>
@@ -35,7 +35,7 @@
               </mat-toolbar>
               <mat-card-content>
                 <div layout="column" layout-padding>
-                  <div class="md-subhead">{{item.title}}</div>
+                  <div class="mat-subheading-2">{{item.title}}</div>
                 </div>
               </mat-card-content>
             </mat-card>
@@ -58,7 +58,7 @@
               </mat-toolbar>
               <mat-card-content>
                 <div layout="column" layout-padding>
-                  <div class="md-subhead">Angular Material <mat-icon class="text-md tc-grey-600" title="External docs">launch</mat-icon></div>
+                  <div class="mat-subheading-2">Angular Material <mat-icon class="text-md tc-grey-600" title="External docs">launch</mat-icon></div>
                 </div>
               </mat-card-content>
             </mat-card>
@@ -72,7 +72,7 @@
               </mat-toolbar>
               <mat-card-content>
                 <div layout="column" layout-padding>
-                  <div class="md-subhead">{{item.title}}</div>
+                  <div class="mat-subheading-2">{{item.title}}</div>
                 </div>
               </mat-card-content>
             </mat-card>

--- a/src/app/components/components/pipes/pipes.component.html
+++ b/src/app/components/components/pipes/pipes.component.html
@@ -3,9 +3,9 @@
   <mat-card-subtitle>Custom Angular pipes (filters)</mat-card-subtitle>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <blockquote class="md-subhead pull-left-none">Every application starts out with what seems like a simple task: get data, transform them, and show them to users. Getting data could be as simple as creating a local variable or as complex as streaming data over a Websocket.</blockquote>
+    <blockquote class="mat-subheading-2 pull-left-none">Every application starts out with what seems like a simple task: get data, transform them, and show them to users. Getting data could be as simple as creating a local variable or as complex as streaming data over a Websocket.</blockquote>
 
-    <blockquote class="md-subhead pull-left-none">A pipe takes in data as input and transforms it to a desired output.</blockquote>
+    <blockquote class="mat-subheading-2 pull-left-none">A pipe takes in data as input and transforms it to a desired output.</blockquote>
 
     <h3>Setup:</h3>
     <p>Import the [CovalentCommonModule] in your NgModule:</p>
@@ -33,7 +33,7 @@
   <mat-card-title>Digits Conversion</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">The <code>digits</code> pipe takes a number and converts the output to an appropriate numerical measurement with an optional <code>precision</code> argument.</p>
+    <p class="mat-body-1">The <code>digits</code> pipe takes a number and converts the output to an appropriate numerical measurement with an optional <code>precision</code> argument.</p>
     <mat-list>
       <mat-list-item *ngFor="let log of logs">
         <!-- original output -->
@@ -66,7 +66,7 @@
   <mat-card-title>Byte Conversion</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">The <code>bytes</code> pipe takes a number and converts the output to an appropriate data measurement with an optional <code>precision</code> argument.</p>
+    <p class="mat-body-1">The <code>bytes</code> pipe takes a number and converts the output to an appropriate data measurement with an optional <code>precision</code> argument.</p>
     <mat-list>
       <mat-list-item *ngFor="let log of logs">
         <!-- original output -->
@@ -99,7 +99,7 @@
   <mat-card-title>Time Ago</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">The <code>timeAgo</code> pipe takes a string, number or Date timestamp (example: <code>2016-01-29T17:59:59.000Z</code>) and tranforms it to the amount of time that has gone by. </p>
+    <p class="mat-body-1">The <code>timeAgo</code> pipe takes a string, number or Date timestamp (example: <code>2016-01-29T17:59:59.000Z</code>) and tranforms it to the amount of time that has gone by. </p>
     <mat-list>
       <mat-list-item *ngFor="let log of logs">
         <h3 matLine>Timestamp: {{ log.timestamp }} | {{ log.timestamp | timeAgo:log.reference }}</h3>
@@ -126,7 +126,7 @@
   <mat-card-title>Time Difference</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">The <code>timeDifference</code> pipe outputs the difference between two times. Strings, Numbers or Date timestamps are acceptable types. (example: <code>2016-01-29T17:59:59.000Z</code>).</p>
+    <p class="mat-body-1">The <code>timeDifference</code> pipe outputs the difference between two times. Strings, Numbers or Date timestamps are acceptable types. (example: <code>2016-01-29T17:59:59.000Z</code>).</p>
     <mat-list>
       <mat-list-item *ngFor="let log of logs">
         <!-- Start and end time output -->
@@ -137,7 +137,7 @@
         <p matLine>Difference relative to current time: {{ log.timestamp | timeDifference }}</p>
       </mat-list-item>
     </mat-list>
-    <p class="md-body-1"><strong>Note: </strong> Using this pipe without arguments outputs the time difference relative to the current time. </p>
+    <p class="mat-body-1"><strong>Note: </strong> Using this pipe without arguments outputs the time difference relative to the current time. </p>
   <p>Usage:</p>
     <td-highlight lang="html">
         <![CDATA[
@@ -160,7 +160,7 @@
   <mat-card-title>Truncate</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">The <code>truncate</code> pipe limits a string to a specified <code>length</code> and adds an ellipsis.</p>
+    <p class="mat-body-1">The <code>truncate</code> pipe limits a string to a specified <code>length</code> and adds an ellipsis.</p>
     <mat-list>
       <mat-list-item *ngFor="let log of logs">
         <!-- original value output -->
@@ -182,7 +182,7 @@
           </mat-list>
         ]]>
     </td-highlight>
-    <p class="md-body-1"><strong>Note: </strong>  If the last character in a returned output is a space, then that space is removed.</p>
+    <p class="mat-body-1"><strong>Note: </strong>  If the last character in a returned output is a space, then that space is removed.</p>
     <td-highlight lang="html">
         <![CDATA[
           <!-- Both have the same output because -->

--- a/src/app/components/components/search/search.component.html
+++ b/src/app/components/components/search/search.component.html
@@ -22,7 +22,7 @@
     <div layout-gt-xs="row">
       <mat-card flex-gt-xs="60">
         <div layout="row" layout-align="start center" class="push-left push-right">
-          <span class="md-title">Card</span>
+          <span class="mat-title">Card</span>
           <span flex></span>
           <td-search-box *ngIf="debounce" placeholder="Search here" [alwaysVisible]="alwaysVisible" (searchDebounce)="searchBoxTerm = $event" flex></td-search-box>
           <td-search-box *ngIf="!debounce" placeholder="Search here" [alwaysVisible]="alwaysVisible" (search)="searchBoxTerm = $event" (clear)="searchBoxTerm = ''" flex></td-search-box>

--- a/src/app/components/components/steps/steps.component.html
+++ b/src/app/components/components/steps/steps.component.html
@@ -3,7 +3,7 @@
   <mat-card-subtitle>A sequence of logical & numbered steps</mat-card-subtitle>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <h3 class="md-title">Basic Stepper</h3>
+    <h3 class="mat-title">Basic Stepper</h3>
     <mat-tab-group mat-stretch-tabs>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>

--- a/src/app/components/design-patterns/cards/cards.component.html
+++ b/src/app/components/design-patterns/cards/cards.component.html
@@ -43,11 +43,11 @@
           <p>A card can be used with any of the optional card sub-elements including:</p>
           <mat-list>
             <a mat-list-item>
-              <span matLine>md-title</span>
+              <span matLine>mat-card-title</span>
             </a>
             <mat-divider></mat-divider>
             <a mat-list-item>
-              <span matLine>md-subtitle</span>
+              <span matLine>mat-card-subtitle</span>
             </a>
             <mat-divider></mat-divider>
             <a mat-list-item>
@@ -135,7 +135,7 @@
             <div>
               <td-highlight lang="html">
                   <![CDATA[
-                    <mat-card-title layout="row" layout-align="start center"><mat-icon class="mat-icon-logo" svgIcon="assets:teradata"></mat-icon> <span class="md-title">Login</span></mat-card-title>
+                    <mat-card-title layout="row" layout-align="start center"><mat-icon class="mat-icon-logo" svgIcon="assets:teradata"></mat-icon> <span class="mat-title">Login</span></mat-card-title>
                       <mat-card-subtitle>Sign In with Your Credentials</mat-card-subtitle>
                       <mat-divider></mat-divider>
                       <mat-card-content class="push-bottom-none">
@@ -175,7 +175,7 @@
           </div>
           <mat-card class="push-md">
             <mat-card-title layout="row" layout-align="start center">
-              <mat-icon class="mat-icon-logo" svgIcon="assets:teradata"></mat-icon> <span class="md-title">Login</span>
+              <mat-icon class="mat-icon-logo" svgIcon="assets:teradata"></mat-icon> <span class="mat-title">Login</span>
             </mat-card-title>
             <mat-card-subtitle>Sign In with Your Credentials</mat-card-subtitle>
             <mat-divider></mat-divider>
@@ -362,8 +362,8 @@
                           <mat-icon matListAvatar>apps</mat-icon>
                           <h3 matLine>App Name</h3>
                           <span flex></span>
-                          <span flex="30" class="pad-left md-body-1 tc-grey-500">Owner</span>
-                          <span flex="30" class="md-body-1 tc-grey-500">Modified</span>
+                          <span flex="30" class="pad-left mat-body-1 tc-grey-500">Owner</span>
+                          <span flex="30" class="mat-body-1 tc-grey-500">Modified</span>
                         </mat-list-item>
                         <ng-template let-item="$implicit" let-i="index" let-last="last" ngFor [ngForOf]="[1, 2, 3, 4]">
                           <a mat-list-item>
@@ -371,8 +371,8 @@
                             <h3 matLine> Item { {i} } </h3>
                             <p matLine> Item Description </p>
                             <span flex></span>
-                            <span flex="30" class="md-body-1 tc-grey-500">Firstname Lastname</span>
-                            <span flex="30" class="md-body-1 tc-grey-500">Apr 14, 2016 12:32 PM</span>
+                            <span flex="30" class="mat-body-1 tc-grey-500">Firstname Lastname</span>
+                            <span flex="30" class="mat-body-1 tc-grey-500">Apr 14, 2016 12:32 PM</span>
                           </a>
                           <mat-divider *ngIf="!last" matInset></mat-divider>
                         </ng-template>
@@ -395,8 +395,8 @@
                   <mat-icon matListAvatar>apps</mat-icon>
                   <h3 matLine>App Name</h3>
                   <span flex></span>
-                  <span flex="30" class="pad-left md-body-1 tc-grey-500">Owner</span>
-                  <span flex="30" class="md-body-1 tc-grey-500" hide-md hide-sm hide-xs>Modified</span>
+                  <span flex="30" class="pad-left mat-body-1 tc-grey-500">Owner</span>
+                  <span flex="30" class="mat-body-1 tc-grey-500" hide-md hide-sm hide-xs>Modified</span>
                 </mat-list-item>
                 <ng-template let-item="$implicit" let-i="index" let-last="last" ngFor [ngForOf]="[1, 2, 3, 4]">
                   <a mat-list-item>
@@ -404,8 +404,8 @@
                     <h3 matLine> Item {{i}} </h3>
                     <p matLine> Item Description </p>
                     <span flex></span>
-                    <span flex="30" class="md-body-1 tc-grey-500">Firstname Lastname</span>
-                    <span flex="30" class="md-body-1 tc-grey-500" hide-md hide-sm hide-xs>Apr 14, 2016 12:32 PM</span>
+                    <span flex="30" class="mat-body-1 tc-grey-500">Firstname Lastname</span>
+                    <span flex="30" class="mat-body-1 tc-grey-500" hide-md hide-sm hide-xs>Apr 14, 2016 12:32 PM</span>
                   </a>
                   <mat-divider *ngIf="!last" matInset></mat-divider>
                 </ng-template>

--- a/src/app/components/design-patterns/management-list/management-list.component.html
+++ b/src/app/components/design-patterns/management-list/management-list.component.html
@@ -100,7 +100,7 @@
                             <mat-card>
                               <div layout="row" layout-align="start center" class="pad-left-sm pad-right-sm">
                                 <span *ngIf="!searchBox.searchVisible" class="push-left-sm">
-                                  <span class="md-title">Title here</span>
+                                  <span class="mat-title">Title here</span>
                                 </span>
                                 <td-search-box #searchBox backIcon="arrow_back" class="push-right-sm" placeholder="Search here" (searchDebounce)="search($event)" flex>
                                 </td-search-box>
@@ -120,8 +120,8 @@
                                   <mat-icon matListAvatar>apps</mat-icon>
                                   <h3 matLine>App Name</h3>
                                   <span flex></span>
-                                  <span hide-xs flex="30" class="pad-left md-body-1 tc-grey-500">Owner</span>
-                                  <span hide-xs class="md-sort-header" flex="40" layout="row" layout-align="center center" class="pad-left md-body-1 tc-grey-500">
+                                  <span hide-xs flex="30" class="pad-left mat-body-1 tc-grey-500">Owner</span>
+                                  <span hide-xs class="md-sort-header" flex="40" layout="row" layout-align="center center" class="pad-left mat-body-1 tc-grey-500">
                                     <mat-select flex="90" [(ngModel)]="sortKey">
                                       <mat-option *ngFor="let option of columnOptions" [value]="option.value" (click)="sortBy(sortKey)">
                                         { {option.name}}
@@ -143,7 +143,7 @@
                                     <span hide-xs flex="10">
                                       { {item.owner}}
                                     </span>
-                                    <span hide-xs flex="60" class="text-right md-body-1 tc-grey-500 pad-right">
+                                    <span hide-xs flex="60" class="text-right mat-body-1 tc-grey-500 pad-right">
                                       { {item[sortKey] | date:'short'}}
                                     </span>
                                   </mat-list-item>
@@ -211,7 +211,7 @@
           <mat-card class="push-md">
             <div layout="row" layout-align="start center" class="pad-left-sm pad-right-sm">
               <span *ngIf="!searchBox.searchVisible" class="push-left-sm">
-                <span class="md-title">Title here</span>
+                <span class="mat-title">Title here</span>
               </span>
               <td-search-box #searchBox backIcon="arrow_back" class="push-right-sm" placeholder="Search here" (searchDebounce)="search()"
                 flex>
@@ -232,8 +232,8 @@
                 <mat-icon matListAvatar>apps</mat-icon>
                 <h3 matLine>App Name</h3>
                 <span flex></span>
-                <span hide-sm flex="40" class="pad-left md-body-1 tc-grey-500">Owner</span>
-                <span hide-xs class="md-sort-header" flex="30" layout="row" layout-align="center center" class="pad-left md-body-1 tc-grey-500">
+                <span hide-sm flex="40" class="pad-left mat-body-1 tc-grey-500">Owner</span>
+                <span hide-xs class="md-sort-header" flex="30" layout="row" layout-align="center center" class="pad-left mat-body-1 tc-grey-500">
                   <mat-select flex="90" [(ngModel)]="sortKey">
                     <mat-option *ngFor="let option of columnOptions" [value]="option.value" (click)="sortBy(sortKey)">
                       {{option.name}}
@@ -255,7 +255,7 @@
                   <span hide-sm flex="10">
                     {{item.owner}}
                   </span>
-                  <span hide-xs flex="60" class="text-right md-body-1 tc-grey-500 pad-right">
+                  <span hide-xs flex="60" class="text-right mat-body-1 tc-grey-500 pad-right">
                     {{item[sortKey] | date:'short'}}
                   </span>
                 </mat-list-item>

--- a/src/app/components/docs/theme/theme.component.html
+++ b/src/app/components/docs/theme/theme.component.html
@@ -60,7 +60,7 @@
   </mat-card-content>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <h3 class="md-title"><span class="tc-blue-700">Blue Primary</span> / <span class="tc-orange-700">Orange Accent</span></h3>
+    <h3 class="mat-title"><span class="tc-blue-700">Blue Primary</span> / <span class="tc-orange-700">Orange Accent</span></h3>
     <div layout-gt-xs="row" layout-margin>
       <div flex-gt-xs="50" class="pad-top-sm">
         <td-highlight lang="scss">
@@ -102,7 +102,7 @@
       </div>
     </div>
     <mat-divider></mat-divider>
-    <h3 class="md-title"><span class="tc-blue-grey-700">Blue Grey Primary</span> / <span class="tc-deep-orange-700">Deep Orange Accent</span></h3>
+    <h3 class="mat-title"><span class="tc-blue-grey-700">Blue Grey Primary</span> / <span class="tc-deep-orange-700">Deep Orange Accent</span></h3>
     <div layout-gt-xs="row" layout-margin>
       <div flex-gt-xs="50" class="pad-top-sm">
         <td-highlight lang="scss">

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -10,9 +10,9 @@
           <div class="push-top-xl" hide-xs></div>
           <div tdMediaToggle="gt-sm" [mediaClasses]="['push-lg']">
             <div layout="row" layout-align="start center">
-              <h1 class="md-display-1 tc-blue-grey-50 push-top-xs push-bottom-sm" tdMediaToggle="xs" [mediaClasses]="['md-headline']">Covalent UI Platform for <span hide-xs>building</span> enterprise <span hide-xs>desktop</span> web apps</h1>
+              <h1 class="mat-display-1 tc-blue-grey-50 push-top-xs push-bottom-sm" tdMediaToggle="xs" [mediaClasses]="['mat-headline']">Covalent UI Platform for <span hide-xs>building</span> enterprise <span hide-xs>desktop</span> web apps</h1>
             </div>
-            <h2 class="md-headline tc-blue-grey-100 push-top-xs push-bottom-sm" tdMediaToggle="xs" [mediaClasses]="['text-lg']">An open-source UI Platform from Teradata that combines a comprehensive design language with a powerful web framework, built on Angular &amp; Angular Material (Design).</h2>
+            <h2 class="mat-headline tc-blue-grey-100 push-top-xs push-bottom-sm" tdMediaToggle="xs" [mediaClasses]="['text-lg']">An open-source UI Platform from Teradata that combines a comprehensive design language with a powerful web framework, built on Angular &amp; Angular Material (Design).</h2>
             <div class="push-top-xl" hide-xs></div>
             <button mat-raised-button color="accent" class="text-upper" tdMediaToggle="gt-xs" [mediaClasses]="['text-xxl']" [routerLink]="['/docs']">View Docs</button>
             <a mat-raised-button color="primary" class="push-left" tdMediaToggle="gt-xs" [mediaClasses]="['text-xxl']" matTooltip="Star us on Github!" matTooltipPosition="below" href="https://github.com/Teradata/covalent/stargazers" target="_blank">
@@ -52,9 +52,9 @@
                       <mat-icon class="push-right-sm">
                         <span class="tc-{{item.color}}">{{item.icon}}</span>
                       </mat-icon>
-                      <div class="md-title text-xxl tc-blue-grey-900">{{item.title}}</div>
+                      <div class="mat-title text-xxl tc-blue-grey-900">{{item.title}}</div>
                     </div>
-                    <div class="md-subhead tc-blue-grey-700 text-wrap text-left" hide-sm hide-md> {{item.description}} </div>   
+                    <div class="mat-subheading-2 tc-blue-grey-700 text-wrap text-left" hide-sm hide-md> {{item.description}} </div>   
                   </a>
                 </div>
               </ng-template>
@@ -69,9 +69,9 @@
         <div flex flex-order-xs="2" class="pad" tdMediaToggle="gt-xs" [mediaClasses]="['pad-xl']">
           <div class="push-top-xxl" hide-xs></div>
           <div tdMediaToggle="gt-sm" [mediaClasses]="['push-lg']">
-            <h2 class="md-display-1 tc-red-500 push-top-xs push-bottom-sm">Built with <mat-icon>favorite</mat-icon> on Angular</h2>
-            <h3 class="md-headline tc-blue-grey-100 push-top-xs push-bottom-sm">Teradata is one of the largest enterprise consumers of Angular. Currently the entire product suite is being built or revamped on Angular v4.</h3>
-            <h4 class="md-headline tc-blue-grey-200 push-top-xs push-bottom-sm" hide-xs>As Angular unites Teradata developers across the organization, they are able to contribute back to the open-source community with the powerful new tools being developed internally.</h4>
+            <h2 class="mat-display-1 tc-red-500 push-top-xs push-bottom-sm">Built with <mat-icon>favorite</mat-icon> on Angular</h2>
+            <h3 class="mat-headline tc-blue-grey-100 push-top-xs push-bottom-sm">Teradata is one of the largest enterprise consumers of Angular. Currently the entire product suite is being built or revamped on Angular v4.</h3>
+            <h4 class="mat-headline tc-blue-grey-200 push-top-xs push-bottom-sm" hide-xs>As Angular unites Teradata developers across the organization, they are able to contribute back to the open-source community with the powerful new tools being developed internally.</h4>
           </div>
           <div class="push-bottom-xl" hide-xs></div>
         </div>
@@ -104,8 +104,8 @@
                         <span class="tc-{{item.color}}">{{item.icon}}</span>
                       </mat-icon>
                       <div class="tc-white text-left text-wrap">
-                        <div class="md-title push-bottom-xs">{{item.title}}</div>
-                        <div class="md-subhead" hide-sm hide-md> {{item.description}} </div>   
+                        <div class="mat-title push-bottom-xs">{{item.title}}</div>
+                        <div class="mat-subheading-2" hide-sm hide-md> {{item.description}} </div>   
                       </div>
                     </div>
                   </a>
@@ -122,9 +122,9 @@
         <div flex flex-order="2" class="pad" tdMediaToggle="gt-xs" [mediaClasses]="['pad-xl']">
           <div class="push-top-xxl" hide-xs></div>
           <div tdMediaToggle="gt-sm" [mediaClasses]="['push-lg']">
-            <h2 class="md-display-1 tc-green-A700 push-top-xs push-bottom-sm">Following the Material Design spec</h2>
-            <h3 class="md-headline tc-blue-grey-700 push-top-xs push-bottom-sm">Covalent follows the Material Design specification as closely as possible through the construction of all components.</h3>
-            <h4 class="md-headline tc-blue-grey-600 push-top-xs push-bottom-sm" hide-xs>Adopting Material Design as our own spec allows our UI/UX staff to adopt and share powerful open-source resources, while Covalent end users enjoy the immediate familiarity and affordance of this global deign spec.</h4>
+            <h2 class="mat-display-1 tc-green-A700 push-top-xs push-bottom-sm">Following the Material Design spec</h2>
+            <h3 class="mat-headline tc-blue-grey-700 push-top-xs push-bottom-sm">Covalent follows the Material Design specification as closely as possible through the construction of all components.</h3>
+            <h4 class="mat-headline tc-blue-grey-600 push-top-xs push-bottom-sm" hide-xs>Adopting Material Design as our own spec allows our UI/UX staff to adopt and share powerful open-source resources, while Covalent end users enjoy the immediate familiarity and affordance of this global deign spec.</h4>
           </div>
           <div class="push-bottom-xl" hide-xs></div>
         </div>
@@ -137,7 +137,7 @@
       <div layout-gt-xs="row">
         <div flex class="pad" tdMediaToggle="gt-xs" [mediaClasses]="['pad-xl']">
           <div class="push-top-xl" hide-xs></div>
-          <h3 class="md-title">FAQs</h3>
+          <h3 class="mat-title">FAQs</h3>
           <td-expansion-panel-group>
             <td-expansion-panel label="What is Covalent?" sublabel="what is this thing?">
               <div class="md-padding">
@@ -252,7 +252,7 @@
               <div class="md-padding">
                 <mat-card>
                   <mat-card-content>
-                    <div class="md-subhead">
+                    <div class="mat-subheading-2">
                       To build an atomic, standardized, reusable UI component platform based on Material Design, for Teradata to use for all user interfaces, while collaborating in an open source model.
                     </div>
                   </mat-card-content>
@@ -308,7 +308,7 @@
   </div>
   <td-layout-footer color="primary" tdMediaToggle="xs" [mediaClasses]="['text-center']">
     <div layout-gt-xs="row" layout-align="start center">
-      <div class="md-caption">Copyright &copy; 2016 - 2017 Teradata. All rights reserved</div>
+      <div class="mat-caption">Copyright &copy; 2016 - 2017 Teradata. All rights reserved</div>
       <span flex></span>
       <div layout-gt-xs="row">
         <a href="https://gitter.im/Teradata/covalent" target="_blank" mat-button class="text-upper">Gitter Chat</a>

--- a/src/app/components/layouts/card-over/card-over.component.html
+++ b/src/app/components/layouts/card-over/card-over.component.html
@@ -196,7 +196,7 @@
         </td-layout>
       ]]>
     </td-highlight>
-    <h3 class="md-title">TypeScript:</h3>
+    <h3 class="mat-title">TypeScript:</h3>
     <td-highlight lang="typescript">
       <![CDATA[
         import { Component, ChangeDetectionStrategy } from '@angular/core';

--- a/src/app/components/layouts/manage-list/manage-list.component.html
+++ b/src/app/components/layouts/manage-list/manage-list.component.html
@@ -221,7 +221,7 @@
         </td-layout-manage-list>
         <td-layout-footer>
           <div layout="row" layout-align="start center">
-            <span class="md-caption">Copyright &copy; 2017 Teradata. All rights reserved</span>
+            <span class="mat-caption">Copyright &copy; 2017 Teradata. All rights reserved</span>
           </div>
         </td-layout-footer>
       </td-layout-nav>
@@ -345,14 +345,14 @@
             </td-layout-manage-list>
             <td-layout-footer>
               <div layout="row" layout-align="start center">
-                <span class="md-caption">Copyright &copy; 2017 Teradata. All rights reserved</span>
+                <span class="mat-caption">Copyright &copy; 2017 Teradata. All rights reserved</span>
               </div>
             </td-layout-footer>
           </td-layout-nav>
         </td-layout>
       ]]>
     </td-highlight>
-    <h3 class="md-title">TypeScript:</h3>
+    <h3 class="mat-title">TypeScript:</h3>
     <td-highlight lang="typescript">
       <![CDATA[
         import { Component, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';

--- a/src/app/components/layouts/nav-list/nav-list.component.html
+++ b/src/app/components/layouts/nav-list/nav-list.component.html
@@ -158,7 +158,7 @@
         </td-layout-footer-inner>
         <td-layout-footer>
           <div layout="row" layout-align="start center">
-            <span class="md-caption">Copyright &copy; 2017 Teradata. All rights reserved</span>
+            <span class="mat-caption">Copyright &copy; 2017 Teradata. All rights reserved</span>
           </div>
         </td-layout-footer>
       </td-layout-nav-list>
@@ -231,14 +231,14 @@
             </td-layout-footer-inner>
             <td-layout-footer>
               <div layout="row" layout-align="start center">
-                <span class="md-caption">Copyright &copy; 2017 Teradata. All rights reserved</span>
+                <span class="mat-caption">Copyright &copy; 2017 Teradata. All rights reserved</span>
               </div>
             </td-layout-footer>
           </td-layout-nav-list>
         </td-layout>
       ]]>
     </td-highlight>
-    <h3 class="md-title">TypeScript:</h3>
+    <h3 class="mat-title">TypeScript:</h3>
     <td-highlight lang="typescript">
       <![CDATA[
         import { Component, HostBinding, ChangeDetectionStrategy } from '@angular/core';

--- a/src/app/components/layouts/nav-view/nav-view.component.html
+++ b/src/app/components/layouts/nav-view/nav-view.component.html
@@ -161,7 +161,7 @@
         </div>
         <td-layout-footer>
           <div layout="row" layout-align="start center">
-            <span class="md-caption">Copyright &copy; 2017 Teradata. All rights reserved</span>
+            <span class="mat-caption">Copyright &copy; 2017 Teradata. All rights reserved</span>
           </div>
         </td-layout-footer>
       </td-layout-nav>
@@ -244,14 +244,14 @@
           </div>
           <td-layout-footer>
             <div layout="row" layout-align="start center">
-              <span class="md-caption">Copyright &copy; 2017 Teradata. All rights reserved</span>
+              <span class="mat-caption">Copyright &copy; 2017 Teradata. All rights reserved</span>
             </div>
           </td-layout-footer>
         </td-layout-nav>
       </td-layout>
       ]]>
     </td-highlight>
-    <h3 class="md-title">TypeScript:</h3>
+    <h3 class="mat-title">TypeScript:</h3>
     <td-highlight lang="typescript">
       <![CDATA[
         import { Component, ChangeDetectionStrategy } from '@angular/core';

--- a/src/app/components/layouts/overview/overview.component.html
+++ b/src/app/components/layouts/overview/overview.component.html
@@ -8,8 +8,8 @@
       <ng-template let-item let-last="last" ngFor [ngForOf]="items">
         <a mat-button flex [routerLink]="[item.route]">
           <img src="app/assets/images/{{item.route}}.png" alt="{{item.title}}">
-          <div class="md-subtitle">{{item.title}}</div>
-          <div class="md-body-1 text-wrap text-left">{{item.description}}</div>
+          <div class="mat-subtitle">{{item.title}}</div>
+          <div class="mat-body-1 text-wrap text-left">{{item.description}}</div>
         </a>
       </ng-template>
     </div>

--- a/src/app/components/style-guide/colors/colors.component.html
+++ b/src/app/components/style-guide/colors/colors.component.html
@@ -34,7 +34,7 @@
         Blue Grey
       </mat-list-item>
     </mat-list>
-    <div class="bgc-grey-100 md-caption" layout="row" layout-align="center center" layout-padding>
+    <div class="bgc-grey-100 mat-caption" layout="row" layout-align="center center" layout-padding>
       <mat-icon class="push-right-sm">info</mat-icon> <span>NOTE: as always, rules are meant to be bent so if you veer from these colors, just have a good justification!</span>
     </div>
     <h3>Hues</h3>
@@ -74,17 +74,21 @@
   <mat-card-subtitle>Products may select colors from the material design color palette. Limit your selection of colors to three hues from the primary palette and one accent color from the secondary palette.</mat-card-subtitle>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <h3 class="md-title"><span class="tc-blue-700">Blue Primary</span> / <span class="tc-orange-700">Orange Accent</span></h3>
+    <h3 class="mat-title"><span class="tc-blue-700">Blue Primary</span> / <span class="tc-orange-700">Orange Accent</span></h3>
     <div layout-gt-xs="row" layout-margin>
       <div flex-gt-xs="50" class="pad-top-sm">
         <mat-toolbar class="bgc-blue-700 tc-white">
-          <span>Primary</span>
+          <mat-toolbar-row>
+            <span>Primary</span>
+          </mat-toolbar-row>
           <mat-toolbar-row>
             <span>Hue: 700</span>
           </mat-toolbar-row>
         </mat-toolbar>
         <mat-toolbar class="bgc-orange-800 tc-white push-top">
-          <span>Accent</span>
+          <mat-toolbar-row>
+            <span>Accent</span>
+          </mat-toolbar-row>
           <mat-toolbar-row>
             <span>Hue: 800</span>
           </mat-toolbar-row>
@@ -92,19 +96,19 @@
       </div>
       <div flex-gt-xs="50">
         <mat-card class="top-toolbar blue-orange">
-          <mat-toolbar color="primary" class="relative">
+          <mat-toolbar color="primary">
             <mat-toolbar-row>
               <span></span>
             </mat-toolbar-row>
-            <mat-toolbar-row>
+            <mat-toolbar-row class="relative">
               <span>App Usage</span>
+              <button mat-fab [style.bottom.px]="-20" class="mat-fab mat-fab-position-bottom-right">
+                <mat-icon>add</mat-icon>
+              </button>
             </mat-toolbar-row>
-            <button mat-fab class="mat-fab mat-fab-position-bottom-right">
-              <mat-icon>add</mat-icon>
-            </button>
           </mat-toolbar>
           <mat-card-content>
-            <h3 class="md-title tc-blue-600">View title</h3>
+            <h3 class="mat-title tc-blue-600">View title</h3>
             <p>
               When using a primary color in your palette, this color should be the most widely used across all screens and components.
             </p>
@@ -116,17 +120,21 @@
       </div>
     </div>
     <mat-divider></mat-divider>
-    <h3 class="md-title"><span class="tc-orange-700">Orange Primary</span> / <span class="tc-light-blue-700">Light Blue Accent</span></h3>
+    <h3 class="mat-title"><span class="tc-orange-700">Orange Primary</span> / <span class="tc-light-blue-700">Light Blue Accent</span></h3>
     <div layout-gt-xs="row" layout-margin>
       <div flex-gt-xs="50" class="pad-top-sm">
         <mat-toolbar class="bgc-orange-800 tc-white">
-          <span>Primary</span>
+          <mat-toolbar-row>
+            <span>Primary</span>
+          </mat-toolbar-row>
           <mat-toolbar-row>
             <span>Hue: 800</span>
           </mat-toolbar-row>
         </mat-toolbar>
         <mat-toolbar class="bgc-light-blue-700 tc-white push-top">
-          <span>Accent</span>
+          <mat-toolbar-row>
+            <span>Accent</span>
+          </mat-toolbar-row>
           <mat-toolbar-row>
             <span>Hue: 700</span>
           </mat-toolbar-row>
@@ -134,19 +142,19 @@
       </div>
       <div flex-gt-xs="50">
         <mat-card class="top-toolbar">
-          <mat-toolbar color="primary" class="relative">
+          <mat-toolbar color="primary">
             <mat-toolbar-row>
               <span></span>
             </mat-toolbar-row>
-            <mat-toolbar-row>
+            <mat-toolbar-row class="relative">
               <span>App Usage</span>
+              <button mat-fab [style.bottom.px]="-20" class="mat-fab mat-fab-position-bottom-right">
+                <mat-icon>add</mat-icon>
+              </button>
             </mat-toolbar-row>
-            <button mat-fab class="mat-fab mat-fab-position-bottom-right">
-              <mat-icon>add</mat-icon>
-            </button>
           </mat-toolbar>
           <mat-card-content>
-            <h3 class="md-title tc-orange-800">View title</h3>
+            <h3 class="mat-title tc-orange-800">View title</h3>
             <p>
               When using a primary color in your palette, this color should be the most widely used across all screens and components.
             </p>
@@ -158,17 +166,21 @@
       </div>
     </div>
     <mat-divider></mat-divider>
-    <h3 class="md-title"><span class="tc-blue-grey-700">Blue-Grey Primary</span> / <span class="tc-deep-orange-700">Deep Orange Accent</span></h3>
+    <h3 class="mat-title"><span class="tc-blue-grey-700">Blue-Grey Primary</span> / <span class="tc-deep-orange-700">Deep Orange Accent</span></h3>
     <div layout-gt-xs="row" layout-margin>
       <div flex-gt-xs="50" class="pad-top-sm">
         <mat-toolbar class="bgc-blue-grey-700 tc-white">
-          <span>Primary</span>
+          <mat-toolbar-row>
+            <span>Primary</span>
+          </mat-toolbar-row>
           <mat-toolbar-row>
             <span>Hue: 700</span>
           </mat-toolbar-row>
         </mat-toolbar>
         <mat-toolbar class="bgc-deep-orange-700 tc-white push-top">
-          <span>Accent</span>
+          <mat-toolbar-row>
+            <span>Accent</span>
+          </mat-toolbar-row>
           <mat-toolbar-row>
             <span>Hue: 700</span>
           </mat-toolbar-row>
@@ -176,19 +188,19 @@
       </div>
       <div flex-gt-xs="50">
         <mat-card class="top-toolbar blue-grey-deep-orange">
-          <mat-toolbar color="primary" class="relative">
+          <mat-toolbar color="primary">
             <mat-toolbar-row>
               <span></span>
             </mat-toolbar-row>
-            <mat-toolbar-row>
+            <mat-toolbar-row class="relative">
               <span>App Usage</span>
+              <button mat-fab [style.bottom.px]="-20" class="mat-fab mat-fab-position-bottom-right">
+                <mat-icon>add</mat-icon>
+              </button>
             </mat-toolbar-row>
-            <button mat-fab class="mat-fab mat-fab-position-bottom-right">
-              <mat-icon>add</mat-icon>
-            </button>
           </mat-toolbar>
           <mat-card-content>
-            <h3 class="md-title tc-blue-grey-700">View title</h3>
+            <h3 class="mat-title tc-blue-grey-700">View title</h3>
             <p>
               When using a primary color in your palette, this color should be the most widely used across all screens and components.
             </p>
@@ -217,7 +229,7 @@
         <div layout-gt-sm="row" layout-wrap>
           <div flex-gt-sm="20" *ngFor="let color of colors">
             <mat-card>
-              <div class="md-caption pad-xs">class="bgc-{{color}}-"</div>
+              <div class="mat-caption pad-xs">class="bgc-{{color}}-"</div>
               <div class="tc-grey-800">
                 <div class="bgc-{{color}}-50 pad-xs">50</div>
                 <div class="bgc-{{color}}-100 pad-xs">100</div>
@@ -244,7 +256,7 @@
           </div>
           <div flex-gt-sm="20" *ngFor="let color of neutrals">
             <mat-card>
-              <div class="md-caption pad-xs">class="bgc-{{color}}-"</div>
+              <div class="mat-caption pad-xs">class="bgc-{{color}}-"</div>
               <div class="tc-grey-800">
                 <div class="bgc-{{color}}-50 pad-xs">50</div>
                 <div class="bgc-{{color}}-100 pad-xs">100</div>
@@ -276,7 +288,7 @@
         <div layout-gt-sm="row" layout-wrap>
           <div flex-gt-sm="25" *ngFor="let color of colors">
             <mat-card>
-              <div class="md-caption pad-xs">class="bgc-dark-{{color}}-"</div>
+              <div class="mat-caption pad-xs">class="bgc-dark-{{color}}-"</div>
               <div class="tc-white">
                 <div class="bgc-dark-{{color}}-500 pad-xs">500</div>
                 <div class="bgc-dark-{{color}}-B100 pad-xs tc-black">B100</div>
@@ -289,7 +301,7 @@
           </div>
           <div flex-gt-sm="25" *ngFor="let color of neutrals">
             <mat-card>
-              <div class="md-caption pad-xs">class="bgc-dark-{{color}}-"</div>
+              <div class="mat-caption pad-xs">class="bgc-dark-{{color}}-"</div>
               <div class="tc-white">
                 <div class="bgc-dark-{{color}}-500 pad-xs">500</div>
                 <div class="bgc-dark-{{color}}-B100 pad-xs tc-black">B100</div>

--- a/src/app/components/style-guide/iconography/iconography.component.html
+++ b/src/app/components/style-guide/iconography/iconography.component.html
@@ -2,13 +2,13 @@
   <mat-card-title>Icons</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <h3 class="md-title">Ligature Material Icons</h3>
-    <p class="md-body-1">The UI Platform ships with 750+ icons as Font (Ligature) icons.</p>
-    <p class="md-body-1">
+    <h3 class="mat-title">Ligature Material Icons</h3>
+    <p class="mat-body-1">The UI Platform ships with 750+ icons as Font (Ligature) icons.</p>
+    <p class="mat-body-1">
       Material design system icons are simple, modern, friendly, and sometimes quirky. Each icon is created using our design guidelines to depict in simple and minimal forms the universal concepts used commonly throughout a UI. Ensuring readability and clarity at both large and small sizes, these icons have been optimized for beautiful display on all common platforms and display resolutions.
     </p>
     <p>This entire library of icons is licensed under Creative Common Attribution 4.0 International License (CC-BY 4.0) and can be used within Teradata products with no attribution (the icon library just can't be sold standalone).</p>
-    <h3 class="md-title">Usage</h3>
+    <h3 class="mat-title">Usage</h3>
     <p>Using font icon within the Teradata UI Plaform is extremely simple:</p>
     <td-highlight lang="html">
       <![CDATA[
@@ -47,7 +47,7 @@
         <div layout-gt-sm="row" layout-wrap>
           <div flex-gt-sm="20" *ngFor="let color of colors">
             <mat-card>
-              <div class="md-caption pad-xs">class="tc-{{color}}-"</div>
+              <div class="mat-caption pad-xs">class="tc-{{color}}-"</div>
               <div class="bgc-{{color}}-50">
                 <mat-icon><span class="tc-{{color}}-50">palette</span></mat-icon>
                 <mat-icon><span class="tc-{{color}}-100">palette</span></mat-icon>
@@ -74,7 +74,7 @@
           </div>
           <div flex-gt-sm="20" *ngFor="let color of neutrals">
             <mat-card>
-              <div class="md-caption pad-xs">class="tc-{{color}}-"</div>
+              <div class="mat-caption pad-xs">class="tc-{{color}}-"</div>
               <div class="bgc-{{color}}-50">
                 <mat-icon><span class="tc-{{color}}-50">palette</span></mat-icon>
                 <mat-icon><span class="tc-{{color}}-100">palette</span></mat-icon>
@@ -110,7 +110,7 @@
         <div layout-gt-sm="row" layout-wrap>
           <div flex-gt-sm="20" *ngFor="let color of colors">
             <mat-card>
-              <div class="md-caption pad-xs">class="tc-dark-{{color}}-"</div>
+              <div class="mat-caption pad-xs">class="tc-dark-{{color}}-"</div>
               <div class="bgc-{{color}}-100">
                 <mat-icon><span class="tc-dark-{{color}}-500">palette</span></mat-icon>
                 <mat-icon><span class="tc-dark-{{color}}-B100">palette</span></mat-icon>
@@ -123,7 +123,7 @@
           </div>
           <div flex-gt-sm="20" *ngFor="let color of neutrals">
             <mat-card>
-              <div class="md-caption pad-xs">class="tc-dark-{{color}}-"</div>
+              <div class="mat-caption pad-xs">class="tc-dark-{{color}}-"</div>
               <div class="bgc-{{color}}-100">
                 <mat-icon><span class="tc-dark-{{color}}-500">palette</span></mat-icon>
                 <mat-icon><span class="tc-dark-{{color}}-B100">palette</span></mat-icon>
@@ -141,8 +141,8 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
-    <h3 class="md-title">Search Icons</h3>
-    <h4 class="md-subhead">Current icons bundled with Icon Service</h4>
+    <h3 class="mat-title">Search Icons</h3>
+    <h4 class="mat-subheading-2">Current icons bundled with Icon Service</h4>
     <mat-tab-group mat-stretch-tabs>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
@@ -154,7 +154,7 @@
           <div *ngIf="filteredList.length > 0" layout="row" layout-align="start center" layout-wrap>
             <div *ngFor="let icon of filteredList" flex-xs="20" flex-sm="25" flex-md="25" flex-lg="15" flex-gt-lg="15" layout="column" layout-align="end center">
                 <mat-icon>{{icon}}</mat-icon>
-                <p class="md-caption">{{icon}}</p>
+                <p class="mat-caption">{{icon}}</p>
             </div>
           </div>
         </mat-card-content>
@@ -172,7 +172,7 @@
               <div *ngIf="filteredList.length > 0" layout="row" layout-align="start center" layout-wrap>
                 <div *ngFor="let icon of filteredList" flex-xs="20" flex-sm="25" flex-md="25" flex-lg="15" flex-gt-lg="15" layout="column" layout-align="end center">
                     <mat-icon>{ {icon} }</mat-icon>
-                    <p class="md-caption">{ {icon} }</p>
+                    <p class="mat-caption">{ {icon} }</p>
                 </div>
               </div>
             </mat-card-content>

--- a/src/app/components/style-guide/logo/logo.component.html
+++ b/src/app/components/style-guide/logo/logo.component.html
@@ -2,15 +2,15 @@
   <mat-card-title>Including Your Logo</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">Your company logo can be implemented with <code>mat-icon</code>.</p>
+    <p class="mat-body-1">Your company logo can be implemented with <code>mat-icon</code>.</p>
     
-    <p class="md-body-1">For example:</p>
+    <p class="mat-body-1">For example:</p>
     <td-highlight lang="html">
       <![CDATA[
         <mat-icon class="mat-icon-logo" svgIcon="assets:teradata"></mat-icon>
       ]]>
     </td-highlight>
-    <p class="md-body-1">The code above will output an inline SVG with 100px width and auto height:</p>
+    <p class="mat-body-1">The code above will output an inline SVG with 100px width and auto height:</p>
     <mat-icon class="mat-icon-logo" svgIcon="assets:teradata"></mat-icon>
     <mat-divider class="push-top push-bottom"></mat-divider>
     <td-message class="push-bottom" sublabel="Tip: if you need a custom logo size use this snippet with your logo size in /src/styles.scss" color="light-blue" icon="info"></td-message>

--- a/src/app/components/style-guide/product-icons/product-icons.component.html
+++ b/src/app/components/style-guide/product-icons/product-icons.component.html
@@ -2,26 +2,26 @@
   <mat-card-title>SVG Product Icons</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <h3 class="md-title">Style</h3>
-    <p class="md-body-1">While Teradata doesn't have product logos, products do have illustrated vector icons.</p>
-    <p class="md-body-1">Product icons will be flat, angled, and incorporate arrows or movement into dimensionality.</p>
-    <h4 class="md-subtitle">Examples</h4>
+    <h3 class="mat-title">Style</h3>
+    <p class="mat-body-1">While Teradata doesn't have product logos, products do have illustrated vector icons.</p>
+    <p class="mat-body-1">Product icons will be flat, angled, and incorporate arrows or movement into dimensionality.</p>
+    <h4 class="mat-subheading-1">Examples</h4>
     <div layout="row">
       <div flex layout="column" layout-align="center center">
         <mat-icon class="mat-icon-lg fill-teal-700" svgIcon="assets:appcenter"></mat-icon>
-        <div class="md-subtitle push-top">AppCenter</div>
+        <div class="mat-subheading-1 push-top">AppCenter</div>
       </div>
       <div flex layout="column" layout-align="center center">
         <mat-icon class="mat-icon-lg fill-orange-700" svgIcon="assets:listener"></mat-icon>
-        <div class="md-subtitle push-top">Listener</div>
+        <div class="mat-subheading-1 push-top">Listener</div>
       </div>
       <div flex layout="column" layout-align="center center">
         <mat-icon class="mat-icon-lg fill-cyan-700" svgIcon="assets:querygrid"></mat-icon>
-        <div class="md-subtitle push-top">QueryGrid</div>
+        <div class="mat-subheading-1 push-top">QueryGrid</div>
       </div>
     </div>
-    <h3 class="md-title">Usage</h3>
-    <p class="md-body-1">Use the <code>mat-icon</code> component to load an SVG instead of a typing font icon:</p>
+    <h3 class="mat-title">Usage</h3>
+    <p class="mat-body-1">Use the <code>mat-icon</code> component to load an SVG instead of a typing font icon:</p>
     <td-highlight lang="html">
       <![CDATA[
         <mat-icon svgIcon="assets:appcenter"></mat-icon>
@@ -32,6 +32,6 @@
   </mat-card-content>
   <mat-divider></mat-divider>
   <mat-card-actions>
-    <span class="md-caption">Teradata AppCenter, Teradata Listener & Teradata QuerGrid icons copyright Teradata. All rights reserved.</span>
+    <span class="mat-caption">Teradata AppCenter, Teradata Listener & Teradata QuerGrid icons copyright Teradata. All rights reserved.</span>
   </mat-card-actions>
 </mat-card>

--- a/src/app/components/style-guide/typography/typography.component.html
+++ b/src/app/components/style-guide/typography/typography.component.html
@@ -2,8 +2,8 @@
   <mat-card-title>Typography</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">Angular Material provides typography CSS classes you can use to create visual consistency across your application.</p>
-    <p class="md-body-1">
+    <p class="mat-body-1">Angular Material provides typography CSS classes you can use to create visual consistency across your application.</p>
+    <p class="mat-body-1">
       <strong>Note:</strong> 
       <span>Base font size is 10px for easy rem units (1.2rem = 12px). Body font size is 14px. sp = scalable pixels.</span>
       </p>
@@ -17,7 +17,7 @@
   <mat-card-title>Header Styles</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="md-body-1">To preserve semantic structures, you can optionally style the <code>&lt;h1&gt;</code> - <code>&lt;h6&gt;</code> heading tags with the styling classes shown below:</p>
+    <p class="mat-body-1">To preserve semantic structures, you can optionally style the <code>&lt;h1&gt;</code> - <code>&lt;h6&gt;</code> heading tags with the styling classes shown below:</p>
     <div layout-align="center end">
       <div layout="row" layout-align="start center">
         <code flex="15">.md-display-4</code>
@@ -55,7 +55,7 @@
        </div>
       <mat-divider></mat-divider>
     </div>
-    <h3 class="md-title">Usage</h3>
+    <h3 class="mat-title">Usage</h3>
     <td-highlight lang="html"> 
     <![CDATA[
       <!-- Large Heading -->
@@ -96,7 +96,7 @@
       </div>
       <mat-divider></mat-divider>
     </div>
-    <h3 class="md-title">Usage</h3>
+    <h3 class="mat-title">Usage</h3>
     <td-highlight lang="html"> 
     <![CDATA[
       <!-- body copy -->
@@ -124,7 +124,7 @@
         <div layout-gt-sm="row" layout-wrap>
           <div flex-gt-sm="20" *ngFor="let color of colors">
             <mat-card>
-              <div class="md-caption pad-xs">class="tc-{{color}}-"</div>
+              <div class="mat-caption pad-xs">class="tc-{{color}}-"</div>
               <div class="bgc-grey-800">
                 <div class="tc-{{color}}-50 pad-xs">50</div>
                 <div class="tc-{{color}}-100 pad-xs">100</div>
@@ -151,7 +151,7 @@
           </div>
           <div flex-gt-sm="20" *ngFor="let color of neutrals">
             <mat-card>
-              <div class="md-caption pad-xs">class="tc-{{color}}-"</div>
+              <div class="mat-caption pad-xs">class="tc-{{color}}-"</div>
               <div class="bgc-grey-800">
                 <div class="tc-{{color}}-50 pad-xs">50</div>
                 <div class="tc-{{color}}-100 pad-xs">100</div>
@@ -183,7 +183,7 @@
         <div layout-gt-sm="row" layout-wrap>
           <div flex-gt-sm="20" *ngFor="let color of colors">
             <mat-card>
-              <div class="md-caption pad-xs">class="tc-dark-{{color}}-"</div>
+              <div class="mat-caption pad-xs">class="tc-dark-{{color}}-"</div>
               <div class="bgc-{{color}}-100">
                 <div class="tc-dark-{{color}}-500 pad-xs">500</div>
                 <div class="tc-dark-{{color}}-B100 pad-xs">B100</div>
@@ -196,7 +196,7 @@
           </div>
           <div flex-gt-sm="20" *ngFor="let color of neutrals">
             <mat-card>
-              <div class="md-caption pad-xs">class="tc-dark-{{color}}-"</div>
+              <div class="mat-caption pad-xs">class="tc-dark-{{color}}-"</div>
               <div class="bgc-{{color}}-100">
                 <div class="tc-dark-{{color}}-500 pad-xs">500</div>
                 <div class="tc-dark-{{color}}-B100 pad-xs">B100</div>

--- a/src/app/components/style-guide/utility-styles/utility-styles.component.html
+++ b/src/app/components/style-guide/utility-styles/utility-styles.component.html
@@ -65,7 +65,7 @@
 <div layout-gt-md="row">
   <div flex>
     <mat-card>
-      <mat-card-title class="md-subhead">Pad (Padding) Utilities</mat-card-title>
+      <mat-card-title class="mat-subheading-2">Pad (Padding) Utilities</mat-card-title>
       <mat-card-content>
         <td-highlight lang="css">
           .pad             // 16px
@@ -118,7 +118,7 @@
   </div>
   <div flex>
     <mat-card>
-      <mat-card-title class="md-subhead">Push (Margin) Utilities</mat-card-title>
+      <mat-card-title class="mat-subheading-2">Push (Margin) Utilities</mat-card-title>
       <mat-card-content>
         <td-highlight lang="css">
           .push             // 16px
@@ -171,7 +171,7 @@
   </div>
   <div flex>
     <mat-card>
-      <mat-card-title class="md-subhead">Pull (Negative Margin) Utilities</mat-card-title>
+      <mat-card-title class="mat-subheading-2">Pull (Negative Margin) Utilities</mat-card-title>
       <mat-card-content>
         <td-highlight lang="css">
           .pull             // 16px

--- a/src/app/components/templates/templates.component.html
+++ b/src/app/components/templates/templates.component.html
@@ -6,8 +6,8 @@
     <section class="bgc-blue-grey-600 md-whiteframe-z1">
         <div layout-gt-xs="row" layout-align="center center">
             <div flex-gt-xs="80" class="pad" tdMediaToggle="gt-xs" [mediaClasses]="['pad-lg']">
-                <h2 class="md-display-1 push-bottom-none tc-blue-grey-50">Covalent Templates</h2>
-                <h3 class="md-headline push-top-xs tc-blue-grey-200">Example starter templates for your application</h3>
+                <h2 class="mat-display-1 push-bottom-none tc-blue-grey-50">Covalent Templates</h2>
+                <h3 class="mat-headline push-top-xs tc-blue-grey-200">Example starter templates for your application</h3>
             </div>
         </div>
     </section>

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -19,7 +19,7 @@
     </button>
     <mat-menu #notificationsMenu="matMenu">
       <td-menu>
-        <div td-menu-header class="md-subhead">Updates</div>
+        <div td-menu-header class="mat-subheading-2">Updates</div>
         <mat-nav-list dense>
           <ng-template let-item let-last="last" ngFor [ngForOf]="updates">
             <a mat-list-item [routerLink]="[item.route]">

--- a/src/platform/core/layout/_layout-theme.scss
+++ b/src/platform/core/layout/_layout-theme.scss
@@ -1,5 +1,33 @@
 @import '../common/styles/elevation';
 @import '../common/styles/theme-functions';
+@import '../common/styles/typography-functions';
+
+@mixin td-layout-typography($config) {
+  td-navigation-drawer {
+    .td-navigation-drawer-title {
+      font: {
+        family: td-font-family($config);
+        size: td-font-size($config, subheading-2);
+      }
+    }
+    .td-navigation-drawer-name {
+      font: {
+        family: td-font-family($config);
+        size: td-font-size($config, body-1);
+        weight: 500;
+      }
+      line-height: td-line-height($config, body-1);
+    }
+    .td-navigation-drawer-menu-toggle {
+      font: {
+        family: td-font-family($config);
+        size: td-font-size($config, body-2);
+        weight: 400;
+      }
+      line-height: td-line-height($config, body-2);
+    }
+  }
+}
 
 @mixin td-layout-theme($theme) {
   $primary: map-get($theme, primary);

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.html
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.html
@@ -10,10 +10,10 @@
           (click)="handleNavigationClick()">
       <mat-icon *ngIf="icon">{{icon}}</mat-icon>
       <mat-icon *ngIf="logo && !icon" class="mat-icon-logo" [svgIcon]="logo"></mat-icon>
-      <span *ngIf="sidenavTitle" class="md-subhead">{{sidenavTitle}}</span>
+      <span *ngIf="sidenavTitle" class="td-navigation-drawer-title">{{sidenavTitle}}</span>
     </div>
-    <div class="md-body-2" *ngIf="email && name">{{name}}</div>
-    <div class="td-navigation-drawer-menu-toggle md-body-1"
+    <div class="td-navigation-drawer-name" *ngIf="email && name">{{name}}</div>
+    <div class="td-navigation-drawer-menu-toggle"
         href
         *ngIf="email || name"
         (click)="toggleMenu()">

--- a/src/platform/core/typography/_all-typography.scss
+++ b/src/platform/core/typography/_all-typography.scss
@@ -45,4 +45,5 @@
   @include td-message-typography($config);
   @include td-paging-bar-typography($config);
   @include td-steps-typography($config);
+  @include td-layout-typography($config);
 }

--- a/src/platform/dynamic-forms/dynamic-forms.component.html
+++ b/src/platform/dynamic-forms/dynamic-forms.component.html
@@ -21,7 +21,7 @@
           [maxLength]="element.maxLength"
           [selections]="element.selections">
         </td-dynamic-element>
-        <div class="tc-red-600 md-caption"
+        <div class="tc-red-600"
              [style.font-size.%]="'70'"
              [style.position]="'absolute'"
              [style.bottom.px]="'10'"


### PR DESCRIPTION
## Description
We are gonna start deprecating our typography and using the material one, so for this we are changing to it in our docs site.

Also fixed a few issues with the old one, since our component were still depending on a few classes from it.

### What's included?
- chore(): migrate to material typography
- fix(): remove md-caption from dynamic-forms
- fix(): add typography for navigation drawer

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [x] `npm run serve`
- [x] Go to getcovalent.com
- [x] Compare sites

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
