### PR TITLE
bugfix(loading): fixed incorrect variable name

### DIFF
--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -210,7 +210,7 @@
           <![CDATA[
             ...
             export class Demo {
-              items: any[] = [
+              itemList: any[] = [
                 {label: 'Light', value: true},
                 {label: 'Console', value: false},
                 {label: 'T.V.', value: true}];


### PR DESCRIPTION
## Description
Fixed type in documentation of Loading component

### What's included?
- bugfix(loading): changed `items` to `itemList`

#### Test Steps
- [ ] `git checkout fix/loading-variable-type`
- [ ] `npm run serve`
- [ ] Open http://localhost:4200 in browser
- [ ] Go to `COMPONENTS` -> `Loading` and scroll down to `[tdLoading] until usage with icons`
- [ ] click on `Code` and verify that Typescript now says 'itemList'

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works
- [ ] `npm run tslint` passes
- [ ] `npm run stylelint` passes
- [ ] `npm test` passes and code coverage is not lower
- [ ] `npm run build:lib` still works

<img width="1061" alt="screen shot 2018-04-12 at 2 34 32 pm" src="https://user-images.githubusercontent.com/437977/38705621-0210aebc-3e5f-11e8-90e6-56d534b249f5.png">

