### PR TITLE
feat(dynamic-forms): add datepicker support (closes #584)

### DIFF
--- a/src/app/components/components/components.module.ts
+++ b/src/app/components/components/components.module.ts
@@ -53,6 +53,8 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatRippleModule } from '@angular/material/core';
+import { MatNativeDateModule } from '@angular/material/core';
+import { MatDatepickerModule } from '@angular/material/datepicker';
 
 import { CovalentCommonModule, CovalentLayoutModule, CovalentMediaModule, CovalentExpansionPanelModule, CovalentFileModule,
          CovalentStepsModule, CovalentLoadingModule, CovalentDialogsModule, CovalentSearchModule, CovalentPagingModule,
@@ -121,6 +123,8 @@ import { ToolbarModule } from '../../components/toolbar/toolbar.module';
     MatAutocompleteModule,
     MatGridListModule,
     MatRippleModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
     /** Covalent Modules */
     CovalentCommonModule,
     CovalentLayoutModule,

--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.html
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.html
@@ -90,19 +90,29 @@
               </mat-form-field>
             </div>
             <div *ngIf="isMinMaxSupported(model.type)" layout="row">
-              <mat-form-field class="pad-right-xs" flex>
+              <mat-form-field *ngIf="!isDate(model.type)" class="pad-right-xs" flex>
+                <input matInput type="number" placeholder="Min" [(ngModel)]="model.min" name="min">
+              </mat-form-field>
+              <mat-form-field *ngIf="isDate(model.type)" class="pad-right-xs" flex>
                 <input matInput
-                      type="number"
+                      [matDatepicker]="minDatepicker"
                       placeholder="Min"
                       [(ngModel)]="model.min"
                       name="min">
+                <mat-datepicker-toggle matSuffix [for]="minDatepicker"></mat-datepicker-toggle>
+                <mat-datepicker #minDatepicker></mat-datepicker>
               </mat-form-field>
-              <mat-form-field flex="50">
+              <mat-form-field *ngIf="!isDate(model.type)" flex="50">
+                <input matInput type="number" placeholder="Max" [(ngModel)]="model.max" name="max">
+              </mat-form-field>
+              <mat-form-field *ngIf="isDate(model.type)" flex="50">
                 <input matInput
-                      type="number"
-                      placeholder="Max"
-                      [(ngModel)]="model.max"
-                      name="max">
+                       [matDatepicker]="maxDatepicker"
+                       placeholder="Max"
+                       [(ngModel)]="model.max"
+                       name="max">
+                <mat-datepicker-toggle matSuffix [for]="maxDatepicker"></mat-datepicker-toggle>
+                <mat-datepicker #maxDatepicker></mat-datepicker>
               </mat-form-field>
             </div>
             <div *ngIf="isMinMaxLengthSupported(model.type)" layout="row">
@@ -254,6 +264,35 @@
     </mat-tab-group>
   </mat-card-content>
 </mat-card>
+
+<mat-card>
+  <mat-card-content>
+    <h3 class="mat-title">Dynamic Datepicker Element</h3>
+    <mat-divider></mat-divider>
+    <mat-tab-group mat-stretch-tabs dynamicHeight>
+      <mat-tab>
+        <ng-template matTabLabel>Demo</ng-template>
+        <td-dynamic-forms [elements]="dateElements">
+        </td-dynamic-forms>
+      </mat-tab>
+      <mat-tab>
+        <ng-template matTabLabel>Code</ng-template>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-dynamic-forms [elements]="dateElements">
+            </td-dynamic-forms>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          {{dateElements | json}}
+        </td-highlight>
+      </mat-tab>
+    </mat-tab-group>
+  </mat-card-content>
+</mat-card>
+
 <mat-card>
   <mat-card-content>
     <h3 class="mat-title">Dynamic Array Elements</h3>

--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
@@ -115,6 +115,13 @@ export class DynamicFormsDemoComponent {
     type: TdDynamicElement.FileInput,
   }];
 
+  dateElements: ITdDynamicElementConfig[] = [{
+    name: 'date-input',
+    label: 'Select a date',
+    type: TdDynamicElement.Datepicker,
+    min: new Date(2018, 1, 1).setHours(0, 0, 0, 0),
+  }];
+
   dynamicElements: ITdDynamicElementConfig[] = [{
     name: 'element-0',
     type: TdDynamicType.Text,
@@ -131,6 +138,7 @@ export class DynamicFormsDemoComponent {
   elementOptions: any[] = [
     TdDynamicElement.Input,
     TdDynamicType.Number,
+    TdDynamicElement.Datepicker,
     TdDynamicElement.Password,
     TdDynamicElement.Textarea,
     TdDynamicElement.Slider,
@@ -203,7 +211,11 @@ export class DynamicFormsDemoComponent {
   }];
 
   isMinMaxSupported(type: TdDynamicElement | TdDynamicType): boolean {
-    return type === TdDynamicElement.Slider || type === TdDynamicType.Number;
+    return type === TdDynamicElement.Slider || type === TdDynamicType.Number || this.isDate(type);
+  }
+
+  isDate(type: TdDynamicElement | TdDynamicType): boolean {
+    return type === TdDynamicElement.Datepicker;
   }
 
   isMinMaxLengthSupported(type: TdDynamicElement | TdDynamicType): boolean {

--- a/src/platform/dynamic-forms/README.md
+++ b/src/platform/dynamic-forms/README.md
@@ -110,6 +110,12 @@ export class Demo {
     name: 'file-input',
     label: 'Label',
     type: TdDynamicElement.FileInput,
+  }, {
+    name: 'datepicker',
+    label: 'Date',
+    type: TdDynamicElement.Datepicker,
   }];
 }
 ```
+
+Note: To use the datepicker you need to provide an implementation of `DateAdapter`.. click [here] for more information on the material datepicker(https://material.angular.io/components/datepicker/overview#choosing-a-date-implementation-and-date-format-settings)

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.html
@@ -1,0 +1,15 @@
+<div class="td-dynamic-datepicker-wrapper">
+  <mat-form-field class="td-dynamic-datepicker-field">
+    <input #elementInput
+            matInput
+            [matDatepicker]="dynamicDatePicker"
+            [(ngModel)]="value"
+            [formControl]="control"
+            [placeholder]="label"
+            [required]="required"
+            [min]="min"
+            [max]="max"/>
+    <mat-datepicker-toggle matSuffix [for]="dynamicDatePicker"></mat-datepicker-toggle>
+    <mat-datepicker #dynamicDatePicker></mat-datepicker>
+  </mat-form-field>
+</div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.scss
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.scss
@@ -1,0 +1,12 @@
+.td-dynamic-datepicker-wrapper {
+  // [layout="row"]
+  flex-direction: row;
+  // [layout]
+  display: flex;
+  box-sizing: border-box;
+  .td-dynamic-datepicker-field {
+    // [flex]
+    flex: 1;
+    box-sizing: border-box;
+  }
+}

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.ts
@@ -1,0 +1,32 @@
+import { Component, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR, ControlValueAccessor, FormControl } from '@angular/forms';
+
+import { AbstractControlValueAccessor } from '../abstract-control-value-accesor';
+
+export const DATEPICKER_INPUT_CONTROL_VALUE_ACCESSOR: any = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => TdDynamicDatepickerComponent),
+  multi: true,
+};
+
+@Component({
+  providers: [DATEPICKER_INPUT_CONTROL_VALUE_ACCESSOR],
+  selector: 'td-dynamic-datepicker',
+  styleUrls: ['./dynamic-datepicker.component.scss'],
+  templateUrl: './dynamic-datepicker.component.html',
+})
+export class TdDynamicDatepickerComponent extends AbstractControlValueAccessor implements ControlValueAccessor {
+
+  control: FormControl;
+
+  label: string = '';
+
+  type: string = undefined;
+
+  required: boolean = undefined;
+
+  min: number = undefined;
+
+  max: number = undefined;
+
+}

--- a/src/platform/dynamic-forms/dynamic-forms.component.spec.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.component.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/core/testing';
 import 'hammerjs';
 import { Component } from '@angular/core';
+import { MatNativeDateModule } from '@angular/material/core';
 import { Validators, AbstractControl } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
@@ -18,6 +19,7 @@ describe('Component: TdDynamicForms', () => {
     TestBed.configureTestingModule({
       imports: [
         NoopAnimationsModule,
+        MatNativeDateModule,
         CovalentDynamicFormsModule,
       ],
       declarations: [
@@ -65,10 +67,13 @@ describe('Component: TdDynamicForms', () => {
       name: 'sex',
       type: TdDynamicType.Array,
       selections: ['M', 'F'],
+    }, {
+      name: 'dob',
+      type: TdDynamicElement.Datepicker,
     }];
     fixture.detectChanges();
     fixture.whenStable().then(() => {
-      expect(fixture.debugElement.queryAll(By.directive(TdDynamicElementComponent)).length).toBe(7);
+      expect(fixture.debugElement.queryAll(By.directive(TdDynamicElementComponent)).length).toBe(8);
     });
   })));
 
@@ -131,6 +136,7 @@ describe('Component: TdDynamicForms', () => {
     let component: TdDynamicFormsTestComponent = fixture.debugElement.componentInstance;
 
     expect(fixture.debugElement.queryAll(By.directive(TdDynamicElementComponent)).length).toBe(0);
+    let dob: Date = new Date();
     component.elements = [{
       name: 'first_name',
       type: TdDynamicType.Text,
@@ -142,15 +148,20 @@ describe('Component: TdDynamicForms', () => {
       default: 20,
       min: 18,
       max: 30,
+    }, {
+      name: 'dob',
+      type: TdDynamicType.Date,
+      default: dob,
+      required: true,
     }];
     fixture.detectChanges();
     fixture.whenStable().then(() => {
-      expect(fixture.debugElement.queryAll(By.directive(TdDynamicElementComponent)).length).toBe(2);
+      expect(fixture.debugElement.queryAll(By.directive(TdDynamicElementComponent)).length).toBe(3);
       let dynamicFormsComponent: TdDynamicFormsComponent =
           fixture.debugElement.query(By.directive(TdDynamicFormsComponent)).componentInstance;
       expect(dynamicFormsComponent.valid).toBeTruthy();
       /* tslint:disable-next-line */
-      expect(JSON.stringify(dynamicFormsComponent.value)).toBe(JSON.stringify({first_name: 'name', age: 20}));
+      expect(JSON.stringify(dynamicFormsComponent.value)).toBe(JSON.stringify({first_name: 'name', age: 20, dob: dob}));
     });
   })));
 

--- a/src/platform/dynamic-forms/dynamic-forms.module.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.module.ts
@@ -9,6 +9,7 @@ import { MatSliderModule } from '@angular/material/slider';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDatepickerModule } from '@angular/material/datepicker';
 
 import { CovalentCommonModule } from '../core';
 import { CovalentFileModule } from '../core';
@@ -28,6 +29,7 @@ import {
 } from './dynamic-elements/dynamic-checkbox/dynamic-checkbox.component';
 import { TdDynamicSliderComponent } from './dynamic-elements/dynamic-slider/dynamic-slider.component';
 import { TdDynamicSelectComponent } from './dynamic-elements/dynamic-select/dynamic-select.component';
+import { TdDynamicDatepickerComponent } from './dynamic-elements/dynamic-datepicker/dynamic-datepicker.component';
 
 const TD_DYNAMIC_FORMS: Type<any>[] = [
   TdDynamicFormsComponent,
@@ -44,6 +46,7 @@ const TD_DYNAMIC_FORMS_ENTRY_COMPONENTS: Type<any>[] = [
   TdDynamicCheckboxComponent,
   TdDynamicSliderComponent,
   TdDynamicSelectComponent,
+  TdDynamicDatepickerComponent,
 ];
 
 @NgModule({
@@ -61,6 +64,7 @@ const TD_DYNAMIC_FORMS_ENTRY_COMPONENTS: Type<any>[] = [
     MatSlideToggleModule,
     MatIconModule,
     MatButtonModule,
+    MatDatepickerModule,
     CovalentCommonModule,
     CovalentFileModule,
   ],

--- a/src/platform/dynamic-forms/services/dynamic-forms.service.ts
+++ b/src/platform/dynamic-forms/services/dynamic-forms.service.ts
@@ -8,16 +8,19 @@ import { TdDynamicSlideToggleComponent } from '../dynamic-elements/dynamic-slide
 import { TdDynamicCheckboxComponent } from '../dynamic-elements/dynamic-checkbox/dynamic-checkbox.component';
 import { TdDynamicSliderComponent } from '../dynamic-elements/dynamic-slider/dynamic-slider.component';
 import { TdDynamicSelectComponent } from '../dynamic-elements/dynamic-select/dynamic-select.component';
+import { TdDynamicDatepickerComponent } from '../dynamic-elements/dynamic-datepicker/dynamic-datepicker.component';
 
 export enum TdDynamicType {
   Text = <any>'text',
   Boolean = <any>'boolean',
   Number = <any>'number',
   Array = <any>'array',
+  Date = <any>'date',
 }
 
 export enum TdDynamicElement {
   Input = <any>'input',
+  Datepicker = <any>'datepicker',
   Password = <any>'password',
   Textarea = <any>'textarea',
   Slider = <any>'slider',
@@ -86,6 +89,9 @@ export class TdDynamicFormsService {
         return TdDynamicSelectComponent;
       case TdDynamicElement.FileInput:
         return TdDynamicFileInputComponent;
+      case TdDynamicElement.Datepicker:
+      case TdDynamicType.Date:
+        return TdDynamicDatepickerComponent;
       default:
         throw new Error(`Error: type ${element} does not exist or not supported.`);
     }


### PR DESCRIPTION
## Description
Add support for `mat-datepicker` to the `dynamic-forms` module.. this way we can now render datepicker elements dynamically.

### What's included?
<!-- List features included in this PR -->
- Datepicker support.
- Unit tests
- Updated DEMO and README

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to http://localhost:4200/#/components/dynamic-forms
- [ ] See demo builder with `datepicker` option

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

##### Screenshots or link to StackBlitz/Plunker

![image](https://user-images.githubusercontent.com/5846742/34500144-4ddd59ac-efbe-11e7-9bd6-58aeaacd34f7.png)

closes https://github.com/Teradata/covalent/issues/584

