### PR TITLE
chore(): rename `npm run serve:test-bed` to `npm run serve:experimental`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "coverage:mac": "open -a \"Google Chrome\" coverage/index.html",
     "coveralls": "cat ./coverage/lcov.info | node ./node_modules/coveralls/bin/coveralls.js",
     "serve": "node --max_old_space_size=5048 ./node_modules/@angular/cli/bin/ng serve",
-    "serve:test-bed": "node --max_old_space_size=5048 ./node_modules/@angular/cli/bin/ng serve covalent-test-bed",
+    "serve:experimental": "node --max_old_space_size=5048 ./node_modules/@angular/cli/bin/ng serve covalent-test-bed",
     "serve:prod": "node --max_old_space_size=5048 ./node_modules/@angular/cli/bin/ng serve --aot --prod --source-map=false --optimization",
     "build:docs": "node --max_old_space_size=5048 ./node_modules/@angular/cli/bin/ng build --aot --prod --source-map=false --optimization",
     "build:lib": "bash scripts/build-release && gulp version-placeholder",

--- a/src/platform/experimental/README.md
+++ b/src/platform/experimental/README.md
@@ -38,7 +38,9 @@ ___
 
 ### How to install experimental modules
 
-To use (__be aware that its experimental and contracts might change!__) our experimental package, install the experimental nightly build:
+WARNING: Experimental features are prone to change or be removed at any time. Do not use in production as these features are unsupported!
+
+#### Installation
 
 ```bash
 npm install --save https://github.com/Teradata/covalent-experimental-nightly.git

--- a/src/platform/experimental/README.md
+++ b/src/platform/experimental/README.md
@@ -24,6 +24,10 @@ ___
 5. Open all the files in the directory with a text editor and anywhere you see `rename-me` `renameMe` or `RenameMe` replace it with your experiments name. Respective of casing style.
 6. In a text editor open `src/platform/experimental/public-api.ts` and include your experiment by adding the following line to the end of the file: `export * from './<my-new-experiment>/index';` (Replace above my-new-experiment to the name of your experiment)
 
+**Step 4:** Run test-bed application
+
+1. `npm run serve:experimental`
+
 **Notes:** 
 1. By following the template your experiment will be compiled into standard compliant Angular Package Format (APF) via [ng-packagr](https://github.com/dherges/ng-packagr). If you would like to learn more about the benefits of APF you can reference this [link](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/edit).
 2. Don't forget to update your experiments `public-api.ts` and your experiments `*.module.ts` files as you decide what parts of your new experiment/feature you want to publicly expose to your fellow developers using it.
@@ -31,3 +35,27 @@ ___
 4. If you experiment starts to become a serious project: (1) fill out your experiments `README.md` and (2) write unit tests for it.
 5. If you have question please don't hesitate to ask us by either opening a GitHub issue or connecting with us in the [Covalent Gitter channel](https://gitter.im/Teradata/covalent).
 
+
+### How to install experimental modules
+
+To use (__be aware that its experimental and contracts might change!__) our experimental package, install the experimental nightly build:
+
+```bash
+npm install --save https://github.com/Teradata/covalent-experimental-nightly.git
+```
+
+#### Import the Covalent Experimental NgModules
+  
+**src/app/app.module.ts**
+```ts
+import { CovalentTabSelectModule } from '@covalent/experimental/tab-select';
+...
+// other imports 
+@NgModule({
+  imports: [
+    CovalentTabSelectModule,
+  ],
+  ...
+})
+export class AppModule { }
+```


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Modify experimental README to explain how to run the test-bed
application and also how to install the experimental build

### What's included?
<!-- List features included in this PR -->
- rename `npm run serve:test-bed` to `npm run serve:experimental`
- Update experimental README on how to serve and how to install

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve:experimental`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
