### PR TITLE
fix(dynamic-forms): make sure hints and errors dont overlap

### DIFF
--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.html
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.html
@@ -538,6 +538,13 @@
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
         <td-dynamic-forms [elements]="customElements">
+          <ng-template let-element ngFor [ngForOf]="customElements">
+            <ng-template let-control="control" [tdDynamicFormsError]="element.name">
+              <span *ngIf="control.touched || !control.pristine">
+                <span *ngIf="control.hasError('invalidChips')">No more than 2 chips</span>
+              </span>
+            </ng-template>
+          </ng-template>
         </td-dynamic-forms>
       </mat-tab>
       <mat-tab>
@@ -546,12 +553,20 @@
         <p>Custom Component:</p>
         <td-highlight lang="typescript">
           <![CDATA[
-            import { Component } from '@angular/core';
+            import { Component, TemplateRef } from '@angular/core';
             import { FormControl } from '@angular/forms';
 
             @Component({
               selector: 'td-dynamic-input-test',
-              template: `<td-chips [items]="selections" [formControl]="control"></td-chips>`,
+              template: `<td-chips [items]="selections" [formControl]="control"></td-chips>
+                          <div *ngIf="errorMessageTemplate && control?.errors"
+                              class="tc-red-600"
+                              [style.font-size.%]="'70'">
+                            <ng-template
+                              [ngTemplateOutlet]="errorMessageTemplate"
+                              [ngTemplateOutletContext]="{control: control, errors: control?.errors}">
+                            </ng-template>
+                          </div>`,
             })
             export class TdTestDynamicComponent {
 
@@ -560,6 +575,9 @@
 
               /* map any of the properties you passed in the config */
               selections: string[] = [];
+
+              /* map the error message template and use it anywhere you need to */
+              errorMessageTemplate: TemplateRef<any>;
 
             }
           ]]>
@@ -590,6 +608,13 @@
         <td-highlight lang="html">
           <![CDATA[
             <td-dynamic-forms [elements]="customElements">
+              <ng-template let-element ngFor [ngForOf]="customElements">
+                <ng-template let-control="control" [tdDynamicFormsError]="element.name">
+                  <span *ngIf="control.touched || !control.pristine">
+                    <span *ngIf="control.hasError('invalidChips')">No more than 2 chips</span>
+                  </span>
+                </ng-template>
+              </ng-template>
             </td-dynamic-forms>
           ]]>
         </td-highlight>
@@ -602,6 +627,12 @@
               default: ['list1'],
               selections: ['list1', 'list2', 'list3'],
               flex: 100,
+              validators: [{
+                validator: (control: AbstractControl) => {
+                  let isValid: boolean = control.value.length <= 2;
+                  return !isValid ? {invalidChips: true} : undefined;
+                },
+              }],
             }];
           ]]>
         </td-highlight>

--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding } from '@angular/core';
+import { Component, HostBinding, TemplateRef } from '@angular/core';
 import { AbstractControl, Validators } from '@angular/forms';
 import { TdCollapseAnimation } from '@covalent/core/common';
 import { slideInDownAnimation } from '../../../app.animations';
@@ -15,12 +15,21 @@ import { FormControl } from '@angular/forms';
 
 @Component({
   selector: 'td-dynamic-input-test',
-  template: `<td-chips [items]="selections" [formControl]="control"></td-chips>`,
+  template: `<td-chips [items]="selections" [formControl]="control"></td-chips>
+              <div *ngIf="errorMessageTemplate && control?.errors"
+                  class="tc-red-600"
+                  [style.font-size.%]="'70'">
+                <ng-template
+                  [ngTemplateOutlet]="errorMessageTemplate"
+                  [ngTemplateOutletContext]="{control: control, errors: control?.errors}">
+                </ng-template>
+              </div>`,
 })
 export class TdTestDynamicComponent {
 
   control: FormControl;
   selections: string[] = [];
+  errorMessageTemplate: TemplateRef<any>;
 
 }
 
@@ -80,6 +89,7 @@ export class DynamicFormsDemoComponent {
     name: 'number',
     label: 'Number',
     type: TdDynamicType.Number,
+    hint: 'this is an input hint',
     required: true,
     min: 18,
     max: 70,
@@ -160,6 +170,12 @@ export class DynamicFormsDemoComponent {
     default: ['list1'],
     selections: ['list1', 'list2', 'list3'],
     flex: 100,
+    validators: [{
+      validator: (control: AbstractControl) => {
+        let isValid: boolean = control.value.length <= 2;
+        return !isValid ? {invalidChips: true} : undefined;
+      },
+    }],
   }];
 
   elementOptions: any[] = [

--- a/src/platform/dynamic-forms/README.md
+++ b/src/platform/dynamic-forms/README.md
@@ -90,11 +90,26 @@ Example for HTML usage:
 import { ITdDynamicElementConfig, TdDynamicElement, TdDynamicType } from '@covalent/dynamic-forms';
 ...
 /* CUSTOM TYPE */
-  template: '<label>{{label}}</label><input [formControl]="control">',
+  template: `<label>{{label}}</label>
+              <input [formControl]="control">
+              <div *ngIf="errorMessageTemplate && control?.errors"
+                  class="tc-red-600"
+                  [style.font-size.%]="'70'">
+                <ng-template
+                  [ngTemplateOutlet]="errorMessageTemplate"
+                  [ngTemplateOutletContext]="{control: control, errors: control?.errors}">
+                </ng-template>
+              </div>`,
 })
 export class DynamicCustomComponent {
+  /* control property needed to properly bind the underlying element */
   control: FormControl;
+
+  /* map any of the properties you passed in the config */
   label: string;
+
+  /* map the error message template and use it anywhere you need to */
+  errorMessageTemplate: TemplateRef<any>;
 }
 ...
 })
@@ -142,6 +157,7 @@ export class Demo {
     name: 'custom',
     label: 'Custom',
     type: DynamicCustomComponent,
+    required: true,
   }];
 }
 ```

--- a/src/platform/dynamic-forms/dynamic-element.component.ts
+++ b/src/platform/dynamic-forms/dynamic-element.component.ts
@@ -96,6 +96,11 @@ export class TdDynamicElementComponent extends _TdDynamicElementMixinBase
    */
   @Input() selections: any[] = undefined;
 
+  /**
+   * Sets error message template so it can be injected into dynamic components.
+   */
+  @Input() errorMessageTemplate: TemplateRef<any> = undefined;
+
   @ViewChild(TdDynamicElementDirective) childElement: TdDynamicElementDirective;
 
   @HostBinding('attr.max')
@@ -132,6 +137,7 @@ export class TdDynamicElementComponent extends _TdDynamicElementMixinBase
     this._instance.minLength = this.minLength;
     this._instance.maxLength = this.maxLength;
     this._instance.selections = this.selections;
+    this._instance.errorMessageTemplate = this.errorMessageTemplate;
   }
 
   /**

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.html
@@ -9,6 +9,12 @@
             [min]="min"
             [max]="max"/>
     <mat-hint>{{hint}}</mat-hint>
+    <mat-error>
+      <ng-template
+        [ngTemplateOutlet]="errorMessageTemplate"
+        [ngTemplateOutletContext]="{control: control, errors: control?.errors}">
+      </ng-template>
+    </mat-error>
     <mat-datepicker-toggle matSuffix [for]="dynamicDatePicker"></mat-datepicker-toggle>
     <mat-datepicker #dynamicDatePicker></mat-datepicker>
   </mat-form-field>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, TemplateRef } from '@angular/core';
 import { FormControl } from '@angular/forms';
 
 @Component({
@@ -21,5 +21,7 @@ export class TdDynamicDatepickerComponent {
   min: number = undefined;
 
   max: number = undefined;
+
+  errorMessageTemplate: TemplateRef<any> = undefined;
 
 }

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
@@ -12,6 +12,12 @@
           [placeholder]="label"
           readonly/>
     <mat-hint>{{hint}}</mat-hint>
+    <mat-error>
+      <ng-template
+        [ngTemplateOutlet]="errorMessageTemplate"
+        [ngTemplateOutletContext]="{control: control, errors: control?.errors}">
+      </ng-template>
+    </mat-error>
   </mat-form-field>
   <button mat-icon-button *ngIf="control.value" (click)="fileInput.clear()" (keyup.enter)="fileInput.clear()">
     <mat-icon>cancel</mat-icon>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, TemplateRef } from '@angular/core';
 import { FormControl } from '@angular/forms';
 
 @Component({
@@ -15,6 +15,8 @@ export class TdDynamicFileInputComponent {
   label: string = '';
 
   hint: string = '';
+
+  errorMessageTemplate: TemplateRef<any> = undefined;
 
   _handlefileDrop(value: File): void {
     this.control.setValue(value);

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.html
@@ -11,5 +11,11 @@
             [attr.minLength]="minLength"
             [attr.maxLength]="maxLength"/>
     <mat-hint>{{hint}}</mat-hint>
+    <mat-error>
+      <ng-template
+        [ngTemplateOutlet]="errorMessageTemplate"
+        [ngTemplateOutletContext]="{control: control, errors: control?.errors}">
+      </ng-template>
+    </mat-error>
   </mat-form-field>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, TemplateRef } from '@angular/core';
 import { FormControl } from '@angular/forms';
 
 @Component({
@@ -25,5 +25,7 @@ export class TdDynamicInputComponent {
   minLength: number = undefined;
 
   maxLength: number = undefined;
+
+  errorMessageTemplate: TemplateRef<any> = undefined;
 
 }

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.html
@@ -6,5 +6,11 @@
       <mat-option *ngFor="let selection of selections" [value]="selection.value || selection">{{selection.label || selection}}</mat-option>
     </mat-select>
     <mat-hint>{{hint}}</mat-hint>
+    <mat-error>
+      <ng-template
+        [ngTemplateOutlet]="errorMessageTemplate"
+        [ngTemplateOutletContext]="{control: control, errors: control?.errors}">
+      </ng-template>
+    </mat-error>
   </mat-form-field>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, TemplateRef } from '@angular/core';
 import { FormControl } from '@angular/forms';
 
 @Component({
@@ -17,5 +17,7 @@ export class TdDynamicSelectComponent {
   required: boolean = undefined;
 
   selections: any[] = undefined;
+
+  errorMessageTemplate: TemplateRef<any> = undefined;
 
 }

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-textarea/dynamic-textarea.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-textarea/dynamic-textarea.component.html
@@ -8,5 +8,11 @@
             rows="4">
     </textarea>
     <mat-hint>{{hint}}</mat-hint>
+    <mat-error>
+      <ng-template
+        [ngTemplateOutlet]="errorMessageTemplate"
+        [ngTemplateOutletContext]="{control: control, errors: control?.errors}">
+      </ng-template>
+    </mat-error>
   </mat-form-field>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-textarea/dynamic-textarea.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-textarea/dynamic-textarea.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, TemplateRef } from '@angular/core';
 import { FormControl } from '@angular/forms';
 
 @Component({
@@ -15,5 +15,7 @@ export class TdDynamicTextareaComponent {
   hint: string = '';
 
   required: boolean = undefined;
+
+  errorMessageTemplate: TemplateRef<any> = undefined;
 
 }

--- a/src/platform/dynamic-forms/dynamic-forms.component.html
+++ b/src/platform/dynamic-forms/dynamic-forms.component.html
@@ -20,18 +20,9 @@
           [max]="element.max"
           [minLength]="element.minLength"
           [maxLength]="element.maxLength"
-          [selections]="element.selections">
+          [selections]="element.selections"
+          [errorMessageTemplate]="getErrorTemplateRef(element.name)">
         </td-dynamic-element>
-        <div class="tc-red-600"
-             [style.font-size.%]="'70'"
-             [style.position]="'absolute'"
-             [style.bottom.px]="'10'"
-              *ngIf="getErrorTemplateRef(element.name) && dynamicForm.controls[element.name]?.errors">
-          <ng-template
-            [ngTemplateOutlet]="getErrorTemplateRef(element.name)"
-            [ngTemplateOutletContext]="{control: dynamicForm.controls[element.name], errors: dynamicForm.controls[element.name]?.errors}">
-          </ng-template>
-        </div>
       </div>
     </ng-template>
   </div>


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
properly leveraging the mat-error element on components that use
mat-form-field fixes this issue, but to achieve this we need to
refactor how the error message is shown

also add documentation on how to show the error message when creating a
custom component


### What's included?
<!-- List features included in this PR -->
- use mat-error when possible
- add info in README and demo on how to show error in custom component

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to http://localhost:4200/#/components/dynamic-forms
- [ ] Check out how to set the error in a custom component in the custom components DEMO

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.