### PR TITLE
feat(file): remove deprecated `files` variable

### DIFF
--- a/src/app/components/components/file-upload/file-upload.component.html
+++ b/src/app/components/components/file-upload/file-upload.component.html
@@ -89,7 +89,7 @@
         <td-file-upload #fileMultipleUpload (select)="selectMultipleEvent($event)" (upload)="uploadMultipleEvent($event)" (cancel)="cancelMultipleEvent()"
                         accept=".sql" defaultColor="accent" activeColor="warn" cancelColor="primary" multiple [disabled]="disabled">
           <mat-icon>file_upload</mat-icon>
-          <span>{{ fileMultipleUpload.files?.name || fileMultipleUpload.files?.length }} <span *ngIf="fileMultipleUpload.files?.length">files selected</span></span>
+          <span>{{ fileMultipleUpload.value?.name || fileMultipleUpload.value?.length }} <span *ngIf="fileMultipleUpload.value?.length">files selected</span></span>
           <ng-template td-file-input-label>
             <mat-icon>attach_file</mat-icon>
             <span>
@@ -115,7 +115,7 @@
                             accept=".sql" defaultColor="accent" activeColor="warn" cancelColor="primary" multiple [disabled]="disabled">
               <mat-icon>file_upload</mat-icon>
               <span>
-                { { fileMultipleUpload.files?.name || fileMultipleUpload.files?.length } } <span *ngIf="fileMultipleUpload.files?.length">files selected</span>
+                { { fileMultipleUpload.value?.name || fileMultipleUpload.value?.length } } <span *ngIf="fileMultipleUpload.value?.length">files selected</span>
               </span>
               <ng-template td-file-input-label>
                 <mat-icon>attach_file</mat-icon>

--- a/src/platform/core/file/file-upload/README.md
+++ b/src/platform/core/file/file-upload/README.md
@@ -9,7 +9,7 @@ Example for usage:
 ```html
 <td-file-upload #fileUpload [(ngModel)]="files" defaultColor="accent" activeColor="warn" cancelColor="primary" (select)="selectEvent($event)"
   (upload)="uploadEvent($event)" (cancel)="cancelEvent()" accept=".ext,.anotherExt" [disabled]="disabled" multiple>
-  <mat-icon>file_upload</mat-icon><span>{{ fileUpload.files?.name }}</span>
+  <mat-icon>file_upload</mat-icon><span>{{ files?.name }}</span>
   <ng-template td-file-input-label>
     <mat-icon>attach_file</mat-icon>
     <span>

--- a/src/platform/core/file/file-upload/file-upload.component.spec.ts
+++ b/src/platform/core/file/file-upload/file-upload.component.spec.ts
@@ -53,7 +53,7 @@ describe('Component: FileUpload', () => {
           fixture.whenStable().then(() => {
             expect(fixture.debugElement.query(By.css('td-file-input'))).toBeTruthy();
             expect(fixture.debugElement.query(By.css('.td-file-upload'))).toBeFalsy();
-            expect(fixture.debugElement.query(By.directive(TdFileUploadComponent)).componentInstance.files)
+            expect(fixture.debugElement.query(By.directive(TdFileUploadComponent)).componentInstance.value)
             .toBeUndefined();
           });
         });
@@ -81,7 +81,7 @@ describe('Component: FileUpload', () => {
           fixture.whenStable().then(() => {
             expect(fixture.debugElement.query(By.css('td-file-input'))).toBeTruthy();
             expect(fixture.debugElement.query(By.css('.td-file-upload'))).toBeFalsy();
-            expect(fixture.debugElement.query(By.directive(TdFileUploadComponent)).componentInstance.files).toBeUndefined();
+            expect(fixture.debugElement.query(By.directive(TdFileUploadComponent)).componentInstance.value).toBeUndefined();
           });
         });
       });
@@ -196,7 +196,7 @@ describe('Component: FileUpload', () => {
   template: `
   <td-file-upload #fileUpload [multiple]="multiple" [disabled]="disabled" (select)="selectEvent($event)"
                   (upload)="uploadEvent($event)" (cancel)="cancelEvent()">
-    <span>{{ fileUpload.files?.name }}</span>
+    <span>{{ fileUpload.value?.name }}</span>
     <ng-template td-file-input-label>
       <span>Choose a file...</span>
     </ng-template>

--- a/src/platform/core/file/file-upload/file-upload.component.ts
+++ b/src/platform/core/file/file-upload/file-upload.component.ts
@@ -48,13 +48,6 @@ export class TdFileUploadComponent extends _TdFileUploadMixinBase implements Con
   private _multiple: boolean = false;
   private _required: boolean = false;
 
-  /**
-   * @deprecated use value property instead
-   */
-  get files(): FileList | File {
-    return this.value;
-  }
-
   @ViewChild(TdFileInputComponent) fileInput: TdFileInputComponent;
 
   @ContentChild(TdFileInputLabelDirective) inputLabel: TdFileInputLabelDirective;


### PR DESCRIPTION
## Description
This property was deprecated in beta.6, so we are just removing it from the codebase.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.
