### PR TITLE
feat(file-upload): change API from tables to lists 

### DIFF
--- a/src/platform/core/file/file-upload/README.md
+++ b/src/platform/core/file/file-upload/README.md
@@ -49,7 +49,6 @@ export class Demo {
 
 ## API Summary
 
-| `defaultColor` | `string` | Sets browse button color. Uses same color palette accepted as [MatButton] and defaults to 'primary'.
 #### Inputs
 
 + defaultColor: string

--- a/src/platform/core/file/file-upload/README.md
+++ b/src/platform/core/file/file-upload/README.md
@@ -49,19 +49,30 @@ export class Demo {
 
 ## API Summary
 
-Properties:
-
-| Name | Type | Description |
-| --- | --- | 650--- |
 | `defaultColor` | `string` | Sets browse button color. Uses same color palette accepted as [MatButton] and defaults to 'primary'.
-| `activeColor` | `string` | Sets upload button color. Uses same color palette accepted as [MatButton] and defaults to 'accent'.
-| `cancelColor` | `string` | Sets cancel button color. Uses same color palette accepted as [MatButton] and defaults to 'warn'.
-| `multiple` | `boolean` | Sets if multiple files can be dropped/selected at once in [TdFileUploadComponent].
-| `accept` | `string` | Sets files accepted when opening the file browser dialog. Same as "accept" attribute in `<input/>` element.
-| `disabled` | `boolean` | Disables [TdFileUploadComponent] and clears selected/dropped files.
-| `upload` | `function($event)` | Event emitted when upload button is clicked. Emits a [File or FileList] object.
-| `select` | `function($event)` | Event emitted when a file is selected. Emits a [File or FileList] object.
-| `cancel` | `function()` | Event emitted when cancel button is clicked.
+#### Inputs
+
++ defaultColor: string
+  + Sets browse button color. Uses same color palette accepted as [MatButton] and defaults to 'primary'.
++ activeColor: string
+  + Sets upload button color. Uses same color palette accepted as [MatButton] and defaults to 'accent'.
++ cancelColor: string
+  + Sets cancel button color. Uses same color palette accepted as [MatButton] and defaults to 'warn'.
++ multiple: boolean
+  + Sets if multiple files can be dropped/selected at once in [TdFileUploadComponent].
++ accept: string
+  + Sets files accepted when opening the file browser dialog. Same as "accept" attribute in `<input/>` element.
++ disabled: boolean
+  + Disables [TdFileUploadComponent] and clears selected/dropped files.
+
+##### Events
+
++ upload: function($event)
+  + Event emitted when upload button is clicked. Emits a [File or FileList] object.
++ select: function($event)
+  + Event emitted when a file is selected. Emits a [File or FileList] object.
++ cancel: function
+  + Event emitted when cancel button is clicked.
 
 ## Setup
 

--- a/src/platform/core/file/file-upload/README.md
+++ b/src/platform/core/file/file-upload/README.md
@@ -73,6 +73,11 @@ export class Demo {
 + cancel: function
   + Event emitted when cancel button is clicked.
 
+#### Methods
+
++ cancel: function
+  + Method used to clear the files selected.
+
 ## Setup
 
 Import the [CovalentFileModule] in your NgModule:
@@ -91,9 +96,17 @@ export class MyModule {}
 
 ## tdFileService
 
-## Usage
-
 Service provided with methods that wrap complexity for as easier file upload experience.
+
+## API Summary
+
+#### Methods
+
++ upload: function(IUploadState)
+  + Uses underlying [XMLHttpRequest] to upload a file to a url. 
+  + Will be depricated when angular fixes [Http] to allow [FormData] as body.
+
+## Usage
 
 Recieves as parameter an object that implements the [IUploadOptions] interface. You have to assign a value either to `[file]` or to `[formData]`. If `[file]` is assigned then `[formData]` will be ignored; when only `[formData]` is assigned then it will be sent as form data.
 
@@ -134,13 +147,3 @@ export class Demo {
   
 }
 ```
-
-## API Summary
-
-#### Methods
-
-+ upload: function(IUploadState)
-  + Uses underlying [XMLHttpRequest] to upload a file to a url. 
-  + Will be depricated when angular fixes [Http] to allow [FormData] as body.
-
-  &nbsp;

--- a/src/platform/core/file/file-upload/README.md
+++ b/src/platform/core/file/file-upload/README.md
@@ -64,7 +64,7 @@ export class Demo {
 + disabled: boolean
   + Disables [TdFileUploadComponent] and clears selected/dropped files.
 
-##### Events
+#### Events
 
 + upload: function($event)
   + Event emitted when upload button is clicked. Emits a [File or FileList] object.
@@ -72,12 +72,6 @@ export class Demo {
   + Event emitted when a file is selected. Emits a [File or FileList] object.
 + cancel: function
   + Event emitted when cancel button is clicked.
-
-##### Methods
-
-+ upload: function(IUploadState)
-  + Uses underlying [XMLHttpRequest] to upload a file to a url. 
-  + Will be depricated when angular fixes [Http] to allow [FormData] as body.
 
 ## Setup
 
@@ -140,3 +134,13 @@ export class Demo {
   
 }
 ```
+
+## API Summary
+
+#### Methods
+
++ upload: function(IUploadState)
+  + Uses underlying [XMLHttpRequest] to upload a file to a url. 
+  + Will be depricated when angular fixes [Http] to allow [FormData] as body.
+
+  &nbsp;

--- a/src/platform/core/file/file-upload/README.md
+++ b/src/platform/core/file/file-upload/README.md
@@ -73,6 +73,12 @@ export class Demo {
 + cancel: function
   + Event emitted when cancel button is clicked.
 
+##### Methods
+
++ upload: function(IUploadState)
+  + Uses underlying [XMLHttpRequest] to upload a file to a url. 
+  + Will be depricated when angular fixes [Http] to allow [FormData] as body.
+
 ## Setup
 
 Import the [CovalentFileModule] in your NgModule:
@@ -134,14 +140,3 @@ export class Demo {
   
 }
 ```
-
-## API Summary
-
-Methods:
-
-| Name | Type | Description |
-| --- | --- | 650--- |
-| upload | function(IUploadState) | Uses underlying [XMLHttpRequest] to upload a file to a url. Will be depricated when angular fixes [Http] to allow [FormData] as body.
-
-
----


### PR DESCRIPTION
## Description
Show the API's as lists rather than data-tables.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to file upload button demo
- [ ] See API in readme

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1405" alt="screen shot 2018-01-15 at 2 58 48 pm" src="https://user-images.githubusercontent.com/17860952/34964859-9dc6c6e2-fa04-11e7-8734-662ef887ce6a.png">

Before (left), After (right)
<img width="1680" alt="screen shot 2018-01-15 at 3 08 22 pm" src="https://user-images.githubusercontent.com/17860952/34965095-72290eb2-fa06-11e7-9648-4c6212e46321.png">
