### PR TITLE
feat(layout): change API from tables to lists

### DIFF
--- a/src/platform/core/layout/README.md
+++ b/src/platform/core/layout/README.md
@@ -5,12 +5,16 @@
 
 ## API Summary
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| mode | 'over', 'side' or 'push' | The mode or styling of the sidenav. Defaults to 'over'.
-| opened | boolean | Whether or not the sidenav is opened. Use this binding to open/close the sidenav. Defaults to 'false'.
-| sidenavWidth | string | Sets the 'width' of the sidenav in either 'px' or '%'. Defaults to '320px'.
+#### Inputs
 
++ mode: 'over', 'side' or 'push'
+  + The mode or styling of the sidenav. Defaults to 'over'.
++ opened: boolean
+  + Whether or not the sidenav is opened. Use this binding to open/close the sidenav. 
+  + Defaults to 'false'.
++ sidenavWidth: string
+  + Sets the 'width' of the sidenav in either 'px' or '%'. 
+  + Defaults to '320px'.
 
 ## Usage
 
@@ -83,17 +87,28 @@ See [theming](https://teradata.github.io/covalent/#/docs/theme) in the covalent 
 
 ## API Summary
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| sidenavTitle | string | Title set in toolbar.
-| icon | string | icon name to be displayed before the title
-| logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
-| color | string | optional sidenav toolbar color.
-| navigationRoute | string | option to set the combined route for the icon, logo, and sidenavTitle.
-| backgroundUrl | SafeResourceUrl | image to be displayed as the background of the toolbar. URL used will be sanitized, but it should be always from a trusted source to avoid XSS.
-| name | string | string to be displayed as part of the navigation drawer sublabel. if [email] is not set, then [name] will be the toggle menu text.
-| email | string | string to be displayed as part of the navigation drawer sublabel in the [toggle] menu text. if [email] and [name] are not set, then the toggle menu is not rendered.
+#### Inputs
 
++ sidenavTitle: string
+  + Title set in toolbar.
++ icon: string
+  + Icon name to be displayed before the title.
++ logo: string
+  + Logo icon name to be displayed before the title. 
+  + If [icon] is set, then this will not be shown.
++ color: string
+  + Optional sidenav toolbar color.
++ navigationRoute: string
+  + Option to set the combined route for the icon, logo, and sidenavTitle.
++ backgroundUrl: SafeResourceUrl
+  + Image to be displayed as the background of the toolbar. 
+  + URL used will be sanitized, but it should be always from a trusted source to avoid XSS.
++ name: string
+  + String to be displayed as part of the navigation drawer sublabel.
+  + If [email] is not set, then [name] will be the toggle menu text.
++ email: string
+  + String to be displayed as part of the navigation drawer sublabel in the [toggle] menu text. 
+  + If [email] and [name] are not set, then the toggle menu is not rendered.
 
 ## Usage
 

--- a/src/platform/core/layout/README.md
+++ b/src/platform/core/layout/README.md
@@ -7,7 +7,7 @@
 
 #### Inputs
 
-+ mode: 'over', 'side' or 'push'
++ mode: 'over' | 'side' | 'push'
   + The mode or styling of the sidenav. Defaults to 'over'.
 + opened: boolean
   + Whether or not the sidenav is opened. Use this binding to open/close the sidenav. 

--- a/src/platform/core/layout/layout-card-over/README.md
+++ b/src/platform/core/layout/layout-card-over/README.md
@@ -5,13 +5,18 @@
 
 ## API Summary
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| cardTitle | string | Title set in card.
-| cardSubtitle | string | subtitle set in card.
-| cardWidth | string | Card flex width in %. Defaults to 70.
-| color | string | optional toolbar color. Defaults to primary.
+#### Inputs
 
++ cardTitle: string 
+  + Title set in card.
++ cardSubtitle: string 
+  + Subtitle set in card.
++ cardWidth: string 
+  + Card flex width in %. 
+  + Defaults to 70.
++ color: string 
+  + Optional toolbar color. 
+  + Defaults to primary.
 
 ## Usage
 

--- a/src/platform/core/layout/layout-manage-list/README.md
+++ b/src/platform/core/layout/layout-manage-list/README.md
@@ -7,7 +7,7 @@
 
 #### Inputs
 
-+ mode: 'over', 'side' or 'push'
++ mode: 'over' | 'side' | 'push'
   + The mode or styling of the sidenav. Defaults to 'side'.
 + opened: boolean 
   + Whether or not the sidenav is opened. 

--- a/src/platform/core/layout/layout-manage-list/README.md
+++ b/src/platform/core/layout/layout-manage-list/README.md
@@ -5,12 +5,17 @@
 
 ## API Summary
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| mode | 'over', 'side' or 'push' | The mode or styling of the sidenav. Defaults to 'side'.
-| opened | boolean | Whether or not the sidenav is opened. Use this binding to open/close the sidenav. Defaults to 'true'.
-| sidenavWidth | string | Sets the 'width' of the sidenav in either 'px' or '%'. Defaults to '257px'.
+#### Inputs
 
++ mode: 'over', 'side' or 'push'
+  + The mode or styling of the sidenav. Defaults to 'side'.
++ opened: boolean 
+  + Whether or not the sidenav is opened. 
+  + Use this binding to open/close the sidenav. 
+  + Defaults to 'true'.
++ sidenavWidth: string 
+  + Sets the 'width' of the sidenav in either 'px' or '%'. 
+  + Defaults to '257px'.
 
 ## Usage
 

--- a/src/platform/core/layout/layout-nav-list/README.md
+++ b/src/platform/core/layout/layout-nav-list/README.md
@@ -5,17 +5,30 @@
 
 ## API Summary
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| toolbarTitle | string | Title set in toolbar.
-| icon | string | icon name to be displayed before the title
-| logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
-| color | string | optional toolbar color. Defaults to primary.
-| navigationRoute | string | option to set the combined route for the icon, logo, and toolbarTitle.
-| mode | 'over', 'side' or 'push' | The mode or styling of the sidenav. Defaults to 'side'.
-| opened | boolean | Whether or not the sidenav is opened. Use this binding to open/close the sidenav. Defaults to 'true'.
-| sidenavWidth | string | Sets the 'width' of the sidenav in either 'px' or '%'. Defaults to '257px'.
+#### Inputs
 
++ toolbarTitle: string
+  + Title set in toolbar.
++ icon: string
+  + Icon name to be displayed before the title.
++ logo: string
+  + Logo icon name to be displayed before the title. 
+  + If [icon] is set, then this will not be shown.
++ color:  string
+  + optional toolbar color. 
+  + Defaults to primary.
++ navigationRoute: string
+  + option to set the combined route for the icon, logo, and toolbarTitle.
++ mode: 'over', 'side' or 'push'
+  + The mode or styling of the sidenav. 
+  + Defaults to 'side'.
++ opened: boolean
+  + Whether or not the sidenav is opened. 
+  + Use this binding to open/close the sidenav. 
+  + Defaults to 'true'.
++ sidenavWidth: string
+  + Sets the 'width' of the sidenav in either 'px' or '%'. 
+  + Defaults to '257px'.
 
 ## Usage
 

--- a/src/platform/core/layout/layout-nav-list/README.md
+++ b/src/platform/core/layout/layout-nav-list/README.md
@@ -19,7 +19,7 @@
   + Defaults to primary.
 + navigationRoute: string
   + option to set the combined route for the icon, logo, and toolbarTitle.
-+ mode: 'over', 'side' or 'push'
++ mode: 'over' | 'side' | 'push'
   + The mode or styling of the sidenav. 
   + Defaults to 'side'.
 + opened: boolean

--- a/src/platform/core/layout/layout-nav/README.md
+++ b/src/platform/core/layout/layout-nav/README.md
@@ -5,14 +5,20 @@
 
 ## API Summary
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| toolbarTitle | string | Title set in toolbar.
-| icon | string | icon name to be displayed before the title
-| logo | string | logo icon name to be displayed before the title. If [icon] is set, then this will not be shown.
-| color | string | optional toolbar color. Defaults to primary.
-| navigationRoute | string | option to set the combined route for the icon, logo, and toolbarTitle.
+#### Inputs
 
++ toolbarTitle: string
+  + Title set in toolbar.
++ icon: string
+  + Icon name to be displayed before the title.
++ logo: string
+  + Logo icon name to be displayed before the title. 
+  + If [icon] is set, then this will not be shown.
++ color: string
+  + Optional toolbar color. 
+  + Defaults to primary.
++ navigationRoute: string 
+  + Option to set the combined route for the icon, logo, and toolbarTitle.
 
 ## Usage
 


### PR DESCRIPTION
## Description
Show the API's as lists rather than data-tables.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to layouts demo
- [ ] See API in readme

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1405" alt="screen shot 2018-01-15 at 2 58 48 pm" src="https://user-images.githubusercontent.com/17860952/34964859-9dc6c6e2-fa04-11e7-8734-662ef887ce6a.png">

Before (left), After (right)
<img width="1680" alt="screen shot 2018-01-15 at 3 08 22 pm" src="https://user-images.githubusercontent.com/17860952/34965095-72290eb2-fa06-11e7-9648-4c6212e46321.png">
