### PR TITLE
feat(json-formatter): support properly RTL

### DIFF
--- a/src/platform/core/json-formatter/json-formatter.component.html
+++ b/src/platform/core/json-formatter/json-formatter.component.html
@@ -9,8 +9,8 @@
     <span *ngIf="key" class="key">{{key}}:</span>
     <span class="value">
       <span [class.td-empty]="!hasChildren()" *ngIf="isObject()" [matTooltip]="getPreview()" matTooltipPosition="after">
-        <span>{{getObjectName()}}</span>
-        <span *ngIf="isArray()">[{{data.length}}]</span>
+        <span class="td-object-name">{{getObjectName()}}</span>
+        <span class="td-array-length" *ngIf="isArray()">[{{data.length}}]</span>
       </span>
       <span *ngIf="!isObject()" [class]="getType(data)">{{getValue(data)}}</span>
     </span>

--- a/src/platform/core/json-formatter/json-formatter.component.scss
+++ b/src/platform/core/json-formatter/json-formatter.component.scss
@@ -1,5 +1,11 @@
 :host {
   display: block;
+  .function:after,
+  .date:after,
+  .td-object-name:after,
+  .td-array-length:after {
+    content: "\200E‎";
+  }
 }
 .td-json-formatter-wrapper {
   padding-top: 2px;


### PR DESCRIPTION
## Description
Show functions, dates and array lengths properly in RTL when using the `json-formatter` component,

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to json-formatter demo
- [ ] Compare with getcovalent.com

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

Part of https://github.com/Teradata/covalent/issues/323