### PR TITLE
feat(messages): change API from tables to lists

### DIFF
--- a/src/platform/core/message/README.md
+++ b/src/platform/core/message/README.md
@@ -17,11 +17,11 @@ But you can also set a `color` from our lib and it can be applied in the compone
   + The icon to be displayed before the title. Defaults to `info_outline` icon.
 + color?: 'primary', 'accent' or 'warn'
   + Sets the color of the message. Can also use any material color: `purple`, `light-blue`, etc.
++ opened?: boolean
+  + Shows or hides the message depending on its value. Defaults to 'true'.
 
 #### Methods
 
-+ opened?: boolean
-  + Shows or hides the message depending on its value. Defaults to 'true'.
 + open: function 
   + Renders the message on screen.
 + close: function

--- a/src/platform/core/message/README.md
+++ b/src/platform/core/message/README.md
@@ -15,7 +15,7 @@ But you can also set a `color` from our lib and it can be applied in the compone
   + Sets the sublabel of the message.
 + icon?: string
   + The icon to be displayed before the title. Defaults to `info_outline` icon.
-+ color?: 'primary', 'accent' or 'warn'
++ color?: 'primary' | 'accent' | 'warn'
   + Sets the color of the message. Can also use any material color: `purple`, `light-blue`, etc.
 + opened?: boolean
   + Shows or hides the message depending on its value. Defaults to 'true'.

--- a/src/platform/core/message/README.md
+++ b/src/platform/core/message/README.md
@@ -7,18 +7,27 @@ But you can also set a `color` from our lib and it can be applied in the compone
 
 ## API Summary
 
-Properties:
+#### Inputs
 
-| Name | Type | Description |
-| --- | --- | 650--- |
-| `label?` | `string` | Sets the label of the message.
-| `sublabel?` | `string` | Sets the sublabel of the message.
-| `icon?` | `string` | The icon to be displayed before the title. Defaults to `info_outline` icon
-| `color?` | `'primary', 'accent' or 'warn'` | Sets the color of the message. Can also use any material color: `purple`, `light-blue`, etc.
-| `opened?` | `boolean` | Shows or hiddes the message depending on its value. Defaults to 'true'.
-| `open` | `function()` | Renders the message on screen.
-| `close` | `function()` | Removes the message content from screen.
-| `toggle` | `function()` | Toggles between open and close depending on state.
++ label?: string
+  + Sets the label of the message.
++ sublabel?: string
+  + Sets the sublabel of the message.
++ icon?: string
+  + The icon to be displayed before the title. Defaults to `info_outline` icon.
++ color?: 'primary', 'accent' or 'warn'
+  + Sets the color of the message. Can also use any material color: `purple`, `light-blue`, etc.
+
+#### Methods
+
++ opened?: boolean
+  + Shows or hides the message depending on its value. Defaults to 'true'.
++ open: function 
+  + Renders the message on screen.
++ close: function
+  +  Removes the message content from screen.
++ toggle: function
+  +  Toggles between open and close depending on state.
 
 ## Setup
 


### PR DESCRIPTION
## Description
Show the API's as lists rather than data-tables.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to messages demo
- [ ] See API in readme

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:release` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1391" alt="screen shot 2018-01-15 at 6 16 03 pm" src="https://user-images.githubusercontent.com/17860952/34968794-2da3fe2c-fa20-11e7-94ce-24030feca31e.png">


