### PR TITLE
feat(animations): collapse animation params

### DIFF
--- a/src/app/components/components/animations/animations.component.html
+++ b/src/app/components/components/animations/animations.component.html
@@ -137,12 +137,12 @@
   <mat-card-title>Collapse Animation</mat-card-title>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <p class="mat-body-1">Use <code>TdCollapseAnimation</code> to collapse any element based on a boolean state.</p>
+    <p class="mat-body-1">Use <code>tdCollapseAnimation</code> to collapse any element based on a boolean state.</p>
     <div>
       <h3>Demo 1:</h3>
 
       <button mat-raised-button color="accent" (click)="collapseState1 = !collapseState1">Collapse</button>
-      <div [style.overflow]="'hidden'" [@tdCollapse]="collapseState1">
+      <div [style.overflow]="'hidden'" [@tdCollapse]="{ value: collapseState1, params: { duration: 500 }}">
         <mat-card>
           <mat-card-title>Collapse card</mat-card-title>
           <mat-card-content>Collapse card with a click!</mat-card-content>
@@ -153,10 +153,10 @@
       <p>Typescript:</p>
       <td-highlight lang="typescript">
         <![CDATA[
-          import { TdCollapseAnimation } from '@covalent/core/common';
+          import { tdCollapseAnimation } from '@covalent/core/common';
           ...
           animations: [
-            TdCollapseAnimation(), // using implicit anchor name 'tdCollapse' in template
+            tdCollapseAnimation, // using implicit anchor name 'tdCollapse' in template
           ],
           ...
           class MyDemo {
@@ -168,7 +168,7 @@
       <td-highlight lang="html">
         <![CDATA[
           <button mat-raised-button color="accent" (click)="triggerState = !triggerState">Collapse</button>
-          <div [style.overflow]="'hidden'" [@tdCollapse]="triggerState">
+          <div [style.overflow]="'hidden'" [@tdCollapse]="{ value: triggerState, params: { duration: 500 }}">
             <mat-card>
               <mat-card-title>Collapse card</mat-card-title>
               <mat-card-content>Collapse card with a click!</mat-card-content>
@@ -180,13 +180,8 @@
     </div>
     <mat-divider></mat-divider>
     <div>
-      <h2>API:</h2>
+      <h2>Acceptable params options:</h2>
       <mat-list>
-        <mat-list-item>
-          <h3 matLine>anchor?: string</h3>
-          <p matLine> The anchor name is used to attach the animation to an arbitrary element in the template. Defaults to 'tdCollapse'.</p>
-        </mat-list-item>
-        <mat-divider></mat-divider>
         <mat-list-item>
           <h3 matLine>duration?: number</h3>
           <p matLine> Duration the animation will run in milliseconds. Defaults to 150 ms. </p>

--- a/src/app/components/components/animations/animations.component.html
+++ b/src/app/components/components/animations/animations.component.html
@@ -101,7 +101,7 @@
     </div>
     <mat-divider></mat-divider>
     <div>
-      <h2>Acceptable params options:</h2>
+      <h2>Parameter Options:</h2>
       <mat-list>
         <mat-list-item>
           <h3 matLine>degressStart?: number</h3>
@@ -112,6 +112,7 @@
           <h3 matLine>degreesEnd?: number</h3>
           <p matLine> Degrees of rotation that the dom object will end up in during the "true" state </p>
         </mat-list-item>
+        <mat-divider></mat-divider>
         <mat-list-item>
           <h3 matLine>duration?: number</h3>
           <p matLine> Duration the animation will run in milliseconds. Defaults to 250 ms. </p>
@@ -126,7 +127,6 @@
           <h3 matLine>ease?: string</h3>
           <p matLine>Animation accelerate and decelerate style. Defaults to ease-in.</p>
         </mat-list-item>
-        <mat-divider></mat-divider>
       </mat-list>
     </div>
 
@@ -180,14 +180,14 @@
     </div>
     <mat-divider></mat-divider>
     <div>
-      <h2>Acceptable params options:</h2>
+      <h2>Parameter Options:</h2>
       <mat-list>
         <mat-list-item>
           <h3 matLine>duration?: number</h3>
           <p matLine> Duration the animation will run in milliseconds. Defaults to 150 ms. </p>
         </mat-list-item>
         <mat-divider></mat-divider>
-         <mat-list-item>
+        <mat-list-item>
           <h3 matLine>delay?: number</h3>
           <p matLine> Delay before the animation will run in milliseconds. Defaults to 0 ms. </p>
         </mat-list-item>
@@ -201,7 +201,6 @@
           <h3 matLine>easeOnOpen?: string</h3>
           <p matLine>Animation accelerates and decelerates when opening. Defaults to ease-out.</p>
         </mat-list-item>
-        <mat-divider></mat-divider>
       </mat-list>
     </div>
 
@@ -282,7 +281,6 @@
           <h3 matLine>easeOnOut?: string</h3>
           <p matLine>Animation accelerates and decelerates when fading out. Defaults to ease-out.</p>
         </mat-list-item>
-        <mat-divider></mat-divider>
       </mat-list>
     </div>
   </mat-card-content>
@@ -382,7 +380,6 @@
           <h3 matLine>delay?: number</h3>
           <p matLine> Delay before the animation will run in milliseconds. Defaults to 0 ms. </p>
         </mat-list-item>
-        <mat-divider></mat-divider>
       </mat-list>
     </div>
   </mat-card-content>

--- a/src/app/components/components/animations/animations.component.ts
+++ b/src/app/components/components/animations/animations.component.ts
@@ -2,7 +2,7 @@ import { Component, HostBinding } from '@angular/core';
 
 import { slideInDownAnimation } from '../../../app.animations';
 import { tdRotateAnimation } from '../../../../platform/core/common/animations/rotate/rotate.animation';
-import { TdCollapseAnimation } from '../../../../platform/core/common/animations/collapse/collapse.animation';
+import { tdCollapseAnimation } from '../../../../platform/core/common/animations/collapse/collapse.animation';
 import { TdFadeInOutAnimation } from '../../../../platform/core/common/animations/fade/fadeInOut.animation';
 import { TdBounceAnimation } from '../../../../platform/core/common/animations/bounce/bounce.animation';
 import { TdFlashAnimation } from '../../../../platform/core/common/animations/flash/flash.animation';
@@ -17,7 +17,7 @@ import { TdPulseAnimation } from '../../../../platform/core/common/animations/pu
   animations: [
     slideInDownAnimation,
     tdRotateAnimation,
-    TdCollapseAnimation(),
+    tdCollapseAnimation,
     TdFadeInOutAnimation(),
     TdBounceAnimation(),
     TdFlashAnimation(),

--- a/src/app/components/components/components.module.ts
+++ b/src/app/components/components/components.module.ts
@@ -55,6 +55,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatRippleModule } from '@angular/material/core';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatDividerModule } from '@angular/material/divider';
 
 import { CovalentCommonModule, CovalentLayoutModule, CovalentMediaModule, CovalentExpansionPanelModule, CovalentFileModule,
          CovalentStepsModule, CovalentLoadingModule, CovalentDialogsModule, CovalentSearchModule, CovalentPagingModule,
@@ -125,6 +126,7 @@ import { ToolbarModule } from '../../components/toolbar/toolbar.module';
     MatRippleModule,
     MatDatepickerModule,
     MatNativeDateModule,
+    MatDividerModule,
     /** Covalent Modules */
     CovalentCommonModule,
     CovalentLayoutModule,

--- a/src/platform/core/common/animations/collapse/collapse.animation.ts
+++ b/src/platform/core/common/animations/collapse/collapse.animation.ts
@@ -8,18 +8,17 @@ export interface ICollapseAnimation extends IAnimationOptions {
 }
 
 /**
- * Function TdCollapseAnimation
+ * const tdCollapseAnimation
  *
- * params:
- * * anchor: Name of the anchor that will attach to a dom element in the components template that will contain the animation. Defaults to tdCollapse.
+ * Parameter Options:
  * * duration: Duration the animation will run in milliseconds. Defaults to 150 ms.
  * * delay: Delay before the animation will run in milliseconds. Defaults to 0 ms.
  * * easeOnClose: Animation accelerates and decelerates when closing. Defaults to ease-in.
  * * easeOnOpen: Animation accelerates and decelerates when opening. Defaults to ease-out.
  *
- * Returns an [AnimationTriggerMetadata] object with states for a collapse/expand animation.
+ * Returns an [AnimationTriggerMetadata] object with boolean states for a collapse/expand animation.
  *
- * usage: [@tdCollapse]="true|false"
+ * usage: [@tdCollapse]="{ value: true | false, params: { duration: 500 }}"
  */
 export const tdCollapseAnimation: AnimationTriggerMetadata = trigger('tdCollapse', [
     state('1', style({

--- a/src/platform/core/common/animations/collapse/collapse.animation.ts
+++ b/src/platform/core/common/animations/collapse/collapse.animation.ts
@@ -7,6 +7,20 @@ export interface ICollapseAnimation extends IAnimationOptions {
    easeOnOpen?: string;
 }
 
+/**
+ * Function TdCollapseAnimation
+ *
+ * params:
+ * * anchor: Name of the anchor that will attach to a dom element in the components template that will contain the animation. Defaults to tdCollapse.
+ * * duration: Duration the animation will run in milliseconds. Defaults to 150 ms.
+ * * delay: Delay before the animation will run in milliseconds. Defaults to 0 ms.
+ * * easeOnClose: Animation accelerates and decelerates when closing. Defaults to ease-in.
+ * * easeOnOpen: Animation accelerates and decelerates when opening. Defaults to ease-out.
+ *
+ * Returns an [AnimationTriggerMetadata] object with states for a collapse/expand animation.
+ *
+ * usage: [@tdCollapse]="true|false"
+ */
 export const tdCollapseAnimation: AnimationTriggerMetadata = trigger('tdCollapse', [
     state('1', style({
       height: '0',
@@ -30,7 +44,7 @@ export const tdCollapseAnimation: AnimationTriggerMetadata = trigger('tdCollapse
     ], { params: { duration: 150, delay: '0', ease: 'ease-out' }}),
   ]);
 
-/** @deprecated see tdCotateAnimation */
+/** @deprecated see tdCollapseAnimation */
 export function TdCollapseAnimation(collapseOptions: ICollapseAnimation = {}): AnimationTriggerMetadata {
   return trigger(collapseOptions.anchor || 'tdCollapse', [
     state('1', style({

--- a/src/platform/core/common/animations/collapse/collapse.animation.ts
+++ b/src/platform/core/common/animations/collapse/collapse.animation.ts
@@ -7,20 +7,30 @@ export interface ICollapseAnimation extends IAnimationOptions {
    easeOnOpen?: string;
 }
 
-/**
- * Function TdCollapseAnimation
- *
- * params:
- * * anchor: Name of the anchor that will attach to a dom element in the components template that will contain the animation. Defaults to tdCollapse.
- * * duration: Duration the animation will run in milliseconds. Defaults to 150 ms.
- * * delay: Delay before the animation will run in milliseconds. Defaults to 0 ms.
- * * easeOnClose: Animation accelerates and decelerates when closing. Defaults to ease-in.
- * * easeOnOpen: Animation accelerates and decelerates when opening. Defaults to ease-out.
- *
- * Returns an [AnimationTriggerMetadata] object with states for a collapse/expand animation.
- *
- * usage: [@tdCollapse]="true|false"
- */
+export const tdCollapseAnimation: AnimationTriggerMetadata = trigger('tdCollapse', [
+    state('1', style({
+      height: '0',
+      display: 'none',
+    })),
+    state('0',  style({
+      height: AUTO_STYLE,
+      display: AUTO_STYLE,
+    })),
+    transition('0 => 1', [
+      group([
+        query('@*', animateChild(), { optional: true }),
+        animate('{{ duration }}ms {{ delay }}ms {{ ease }}'),
+      ]),
+    ], { params: { duration: 150, delay: '0', ease: 'ease-in' }}),
+    transition('1 => 0', [
+      group([
+        query('@*', animateChild(), { optional: true }),
+        animate('{{ duration }}ms {{ delay }}ms {{ ease }}'),
+      ]),
+    ], { params: { duration: 150, delay: '0', ease: 'ease-out' }}),
+  ]);
+
+/** @deprecated see tdCotateAnimation */
 export function TdCollapseAnimation(collapseOptions: ICollapseAnimation = {}): AnimationTriggerMetadata {
   return trigger(collapseOptions.anchor || 'tdCollapse', [
     state('1', style({


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
- Improved the collapse animation
- changes made were based on the [Animations Param Enhancement Doc](https://docs.google.com/document/d/18QT1kX3GchskE6PlZ3PfNCdv_DPAVoDPZpOS0e1Fan0/edit)

### What's included?
<!-- List features included in this PR -->
- Modded the pre-canned animation to allow usage of the Angular animations params feature.
- Deprecated the collapse animation pre-canned function.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `yarn serve`
- [ ] Verify the collapse animation demos work correctly on the docs
- [ ] Verify the collapse animation docs match with the changes to the code
- [ ] Verify and use new collapse animation const object based on the updated doc and params exposed. You can play with it in the `src/app/components/components/animations/animations.component.html` file.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
