### PR TITLE
feat(file-input): change API from tables to lists

### DIFF
--- a/src/platform/core/file/file-input/README.md
+++ b/src/platform/core/file/file-input/README.md
@@ -132,5 +132,7 @@ Example for usage:
 #### Events
 
 + fileDrop: function($event)
-  + Event emitted when a file or files are dropped in host element after being validated. 
+  + Event emitted when a file or files are dropped in host element after being validated.  
   + Emits a [FileList or File] object.
+
+&nbsp;

--- a/src/platform/core/file/file-input/README.md
+++ b/src/platform/core/file/file-input/README.md
@@ -89,14 +89,17 @@ Example for usage:
 
 ## API Summary
 
-Properties:
+#### Inputs
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| multiple | boolean | Sets whether multiple files can be selected at once in host element, or just a single file. Can also be "multiple" native attribute.
-| fileSelect | function($event) | Event emitted when a file or files are selected in host [HTMLInputElement]. Emits a [FileList or File] object. Alternative to not use [(ngModel)].
++ multiple: boolean
+  + Sets whether multiple files can be selected at once in host element, or just a single file. 
+  + Can also be "multiple" native attribute.
 
----
+#### Events
+
++ fileSelect: function($event)
+  + Event emitted when a file or files are selected in host [HTMLInputElement]. 
+  + Emits a [FileList or File] object. Alternative to not use [(ngModel)].
 
 ## TdFileDropDirective: tdFileDrop
 
@@ -118,13 +121,16 @@ Example for usage:
 
 ## API Summary
 
-Properties:
+#### Inputs
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| multiple | boolean | Sets whether multiple files can be dropped at once in host element, or just a single file. Can also be "multiple" native attribute.
-| disabled | boolean | Disabled drop events for host element.
-| fileDrop | function($event) | Event emitted when a file or files are dropped in host element after being validated. Emits a [FileList or File] object.
++ multiple: boolean
+  + Sets whether multiple files can be dropped at once in host element, or just a single file. 
+  + Can also be "multiple" native attribute.
++ disabled: boolean
+  + Disabled drop events for host element.
 
+#### Events
 
----
++ fileDrop: function($event)
+  + Event emitted when a file or files are dropped in host element after being validated. 
+  + Emits a [FileList or File] object.

--- a/src/platform/core/file/file-input/README.md
+++ b/src/platform/core/file/file-input/README.md
@@ -33,16 +33,27 @@ export class Demo {
 
 ## API Summary
 
-Properties:
+#### Inputs
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| color | string | Sets button color. Uses same color palette accepted as [MatButton].
-| multiple | boolean | Sets if multiple files can be dropped/selected at once in [TdFileUploadComponent].
-| accept | string | Sets files accepted when opening the file browser dialog. Same as "accept" attribute in `<input/>` element.
-| disabled | boolean | Disables [TdFileUploadComponent] and clears selected/dropped files.
-| select | function($event) | Event emitted when a file is selected. Emits a [File or FileList] object.
-| clear | function() | Used to clear the selected files from the [TdFileInputComponent].
++ color: string
+  + Sets button color. Uses same color palette accepted as [MatButton].
++ multiple: boolean
+  + Sets if multiple files can be dropped/selected at once in [TdFileUploadComponent].
++ accept: string
+  + Sets files accepted when opening the file browser dialog. Same as "accept" attribute in `<input/>` element.
++ disabled: boolean
+  + Disables [TdFileUploadComponent] and clears selected/dropped files.
+
+#### Events
+
++ select: function($event)
+  + Event emitted when a file is selected. 
+  + Emits a [File or FileList] object.
+
+#### Methods
+
++ clear: function
+  + Used to clear the selected files from the [TdFileInputComponent].
 
 ## Setup
 


### PR DESCRIPTION
## Description
Show the API's as lists rather than data-tables.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to file input demo (note there are multiple API Summaries)
- [ ] See API in readme

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1405" alt="screen shot 2018-01-15 at 2 33 17 pm" src="https://user-images.githubusercontent.com/17860952/34964289-b2c9a2b0-fa01-11e7-9957-ccf1f857f8d3.png">


