### PR TITLE
fix(datatable): Firefox - Row selection checkbox incorrectly fires row click event

### DIFF
--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -711,8 +711,9 @@ export class TdDataTableComponent extends _TdDataTableMixinBase implements ICont
       // ignoring linting rules here because attribute it actually null or not there
       // can't check for undefined
       const srcElement: any = event.srcElement || event.currentTarget;
+      let element: HTMLElement = event.target as HTMLElement;
       /* tslint:disable-next-line */
-      if (srcElement.getAttribute('stopRowClick') === null) {
+      if (srcElement.getAttribute('stopRowClick') === null && element.tagName.toLowerCase() !== 'mat-pseudo-checkbox') {
         this.onRowClick.emit({
           row: row,
           index: index,


### PR DESCRIPTION
## Description
Row selection checkbox incorrectly fires row click event
closes #1123 

### What's included?
Correct checking of event target for Firefox

#### Test Steps
- [ ] checkout branch
- [ ] `npm run serve`
- [ ] Go to http://localhost:4200/#/components/data-table in Firefox, Chrome, Safari, and Edge
- [ ] Scroll down to `Data Table with components` example
- [ ] Turn on the Clickable rows option
- [ ] Click on a row (not in the checkbox)
- [ ] See alert popup with row you selected
- [ ] Click on a checkbox in the first column
- [ ] See no alert popup but see the row selected
- [ ] See same behavior in Firefox, Chrome, Safari, and Edge

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

![select row](https://user-images.githubusercontent.com/10502797/42715865-ab6ea9f0-86ad-11e8-80ea-bc4dda6e5c1e.gif)

