### PR TITLE
fix(datatable): Fix for ExpressionChangedAfterItHasBeenCheckedError on datatable demo with pagination

### DIFF
--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -153,19 +153,19 @@ export class DataTableDemoComponent implements OnInit {
     this.filter();
   }
 
-  filter(): void {
+  async filter(): Promise<void> {
     let newData: any[] = this.data;
-    let excludedColumns: string[] = this.columns
+    let excludedColumns: string[] = await this.columns
     .filter((column: ITdDataTableColumn) => {
       return ((column.filter === undefined && column.hidden === true) || 
               (column.filter !== undefined && column.filter === false));
     }).map((column: ITdDataTableColumn) => {
       return column.name;
     });
-    newData = this._dataTableService.filterData(newData, this.searchTerm, true, excludedColumns);
+    newData = await this._dataTableService.filterData(newData, this.searchTerm, true, excludedColumns);
     this.filteredTotal = newData.length;
-    newData = this._dataTableService.sortData(newData, this.sortBy, this.sortOrder);
-    newData = this._dataTableService.pageData(newData, this.fromRow, this.currentPage * this.pageSize);
+    newData = await this._dataTableService.sortData(newData, this.sortBy, this.sortOrder);
+    newData = await this._dataTableService.pageData(newData, this.fromRow, this.currentPage * this.pageSize);
     this.filteredData = newData;
   }
 


### PR DESCRIPTION
## Description
Modified the filter method to be async Promise to avoid ExpressionChangedAfterItHasBeenCheckedError on datatable demo

### What's included?
- modified:   src/app/components/components/data-table/data-table.component.ts

#### Test Steps
- [ ] Checkout branch
- [ ] `npm run serve`
- [ ] Go to http://localhost:4200/#/components/data-table
- [ ] Go to the `Data Table with components` section
- [ ] Open the browser debug console
- [ ] Change the Per Page to 100
- [ ] See no error in console
- [ ] See that the amount of rows in table changed

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

![table](https://user-images.githubusercontent.com/10502797/42849135-ded5b8c0-89d6-11e8-92a1-d1cae8106f91.gif)
