### PR TITLE
feat(expansion-panel): change API from data-table representation to lists

### DIFF
--- a/src/platform/core/expansion-panel/README.md
+++ b/src/platform/core/expansion-panel/README.md
@@ -6,19 +6,33 @@ It also contains an optional summary to display anything in collapsed state.
 
 ## API Summary
 
-Properties:
+#### Inputs
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| `label?` | `string` | Sets label of component header.
-| `sublabel?` | `string` | Sets sublabel of component header.
-| `expand?` | `boolean` | Toggles component between expand/collapse state.
-| `disableRipple?` | `boolean` | Whether the ripple effect for this component is disabled.
-| `expanded?` | `function` | Event emitted when component is expanded.
-| `collapsed?` | `function` | Event emitted when component is collapsed.
-| `toggle?` | `function` | Toggle state of component. Returns "true" if successful, else "false".
-| `open?` | `function` | Opens component and sets state to expanded. Retuns "true" if successful, else "false".
-| `close?` | `function` | Closes component and sets state to collapsed. Retuns "true" if successful, else "false".
++ label?: string
+  + Sets label of component header.
++ sublabel?: string
+  + Sets sublabel of component header.
++ expand?: boolean
+  + Toggles component between expand/collapse state.
++ disableRipple?: boolean
+  + Whether the ripple effect for this component is disabled.
+
+#### Events
+
++ expanded: function
+  + Event emitted when component is expanded.
++ collapsed: function
+  + Event emitted when component is collapsed.
+
+#### Methods
+
++ toggle: function
+  + Toggle state of component. Returns "true" if successful, else "false".
++ open: function
+  + Opens component and sets state to expanded. Retuns "true" if successful, else "false".
++ close: function
+  + Closes component and sets state to collapsed. Retuns "true" if successful, else "false".
+
 
 ## Setup
 


### PR DESCRIPTION
## Description
Sinde now we support list rendering from markdown, we are going to show the API's as lists rather than data-tables.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to expansion-panel demo
- [ ] See API in readme

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

![image](https://user-images.githubusercontent.com/5846742/34958981-04f155c4-f9e9-11e7-9c56-ac88b63225f8.png)
