### PR TITLE
feat(animations): rotate animation params

### DIFF
--- a/src/app/components/components/animations/animations.component.html
+++ b/src/app/components/components/animations/animations.component.html
@@ -7,21 +7,15 @@
 
     <h3>Setup:</h3>
     <p>Import individual animation utilities as needed into the component that will contain the elements you want to animate.</p>
-    <p>Replace the "TdAnimationUtility" stub variable in code setup below with the respective animation utilities you decide to equip.</p>
-    <p>
-      Every utility function has default animation properties that can be modified. One of which is a default anchor name that
-      can be used implicitly or overridden with your own custom name. The anchor name is used to attach the animation to an arbitrary
-      element in the template.
-    </p>
     <td-highlight lang="typescript">
       <![CDATA[
-        import { TdAnimationUtility_A, TdAnimationUtility_B } from '@covalent/core/common';
+        import { tdAnimationUtility_A, tdAnimationUtility_B } from '@covalent/core/common';
 
         @Component({
           ...
           animations: [
-            TdAnimationUtility_A(), // using implicit anchor name in template
-            TdAnimationUtility_B({ anchor: 'myAnchor' }), // using custom anchor name in template
+            tdAnimationUtility_A,
+            tdAnimationUtility_B,
           ],
         })
         export class MyComponent {
@@ -42,7 +36,7 @@
   <mat-card-title>Rotate Animation</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="mat-body-1">Use <code>TdRotateAnimation</code> to rotate any element based on a boolean state.</p>
+    <p class="mat-body-1">Use <code>tdRotateAnimation</code> to rotate any element based on a boolean state.</p>
     <div>
       <h3>Demo 1:</h3>
 
@@ -53,10 +47,10 @@
       <p>Typescript:</p>
       <td-highlight lang="typescript">
         <![CDATA[
-          import { TdRotateAnimation } from '@covalent/core/common';
+          import { tdRotateAnimation } from '@covalent/core/common';
           ...
           animations: [
-            TdRotateAnimation(), // using implicit anchor name 'tdRotate' in template
+            tdRotateAnimation, // using implicit anchor name '@tdRotate' in template
           ],
           ...
           class MyDemo {
@@ -78,18 +72,17 @@
 
     <div>
       <h3>Demo 2:</h3>
-      <button mat-raised-button [@tdRotateNeg45]="rotateState2" (click)="rotateState2 = !rotateState2" color="accent">
-        Rotate -45&deg;<mat-icon [@tdRotate545]="rotateState2">mood</mat-icon>
+      <button mat-raised-button [@tdRotate]="{ value: rotateState2, params: { duration: 500, degreesEnd: -45 } }" (click)="rotateState2 = !rotateState2" color="accent">
+        Rotate -45&deg;<mat-icon [@tdRotate]="{ value: rotateState2, params: { duration: 750, degreesEnd: 545 } }">mood</mat-icon>
       </button>
 
       <p>Typescript:</p>
       <td-highlight lang="typescript">
         <![CDATA[
-          import { TdRotateAnimation } from '@covalent/core/common';
+          import { tdRotateAnimation } from '@covalent/core/common';
           ...
           animations: [
-            TdRotateAnimation({ anchor: 'tdRotate545', duration: 750, degrees: 545, ease: 'ease-in' }),
-            TdRotateAnimation({ anchor: 'tdRotateNeg45', duration: 500, degrees: -45 }),
+            tdRotateAnimation,
           ],
           ...
           class MyDemo {
@@ -100,21 +93,25 @@
       <p>HTML:</p>
       <td-highlight lang="html">
         <![CDATA[
-          <button mat-raised-button [@tdRotateNeg45]="triggerState" (click)="triggerState = !triggerState" color="accent">
-            Rotate -45&deg;<mat-icon [@tdRotate545]="triggerState">mood</mat-icon>
+          <button mat-raised-button [@tdRotate]="{ value: rotateState2, params: { duration: 500, degreesEnd: -45 } }" (click)="triggerState = !triggerState" color="accent">
+            Rotate -45&deg;<mat-icon [@tdRotate]="{ value: rotateState2, params: { duration: 750, degreesEnd: 545 } }">mood</mat-icon>
           </button>
         ]]>
       </td-highlight>
     </div>
     <mat-divider></mat-divider>
     <div>
-      <h2>API:</h2>
+      <h2>Acceptable params options:</h2>
       <mat-list>
         <mat-list-item>
-          <h3 matLine>anchor?: string</h3>
-          <p matLine> The anchor name is used to attach the animation to an arbitrary element in the template. Defaults to 'tdRotate'.</p>
+          <h3 matLine>degressStart?: number</h3>
+          <p matLine> Degrees of rotation that the dom object will end up in during the "false" state </p>
         </mat-list-item>
         <mat-divider></mat-divider>
+        <mat-list-item>
+          <h3 matLine>degreesEnd?: number</h3>
+          <p matLine> Degrees of rotation that the dom object will end up in during the "true" state </p>
+        </mat-list-item>
         <mat-list-item>
           <h3 matLine>duration?: number</h3>
           <p matLine> Duration the animation will run in milliseconds. Defaults to 250 ms. </p>
@@ -126,13 +123,8 @@
         </mat-list-item>
         <mat-divider></mat-divider>
         <mat-list-item>
-          <h3 matLine>degrees?: number</h3>
-          <p matLine> Degrees of rotation the dom object will animation. A negative value will cause the animation to initially rotate counter-clockwise. Defaults to 180 degrees. </p>
-        </mat-list-item>
-        <mat-divider></mat-divider>
-        <mat-list-item>
           <h3 matLine>ease?: string</h3>
-          <p matLine>Animation accelerates and decelerates when rotation. Defaults to ease-in.</p>
+          <p matLine>Animation accelerate and decelerate style. Defaults to ease-in.</p>
         </mat-list-item>
         <mat-divider></mat-divider>
       </mat-list>

--- a/src/app/components/components/animations/animations.component.ts
+++ b/src/app/components/components/animations/animations.component.ts
@@ -1,7 +1,7 @@
 import { Component, HostBinding } from '@angular/core';
 
 import { slideInDownAnimation } from '../../../app.animations';
-import { TdRotateAnimation } from '../../../../platform/core/common/animations/rotate/rotate.animation';
+import { tdRotateAnimation } from '../../../../platform/core/common/animations/rotate/rotate.animation';
 import { TdCollapseAnimation } from '../../../../platform/core/common/animations/collapse/collapse.animation';
 import { TdFadeInOutAnimation } from '../../../../platform/core/common/animations/fade/fadeInOut.animation';
 import { TdBounceAnimation } from '../../../../platform/core/common/animations/bounce/bounce.animation';
@@ -16,9 +16,7 @@ import { TdPulseAnimation } from '../../../../platform/core/common/animations/pu
   templateUrl: './animations.component.html',
   animations: [
     slideInDownAnimation,
-    TdRotateAnimation(),
-    TdRotateAnimation({ anchor: 'tdRotate545', duration: 750, degrees: 545, ease: 'ease-in' }),
-    TdRotateAnimation({ anchor: 'tdRotateNeg45', duration: 500, degrees: -45 }),
+    tdRotateAnimation,
     TdCollapseAnimation(),
     TdFadeInOutAnimation(),
     TdBounceAnimation(),

--- a/src/platform/core/common/animations/rotate/rotate.animation.ts
+++ b/src/platform/core/common/animations/rotate/rotate.animation.ts
@@ -1,4 +1,8 @@
-import { trigger, state, style, transition, animate, AnimationTriggerMetadata, AUTO_STYLE, query, animateChild, group } from '@angular/animations';
+import {
+  trigger, state, style, transition, animate, AnimationTriggerMetadata,
+  query, animateChild, group,
+} from '@angular/animations';
+
 import { IAnimationOptions } from '../common/interfaces';
 
 export interface IRotateAnimation extends IAnimationOptions {
@@ -6,20 +10,22 @@ export interface IRotateAnimation extends IAnimationOptions {
   ease?: string;
 }
 
-/**
- * Function TdRotateAnimation
- *
- * params:
- * * anchor: Name of the anchor that will attach to a dom element in the components template that will contain the animation. Defaults to tdRotate.
- * * duration: Duration the animation will run in milliseconds. Defaults to 250 ms.
- * * delay: Delay before the animation will run in milliseconds. Defaults to 0 ms.
- * * degrees: Degrees of rotation that the dom object will animation. A negative value will cause the animation to initially rotate counter-clockwise.
- * * ease: Animation accelerates and decelerates when rotation. Defaults to ease-in.
- *
- * Returns an [AnimationTriggerMetadata] object with states for a boolean trigger based rotation animation.
- *
- * usage: [@myAnchorName]="true|false"
- */
+export const tdRotateAnimation: AnimationTriggerMetadata = trigger('tdRotate', [
+  state('0', style({
+    transform: 'rotate({{ degressStart }}deg)',
+  }), { params: { degressStart: 0 }}),
+  state('1',  style({
+    transform: 'rotate({{ degreesEnd }}deg)',
+  }), { params: { degreesEnd: 180 }}),
+  transition('0 <=> 1', [
+    group([
+      query('@*', animateChild(), { optional: true }),
+      animate('{{ duration }}ms {{ delay }}ms {{ ease }}'),
+    ]),
+  ], { params: { duration: 250, delay: '0', ease: 'ease-in' }}),
+]);
+
+/** @deprecated see tdRotateAnimation */
 export function TdRotateAnimation(rotateOptions: IRotateAnimation = {}): AnimationTriggerMetadata {
   return trigger(rotateOptions.anchor || 'tdRotate', [
     state('0', style({

--- a/src/platform/core/expansion-panel/expansion-panel.component.ts
+++ b/src/platform/core/expansion-panel/expansion-panel.component.ts
@@ -10,7 +10,7 @@ import {
   mixinDisabled,
   ICanDisableRipple,
   mixinDisableRipple,
-  TdRotateAnimation,
+  tdRotateAnimation,
 } from '@covalent/core/common';
 
 @Directive({
@@ -58,7 +58,7 @@ export const _TdExpansionPanelMixinBase = mixinDisableRipple(mixinDisabled(TdExp
   inputs: ['disabled', 'disableRipple'],
   animations: [
     TdCollapseAnimation(),
-    TdRotateAnimation({ anchor: 'tdRotate' }),
+    tdRotateAnimation,
   ],
 })
 export class TdExpansionPanelComponent extends _TdExpansionPanelMixinBase implements ICanDisable, ICanDisableRipple {


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
- Improved the rotate animation
- changes made were based on the [Animations Param Enhancement Doc](https://docs.google.com/document/d/18QT1kX3GchskE6PlZ3PfNCdv_DPAVoDPZpOS0e1Fan0/edit)

### What's included?
<!-- List features included in this PR -->
- Modded the pre-canned animation to allow usage of the Angular animations params feature.
- Deprecated the rotate animation pre-canned function.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `yarn serve`
- [ ] Verify the rotate animation demos work correctly on the docs
- [ ] Verify the rotate animation docs match with the changes to the code
- [ ] Verify and use new rotate animation const object based on the updated doc and params exposed. You can play with it in the `src/app/components/components/animations/animations.component.html` file.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
