### PR TITLE
feat(tab-select): add stretchTabs input to stretch tabs on mat-tab-group

### DIFF
--- a/src/platform/experimental/tab-select/README.md
+++ b/src/platform/experimental/tab-select/README.md
@@ -12,6 +12,8 @@
   + Sets disabled state of the component.
 + disabledRipple?: boolean
   + Disables ripple effect on component.
++ stretchTabs?: boolean
+  + Makes the tabs stretch to fit the parent container.
 + color?: ThemePalette
   + Color of the tab group.
 + backgroundColor?: ThemePalette
@@ -82,6 +84,7 @@ Example with all inputs/outputs:
                 [color]="'accent'"
                 [disabled]="false"
                 [disabledRipple]="false"
+                [stretchTabs]="true"
                 (valueChange)="myValue = $event">
   <td-tab-option [value]="1" [disabled]="false">Label 1</td-tab-option>
   <td-tab-option [value]="2">Label 2</td-tab-option>

--- a/src/platform/experimental/tab-select/tab-select.component.html
+++ b/src/platform/experimental/tab-select/tab-select.component.html
@@ -1,4 +1,5 @@
-<mat-tab-group [backgroundColor]="backgroundColor"
+<mat-tab-group [attr.mat-stretch-tabs]="stretchTabs ? true : undefined"
+                [backgroundColor]="backgroundColor"
                 [color]="color"
                 [disableRipple]="disableRipple"
                 [selectedIndex]="selectedIndex"

--- a/src/platform/experimental/tab-select/tab-select.component.ts
+++ b/src/platform/experimental/tab-select/tab-select.component.ts
@@ -17,6 +17,7 @@ import {
 } from '@angular/forms';
 
 import { ThemePalette } from '@angular/material/core';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 
 import { ICanDisable,
           mixinDisabled,
@@ -57,6 +58,7 @@ export class TdTabSelectComponent extends _TdTabSelectMixinBase
 
   private _values: any[] = [];
   private _selectedIndex: number = 0;
+  private _stretchTabs: boolean = false;
 
   get selectedIndex(): number {
     return this._selectedIndex;
@@ -69,6 +71,14 @@ export class TdTabSelectComponent extends _TdTabSelectMixinBase
 
   get tabOptions(): TdTabOptionComponent[] {
     return this._tabOptions ? this._tabOptions.toArray() : undefined;
+  }
+
+  @Input('stretchTabs')
+  set stretchTabs(stretchTabs: boolean) {
+    this._stretchTabs = coerceBooleanProperty(stretchTabs);
+  }
+  get stretchTabs(): boolean {
+    return this._stretchTabs;
   }
 
   /**

--- a/src/test-bed/test-bed/test-bed.component.html
+++ b/src/test-bed/test-bed/test-bed.component.html
@@ -55,8 +55,8 @@
     </td-tab-option>
   </td-tab-select>
 
-  <h3>Disabled ripple on tabs</h3>
-  <td-tab-select disableRipple>
+  <h3>Stretched and disabled ripple on tabs</h3>
+  <td-tab-select stretchTabs disableRipple>
     <td-tab-option>
       MY LABEL
     </td-tab-option>


### PR DESCRIPTION
## Description
We need to be able to set the `mat-stretch-tabs` attribute in the underlying `mat-tab-group`. We will expose an `stretchTabs` that sets or removes said attribute in the `td-tab-select` component.

### What's included?
<!-- List features included in this PR -->
- [stretchTabs] input
- Updated README and Demo

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve:test-bed`
- [ ] Check last demo that uses `stretchTabs`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
