### PR TITLE
fix(docs): GitHub Deployment Docs out of date

### DIFF
--- a/src/app/components/docs/deployment/deployment.component.html
+++ b/src/app/components/docs/deployment/deployment.component.html
@@ -1,39 +1,8 @@
 <mat-card>
-  <mat-card-title>Deployment</mat-card-title>
-  <mat-card-subtitle>Deploy your app via CLI</mat-card-subtitle>
+  <mat-card-title>Building</mat-card-title>
+  <mat-card-subtitle>Build your app via CLI</mat-card-subtitle>
   <mat-divider></mat-divider>
   <mat-card-content>
-     <h3>Command Line Deploy Tasks</h3>
-     <p>You can deploy your apps quickly via:</p>
-    <td-highlight lang="html">
-      ng github-pages:deploy --message "Optional commit message"
-    </td-highlight>
-
-    <p>This will do the following:</p>
-
-    <ul>
-    <li>creates GitHub repo for the current project if one doesn't exist</li>
-    <li>rebuilds the app in production mode at the current <code>HEAD</code></li>
-    <li>creates a local <code>gh-pages</code> branch if one doesn't exist</li>
-    <li>moves your app to the <code>gh-pages</code> branch and creates a commit</li>
-    <li>edit the base tag in index.html to support github pages</li>
-    <li>pushes the <code>gh-pages</code> branch to github</li>
-    <li>returns back to the original <code>HEAD</code></li>
-    </ul>
-
-    <p>Creating the repo requires a token from github, and the remaining functionality
-    relies on ssh authentication for all git operations that communicate with github.com.
-    To simplify the authentication, be sure to <a target="_blank" href="https://help.github.com/articles/generating-ssh-keys/">setup your ssh keys</a>.</p>
-
-    <p>If you are deploying a <a target="_blank" href="https://help.github.com/articles/user-organization-and-project-pages/">user or organization page</a>, you can instead use the following command:</p>
-
-    <td-highlight lang="html">
-      ng github-pages:deploy --user-page --message "Optional commit message"
-    </td-highlight>
-
-    <p>This command pushes the app to the <code>master</code> branch on the github repo instead
-    of pushing to <code>gh-pages</code>, since user and organization pages require this.</p>
-
     <h3>Creating a build</h3>
     <p>The build artifacts will be stored in the dist/ directory.</p>
    <td-highlight lang="html">

--- a/src/app/components/docs/docs.component.ts
+++ b/src/app/components/docs/docs.component.ts
@@ -39,10 +39,10 @@ export class DocsComponent {
     route: 'creating',
     title: 'Creating new views',
   }, {
-    description: 'Deploy your UI',
-    icon: 'local_shipping',
+    description: 'Build your UI',
+    icon: 'cached',
     route: 'deployment',
-    title: 'Deployment',
+    title: 'Building',
   }, {
     description: 'Access 750+ Material Design icons',
     icon: 'photo_size_select_actual',


### PR DESCRIPTION
## Description
Removed section in docs about using ng github-pages:deploy
closes #576 

### What's included?
- Updated documentation

#### Test Steps
- [ ] checkout branch
- [ ] `npm run serve`
- [ ] Go to http://localhost:4200/#/docs/deployment
- [ ] See ng github-pages:deploy section is no longer there

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

<img width="1436" alt="screen shot 2018-07-13 at 4 06 32 pm" src="https://user-images.githubusercontent.com/10502797/42717559-bff5d782-86b6-11e8-80b8-c7ee136e05d5.png">
