### PR TITLE
feat(notifications): change API from tables to lists

### DIFF
--- a/src/platform/core/notifications/README.md
+++ b/src/platform/core/notifications/README.md
@@ -6,16 +6,16 @@
 
 #### Inputs
 
-+ color?: 'primary', 'accent' or 'warn'
++ color?: 'primary' | 'accent' | 'warn'
   + Sets the theme color of the notification tip. 
   + Defaults to 'warn'
-+ notifications?: number or boolean
++ notifications?: number | boolean
   + Number for the notification count. 
   + Shows number if the input is a positive number or its no count state if boolean 'true'.
-+ positionX?: TdNotificationCountPositionX or 'before', 'after' or 'center'
++ positionX?: TdNotificationCountPositionX or 'before' | 'after' | 'center'
   + Sets the X position of the notification tip. 
   + Defaults to 'after' if it has content, else 'center'.
-+ positionY?: TdNotificationCountPositionY or 'top', 'bottom' or 'center'
++ positionY?: TdNotificationCountPositionY or 'top' | 'bottom' | 'center'
   + Sets the Y position of the notification tip. Defaults to 'top' if it has content, else 'center'.
 
 ## Setup

--- a/src/platform/core/notifications/README.md
+++ b/src/platform/core/notifications/README.md
@@ -4,14 +4,19 @@
 
 ## API Summary
 
-Properties:
+#### Inputs
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| `color?` | `'primary', 'accent' or 'warn'` | Sets the theme color of the notification tip. Defaults to 'warn'
-| `notifications?` | `number or boolean` | Number for the notification count. Shows number if the input is a positive number or its no count state if boolean 'true'
-| `positionX?` | `TdNotificationCountPositionX or 'before', 'after' or 'center'` | Sets the X position of the notification tip. Defaults to 'after' if it has content, else 'center'.
-| `positionY?` | `TdNotificationCountPositionY or 'top', 'bottom' or 'center'` | Sets the Y position of the notification tip. Defaults to 'top' if it has content, else 'center'.
++ color?: 'primary', 'accent' or 'warn'
+  + Sets the theme color of the notification tip. 
+  + Defaults to 'warn'
++ notifications?: number or boolean
+  + Number for the notification count. 
+  + Shows number if the input is a positive number or its no count state if boolean 'true'.
++ positionX?: TdNotificationCountPositionX or 'before', 'after' or 'center'
+  + Sets the X position of the notification tip. 
+  + Defaults to 'after' if it has content, else 'center'.
++ positionY?: TdNotificationCountPositionY or 'top', 'bottom' or 'center'
+  + Sets the Y position of the notification tip. Defaults to 'top' if it has content, else 'center'.
 
 ## Setup
 


### PR DESCRIPTION
## Description
Show the API's as lists rather than data-tables.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to notifications demo
- [ ] See API in readme

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1391" alt="screen shot 2018-01-15 at 5 52 29 pm" src="https://user-images.githubusercontent.com/17860952/34968212-eca62510-fa1c-11e7-9163-26ca18985bdb.png">

