### PR TITLE
fix(datatable): Fix for Select All Rows doesn't trigger ngModelChange

### DIFF
--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -606,6 +606,7 @@ export class TdDataTableComponent extends _TdDataTableMixinBase implements ICont
       this._indeterminate = false;
     }
     this.onSelectAll.emit({rows: toggledRows, selected: checked});
+    this.onChange(this.value);
   }
 
   /**


### PR DESCRIPTION
## Description
Fix for Select All Rows doesn't trigger ngModelChange

### What's included?
Added `this.onChange(this.value);` to selectAll method

#### Test Steps
- [ ] checkout branch
- [ ] `npm run serve`
- [ ] Modify src/app/components/components/data-table/data-table.component.html on line 192 change the table definition to:
```
<td-data-table
          #dataTable
          [data]="filteredData"
          [columns]="columns"
          [selectable]="selectable"
          [clickable]="clickable"
          [multiple]="multiple"
          [sortable]="true"
          [sortBy]="sortBy"
          [(ngModel)]="selectedRows"
          (ngModelChange)="getDataArray(selectedRows)"
          [sortOrder]="sortOrder"
          (sortChange)="sort($event)"
          (rowClick)="showAlert($event)">
</td-data-table>
```
- [ ] Modify src/app/components/components/data-table/data-table.component.ts add the following method:
```
getDataArray(rows: any): void {
    for (let i: number = 0; i < rows.length; i++) {
      // do something
      console.log(rows[i];
    }
  }
```
- [ ] Go to the datatable demo page and `Data Table with components` section
- [ ] Try doing individual selects of rows and multi select of rows and see the values outputted in the browser debug console

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![multiselect](https://user-images.githubusercontent.com/10502797/42706976-8902ea22-868d-11e8-887a-9d3585a43519.gif)
