### PR TITLE
feat(docs): change paging API from data-table to list

### DIFF
--- a/src/platform/core/paging/README.md
+++ b/src/platform/core/paging/README.md
@@ -17,17 +17,28 @@ export interface IPageChangeEvent {
 
 ## API Summary
 
-Properties:
+#### Inputs
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| `initialPage` | `number` | Sets starting page for the paging bar. Defaults to 1.
-| `pageLinkCount?` | `number` | Amount of page navigation links for the paging bar. Defaults to 0.
-| `firstLast?` | `boolean` | Shows or hides the first and last page buttons of the paging bar. Defaults to 'false'
-| `pageSize?` | `number` | Selected page size for the pagination. Defaults to 50.
-| `total` | `number` | Total rows for the pagination.
-| `change` | `function($event: IPageChangeEvent)` | Method to be executed when page size changes or any button is clicked in the paging bar.
-| `navigateToPage` | `function(page: number): boolean` | Navigates to a specific valid page. Returns 'true' if page is valid, else 'false'.
++ initialPage?: number
+  + Sets starting page for the paging bar. Defaults to 1.
++ pagingLinkCount?: number
+  + Amount of page navigation links for the paging bar. Defaults t
++ firstLast?: boolean
+  + Shows or hides the first and last page buttons of the paging bar. Defaults to 'false'
++ pageSize?: number
+  + Selected page size for the pagination. Defaults to 50.
++ total: number
+  + Total rows for the pagination.
+
+#### Events
+
++ change: function($event: IPageChangeEvent)
+  + Method to be executed when page size changes or any button is clicked in the paging bar.
+
+#### Methods
+
++ navigateToPage: function(page: number): boolea
+  + Navigates to a specific valid page. Returns 'true' if page is valid, else 'false'.
 
 ## Setup
 

--- a/src/platform/core/paging/README.md
+++ b/src/platform/core/paging/README.md
@@ -22,7 +22,7 @@ export interface IPageChangeEvent {
 + initialPage?: number
   + Sets starting page for the paging bar. Defaults to 1.
 + pagingLinkCount?: number
-  + Amount of page navigation links for the paging bar. Defaults t
+  + Amount of page navigation links for the paging bar. Defaults to 0
 + firstLast?: boolean
   + Shows or hides the first and last page buttons of the paging bar. Defaults to 'false'
 + pageSize?: number
@@ -37,7 +37,7 @@ export interface IPageChangeEvent {
 
 #### Methods
 
-+ navigateToPage: function(page: number): boolea
++ navigateToPage: function(page: number)
   + Navigates to a specific valid page. Returns 'true' if page is valid, else 'false'.
 
 ## Setup


### PR DESCRIPTION
## Description

Show the API's as lists rather than data-tables .

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to paging demo and see README

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.
