### PR TITLE
fix(docs): close sidenav properly when clicking on it in any scenario

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,11 +1,10 @@
 <td-layout #layout
             [class]="activeTheme"
-            [dir]="dir"
-            [sidenavWidth]="(media.registerQuery('gt-md') | async) ? '257px' : '320px'">
+            [dir]="dir">
   <td-navigation-drawer sidenavTitle="Covalent" logo="assets:teradata" navigationRoute="/" flex color="primary">
     <mat-nav-list flex>
       <a mat-list-item
-          (click)="!media.query('gt-md') && layout.close()"
+          tdLayoutClose
           [routerLink]="['/']"
           [routerLinkActive]="['active']"
           [routerLinkActiveOptions]="{exact:true}">
@@ -14,7 +13,7 @@
       </a>
       <a *ngFor="let item of routes" 
           mat-list-item
-          (click)="!media.query('gt-md') && layout.close()"
+           tdLayoutClose
           [routerLink]="[item.route]"
           [routerLinkActive]="['active']">
           <mat-icon matListIcon>{{item.icon}}</mat-icon>


### PR DESCRIPTION
## Description
We forgot to remove the `media` service checkup to see when to close the main sidenav.. because of that it looked like it didnt work. This PR makes sure the main sidenav closes in any case.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Open main sidenav and click on items

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.
