### PR TITLE
feat(): make LayoutToggle class reuse disable mixin

### DIFF
--- a/src/platform/core/layout/layout-toggle.class.ts
+++ b/src/platform/core/layout/layout-toggle.class.ts
@@ -2,6 +2,8 @@ import { Input, HostBinding, HostListener, Renderer2, ElementRef, AfterViewInit,
 
 import { MatSidenav } from '@angular/material/sidenav';
 
+import { ICanDisable, mixinDisabled } from '../common/common.module';
+
 import { Subscription } from 'rxjs/Subscription';
 
 export interface ILayoutTogglable {
@@ -12,17 +14,17 @@ export interface ILayoutTogglable {
   close(): Promise<void>;
 }
 
-export abstract class LayoutToggle implements AfterViewInit, OnDestroy {
+export class LayoutToggleBase { }
+
+/* tslint:disable-next-line */
+export const _TdLayoutToggleMixinBase = mixinDisabled(LayoutToggleBase);
+
+export abstract class LayoutToggle extends _TdLayoutToggleMixinBase implements AfterViewInit, OnDestroy, ICanDisable {
 
   private _toggleSubs: Subscription;
 
   private _initialized: boolean = false;
-  private _disabled: boolean = false;
   private _hideWhenOpened: boolean = false;
-
-  set disabled(disabled: boolean) {
-    this._disabled = disabled;
-  }
 
   /**
    * hideWhenOpened?: boolean
@@ -40,6 +42,7 @@ export abstract class LayoutToggle implements AfterViewInit, OnDestroy {
   constructor(protected _layout: ILayoutTogglable,
               private _renderer: Renderer2,
               private _elementRef: ElementRef) {
+    super();
     this._renderer.addClass(this._elementRef.nativeElement, 'td-layout-menu-button');
   }
 
@@ -66,7 +69,7 @@ export abstract class LayoutToggle implements AfterViewInit, OnDestroy {
   @HostListener('click', ['$event'])
   clickListener(event: Event): void {
     event.preventDefault();
-    if (!this._disabled) {
+    if (!this.disabled) {
       this.onClick();
     }
   }


### PR DESCRIPTION
## Description
Making we leverage the disable mixin everywhere we use a disable input.
#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] See layout button still work the same

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
