### PR TITLE
Copy array on data table sort

### DIFF
--- a/src/platform/core/data-table/services/data-table.service.ts
+++ b/src/platform/core/data-table/services/data-table.service.ts
@@ -41,6 +41,7 @@ export class TdDataTableService {
    */
   sortData(data: any[], sortBy: string, sortOrder: TdDataTableSortingOrder = TdDataTableSortingOrder.Ascending): any[] {
     if (sortBy) {
+      data = Array.from(data); // Change the array reference to trigger OnPush and not mutate original array
       data.sort((a: any, b: any) => {
         let compA: any = a[sortBy];
         let compB: any = b[sortBy];
@@ -56,7 +57,6 @@ export class TdDataTableService {
         }
         return direction * (sortOrder === TdDataTableSortingOrder.Descending ? -1 : 1);
       });
-      data = Array.from(data); // Change the array reference to trigger OnPush
     }
     return data;
   }

--- a/src/platform/core/data-table/services/data-table.service.ts
+++ b/src/platform/core/data-table/services/data-table.service.ts
@@ -56,6 +56,7 @@ export class TdDataTableService {
         }
         return direction * (sortOrder === TdDataTableSortingOrder.Descending ? -1 : 1);
       });
+      data = Array.from(data); // Change the array reference to trigger OnPush
     }
     return data;
   }


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Copy the sorted array to ensure that `OnPush` change detection is triggered when sorting data table. This also prevents the original array from being mutated.

### What's included?
<!-- List features included in this PR -->
- Add an array copy to the `TdDataTableService.sortData()` method

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] apply sorting to a data table which does not apply filtering or pagination

_full disclosure: I have not manually tested this yet_

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
[Example of broken sorting based on docs demo](http://plnkr.co/edit/K4BL9BP7kjGUIXI3hwiI?p=preview)

This PR was prompted by a [gitter question](https://gitter.im/Teradata/covalent?at=5a2029b6540c78242d69c1cb)

