### PR TITLE
chore(): rename some of the aliases so they are more intuitive

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,6 @@
 - [ ] `npm run serve:prod` still works.
 - [ ] `npm run lint` passes.
 - [ ] `npm test` passes and code coverage is not lower.
-- [ ] `npm run build` still works.
+- [ ] `npm run build:release` still works.
 
 ##### Screenshots or link to StackBlitz/Plunker

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 after_script:
 - npm run coveralls
 after_success:
-- test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "develop" && npm run nightly-publish
+- test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "develop" && npm run publish:nightly
 notifications:
   slack:
     secure: pkXQL5AZiSBh1yWjilrcA7KbcJjC4xxjhd0SAwogJCQgyEf/i8/CfR1ZXiZYsIBJT6HTI7UMdJzwP6TiY/zih6Mq8PqUg38NUsvGyznILkbksMQJieWrg1r+1ideplPJFX7qdXwrOcxvSVoEFIGha26X0Fglq3kXSBHpPR9U0lDCoUxLUO35txQ/iji85Na4hjQnmtBEQkqaJogA0hRdcSLIKxwScgSrb4UU2PXEaIS9Zpr2SOG/RTOMkrrSMOD7bgocZbhAbk3c5shPZNj51gpEN+692Qxp4kQ/nfT10Hu5ATLaFCM5v04+w0D3ZJLA46LpU47qP0ALy6O9d16pGUcxJGbWaMZpV53vV9jIl9y2ahaqN1h1J9BcLIOzJvaQy92km8F7a3l7cN8gWSUZjs5Hd+gPFQH9Flcydmq26e8Maa1tQDF5R3GIdaCw4qkuJYbl4ToE59wtiPQ6M7xVKqNK4Qypu1YNsKOoLG/tZRFvp4771vgWcR5Lu/DqJJ9SAB0jsdrOXpe+0DmdrLBwhoZv2D9FTce+clDHIJ7ObPEc/UKw8rtWAA5iCPCEJ0sPl+WZwOS3ZFp4QmMC+5mzffMUiX6HBnzxiyOZvYGJD/jTy1yA1Cmt4RJYrOPM73csI1ELs5tj4tvqBNJQ8daIenfkg7u42IJfByDGIsJz8to=

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Covalent is a reusable UI platform from Teradata for building web applications w
 
 ## Setup
 
-* Ensure you have Node 6.11.1 or up and NPM 3+ installed.
-* Install Angular CLI `npm i -g @angular/cli@latest`
+* Ensure you have Node 6.12.0 or up and NPM 3+ installed.
+* Install Angular CLI `npm i -g @angular/cli`
 * Install Typescript `npm i -g typescript`
 * Install TSLint `npm install -g tslint`
 * Install Protractor for e2e testing `npm install -g protractor`
 * Install Node packages `npm i`
 * Update Webdriver `webdriver-manager update` and `./node_modules/.bin/webdriver-manager update`
-* Run local build `ng serve` or `ng serve --aot`
+* Run local build `npm run serve` or `npm run serve:prod`
 * If using yarn locally, `npm rebuild node-sass` is required for https://github.com/yarnpkg/yarn/issues/1981 as of `v0.22.0`
 ---
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,11 +14,11 @@
 2. Notifications need to be updated in the covalent `home` screen.
 3. Make sure the `platform` `package.json`s point to the correct versions.
 4. `ng serve --aot` works fine.
-5. `npm run build` works fine.
+5. `npm run build:release` works fine.
 
 #### Start Release
 
-Execute `npm run start-release -- [version]` to start the automatic release process. The steps executed are:
+Execute `npm run release:start -- [version]` to start the automatic release process. The steps executed are:
   1. Creating a `release/v[version]` branch using `git flow release`.
   2. Bumping its version to [version] release and commiting bumped version files.
   3. Publishing `release/v[version]` branch into repository. 
@@ -28,7 +28,7 @@ The release is published in case there is a need for any additional tests, versi
 
 #### Finish Release
 
-Execute `git flow release finish v[version]` and `npm run finish-release` to finish the release process. The steps executed are:
+Execute `git flow release finish v[version]` and `npm run release:finish` to finish the release process. The steps executed are:
   1. Finishes, tags and deletes the `release/[version]` branch.
   2. Pushes the new `[version]` tag into the repository.
   3. Merges release into `develop` and pushes changes to repository.
@@ -37,13 +37,13 @@ Execute `git flow release finish v[version]` and `npm run finish-release` to fin
 
 #### Publish Release
 
-Execute `npm run npm-publish` from develop branch to start the automatic publishing process. The steps executed are:
-  1. Executes `npm run build` process.
+Execute `npm run publish:npm` from develop branch to start the automatic publishing process. The steps executed are:
+  1. Executes `npm run build:release` process.
   2. Executes `bash scripts/npm-publish` process.
 
 #### Post Release Checklist
 
-1. Deploy to ghpages using `npm run ghpages-deploy`
+1. Deploy to ghpages using `npm run ghpages:deploy`
 2. Update release `plnkr` (and nightly release `plnkr` if needed)
 3. Update Covalent Quickstart (or Seed) with small commits to show step by step the upgrade process
 4. Update UPGRADE.md as necessary.

--- a/package.json
+++ b/package.json
@@ -9,13 +9,11 @@
     "reusable"
   ],
   "scripts": {
-    "e2e": "protractor",
-    "e2e-test": "protractor ./protractor.conf.js",
     "webdriver-update": "bash ./node_modules/.bin/webdriver-manager update",
     "lint": "tslint --format codeFrame -c ./tslint.json \"./src/**/*.ts\" -e \"./src/**/typings.d.ts\" -e \"./src/environments/**\"",
     "postinstall": "webdriver-manager update",
     "reinstall": "rm -rf node_modules tmp deploy dist && yarn install && npm rebuild node-sass",
-    "reinstall:latest": "rm -rf node_modules tmp deploy dist && npm install",  
+    "reinstall:latest": "rm -rf node_modules tmp deploy dist && npm install",
     "test": "ng test --code-coverage --single-run --sourcemap=false",
     "coverage:win": "start chrome ./coverage/index.html",
     "coverage:mac": "open -a \"Google Chrome\" coverage/index.html",
@@ -27,13 +25,15 @@
     "aot": "./node_modules/.bin/ngc -p deploy/platform/tsconfig-aot.json && tsc -p src/platform/tsconfig-aot.json",
     "serve": "node --max_old_space_size=5048 ./node_modules/@angular/cli/bin/ng serve",
     "serve:prod": "node --max_old_space_size=5048 ./node_modules/@angular/cli/bin/ng serve --aot --prod --sourcemap=false --build-optimizer",
-    "build": "bash scripts/build-release",
-    "npm-publish": "npm run build && bash scripts/npm-publish",
-    "nightly-publish": "npm run build && bash scripts/nightly-publish",
-    "ghpages-deploy": "node --max_old_space_size=5048 ./node_modules/@angular/cli/bin/ng build --base-href /covalent/ --aot --prod --sourcemap=false --build-optimizer && bash scripts/ghpages-deploy",
-    "start-release": "bash scripts/start-release",
-    "finish-release": "bash scripts/finish-release",
-    "combat-training": "bash scripts/combat-training"
+    "build:docs": "node --max_old_space_size=5048 ./node_modules/@angular/cli/bin/ng build --aot --prod --sourcemap=false --build-optimizer",
+    "build:release": "bash scripts/build-release",
+    "publish:npm": "npm run build:release && bash scripts/npm-publish",
+    "publish:nightly": "npm run build:release && bash scripts/nightly-publish",
+    "ghpages:deploy": "npm run build:docs -- --base-href /covalent/ && bash scripts/ghpages-deploy",
+    "release:start": "bash scripts/start-release",
+    "release:finish": "bash scripts/finish-release",
+    "combat-training": "bash scripts/combat-training",
+    "bundle-report": "npm run build:docs -- --stats-json && webpack-bundle-analyzer dist/stats.json"
   },
   "engines": {
     "node": ">=6.11.1 < 7",
@@ -134,6 +134,8 @@
     "ts-node": "^3.0.4",
     "tslint": "5.2.0",
     "typescript": "~2.4.2",
-    "uglify-js": "^2.8.14"
+    "uglify-js": "^2.8.14",
+    "webpack-bundle-analyzer": "^2.9.1",
+    "webpack-stats-plugin": "^0.1.5"
   }
 }

--- a/scripts/combat-training
+++ b/scripts/combat-training
@@ -9,7 +9,7 @@ cd $(git rev-parse --show-toplevel)
 # This is so we can interact with the latest changes we made locally to any Covalent components and see if any
 # new changes made are not compatiable with server side rendering.
 rm -rf ./node_modules/@covalent/core
-npm run build
+npm run build:release
 cp -r ./deploy/platform/core ./node_modules/@covalent/core
 
 # Compile the combat-training app to generate the ngfactories which are used for rendering our components on the

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,6 +286,10 @@ acorn@^5.0.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
 
+acorn@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
+
 adm-zip@0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.4.tgz#a61ed5ae6905c3aea58b3a657d25033091052736"
@@ -532,6 +536,10 @@ async-each@^1.0.0:
 async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
+
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
 async@^0.9.0:
   version "0.9.2"
@@ -2042,6 +2050,10 @@ duplexer2@0.0.2:
   dependencies:
     readable-stream "~1.1.9"
 
+duplexer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+
 duplexify@^3.1.2, duplexify@^3.2.0, duplexify@^3.4.2, duplexify@^3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.1.tgz#4e1516be68838bc90a49994f0b39a6e5960befcd"
@@ -2061,7 +2073,7 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-ejs@^2.5.7:
+ejs@^2.5.6, ejs@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
@@ -2420,6 +2432,41 @@ express@^4.13.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+express@^4.15.2:
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.16.2.tgz#e35c6dfe2d64b7dca0a5cd4f21781be3299e076c"
+  dependencies:
+    accepts "~1.3.4"
+    array-flatten "1.1.1"
+    body-parser "1.18.2"
+    content-disposition "0.5.2"
+    content-type "~1.0.4"
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.1"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "1.1.0"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.2"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.2"
+    qs "6.5.1"
+    range-parser "~1.2.0"
+    safe-buffer "5.1.1"
+    send "0.16.1"
+    serve-static "1.13.1"
+    setprototypeof "1.1.0"
+    statuses "~1.3.1"
+    type-is "~1.6.15"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
 extend-shallow@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-1.1.4.tgz#19d6bf94dfc09d76ba711f39b872d21ff4dd9071"
@@ -2523,6 +2570,10 @@ fileset@^2.0.2:
   dependencies:
     glob "^7.0.3"
     minimatch "^3.0.3"
+
+filesize@^3.5.9:
+  version "3.5.11"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
 
 fill-range@^2.1.0:
   version "2.2.3"
@@ -3140,6 +3191,12 @@ gulplog@^1.0.0:
   resolved "https://registry.yarnpkg.com/gulplog/-/gulplog-1.0.0.tgz#e28c4d45d05ecbbed818363ce8f9c5926229ffe5"
   dependencies:
     glogg "^1.0.0"
+
+gzip-size@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
+  dependencies:
+    duplexer "^0.1.1"
 
 hammerjs@^2.0.8:
   version "2.0.8"
@@ -4935,6 +4992,10 @@ once@~1.3.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
   dependencies:
     wrappy "1"
+
+opener@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
 
 opn@^5.1.0, opn@~5.1.0:
   version "5.1.0"
@@ -7052,6 +7113,10 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
+ultron@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+
 unc-path-regex@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
@@ -7333,6 +7398,22 @@ webdriver-manager@^12.0.6:
     semver "^5.3.0"
     xml2js "^0.4.17"
 
+webpack-bundle-analyzer@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.9.1.tgz#c2c8e03e8e5768ed288b39ae9e27a8b8d7b9d476"
+  dependencies:
+    acorn "^5.1.1"
+    chalk "^1.1.3"
+    commander "^2.9.0"
+    ejs "^2.5.6"
+    express "^4.15.2"
+    filesize "^3.5.9"
+    gzip-size "^3.0.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    opener "^1.4.3"
+    ws "^3.3.1"
+
 webpack-concat-plugin@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/webpack-concat-plugin/-/webpack-concat-plugin-1.4.2.tgz#b60bbb626ce5001911809d6e2329fa32f4978a88"
@@ -7408,6 +7489,10 @@ webpack-sources@^1.0.1:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.5.3"
+
+webpack-stats-plugin@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/webpack-stats-plugin/-/webpack-stats-plugin-0.1.5.tgz#29e5f12ebfd53158d31d656a113ac1f7b86179d9"
 
 webpack-subresource-integrity@^1.0.1:
   version "1.0.1"
@@ -7530,6 +7615,14 @@ ws@^1.0.1:
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
+
+ws@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.2.tgz#96c1d08b3fefda1d5c1e33700d3bfaa9be2d5608"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
 
 wtf-8@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### What's included?
<!-- List features included in this PR -->
- Renamed a few aliases so they are grouped better.
- Added alias `npm run bundle-report` to check the build sizes
- Updated docs with new aliases

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

##### Screenshots or link to StackBlitz/Plunker
