### PR TITLE
fix(message): remove second host animation since it makes ngIf duplicate the component

### DIFF
--- a/src/platform/core/message/message.component.ts
+++ b/src/platform/core/message/message.component.ts
@@ -17,7 +17,6 @@ export class TdMessageContainerDirective {
   styleUrls: ['./message.component.scss'],
   animations: [
     TdCollapseAnimation({ duration: 100 }),
-    TdFadeInOutAnimation({ duration: 100 }),
   ],
 })
 export class TdMessageComponent implements AfterViewInit {
@@ -30,14 +29,6 @@ export class TdMessageComponent implements AfterViewInit {
 
   @ViewChild(TdMessageContainerDirective) _childElement: TdMessageContainerDirective;
   @ViewChild(TemplateRef) _template: TemplateRef<any>;
-
-  /**
-   * Binding host to tdFadeInOut animation
-   */
-  @HostBinding('@tdFadeInOut')
-  get fadeAnimation(): boolean {
-    return this._opened;
-  }
 
   /**
    * Binding host to tdCollapse animation


### PR DESCRIPTION
for some reason having 2 host animations on a component combined with ngIf makes the component stay when setting the ngIf input as false, and because of that when setting it back to true it adds it again

#### General Tests for Every PR

- [x] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

closes #981