### PR TITLE
feat(dynamic-forms): replace API data-table with list in README

### DIFF
--- a/src/platform/dynamic-forms/README.md
+++ b/src/platform/dynamic-forms/README.md
@@ -2,18 +2,29 @@
 
 ## API Summary
 
-Properties:
+#### Inputs
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| `elements?` | `ITdDynamicElementConfig[]` | JS Object that will render the elements depending on its config. [name] property is required.
-| `form` | `get(): FormGroup` | Getter property for dynamic [FormGroup].
-| `valid` | `get(): boolean` | Getter property for [valid] of dynamic [FormGroup].
-| `value` | `get(): any` | Getter property for [value] of dynamic [FormGroup].
-| `errors` | `get(): {[name: string]: any}` | Getter property for [errors] of dynamic [FormGroup].
-| `controls` | `get(): {[key: string]: AbstractControl}` | Getter property for [controls] of dynamic [FormGroup].
-| `refresh` | `function` |  Refreshes the form and rerenders all validator/element modifications.
++ elements: ITdDynamicElementConfig[]
+  + JS Object that will render the elements depending on its config.
+  + [name] property is required.
 
+#### Properties (Read only)
+
++ form: FormGroup
+  + Getter property for dynamic [FormGroup].
++ valid: boolean
+  + Getter property for [valid] of dynamic [FormGroup].
++ value: any
+  + Getter property for [value] of dynamic [FormGroup].
++ errors: {[name: string]: any}
+  + Getter property for [errors] of dynamic [FormGroup].
++ controls: {[key: string]: AbstractControl}
+  + Getter property for [controls] of dynamic [FormGroup].
+
+#### Methods
+
++ refresh: function
+  + Refreshes the form and rerenders all validator/element modifications
 
 ## Setup
 


### PR DESCRIPTION
## Description
Sinde now we support list rendering from markdown, we are going to show the API's as lists rather than data-tables.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to dynamic forms demo and see README

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.
