### PR TITLE
fix(docs): Add documentation about clickable input on datatable (closes #1010)

### DIFF
--- a/src/platform/core/data-table/README.md
+++ b/src/platform/core/data-table/README.md
@@ -23,6 +23,9 @@ Use [tdDataTableTemplate] directive for template support which gives context acc
 + sortOrder?: TdDataTableSortingOrder
   + Sets the sort order of the [sortBy] column. [sortable] needs to be enabled.
   + Defaults to 'ASC' or TdDataTableSortingOrder.Ascending
++ clickable?: boolean
+  + Enables row click events, hover.
+  + Defaults to 'false'
 + compareWith: function(row, model)
   + Allows custom comparison between row and model to see if row is selected or not.
 


### PR DESCRIPTION
## Description
Update Readme to add documentation about clickable input on datatable

closes #1010 

### What's included?
- src/platform/core/data-table/README.md

#### Test Steps
- [ ] `npm run serve`
- [ ] Go to http://localhost:4200/#/components/data-table
- [ ] See `clickable` input added to Inputs documentation 

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![screen shot 2018-08-15 at 5 12 28 pm](https://user-images.githubusercontent.com/10502797/44179904-6be93780-a0ae-11e8-9f7a-07c00496a524.png)

closes https://github.com/Teradata/covalent/issues/1010