### PR TITLE
fix(search-box): back arrow clears search (closes #1157)

### DIFF
--- a/src/platform/core/search/search-box/search-box.component.ts
+++ b/src/platform/core/search/search-box/search-box.component.ts
@@ -118,7 +118,9 @@ export class TdSearchBoxComponent extends _TdSearchBoxMixinBase implements ICont
    * Method executed when the search icon is clicked.
    */
   searchClicked(): void {
-    if (this.alwaysVisible || !this._searchVisible) {
+    if (!this.alwaysVisible && this._searchVisible) {
+      this.handleClear();
+    } else if (this.alwaysVisible || !this._searchVisible) {
       this._searchInput.focus();
     }
     this.toggleVisibility();

--- a/src/platform/core/search/search-box/search-box.component.ts
+++ b/src/platform/core/search/search-box/search-box.component.ts
@@ -119,6 +119,7 @@ export class TdSearchBoxComponent extends _TdSearchBoxMixinBase implements ICont
    */
   searchClicked(): void {
     if (!this.alwaysVisible && this._searchVisible) {
+      this.value = '';
       this.handleClear();
     } else if (this.alwaysVisible || !this._searchVisible) {
       this._searchInput.focus();


### PR DESCRIPTION
## Description
Clear value in search box when back arrow is tapped
Fixes bug found in issue:  [Covalent-1157](https://github.com/Teradata/covalent/issues/1157)

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] checkout branch
- [ ] `npm run serve`
- [ ] Go to Components -> Data Table -> Data Table with components
- [ ] Enter search text in search field
- [ ] Verify corresponding results shown
- [ ] Click on the back arrow in search field
- [ ] Verify initial table is displayed

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![covalent-search](https://user-images.githubusercontent.com/437977/40517621-1752a4f6-5f6b-11e8-8cf9-3165689d5f88.gif)

closes https://github.com/Teradata/covalent/issues/1157