### PR TITLE
fix(paging): Fix paging demo with search to jump to page 1 after searching

### DIFF
--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -308,6 +308,7 @@
 
               search(searchTerm: string): void {
                 this.searchTerm = searchTerm;
+                this.pagingBar.navigateToPage(1);
                 this.filter();
               }
 

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnInit, HostBinding } from '@angular/core';
+import { Component, OnInit, HostBinding, ViewChild } from '@angular/core';
 
 import { slideInDownAnimation } from '../../../app.animations';
 
 import { TdDataTableSortingOrder, TdDataTableService, TdDataTableComponent,
-         ITdDataTableSortChangeEvent, ITdDataTableColumn } from '../../../../platform/core';
+  ITdDataTableSortChangeEvent, ITdDataTableColumn, TdPagingBarComponent } from '../../../../platform/core';
 import { IPageChangeEvent } from '../../../../platform/core';
 import { TdDialogService } from '../../../../platform/core';
 
@@ -23,6 +23,8 @@ export class DataTableDemoComponent implements OnInit {
 
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
+
+  @ViewChild(TdPagingBarComponent) pagingBar: TdPagingBarComponent;
 
   cellAttrs: Object[] = [{
     description: `Makes cell follow the numeric data-table specs. Defaults to 'false'`,
@@ -143,6 +145,7 @@ export class DataTableDemoComponent implements OnInit {
 
   search(searchTerm: string): void {
     this.searchTerm = searchTerm;
+    this.pagingBar.navigateToPage(1);
     this.filter();
   }
 


### PR DESCRIPTION
## Description
When jumping to last page and then applying a filter like search on the data, need to jump back to the first page.

closes: #1202 

### What's included?
- modified:   src/app/components/components/data-table/data-table.component.ts

#### Test Steps
- [ ] Checkout branch
- [ ] `npm run serve`
- [ ] Go to http://localhost:4200/covalent/#/components/data-table
- [ ] Scroll down to "Data Table with components" example
- [ ] Click the "last page" button on the td-paging-bar component. 
- [ ] The paging bar shows Rows per page 50 451-500 of 500.
- [ ] Click on the search icon and type in "abc" into the search input field.
The data table shows the results, the paging bar shows rows per page 50, 1-3

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

![table](https://user-images.githubusercontent.com/10502797/43294156-cc2ac7ba-90f2-11e8-83de-bf6705d99ff6.gif)
