### PR TITLE
feat(data-table): add index to row select and row click outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "d3": "^4.4.0",
     "hammerjs": "^2.0.8",
     "highlight.js": "9.11.0",
-    "rxjs": "^5.5.2",
+    "rxjs": "5.5.2",
     "showdown": "1.6.4",
     "tslib": "^1.7.1",
     "web-animations-js": "2.3.1",

--- a/src/platform/core/data-table/data-table.component.html
+++ b/src/platform/core/data-table/data-table.component.html
@@ -44,7 +44,7 @@
         [tabIndex]="selectable ? 0 : -1"
         [selected]="(clickable || selectable) && isRowSelected(row)"
         *ngFor="let row of virtualData; let rowIndex = index"
-        (click)="handleRowClick(row, $event)"
+        (click)="handleRowClick(row, fromRow + rowIndex, $event)"
         (keyup)="selectable && _rowKeyup($event, row, rowIndex)"
         (keydown.space)="blockEvent($event)"
         (keydown.shift.space)="blockEvent($event)"

--- a/src/platform/core/data-table/data-table.component.spec.ts
+++ b/src/platform/core/data-table/data-table.component.spec.ts
@@ -361,6 +361,7 @@ describe('Component: DataTable', () => {
           fixture.debugElement.queryAll(By.directive(TdDataTableRowComponent))[1].nativeElement.click();
           fixture.detectChanges();
           fixture.whenStable().then(() => {
+            expect(clickEventSpy.calls.argsFor(0)[0].index).toBe(1);
             expect(clickEventSpy.calls.count()).toBe(1);
             expect(selectEventSpy.calls.count()).toBe(0);
 
@@ -369,6 +370,7 @@ describe('Component: DataTable', () => {
               fixture.debugElement.queryAll(By.directive(MatPseudoCheckbox))[0].nativeElement.click();
               fixture.detectChanges();
               fixture.whenStable().then(() => {
+                expect(selectEventSpy.calls.argsFor(0)[0].index).toBe(0);
                 expect(clickEventSpy.calls.count()).toBe(1);
                 expect(selectEventSpy.calls.count()).toBe(1);
               });
@@ -492,8 +494,8 @@ class TdDataTableRowClickTestComponent {
         [columns]="columns"
         [selectable]="selectable"
         [clickable]="clickable"
-        (rowClick)="clickEvent()"
-        (rowSelect)="selectEvent()">
+        (rowClick)="clickEvent($event)"
+        (rowSelect)="selectEvent($event)">
     </td-data-table>`,
 })
 class TdDataTableSelectableRowClickTestComponent {
@@ -508,10 +510,10 @@ class TdDataTableSelectableRowClickTestComponent {
   ];
   selectable: boolean = false;
   clickable: boolean = false;
-  clickEvent(): void {
+  clickEvent(event: any): void {
     /* noop */
   }
-  selectEvent(): void {
+  selectEvent(event: any): void {
     /* noop */
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6170,7 +6170,7 @@ rw@1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
 
-rxjs@^5.5.2:
+rxjs@5.5.2, rxjs@^5.5.2:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.2.tgz#28d403f0071121967f18ad665563255d54236ac3"
   dependencies:


### PR DESCRIPTION
## Description
`index` property is added to both `rowClick` and `rowSelect` output events.

#### General Tests for Every PR

- [ ] `ng serve --aot` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

closes #992