### PR TITLE
fix(notifications): fix menu header margin in demo (closes #1038)

### DIFF
--- a/src/app/components/components/notifications/notifications.component.html
+++ b/src/app/components/components/notifications/notifications.component.html
@@ -26,7 +26,7 @@
           </button>
           <mat-menu #notificationsMenu="matMenu" [overlapTrigger]="false">
             <td-menu>
-              <div td-menu-header class="mat-subheading-2">Notifications</div>
+              <div td-menu-header class="mat-subheading-2 push-none">Notifications</div>
               <mat-nav-list dense>
                 <ng-template let-last="last" ngFor [ngForOf]="[0,1,2,3,4,5,6,7,8,9]">
                   <a mat-list-item>
@@ -79,7 +79,7 @@
               </button>
               <mat-menu #notificationsMenu="matMenu" [overlapTrigger]="false">
                 <td-menu>
-                  <div td-menu-header class="mat-subheading-2">Notifications</div>
+                  <div td-menu-header class="mat-subheading-2 push-none">Notifications</div>
                   <mat-nav-list dense>
                     <ng-template let-last="last" ngFor [ngForOf]="[0,1,2,3,4,5,6,7,8,9]">
                       <a mat-list-item>


### PR DESCRIPTION
## Description
Fixes margin of menu header in notifications demo since the material typography adds a bottom margin by default.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to notifications demo
- [ ] Open menu and see that there is no margin any more

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

closes https://github.com/Teradata/covalent/issues/1038