### PR TITLE
feat(search): add ngModel support to search-input and search-box

### DIFF
--- a/src/app/components/components/search/search.component.html
+++ b/src/app/components/components/search/search.component.html
@@ -64,7 +64,7 @@
     <p>HTML:</p>
     <td-highlight lang="html">
       <![CDATA[
-        <td-search-input placeholder="Search here" [showUnderline]="false|true" [debounce]="500" (searchDebounce)="searchInputTerm = $event" (search)="searchInputTerm = $event" (clear)="searchInputTerm = ''">
+        <td-search-input placeholder="Search here" [(ngModel)]="searchInputTerm" [showUnderline]="false|true" [debounce]="500" (searchDebounce)="searchInputTerm = $event" (search)="searchInputTerm = $event" (clear)="searchInputTerm = ''">
         </td-search-input>
       ]]>
     </td-highlight>
@@ -107,7 +107,7 @@
     <p>HTML:</p>
     <td-highlight lang="html">
       <![CDATA[
-        <td-search-box backIcon="arrow_back" placeholder="Search here" [showUnderline]="false|true" [debounce]="500" [alwaysVisible]="false|true" (searchDebounce)="searchInputTerm = $event" (search)="searchInputTerm = $event" (clear)="searchInputTerm = ''">
+        <td-search-box backIcon="arrow_back" placeholder="Search here" [(ngModel)]="searchInputTerm" [showUnderline]="false|true" [debounce]="500" [alwaysVisible]="false|true" (searchDebounce)="searchInputTerm = $event" (search)="searchInputTerm = $event" (clear)="searchInputTerm = ''">
         </td-search-box>
       ]]>
     </td-highlight>

--- a/src/platform/core/search/search-box/search-box.component.html
+++ b/src/platform/core/search/search-box/search-box.component.html
@@ -6,6 +6,7 @@
   <td-search-input #searchInput
                    [@inputState]="alwaysVisible || searchVisible"
                    [debounce]="debounce"
+                   [(ngModel)]="value"
                    [showUnderline]="showUnderline"
                    [placeholder]="placeholder"
                    [clearIcon]="clearIcon"

--- a/src/platform/core/search/search-box/search-box.component.spec.ts
+++ b/src/platform/core/search/search-box/search-box.component.spec.ts
@@ -1,0 +1,67 @@
+import {
+  TestBed,
+  inject,
+  async,
+  ComponentFixture,
+} from '@angular/core/testing';
+import 'hammerjs';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { TdSearchInputComponent } from '../search-input/search-input.component';
+import { CovalentSearchModule } from '../search.module';
+import { NgModule, DebugElement } from '@angular/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Component: SearchBox', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule,
+        FormsModule,
+        CovalentSearchModule,
+      ],
+      declarations: [
+        TestNgModelSupportComponent,
+      ],
+    });
+    TestBed.compileComponents();
+  }));
+
+  it('should leverage ngModel to set a value', (done: DoneFn) => {
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TestNgModelSupportComponent);
+    let component: TestNgModelSupportComponent = fixture.debugElement.componentInstance;
+    let inputComponent: DebugElement = fixture.debugElement.query(By.directive(TdSearchInputComponent));
+
+    expect(inputComponent).toBeTruthy();
+
+    component.value = 'test';
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(inputComponent.componentInstance.value).toBe('test');
+
+        component.value = 'another_test';
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(inputComponent.componentInstance.value).toBe('another_test');
+            done();
+          });
+        });
+      });
+    });
+  });
+});
+
+@Component({
+  template: `
+    <td-search-box [(ngModel)]="value">
+    </td-search-box>`,
+})
+class TestNgModelSupportComponent {
+  value: string;
+}

--- a/src/platform/core/search/search-box/search-box.component.ts
+++ b/src/platform/core/search/search-box/search-box.component.ts
@@ -1,13 +1,28 @@
-import { Component, ViewChild, Input, Output, EventEmitter, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, ViewChild, Input, Output, EventEmitter, ChangeDetectionStrategy, ChangeDetectorRef, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { trigger, state, style, transition, animate, AUTO_STYLE } from '@angular/animations';
 
 import { TdSearchInputComponent } from '../search-input/search-input.component';
+import { IControlValueAccessor, mixinControlValueAccessor } from '../../common/common.module';
+
+export class TdSearchBoxBase {
+  constructor(public _changeDetectorRef: ChangeDetectorRef) { }
+}
+
+/* tslint:disable-next-line */
+export const _TdSearchBoxMixinBase = mixinControlValueAccessor(TdSearchBoxBase);
 
 @Component({
+  providers: [{
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => TdSearchBoxComponent),
+    multi: true,
+  }],
   selector: 'td-search-box',
   templateUrl: './search-box.component.html',
   styleUrls: ['./search-box.component.scss' ],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  inputs: ['value'],
   animations: [
     trigger('inputState', [
       state('0', style({
@@ -23,18 +38,10 @@ import { TdSearchInputComponent } from '../search-input/search-input.component';
     ]),
   ],
 })
-export class TdSearchBoxComponent {
+export class TdSearchBoxComponent extends _TdSearchBoxMixinBase implements IControlValueAccessor {
 
   private _searchVisible: boolean = false;
   @ViewChild(TdSearchInputComponent) _searchInput: TdSearchInputComponent;
-
-  set value(value: any) {
-    this._searchInput.value = value;
-    this._changeDetectorRef.markForCheck();
-  }
-  get value(): any {
-    return this._searchInput.value;
-  }
 
   get searchVisible(): boolean {
     return this._searchVisible;
@@ -103,7 +110,9 @@ export class TdSearchBoxComponent {
    */
   @Output('clear') onClear: EventEmitter<void> = new EventEmitter<void>();
 
-  constructor(private _changeDetectorRef: ChangeDetectorRef) {}
+  constructor(_changeDetectorRef: ChangeDetectorRef) {
+    super(_changeDetectorRef);
+  }
 
   /**
    * Method executed when the search icon is clicked.

--- a/src/platform/core/search/search-input/search-input.component.spec.ts
+++ b/src/platform/core/search/search-input/search-input.component.spec.ts
@@ -1,0 +1,68 @@
+import {
+  TestBed,
+  inject,
+  async,
+  ComponentFixture,
+} from '@angular/core/testing';
+import 'hammerjs';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { TdSearchInputComponent } from './search-input.component';
+import { CovalentSearchModule } from '../search.module';
+import { NgModule, DebugElement } from '@angular/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Component: SearchInput', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule,
+        FormsModule,
+        CovalentSearchModule,
+      ],
+      declarations: [
+        TestNgModelSupportComponent,
+      ],
+    });
+    TestBed.compileComponents();
+  }));
+
+  it('should leverage ngModel to set a value', (done: DoneFn) => {
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TestNgModelSupportComponent);
+    let component: TestNgModelSupportComponent = fixture.debugElement.componentInstance;
+    let inputElement: DebugElement = fixture.debugElement.query(By.css('input'));
+
+    expect(inputElement.nativeElement).toBeTruthy();
+
+    component.value = 'test';
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(inputElement.nativeElement.value).toBe('test');
+
+        component.value = 'another_test';
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(inputElement.nativeElement.value).toBe('another_test');
+            done();
+          });
+        });
+      });
+    });
+    
+  });
+});
+
+@Component({
+  template: `
+    <td-search-input [(ngModel)]="value">
+    </td-search-input>`,
+})
+class TestNgModelSupportComponent {
+  value: string;
+}

--- a/src/platform/core/search/search-input/search-input.component.ts
+++ b/src/platform/core/search/search-input/search-input.component.ts
@@ -1,17 +1,33 @@
-import { Component, ViewChild, OnInit, Input, Output, EventEmitter, Optional, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, ViewChild, OnInit, Input, Output, EventEmitter, Optional,
+         ChangeDetectionStrategy, ChangeDetectorRef, forwardRef } from '@angular/core';
 import { trigger, state, style, transition, animate } from '@angular/animations';
-import { FormControl } from '@angular/forms';
+import { FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Dir } from '@angular/cdk/bidi';
 import { MatInput } from '@angular/material/input';
 
 import { debounceTime } from 'rxjs/operators/debounceTime';
 import { skip } from 'rxjs/operators/skip';
 
+import { IControlValueAccessor, mixinControlValueAccessor } from '../../common/common.module';
+
+export class TdSearchInputBase {
+  constructor(public _changeDetectorRef: ChangeDetectorRef) { }
+}
+
+/* tslint:disable-next-line */
+export const _TdSearchInputMixinBase = mixinControlValueAccessor(TdSearchInputBase);
+
 @Component({
+  providers: [{
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => TdSearchInputComponent),
+    multi: true,
+  }],
   selector: 'td-search-input',
   templateUrl: './search-input.component.html',
   styleUrls: ['./search-input.component.scss' ],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  inputs: ['value'],
   animations: [
     trigger('searchState', [
       state('hide-left', style({
@@ -31,11 +47,9 @@ import { skip } from 'rxjs/operators/skip';
     ]),
   ],
 })
-export class TdSearchInputComponent implements OnInit {
+export class TdSearchInputComponent extends _TdSearchInputMixinBase implements IControlValueAccessor, OnInit {
 
   @ViewChild(MatInput) _input: MatInput;
-
-  value: string;
 
   /**
    * showUnderline?: boolean
@@ -94,7 +108,8 @@ export class TdSearchInputComponent implements OnInit {
   }
 
   constructor(@Optional() private _dir: Dir,
-              private _changeDetectorRef: ChangeDetectorRef) {
+              _changeDetectorRef: ChangeDetectorRef) {
+    super(_changeDetectorRef);
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
## Description
This leverages the mixin for controlValueAccessor for both the `td-search-input` and `td-search-box`

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to search demo and try using ngModel

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

closes https://github.com/Teradata/covalent/issues/995
