### PR TITLE
chore(): blacklist @covalent/core import and import from secondary entry

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -36,7 +36,9 @@ npm install --save https://github.com/Teradata/covalent-nightly.git
   
 **src/app/app.module.ts**
 ```ts
-import { CovalentLayoutModule, CovalentStepsModule /*, any other modules */ } from '@covalent/core';
+import { CovalentLayoutModule } from '@covalent/core/layout';
+import { CovalentStepsModule  } from '@covalent/core/steps';
+/* any other core modules */
 // (optional) Additional Covalent Modules imports
 import { CovalentHttpModule } from '@covalent/http';
 import { CovalentHighlightModule } from '@covalent/highlight';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectorRef } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { Dir } from '@angular/cdk/bidi';
 import { MatIconRegistry } from '@angular/material/icon';
-import { TdMediaService } from '@covalent/core';
+import { TdMediaService } from '@covalent/core/media';
 import { TranslateService } from '@ngx-translate/core';
 
 import { getSelectedLanguage } from './utilities/translate';

--- a/src/app/components/components/animations/animations.component.html
+++ b/src/app/components/components/animations/animations.component.html
@@ -15,7 +15,7 @@
     </p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { TdAnimationUtility_A, TdAnimationUtility_B } from '@covalent/core';
+        import { TdAnimationUtility_A, TdAnimationUtility_B } from '@covalent/core/common';
 
         @Component({
           ...
@@ -53,7 +53,7 @@
       <p>Typescript:</p>
       <td-highlight lang="typescript">
         <![CDATA[
-          import { TdRotateAnimation } from '@covalent/core';
+          import { TdRotateAnimation } from '@covalent/core/common';
           ...
           animations: [
             TdRotateAnimation(), // using implicit anchor name 'tdRotate' in template
@@ -85,7 +85,7 @@
       <p>Typescript:</p>
       <td-highlight lang="typescript">
         <![CDATA[
-          import { TdRotateAnimation } from '@covalent/core';
+          import { TdRotateAnimation } from '@covalent/core/common';
           ...
           animations: [
             TdRotateAnimation({ anchor: 'tdRotate545', duration: 750, degrees: 545, ease: 'ease-in' }),
@@ -161,7 +161,7 @@
       <p>Typescript:</p>
       <td-highlight lang="typescript">
         <![CDATA[
-          import { TdCollapseAnimation } from '@covalent/core';
+          import { TdCollapseAnimation } from '@covalent/core/common';
           ...
           animations: [
             TdCollapseAnimation(), // using implicit anchor name 'tdCollapse' in template
@@ -241,7 +241,7 @@
       <p>Typescript:</p>
       <td-highlight lang="typescript">
         <![CDATA[
-          import { TdFadeInOutAnimation } from '@covalent/core';
+          import { TdFadeInOutAnimation } from '@covalent/core/common';
           ...
           animations: [
             TdFadeInOutAnimation(), // using implicit anchor name 'tdFadeInOut' in template
@@ -337,7 +337,7 @@
             TdHeadshakeAnimation,
             TdJelloAnimation,
             TdPulseAnimation,
-          } from '@covalent/core';
+          } from '@covalent/core/common';
           ...
           animations: [
             TdBounceAnimation(), // using implicit anchor name 'tdBounce' in template

--- a/src/app/components/components/components.component.ts
+++ b/src/app/components/components/components.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostBinding, ChangeDetectorRef } from '@angular/core';
 
-import { TdMediaService } from '@covalent/core';
+import { TdMediaService } from '@covalent/core/media';
 
 @Component({
   selector: 'app-components',

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -72,8 +72,8 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { ITdDataTableColumn } from '@covalent/core';
-            import { TdDialogService } from '@covalent/core';
+            import { ITdDataTableColumn } from '@covalent/core/data-table';
+            import { TdDialogService } from '@covalent/core/dialogs';
             ...
             const DECIMAL_FORMAT: (v: any) => any = (v: number) => v.toFixed(2);
             ...
@@ -144,7 +144,7 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { ITdDataTableColumn } from '@covalent/core';
+            import { ITdDataTableColumn } from '@covalent/core/data-table';
             ...
             const DECIMAL_FORMAT: (v: any) => any = (v: number) => v.toFixed(2);
             ...
@@ -266,8 +266,8 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { TdDataTableService, TdDataTableSortingOrder, ITdDataTableSortChangeEvent, ITdDataTableColumn } from '@covalent/core';
-            import { IPageChangeEvent } from '@covalent/core';
+            import { TdDataTableService, TdDataTableSortingOrder, ITdDataTableSortChangeEvent, ITdDataTableColumn } from '@covalent/core/data-table';
+            import { IPageChangeEvent } from '@covalent/core/dialogs';
             ...
             const DECIMAL_FORMAT: (v: any) => any = (v: number) => v.toFixed(2);
             ...

--- a/src/app/components/components/dialogs/dialogs.component.html
+++ b/src/app/components/components/dialogs/dialogs.component.html
@@ -32,7 +32,7 @@
     <td-highlight lang="typescript">
       <![CDATA[
         import { ViewContainerRef } from '@angular/core';
-        import { TdDialogService } from '@covalent/core';
+        import { TdDialogService } from '@covalent/core/dialogs';
         ...
         })
         export class Demo {
@@ -95,7 +95,7 @@
     <p>Import the [CovalentDialogsModule] in your NgModule:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { CovalentDialogsModule } from '@covalent/core';
+        import { CovalentDialogsModule } from '@covalent/core/dialogs';
 
         @NgModule({
           imports: [

--- a/src/app/components/components/directives/directives.component.html
+++ b/src/app/components/components/directives/directives.component.html
@@ -11,7 +11,7 @@
     <p>Import the [CovalentCommonModule] in your NgModule:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { CovalentCommonModule } from '@covalent/core';
+        import { CovalentCommonModule } from '@covalent/core/common';
         @NgModule({
           imports: [
             CovalentCommonModule,

--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostBinding } from '@angular/core';
 import { AbstractControl, Validators } from '@angular/forms';
-import { TdCollapseAnimation } from '@covalent/core';
+import { TdCollapseAnimation } from '@covalent/core/common';
 import { slideInDownAnimation } from '../../../app.animations';
 
 import {

--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -49,7 +49,7 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { TdLoadingService } from '@covalent/core';
+            import { TdLoadingService } from '@covalent/core/loading';
             ...
             export class Demo implements OnInit {
               overlayStarSyntax: boolean = false;
@@ -128,7 +128,7 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { TdLoadingService } from '@covalent/core';
+            import { TdLoadingService } from '@covalent/core/loading';
             ...
             export class Demo {
               replaceDemo: any = {
@@ -376,7 +376,7 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { TdLoadingService } from '@covalent/core';
+            import { TdLoadingService } from '@covalent/core/loading';
             ...
             export class Demo implements OnInit {
               constructor(private _loadingService: TdLoadingService) {}
@@ -422,7 +422,7 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { TdLoadingService } from '@covalent/core';
+            import { TdLoadingService } from '@covalent/core/loading';
             ...
             export class Demo {
               constructor(private _loadingService: TdLoadingService) {
@@ -504,7 +504,7 @@
     <p>Typescript:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { TdLoadingService } from '@covalent/core';
+        import { TdLoadingService } from '@covalent/core/loading';
         ...
         })
         export class Demo {
@@ -530,7 +530,7 @@
     <p>Import the [CovalentLoadingModule] in your NgModule:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { CovalentLoadingModule } from '@covalent/core';
+        import { CovalentLoadingModule } from '@covalent/core/loading';
 
         @NgModule({
           imports: [
@@ -576,7 +576,7 @@
     <p>Typescript:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { TdLoadingService, LoadingType, LoadingMode } from '@covalent/core';
+        import { TdLoadingService, LoadingType, LoadingMode } from '@covalent/core/loading';
         ...
         export class Demo {
           constructor(private _loadingService: TdLoadingService) {

--- a/src/app/components/components/media/media.component.html
+++ b/src/app/components/components/media/media.component.html
@@ -56,7 +56,7 @@
     <td-highlight lang="typescript">
       <![CDATA[
         import { Component, NgZone, OnInit, OnDestroy } from '@angular/core';
-        import { TdMediaService } from '@covalent/core';
+        import { TdMediaService } from '@covalent/core/media';
         import { Subscription } from 'rxjs/Subscription';
         ...
         })
@@ -97,7 +97,7 @@
     <p>Import the [CovalentMediaModule] in your NgModule:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { CovalentMediaModule } from '@covalent/core';
+        import { CovalentMediaModule } from '@covalent/core/media';
         @NgModule({
           imports: [
             CovalentMediaModule,

--- a/src/app/components/components/ngx-charts/ngx-charts.component.html
+++ b/src/app/components/components/ngx-charts/ngx-charts.component.html
@@ -238,7 +238,7 @@
             import { Component } from '@angular/core';
             import { single, multi } from './data';
 
-            import { TdDigitsPipe } from '@covalent/core';
+            import { TdDigitsPipe } from '@covalent/core/common';
 
             @Component({
               selector: 'ngx-charts-demo',

--- a/src/app/components/components/ngx-charts/ngx-charts.component.ts
+++ b/src/app/components/components/ngx-charts/ngx-charts.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { single, multi } from './data';
 
-import { TdDigitsPipe } from '@covalent/core';
+import { TdDigitsPipe } from '@covalent/core/common';
 
 @Component({
   selector: 'ngx-charts-demo',

--- a/src/app/components/components/ngx-translate/ngx-translate.component.html
+++ b/src/app/components/components/ngx-translate/ngx-translate.component.html
@@ -323,7 +323,7 @@
         <td-highlight lang="typescript">
           <![CDATA[
             import { TranslateService } from '@ngx-translate/core';
-            import { TdDialogService } from '@covalent/core';
+            import { TdDialogService } from '@covalent/core/dialogs';
             ...
             export class MyAppComponent {
 

--- a/src/app/components/components/ngx-translate/ngx-translate.component.ts
+++ b/src/app/components/components/ngx-translate/ngx-translate.component.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 
 import { TranslateService } from '@ngx-translate/core';
 
-import { TdDialogService } from '@covalent/core';
+import { TdDialogService } from '@covalent/core/dialogs';
 
 import { TRANSLATE_STORAGE_KEY } from '../../../utilities/translate';
 

--- a/src/app/components/components/overview/overview.component.ts
+++ b/src/app/components/components/overview/overview.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostBinding } from '@angular/core';
 
-import { TdMediaService } from '@covalent/core';
+import { TdMediaService } from '@covalent/core/media';
 
 import { slideInDownAnimation } from '../../../app.animations';
 

--- a/src/app/components/components/paging/paging.component.html
+++ b/src/app/components/components/paging/paging.component.html
@@ -33,7 +33,7 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { IPageChangeEvent } from '@covalent/core';
+            import { IPageChangeEvent } from '@covalent/core/paging';
             ...
             export class Demo {
               event: IPageChangeEvent;
@@ -107,7 +107,7 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { IPageChangeEvent } from '@covalent/core';
+            import { IPageChangeEvent } from '@covalent/core/paging';
             ...
             export class Demo {
               eventPageSize: IPageChangeEvent;
@@ -159,7 +159,7 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { IPageChangeEvent } from '@covalent/core';
+            import { IPageChangeEvent } from '@covalent/core/paging';
             ...
             export class Demo {
               eventLinks: IPageChangeEvent;
@@ -232,7 +232,7 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { IPageChangeEvent } from '@covalent/core';
+            import { IPageChangeEvent } from '@covalent/core/paging';
             ...
             export class Demo {
               eventInput: IPageChangeEvent;
@@ -327,7 +327,7 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { IPageChangeEvent } from '@covalent/core';
+            import { IPageChangeEvent } from '@covalent/core/paging';
             ...
             export class Demo {
               eventResponsive: IPageChangeEvent;

--- a/src/app/components/components/pipes/pipes.component.html
+++ b/src/app/components/components/pipes/pipes.component.html
@@ -11,7 +11,7 @@
     <p>Import the [CovalentCommonModule] in your NgModule:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { CovalentCommonModule } from '@covalent/core';
+        import { CovalentCommonModule } from '@covalent/core/common';
         @NgModule({
           imports: [
             CovalentCommonModule,

--- a/src/app/components/components/search/search.component.html
+++ b/src/app/components/components/search/search.component.html
@@ -72,7 +72,7 @@
     <p>Import the [CovalentSearchModule] in your NgModule:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { CovalentSearchModule } from '@covalent/core';
+        import { CovalentSearchModule } from '@covalent/core/search';
         @NgModule({
           imports: [
             CovalentSearchModule,

--- a/src/app/components/components/steps/steps.component.html
+++ b/src/app/components/components/steps/steps.component.html
@@ -73,7 +73,7 @@
         <p>Typescript:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { StepState } from '@covalent/core';
+            import { StepState } from '@covalent/core/steps';
             ...
             })
             export class Demo {
@@ -142,7 +142,7 @@
     <p>Typescript:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { IStepChangeEvent } from '@covalent/core';
+        import { IStepChangeEvent } from '@covalent/core/steps';
         ...
         })
         export class Demo {
@@ -156,7 +156,7 @@
     <p>Import the [CovalentStepsModule] in your NgModule:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { CovalentStepsModule } from '@covalent/core';
+        import { CovalentStepsModule } from '@covalent/core/steps';
         @NgModule({
           imports: [
             CovalentStepsModule,
@@ -213,7 +213,7 @@
     <p>Typescript:</p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { StepState } from '@covalent/core';
+        import { StepState } from '@covalent/core/steps';
         ...
         })
         export class Demo {

--- a/src/app/components/components/virtual-scroll/virtual-scroll.component.ts
+++ b/src/app/components/components/virtual-scroll/virtual-scroll.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, HostBinding, ChangeDetectionStrategy } from '@angular/core';
 
-import { TdCollapseAnimation } from '@covalent/core';
+import { TdCollapseAnimation } from '@covalent/core/common';
 import { slideInDownAnimation } from '../../../app.animations';
 
 @Component({

--- a/src/app/components/design-patterns/alerts/alerts.component.html
+++ b/src/app/components/design-patterns/alerts/alerts.component.html
@@ -88,7 +88,7 @@
                   <ng-template matTabLabel>Typescript</ng-template>
                     <td-highlight lang="typescript">
                       <![CDATA[
-                          import { TdDialogService } from '@covalent/core';
+                          import { TdDialogService } from '@covalent/core/dialogs';
                           ...
                           constructor(private _dialogService: TdDialogService) {
                           }

--- a/src/app/components/design-patterns/alerts/alerts.component.ts
+++ b/src/app/components/design-patterns/alerts/alerts.component.ts
@@ -3,7 +3,7 @@ import { Component, HostBinding } from '@angular/core';
 import { slideInDownAnimation } from '../../../app.animations';
 
 import { TdDialogService } from '../../../../platform/core';
-import { TdCollapseAnimation } from '@covalent/core';
+import { TdCollapseAnimation } from '@covalent/core/common';
 
 import { MatSnackBar } from '@angular/material/snack-bar';
 

--- a/src/app/components/design-patterns/cards/cards.component.ts
+++ b/src/app/components/design-patterns/cards/cards.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostBinding } from '@angular/core';
 
-import { TdCollapseAnimation } from '@covalent/core';
+import { TdCollapseAnimation } from '@covalent/core/common';
 import { slideInDownAnimation } from '../../../app.animations';
 
 @Component({

--- a/src/app/components/design-patterns/design-patterns.component.ts
+++ b/src/app/components/design-patterns/design-patterns.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostBinding, ChangeDetectorRef } from '@angular/core';
-import { TdMediaService } from '@covalent/core';
+import { TdMediaService } from '@covalent/core/media';
 
 @Component({
   selector: 'app-design-patterns',

--- a/src/app/components/design-patterns/design-patterns.module.ts
+++ b/src/app/components/design-patterns/design-patterns.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { CovalentCommonModule } from '@covalent/core';
+import { CovalentCommonModule } from '@covalent/core/common';
  
 import { designPatternsRoutes } from './design-patterns.routes';
 import { DesignPatternsComponent } from './design-patterns.component';

--- a/src/app/components/design-patterns/management-list/management-list.component.ts
+++ b/src/app/components/design-patterns/management-list/management-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, HostBinding } from '@angular/core';
 
-import { TdCollapseAnimation } from '@covalent/core';
+import { TdCollapseAnimation } from '@covalent/core/common';
 import { slideInDownAnimation } from '../../../app.animations';
 
 export enum OrderBy {

--- a/src/app/components/design-patterns/navigation-drawer/navigation-drawer.component.ts
+++ b/src/app/components/design-patterns/navigation-drawer/navigation-drawer.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostBinding } from '@angular/core';
 
-import { TdCollapseAnimation } from '@covalent/core';
+import { TdCollapseAnimation } from '@covalent/core/common';
 import { slideInDownAnimation } from '../../../app.animations';
 
 @Component({

--- a/src/app/components/docs/docs.component.ts
+++ b/src/app/components/docs/docs.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostBinding, ChangeDetectorRef } from '@angular/core';
-import { TdMediaService } from '@covalent/core';
+import { TdMediaService } from '@covalent/core/media';
 
 @Component({
   selector: 'app-docs',

--- a/src/app/components/layouts/manage-list/manage-list.component.html
+++ b/src/app/components/layouts/manage-list/manage-list.component.html
@@ -356,7 +356,7 @@
     <td-highlight lang="typescript">
       <![CDATA[
         import { Component, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
-        import { TdMediaService } from '@covalent/core';
+        import { TdMediaService } from '@covalent/core/media';
 
         @Component({
           changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/components/layouts/manage-list/manage-list.component.ts
+++ b/src/app/components/layouts/manage-list/manage-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostBinding, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
-import { TdMediaService } from '@covalent/core';
+import { TdMediaService } from '@covalent/core/media';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/components/layouts/nav-list/nav-list.component.html
+++ b/src/app/components/layouts/nav-list/nav-list.component.html
@@ -242,7 +242,7 @@
     <td-highlight lang="typescript">
       <![CDATA[
         import { Component, HostBinding, ChangeDetectionStrategy } from '@angular/core';
-        import { TdMediaService } from '@covalent/core';
+        import { TdMediaService } from '@covalent/core/media';
 
         @Component({
           changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/components/layouts/nav-list/nav-list.component.ts
+++ b/src/app/components/layouts/nav-list/nav-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostBinding, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
-import { TdMediaService } from '@covalent/core';
+import { TdMediaService } from '@covalent/core/media';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/components/style-guide/style-guide.component.ts
+++ b/src/app/components/style-guide/style-guide.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostBinding, ChangeDetectorRef } from '@angular/core';
-import { TdMediaService } from '@covalent/core';
+import { TdMediaService } from '@covalent/core/media';
 
 @Component({
   selector: 'app-style-guide',

--- a/src/app/components/templates/templates.component.ts
+++ b/src/app/components/templates/templates.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostBinding, ChangeDetectorRef } from '@angular/core';
-import { TdMediaService } from '@covalent/core';
+import { TdMediaService } from '@covalent/core/media';
 
 import { Observable } from 'rxjs/Observable';
 

--- a/src/platform/core/README.md
+++ b/src/platform/core/README.md
@@ -19,7 +19,9 @@ npm i -save @covalent/core
 Import the modules from `@covalent/core` as needed in your NgModule:
 
 ```typescript
-import { CovalentLayoutModule, CovalentStepsModule /* and many more */ } from '@covalent/core';
+import { CovalentLayoutModule } from '@covalent/core/layout';
+import { CovalentStepsModule  } from '@covalent/core/steps';
+/* and many more */
 @NgModule({
   imports: [
     CovalentLayoutModule,

--- a/src/platform/core/chips/README.md
+++ b/src/platform/core/chips/README.md
@@ -49,7 +49,7 @@ Leverage the templates to create your own chip or contact chip.
 Import the [CovalentChipsModule] in your NgModule:
 
 ```typescript
-import { CovalentChipsModule } from '@covalent/core';
+import { CovalentChipsModule } from '@covalent/core/chips';
 @NgModule({
   imports: [
     CovalentChipsModule,

--- a/src/platform/core/data-table/README.md
+++ b/src/platform/core/data-table/README.md
@@ -52,7 +52,7 @@ Use [tdDataTableTemplate] directive for template support which gives context acc
 Import the [CovalentDataTableModule] in your NgModule:
 
 ```typescript
-import { CovalentDataTableModule } from '@covalent/core';
+import { CovalentDataTableModule } from '@covalent/core/data-table';
 @NgModule({
   imports: [
     CovalentDataTableModule,
@@ -112,7 +112,7 @@ Example for HTML usage:
 ```
 
 ```typescript
-import { ITdDataTableColumn } from '@covalent/core';
+import { ITdDataTableColumn } from '@covalent/core/data-table';
 ...
 })
 export class Demo {

--- a/src/platform/core/expansion-panel/README.md
+++ b/src/platform/core/expansion-panel/README.md
@@ -39,7 +39,7 @@ It also contains an optional summary to display anything in collapsed state.
 Import the [CovalentExpansionPanelModule] in your NgModule:
 
 ```typescript
-import { CovalentExpansionPanelModule } from '@covalent/core';
+import { CovalentExpansionPanelModule } from '@covalent/core/expansion-panel';
 @NgModule({
   imports: [
     CovalentExpansionPanelModule,

--- a/src/platform/core/file/file-input/README.md
+++ b/src/platform/core/file/file-input/README.md
@@ -49,7 +49,7 @@ Properties:
 Import the [CovalentFileModule] in your NgModule:
 
 ```typescript
-import { CovalentFileModule } from '@covalent/core';
+import { CovalentFileModule } from '@covalent/core/file';
 @NgModule({
   imports: [
     CovalentFileModule,

--- a/src/platform/core/file/file-upload/README.md
+++ b/src/platform/core/file/file-upload/README.md
@@ -68,7 +68,7 @@ Properties:
 Import the [CovalentFileModule] in your NgModule:
 
 ```typescript
-import { CovalentFileModule } from '@covalent/core';
+import { CovalentFileModule } from '@covalent/core/file';
 @NgModule({
   imports: [
     CovalentFileModule,
@@ -100,7 +100,7 @@ interface IUploadOptions {
 Example for usage:
 
 ```typescript
-import { TdFileService, IUploadOptions } from '@covalent/core';
+import { TdFileService, IUploadOptions } from '@covalent/core/file';
 ...
   providers: [ TdFileService ]
 })

--- a/src/platform/core/json-formatter/README.md
+++ b/src/platform/core/json-formatter/README.md
@@ -27,7 +27,7 @@ The tree is collapsable/expandable so you can navigate through its nodes.
 Import the [CovalentJsonFormatterModule] in your NgModule:
 
 ```typescript
-import { CovalentJsonFormatterModule } from '@covalent/core';
+import { CovalentJsonFormatterModule } from '@covalent/core/json-formatter';
 @NgModule({
   imports: [
     CovalentJsonFormatterModule,

--- a/src/platform/core/layout/README.md
+++ b/src/platform/core/layout/README.md
@@ -59,7 +59,7 @@ npm i -save @covalent/core
 Import the **[CovalentLayoutModule]** in your NgModule:
 
 ```typescript
-import { CovalentLayoutModule } from '@covalent/core';
+import { CovalentLayoutModule } from '@covalent/core/layout';
 @NgModule({
   imports: [
     CovalentLayoutModule,

--- a/src/platform/core/message/README.md
+++ b/src/platform/core/message/README.md
@@ -25,7 +25,7 @@ Properties:
 Import the [CovalentMessageModule] in your NgModule:
 
 ```typescript
-import { CovalentMessageModule } from '@covalent/core';
+import { CovalentMessageModule } from '@covalent/core/message';
 @NgModule({
   imports: [
     CovalentMessageModule,

--- a/src/platform/core/notifications/README.md
+++ b/src/platform/core/notifications/README.md
@@ -18,7 +18,7 @@ Properties:
 Import the [CovalentNotificationsModule] in your NgModule:
 
 ```typescript
-import { CovalentNotificationsModule } from '@covalent/core';
+import { CovalentNotificationsModule } from '@covalent/core/notifications';
 @NgModule({
   imports: [
     CovalentNotificationsModule,

--- a/src/platform/core/paging/README.md
+++ b/src/platform/core/paging/README.md
@@ -34,7 +34,7 @@ Properties:
 Import the [CovalentPagingModule] in your NgModule:
 
 ```typescript
-import { CovalentPagingModule } from '@covalent/core';
+import { CovalentPagingModule } from '@covalent/core/paging';
 @NgModule({
   imports: [
     CovalentPagingModule,

--- a/src/platform/core/search/README.md
+++ b/src/platform/core/search/README.md
@@ -57,7 +57,7 @@ Example for HTML usage:
 Import the [CovalentSearchModule] in your NgModule:
 
 ```typescript
-import { CovalentSearchModule } from '@covalent/core';
+import { CovalentSearchModule } from '@covalent/core/search';
 @NgModule({
   imports: [
     CovalentSearchModule,

--- a/src/platform/core/virtual-scroll/README.md
+++ b/src/platform/core/virtual-scroll/README.md
@@ -22,7 +22,7 @@ Properties:
 Import the [CovalentVirtualScrollModule] in your NgModule:
 
 ```typescript
-import { CovalentVirtualScrollModule } from '@covalent/core';
+import { CovalentVirtualScrollModule } from '@covalent/core/virtual-scroll';
 @NgModule({
   imports: [
     CovalentVirtualScrollModule,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
       "./node_modules/@types"
     ],
     "paths": {
-      "@covalent/core": ["./platform/core"],
       "@covalent/core/*": ["./platform/core/*"],
       "@covalent/dynamic-forms": ["./platform/dynamic-forms"],
       "@covalent/highlight": ["./platform/highlight"],

--- a/tslint.json
+++ b/tslint.json
@@ -35,7 +35,8 @@
       "rxjs",
       "rxjs/operators",
       "@angular/cdk",
-      "@angular/material"
+      "@angular/material",
+      "@covalent/core"
     ],
     "jsdoc-format": true,
     "label-position": true,


### PR DESCRIPTION
## Description
Since this tslint config is going to be moved the the covalent tools repo, we are going to black list the @covalent/core import and focus on the secondary entry points.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run tslint`
- [ ] See it not fail

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.
