### PR TITLE
feat(search): support OnPush change detection strat

### DIFF
--- a/src/app/components/components/search/search.component.ts
+++ b/src/app/components/components/search/search.component.ts
@@ -1,8 +1,9 @@
-import { Component, HostBinding } from '@angular/core';
+import { Component, HostBinding, ChangeDetectionStrategy } from '@angular/core';
 
 import { slideInDownAnimation } from '../../../app.animations';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'search-demo',
   styleUrls: ['./search.component.scss'],
   templateUrl: './search.component.html',

--- a/src/platform/core/search/search-box/search-box.component.ts
+++ b/src/platform/core/search/search-box/search-box.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, Input, Output, EventEmitter } from '@angular/core';
+import { Component, ViewChild, Input, Output, EventEmitter, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { trigger, state, style, transition, animate, AUTO_STYLE } from '@angular/animations';
 
 import { TdSearchInputComponent } from '../search-input/search-input.component';
@@ -7,6 +7,7 @@ import { TdSearchInputComponent } from '../search-input/search-input.component';
   selector: 'td-search-box',
   templateUrl: './search-box.component.html',
   styleUrls: ['./search-box.component.scss' ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [
     trigger('inputState', [
       state('0', style({
@@ -29,6 +30,7 @@ export class TdSearchBoxComponent {
 
   set value(value: any) {
     this._searchInput.value = value;
+    this._changeDetectorRef.markForCheck();
   }
   get value(): any {
     return this._searchInput.value;
@@ -101,6 +103,8 @@ export class TdSearchBoxComponent {
    */
   @Output('clear') onClear: EventEmitter<void> = new EventEmitter<void>();
 
+  constructor(private _changeDetectorRef: ChangeDetectorRef) {}
+
   /**
    * Method executed when the search icon is clicked.
    */
@@ -113,6 +117,7 @@ export class TdSearchBoxComponent {
 
   toggleVisibility(): void {
     this._searchVisible = !this._searchVisible;
+    this._changeDetectorRef.markForCheck();
   }
 
   handleSearchDebounce(value: string): void {

--- a/src/platform/core/search/search-input/search-input.component.ts
+++ b/src/platform/core/search/search-input/search-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, OnInit, Input, Output, EventEmitter, Optional } from '@angular/core';
+import { Component, ViewChild, OnInit, Input, Output, EventEmitter, Optional, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { trigger, state, style, transition, animate } from '@angular/animations';
 import { FormControl } from '@angular/forms';
 import { Dir } from '@angular/cdk/bidi';
@@ -11,6 +11,7 @@ import { skip } from 'rxjs/operators/skip';
   selector: 'td-search-input',
   templateUrl: './search-input.component.html',
   styleUrls: ['./search-input.component.scss' ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [
     trigger('searchState', [
       state('hide-left', style({
@@ -92,7 +93,8 @@ export class TdSearchInputComponent implements OnInit {
     return false;
   }
 
-  constructor(@Optional() private _dir: Dir) {
+  constructor(@Optional() private _dir: Dir,
+              private _changeDetectorRef: ChangeDetectorRef) {
   }
 
   ngOnInit(): void {
@@ -126,6 +128,7 @@ export class TdSearchInputComponent implements OnInit {
 
   clearSearch(): void {
     this.value = '';
+    this._changeDetectorRef.markForCheck();
     this.onClear.emit(undefined);
   }
 


### PR DESCRIPTION
## Description
Making sure `td-search-box` and `td-search-input` work on OnPush change detection strat.

#### Test Steps
- [ ] `npm run serve`
- [ ] Go to search demo
- [ ] See it working on OnPush

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run lint` passes.