### PR TITLE
chore(): modify npm script and nightly script for experimental package

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -15,7 +15,7 @@ The source has two parts, the platform and a documentation app.
 
 ## Adding a new platform feature (component/module/utility)
 
-Please reference these [docs](https://github.com/Teradata/covalent/blob/93c5a064d1aa19fab5015f5def2b300f48671de2/src/platform/experimental/README.md). 
+Please reference these [docs](https://github.com/Teradata/covalent/blob/develop/src/platform/experimental/README.md). 
 
 
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:lib": "bash scripts/build-release && gulp version-placeholder",
     "build:universal": "bash scripts/build-universal",
     "publish:npm": "npm run build:lib && bash scripts/npm-publish",
-    "publish:nightly": "npm run build:lib && bash scripts/nightly-publish --entrypoint core && bash scripts/nightly-publish --entrypoint experimental",
+    "publish:nightly": "npm run build:lib && bash scripts/nightly-publish core && bash scripts/nightly-publish experimental",
     "ghpages:deploy": "npm run build:docs -- --base-href /covalent/ && bash scripts/ghpages-deploy",
     "release:start": "bash scripts/start-release",
     "release:finish": "bash scripts/finish-release",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:lib": "bash scripts/build-release && gulp version-placeholder",
     "build:universal": "bash scripts/build-universal",
     "publish:npm": "npm run build:lib && bash scripts/npm-publish",
-    "publish:nightly": "npm run build:lib && bash scripts/nightly-publish",
+    "publish:nightly": "npm run build:lib && bash scripts/nightly-publish --entrypoint core && bash scripts/nightly-publish --entrypoint experimental",
     "ghpages:deploy": "npm run build:docs -- --base-href /covalent/ && bash scripts/ghpages-deploy",
     "release:start": "bash scripts/start-release",
     "release:finish": "bash scripts/finish-release",

--- a/scripts/nightly-publish
+++ b/scripts/nightly-publish
@@ -1,16 +1,44 @@
 #!/bin/bash
 
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -e|--entrypoint)
+    ENTRYPOINT="$2"
+    shift # past argument
+    shift # past value
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+if [[ -n $1 ]]; then
+    echo "Last line of file specified as non-opt/last argument:"
+    tail -1 "$1"
+fi
+
 set -o errexit -o nounset
 
-buildDir="deploy/platform/core"
+if [ $ENTRYPOINT = "core" ]
+then
+  buildDir="deploy/platform/core"
+  repoName="covalent-nightly"
+  repoUrl="https://github.com/Teradata/covalent-nightly.git"
+elif [ $ENTRYPOINT = "experimental" ]
+then
+  buildDir="deploy/platform/experimental"
+  repoName="covalent-experimental-nightly"
+  repoUrl="https://github.com/Teradata/covalent-experimental-nightly.git"
+fi
+
 
 commitSha=$(git rev-parse --short HEAD)
 commitAuthorName=$(git --no-pager show -s --format='%an' HEAD)
 commitAuthorEmail=$(git --no-pager show -s --format='%ae' HEAD)
 commitMessage=$(git log --oneline -n 1)
 
-repoName="covalent-nightly"
-repoUrl="https://github.com/Teradata/covalent-nightly.git"
 repoDir="deploy/$repoName"
 
 echo "Cloning $repoUrl into $repoDir"
@@ -18,7 +46,7 @@ git clone $repoUrl $repoDir
 
 echo "Cleaning nightly repo and moving release files into it"
 rm -rf $repoDir/*
-cp -r $buildDir/* $repoDir
+cp -rf $buildDir/* $repoDir
 cd $repoDir
 
 # Prepare Git for pushing the artifacts to the repository.

--- a/scripts/nightly-publish
+++ b/scripts/nightly-publish
@@ -1,44 +1,24 @@
 #!/bin/bash
 
-POSITIONAL=()
-while [[ $# -gt 0 ]]
-do
-key="$1"
-
-case $key in
-    -e|--entrypoint)
-    ENTRYPOINT="$2"
-    shift # past argument
-    shift # past value
-    ;;
-esac
-done
-set -- "${POSITIONAL[@]}" # restore positional parameters
-if [[ -n $1 ]]; then
-    echo "Last line of file specified as non-opt/last argument:"
-    tail -1 "$1"
-fi
-
 set -o errexit -o nounset
 
-if [ $ENTRYPOINT = "core" ]
-then
-  buildDir="deploy/platform/core"
-  repoName="covalent-nightly"
-  repoUrl="https://github.com/Teradata/covalent-nightly.git"
-elif [ $ENTRYPOINT = "experimental" ]
-then
-  buildDir="deploy/platform/experimental"
-  repoName="covalent-experimental-nightly"
-  repoUrl="https://github.com/Teradata/covalent-experimental-nightly.git"
-fi
+package=$1
 
+buildDir="deploy/platform/${package}"
 
 commitSha=$(git rev-parse --short HEAD)
 commitAuthorName=$(git --no-pager show -s --format='%an' HEAD)
 commitAuthorEmail=$(git --no-pager show -s --format='%ae' HEAD)
 commitMessage=$(git log --oneline -n 1)
 
+if [ $package = "core" ]
+then
+  repoName="covalent-nightly"
+  repoUrl="https://github.com/Teradata/covalent-nightly.git"
+else
+  repoName="covalent-${package}-nightly"
+  repoUrl="https://github.com/Teradata/covalent-${package}-nightly.git"
+fi
 repoDir="deploy/$repoName"
 
 echo "Cloning $repoUrl into $repoDir"
@@ -57,9 +37,12 @@ git config credential.helper "store --file=.git/credentials"
 
 echo "https://${COVALENT_NIGHTLY_TOKEN}:@github.com" > .git/credentials
 
-git add -A
-git commit -m "$commitMessage"
-git tag "$commitSha"
-git push origin master --tags
-
-echo "Finished publishing nightly build"
+if [ -n "$(git status --porcelain)" ]; then
+  git add -A
+  git commit -m "$commitMessage"
+  git tag "$commitSha"
+  git push origin master --tags
+  echo "Finished publishing nightly build for ${package}"
+else
+  echo "No changes to commit for ${package}";
+fi

--- a/scripts/npm-publish
+++ b/scripts/npm-publish
@@ -11,10 +11,13 @@ for package in ./deploy/platform/*
 do
   if [ -d ${package} ]
   then
-    npm publish ${package} --access=public --tag=$tag
+    if [ ${package} != "experimental" ]
+    then
+      npm publish ${package} --access=public --tag=$tag
+    fi
   fi
 done
 
 #logout when finished
-npm logout 
+npm logout
 echo "Published successfully [scope: $scope]. Use 'npm install [package-name]' in the project you want to use it."

--- a/scripts/npm-publish
+++ b/scripts/npm-publish
@@ -11,7 +11,8 @@ for package in ./deploy/platform/*
 do
   if [ -d ${package} ]
   then
-    if [ ${package} != "experimental" ]
+    # ignore experimental package
+    if [[ !(${package} =~ "experimental") ]]
     then
       npm publish ${package} --access=public --tag=$tag
     fi

--- a/src/platform/experimental/package.json
+++ b/src/platform/experimental/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@covalent/experimental",
   "description": "Teradata UI Platform Experimental Module",
-  "version": "0.0.0-EXPERIMENTAL",
+  "version": "0.0.0-COVALENT",
   "license": "MIT",
   "author": "Teradata UX",
   "contributors": [

--- a/src/platform/experimental/template-rename-me-experiment-module/rename-me.component.html
+++ b/src/platform/experimental/template-rename-me-experiment-module/rename-me.component.html
@@ -1,1 +1,1 @@
-<a href="https://goo.gl/jrNtS9"> Test Link </a>
+<a href="https://github.com/Teradata/covalent"> Test Link </a>


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
After speaking with Ed + Jeremy, experimental module should be bound to Covalent's versioning rather then be on it's own versioning and it should be consumed though it's own nightly build.

### What's included?
<!-- List features included in this PR -->
- Bound experimental's package.json `version` property to Covalent's build process.
- Experimental nightly build integration

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `yarn build:lib`
- [ ] Verify `/deploy/platform/experimental/package.json` `version` matches the other entry points `version` property (EX: core and experimental `version` are both 2.0.0-beta-2 after the build)
// TODO: update with night build test instructions 


#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
