### PR TITLE
Fix npm links for github badges on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## Covalent: UI Platform based on Angular-Material
 
 [![Build Status](https://travis-ci.org/Teradata/covalent.svg?branch=develop)](https://travis-ci.org/Teradata/covalent)
-[![npm](https://img.shields.io/npm/v/%40covalent/core.svg)](badge-url)
-[![npm](https://img.shields.io/npm/v/%40covalent/core/next.svg)](badge-url)
+[![npm](https://img.shields.io/npm/v/%40covalent/core.svg)](https://www.npmjs.com/package/@covalent/core)
+[![npm](https://img.shields.io/npm/v/%40covalent/core/next.svg)](https://www.npmjs.com/package/@covalent/core/v/next)
 [![Join the chat at https://gitter.im/Teradata/covalent](https://badges.gitter.im/Teradata/covalent.svg)](https://gitter.im/Teradata/covalent?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![Coverage Status](https://coveralls.io/repos/github/Teradata/covalent/badge.svg)](https://coveralls.io/github/Teradata/covalent)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Join the chat at https://gitter.im/Teradata/covalent](https://badges.gitter.im/Teradata/covalent.svg)](https://gitter.im/Teradata/covalent?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![Coverage Status](https://coveralls.io/repos/github/Teradata/covalent/badge.svg)](https://coveralls.io/github/Teradata/covalent)
-[![npm](https://img.shields.io/npm/l/@covalent/core.svg)](badge-url)
+[![npm](https://img.shields.io/npm/l/@covalent/core.svg)](LICENSE)
 
 <img alt="Covalent" src="https://cdn.rawgit.com/Teradata/covalent/develop/src/app/assets/icons/covalent.svg" width="150">
 


### PR DESCRIPTION
## Description
Fix npm link for github badges on Readme

### What's included?
<!-- List features included in this PR -->
- Updates to Readme

#### Test Steps
- [ ] checkout branch
- [ ] Open Readme in vscode
- [ ] Click Previewer for Markdown file
- [ ] Click on links for npm versions
- [ ] Click on License link
- [ ] See it open to correct locations


#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="578" alt="screen shot 2018-05-17 at 2 35 25 pm" src="https://user-images.githubusercontent.com/10502797/40205075-925b470c-59df-11e8-9079-b4b7712f6870.png">