### PR TITLE
chore(): update script to allow publishing `next` or `latest` tags

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -51,7 +51,7 @@ Execute `npm run publish:npm -- next` to publish a beta/RC Release.
 #### Post Release Checklist
 
 1. Deploy to ghpages using `npm run ghpages:deploy`
-2. Update release `plnkr` and `stackblitz` if needed
+2. Update `stackblitz` if needed
 3. Update Covalent Quickstart (or Seed) with small commits to show step by step the upgrade process
 4. Update UPGRADE.md as necessary.
 5. Throw party~

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -38,9 +38,15 @@ Execute `npm run release:finish -- [version]` to finish the release process. The
 
 #### Publish Release
 
+##### Stable Release
+
 Execute `npm run publish:npm` from develop branch to start the automatic publishing process. The steps executed are:
   1. Executes `npm run build:lib` process.
   2. Executes `bash scripts/npm-publish` process.
+
+##### Beta/RC Release
+
+Execute `npm run publish:npm -- next` to publish a beta/RC Release.
 
 #### Post Release Checklist
 

--- a/scripts/npm-publish
+++ b/scripts/npm-publish
@@ -1,5 +1,8 @@
 #!/bin/bash
 scope=@covalent
+tag=latest
+
+[[ $1 = 'next' ]] && tag=next || tag=latest
 
 #login into private registry
 npm login --scope=$scope
@@ -8,7 +11,7 @@ for package in ./deploy/platform/*
 do
   if [ -d ${package} ]
   then
-    npm publish ${package} --access=public
+    npm publish ${package} --access=public --tag=$tag
   fi
 done
 


### PR DESCRIPTION
## Description

Update `publish` script to handle `next` tag as well as `latest` tag.

### What's included?
<!-- List features included in this PR -->
- `npm run publish:npm` now accepts an argument to be able to publish modules with `tag=next`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
