### PR TITLE
fix(expansion-panel): let label flex without sublabel + follow MD spec better (closes #1057)

### DIFF
--- a/src/platform/core/expansion-panel/expansion-panel.component.html
+++ b/src/platform/core/expansion-panel/expansion-panel.component.html
@@ -17,7 +17,6 @@
       <ng-template [cdkPortalHost]="expansionPanelSublabel"></ng-template>
       <ng-template [ngIf]="!expansionPanelSublabel">{{sublabel}}</ng-template>
     </div>
-    <span class="td-expansion-panel-spacer"></span>
     <mat-icon class="td-expand-icon" *ngIf="!disabled" [@tdRotate]="expand">keyboard_arrow_down</mat-icon>
   </div>
 </div>

--- a/src/platform/core/expansion-panel/expansion-panel.component.scss
+++ b/src/platform/core/expansion-panel/expansion-panel.component.scss
@@ -9,7 +9,7 @@
     }
     .td-expansion-panel-header-content {
       height: 48px;
-      padding: 0 16px;
+      padding: 0 24px;
       // layout
       box-sizing: border-box;
       display: flex;
@@ -23,7 +23,7 @@
       align-content: center;
       max-width: 100%;
       .td-expansion-label,
-      .td-expansion-panel-spacer {
+      .td-expansion-sublabel {
         // flex
         flex: 1;
       }
@@ -42,9 +42,9 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-right: 5px;
+  margin-right: 16px;
   ::ng-deep [dir='rtl'] & {
-    margin-left: 5px;
+    margin-left: 16px;
     margin-right: inherit;
   }
 }


### PR DESCRIPTION
## Description
We fixed the label in the expansion-panel when a sublabel is not used so it flexes properly.

Also we changed the margin on labels and header to follow the MD Spec properly

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to expansion-panel demo
- [ ] Test it in mobile without sublabel

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

closes https://github.com/Teradata/covalent/issues/1057