### PR TITLE
Missing closing tags on example code on notifications page #759

### DIFF
--- a/src/platform/core/notifications/README.md
+++ b/src/platform/core/notifications/README.md
@@ -35,7 +35,7 @@ Example for HTML count usage:
 
 ```html
 <td-notification-count positionX="after" positionY="top" [notifications]="1">
-  <mat-icon>notifications<mat-icon>
+  <mat-icon>notifications</mat-icon>
 </td-notification-count>
 ```
 
@@ -43,7 +43,7 @@ Example for HTML count usage:
 
 ```html
 <td-notification-count positionX="after" positionY="top" [notifications]="true">
-  <mat-icon>notifications<mat-icon>
+  <mat-icon>notifications</mat-icon>
 </td-notification-count>
 ```
 


### PR DESCRIPTION
Added missing closing tags for mat-icon tag.

## Description
Updated closing tags for mat-icon in README.md file.

### What's included?
- Closing tags were missing. Updated in README.md file.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [x] `npm run serve`
- [x] Go to notifications component
- [x] Scroll down to end of page.
- [x] In usage example, mat-icon tag should be closed.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

##### Screenshots or link to StackBlitz/Plunker
