### PR TITLE
feat(data-table): change API from data-table representation to lists

### DIFF
--- a/src/platform/core/data-table/README.md
+++ b/src/platform/core/data-table/README.md
@@ -6,23 +6,46 @@ Use [tdDataTableTemplate] directive for template support which gives context acc
 
 ## API Summary
 
-Properties:
+#### Inputs
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| `data` | `any[]` | Rows of data to be displayed.
-| `columns` | `ITdDataTableColumn[]` | List of columns to be displayed.
-| `selectable?` | `boolean` | Enables row selection events, hover and selected row states.
-| `multiple?` | `boolean` | Enables multiple row selection. [selectable] needs to be enabled.
-| `sortable?` | `boolean` | Enables sorting events, sort icons and active column states.
-| `sortBy?` | `string` | Sets the active sort column. [sortable] needs to be enabled.
-| `sortOrder?` | TdDataTableSortingOrder | Sets the sort order of the [sortBy] column. [sortable] needs to be enabled. Defaults to 'ASC' or TdDataTableSortingOrder.Ascending
-| `compareWith` | `function(row, model)` | Allows custom comparison between row and model to see if row is selected or not.
-| `sortChange` | `function` | Event emitted when the column headers are clicked. [sortable] needs to be enabled. Emits an [ITdDataTableSortEvent] implemented object.
-| `rowSelect` | `function` | Event emitted when a row is selected/deselected. [selectable] needs to be enabled. Emits an [ITdDataTableSelectEvent] implemented object.
-| `rowClick` | `function` | Event emitted when a row is clicked. [clickable] needs to be enabled. Emits an [ITdDataTableRowClickEvent] implemented object.
-| `selectAll` | `function` | Event emitted when all rows are selected/deselected by the all checkbox. [selectable] needs to be enabled. Emits an [ITdDataTableSelectAllEvent] implemented object.
-| `refresh` | `function` |  Refreshes data table and rerenders [data] and [columns]
++ data: any[]
+  + Rows of data to be displayed.
++ columns?: ITdDataTableColumn[]
+  + List of columns to be displayed.
++ selectable?: boolean
+  + Enables row selection events, hover and selected row states.
++ multiple?: boolean
+  + Enables multiple row selection. [selectable] needs to be enabled.
++ sortable?: boolean
+  + Enables sorting events, sort icons and active column states.
++ sortBy?: string
+  + Sets the active sort column. [sortable] needs to be enabled.
++ sortOrder?: TdDataTableSortingOrder
+  + Sets the sort order of the [sortBy] column. [sortable] needs to be enabled.
+  + Defaults to 'ASC' or TdDataTableSortingOrder.Ascending
++ compareWith: function(row, model)
+  + Allows custom comparison between row and model to see if row is selected or not.
+
+#### Events
+
++ sortChange: function
+  + Event emitted when the column headers are clicked. [sortable] needs to be enabled.
+  + Emits an [ITdDataTableSortEvent] implemented object.
++ rowSelect: function
+  + Event emitted when a row is selected/deselected. [selectable] needs to be enabled.
+  + Emits an [ITdDataTableSelectEvent] implemented object.
++ rowClick: function
+  + Event emitted when a row is clicked. [clickable] needs to be enabled.
+  + Emits an [ITdDataTableRowClickEvent] implemented object.
++ selectAll: function
+  + Event emitted when all rows are selected/deselected by the all checkbox. [selectable] needs to be enabled.
+  + Emits an [ITdDataTableSelectAllEvent] implemented object.
+
+#### Methods
+
++ refresh: function
+  + Refreshes data table and rerenders [data] and [columns]
+
 
 ## Setup
 


### PR DESCRIPTION
## Description
Sinde now we support list rendering from markdown, we are going to show the API's as lists rather than data-tables.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to data-table demo
- [ ] See API in readme

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

##### Screenshots or link to StackBlitz/Plunker

![image](https://user-images.githubusercontent.com/5846742/34957509-c481d460-f9e2-11e7-804f-d0ba6f55348e.png)

