### PR TITLE
Added missing comma in docs example

### DIFF
--- a/src/platform/dynamic-forms/README.md
+++ b/src/platform/dynamic-forms/README.md
@@ -115,7 +115,7 @@ export class Demo {
     name: 'select',
     type: TdDynamicElement.Select,
     required: true,
-    selections: ['A','B','C']
+    selections: ['A','B','C'],
     default: 'A',
   }, {
     name: 'file-input',


### PR DESCRIPTION
## Description
Added missing comma in docs example

### What's included?
- missing comma

#### Test Steps
- [ ] read doc example

#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

<img width="300" alt="screen shot 2018-04-30 at 08 15 33" src="https://user-images.githubusercontent.com/624760/39413012-b1f0ebec-4c4e-11e8-858b-b8cba580cc54.png">
