### PR TITLE
feat(chips): remove deprecated `readOnly` input

### DIFF
--- a/src/platform/core/chips/chips.component.ts
+++ b/src/platform/core/chips/chips.component.ts
@@ -148,16 +148,6 @@ export class TdChipsComponent extends _TdChipsMixinBase implements ControlValueA
   }
 
   /**
-   * @deprecated 1.0.0@beta.6
-   * readOnly?: boolean
-   * Disables the chips input and chip removal icon.
-   */
-  @Input('readOnly')
-  set readOnly(readOnly: boolean) {
-    this.disabled = readOnly;
-  }
-
-  /**
    * chipAddition?: boolean
    * Disables the ability to add chips. When setting disabled as true, this will be overriden.
    * Defaults to true.


### PR DESCRIPTION
## Description
This input was deprecated in beta.6, so we are just removing it from the codebase.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.