### PR TITLE
chore(): fix release script to rebase instead of merge

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -37,7 +37,7 @@ Execute `npm run release:finish -- [version]` to finish the release process. The
   1. Adds, commits all changes (changelog changes, bump, etc etc).
   2. Creates new `[version]` tag
   3. Pushes commit and new tag into the repository (`develop`).
-  5. Merges `develop` into `master` and pushes changes to repository.
+  5. Rebases `master` with `develop` and pushes changes to repository.
   5. Returns to `develop` branch.
 
 #### Publish Release

--- a/scripts/finish-release
+++ b/scripts/finish-release
@@ -17,9 +17,9 @@ git push --tags
 echo "Pushing changes into develop"
 git push origin develop
 
-echo "Pushing changes into master"
+echo "Rebasing and pushing changes into master"
 git checkout master
-git merge develop
+git rebase develop
 git push origin master
 
 echo "Return to develop branch"


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
When doing `git merge develop` onto `master`.. this generated an extra commit .. this is because git has to generate an extra commit sometimes to be able to merge both histories.. the real way of doing this is via `rebase`.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

