### PR TITLE
feat(paging): support OnPush change detection strat

### DIFF
--- a/src/app/components/components/paging/paging.component.ts
+++ b/src/app/components/components/paging/paging.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, ChangeDetectorRef } from '@angular/core';
+import { Component, HostBinding, ChangeDetectorRef, ChangeDetectionStrategy } from '@angular/core';
 import { TdMediaService } from '../../../../platform/core';
 
 import { slideInDownAnimation } from '../../../app.animations';
@@ -6,6 +6,7 @@ import { slideInDownAnimation } from '../../../app.animations';
 import { IPageChangeEvent } from '../../../../platform/core';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'paging-demo',
   styleUrls: ['./paging.component.scss'],
   templateUrl: './paging.component.html',

--- a/src/platform/core/paging/paging-bar.component.ts
+++ b/src/platform/core/paging/paging-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnInit, Optional } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, Optional, ChangeDetectorRef, ChangeDetectionStrategy } from '@angular/core';
 import { coerceNumberProperty } from '@angular/cdk/coercion';
 import { Dir } from '@angular/cdk/bidi';
 
@@ -12,6 +12,7 @@ export interface IPageChangeEvent {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'td-paging-bar',
   templateUrl: './paging-bar.component.html',
   styleUrls: ['./paging-bar.component.scss' ],
@@ -51,6 +52,7 @@ export class TdPagingBarComponent implements OnInit {
   set pageLinkCount(pageLinkCount: number) {
     this._pageLinkCount = coerceNumberProperty(pageLinkCount);
     this._calculatePageLinks();
+    this._changeDetectorRef.markForCheck();
   }
   get pageLinkCount(): number {
     return this._pageLinkCount;
@@ -67,6 +69,7 @@ export class TdPagingBarComponent implements OnInit {
     if (this._initialized) {
       this._handleOnChange();
     }
+    this._changeDetectorRef.markForCheck();
   }
   get pageSize(): number {
     return this._pageSize;
@@ -81,6 +84,7 @@ export class TdPagingBarComponent implements OnInit {
     this._total = coerceNumberProperty(total);
     this._calculateRows();
     this._calculatePageLinks();
+    this._changeDetectorRef.markForCheck();
   }
   get total(): number {
     return this._total;
@@ -132,13 +136,15 @@ export class TdPagingBarComponent implements OnInit {
     return false;
   }
 
-  constructor(@Optional() private _dir: Dir) {}
+  constructor(@Optional() private _dir: Dir,
+              private _changeDetectorRef: ChangeDetectorRef) {}
 
   ngOnInit(): void {
     this._page = coerceNumberProperty(this.initialPage);
     this._calculateRows();
     this._calculatePageLinks();
     this._initialized = true;
+    this._changeDetectorRef.markForCheck();
   }
 
   /**
@@ -256,6 +262,7 @@ export class TdPagingBarComponent implements OnInit {
       fromRow: this._fromRow,
       toRow: this._toRow,
     };
+    this._changeDetectorRef.markForCheck();
     this.onChange.emit(event);
   }
 


### PR DESCRIPTION
## Description
Making sure `td-paging-bar` works on OnPush change detection strat.

#### Test Steps
- [ ] `npm run serve`
- [ ] Go to paging demo
- [ ] See it working on OnPush

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

Part of https://github.com/Teradata/covalent/issues/325
