### PR TITLE
feat(notification): limit added

### DIFF
--- a/src/app/components/components/notifications/notifications.component.html
+++ b/src/app/components/components/notifications/notifications.component.html
@@ -20,7 +20,7 @@
             <mat-icon>messages</mat-icon>
           </td-notification-count>
           <button class="overflow-visible" mat-icon-button [matMenuTriggerFor]="notificationsMenu">
-            <td-notification-count [notifications]="101">
+            <td-notification-count [notifications]="101" [limit]=50>
               <mat-icon>notifications</mat-icon>
             </td-notification-count>
           </button>
@@ -73,7 +73,7 @@
                 <mat-icon>messages</mat-icon>
               </td-notification-count>
               <button class="overflow-visible" mat-icon-button [matMenuTriggerFor]="notificationsMenu">
-                <td-notification-count [notifications]="101">
+                <td-notification-count [notifications]="101" [limit]=50>
                   <mat-icon>notifications</mat-icon>
                 </td-notification-count>
               </button>

--- a/src/platform/core/notifications/README.md
+++ b/src/platform/core/notifications/README.md
@@ -17,6 +17,9 @@
   + Defaults to 'after' if it has content, else 'center'.
 + positionY?: TdNotificationCountPositionY or 'top' | 'bottom' | 'center'
   + Sets the Y position of the notification tip. Defaults to 'top' if it has content, else 'center'.
++ limit?: number
+  + Limit for the notification count. 
+  + When the notification count exceeds this limit, it will be displayed as limit+. Defaults to 99.
 
 ## Setup
 
@@ -56,5 +59,11 @@ Example for HTML stand alone count usage:
 
 ```html
 <td-notification-count positionX="center" positionY="center" [notifications]="1">
+</td-notification-count>
+```
+Example for HTML limit usage:
+
+```html
+<td-notification-count [notifications]="100" [limit]=50>
 </td-notification-count>
 ```

--- a/src/platform/core/notifications/notification-count.component.spec.ts
+++ b/src/platform/core/notifications/notification-count.component.spec.ts
@@ -21,6 +21,7 @@ describe('Component: NotificationCount', () => {
         TdNotificationCountContentTestComponent,
         TdNotificationCountPositionTestComponent,
         TdNotificationCountPositionContentTestComponent,
+        TdNotificationCountLimitTestComponent,
       ],
       imports: [
         MatIconModule,
@@ -102,7 +103,7 @@ describe('Component: NotificationCount', () => {
       });
   })));
 
-  it('should render component notification tip with count and 99+',
+  it('should render component notification tip with defaultLimit+ when limit is not set and when count exceeds the default',
     async(inject([], () => {
       let fixture: ComponentFixture<any> = TestBed.createComponent(TdNotificationCountBasicTestComponent);
       let component: TdNotificationCountBasicTestComponent = fixture.debugElement.componentInstance;
@@ -114,6 +115,53 @@ describe('Component: NotificationCount', () => {
         expect(fixture.debugElement.query(By.css('.td-notification-no-count'))).toBeFalsy();
         expect(fixture.debugElement.query(By.css('.td-notification-count'))
                .nativeElement.textContent.trim()).toContain('99+');
+      });
+  })));
+
+  it('should render component notification tip with count when limit is not set and when count does not exceed default',
+  async(inject([], () => {
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TdNotificationCountBasicTestComponent);
+    let component: TdNotificationCountBasicTestComponent = fixture.debugElement.componentInstance;
+    component.notifications = 20;
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('.td-notification-count'))).toBeTruthy();
+      expect(fixture.debugElement.query(By.css('.td-notification-no-count'))).toBeFalsy();
+      expect(fixture.debugElement.query(By.css('.td-notification-count'))
+             .nativeElement.textContent.trim()).toContain('20');
+    });
+})));
+
+  it('should render component notification tip with limit+ when limit is set',
+  async(inject([], () => {
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TdNotificationCountLimitTestComponent);
+    let component: TdNotificationCountLimitTestComponent = fixture.debugElement.componentInstance;
+    component.notifications = 100;
+    component.limit = 50;
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('.td-notification-count'))).toBeTruthy();
+      expect(fixture.debugElement.query(By.css('.td-notification-no-count'))).toBeFalsy();
+      expect(fixture.debugElement.query(By.css('.td-notification-count'))
+             .nativeElement.textContent.trim()).toContain('50+');
+    });
+})));
+
+  it('should render component notification tip with notifications when it is less than the limit',
+    async(inject([], () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdNotificationCountLimitTestComponent);
+      let component: TdNotificationCountLimitTestComponent = fixture.debugElement.componentInstance;
+      component.notifications = 20;
+      component.limit = 50;
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(fixture.debugElement.query(By.css('.td-notification-count'))).toBeTruthy();
+        expect(fixture.debugElement.query(By.css('.td-notification-no-count'))).toBeFalsy();
+        expect(fixture.debugElement.query(By.css('.td-notification-count'))
+              .nativeElement.textContent.trim()).toContain('20');
       });
   })));
 
@@ -226,4 +274,16 @@ class TdNotificationCountPositionContentTestComponent {
   positionY: TdNotificationCountPositionY | string;
   notifications: any;
 
+}
+
+@Component({
+  selector: 'td-notification-count-limit-test',
+  template: `
+  <td-notification-count [notifications]="notifications" [limit]="limit">
+  </td-notification-count>
+  `,
+})
+class TdNotificationCountLimitTestComponent {
+  notifications: any;
+  limit: number;
 }

--- a/src/platform/core/notifications/notification-count.component.ts
+++ b/src/platform/core/notifications/notification-count.component.ts
@@ -13,6 +13,8 @@ export enum TdNotificationCountPositionX {
   Center = 'center',
 }
 
+export const DEFAULT_NOTIFICATION_LIMIT: number = 99;
+
 @Component({
   selector: 'td-notification-count',
   styleUrls: ['./notification-count.component.scss' ],
@@ -24,6 +26,7 @@ export class TdNotificationCountComponent implements AfterContentInit {
   private _notifications: number | boolean = 0;
   private _positionY: TdNotificationCountPositionY;
   private _positionX: TdNotificationCountPositionX;
+  private _limit: number = DEFAULT_NOTIFICATION_LIMIT;
 
   /**
    * Div content wrapper of `ng-content`.
@@ -71,6 +74,15 @@ export class TdNotificationCountComponent implements AfterContentInit {
     this._notifications = notifications;
   }
 
+   /**
+    * limit?: number
+    * Limit for notification count. If the number of notifications is greater than limit, then + will be added. Defaults to 99.
+    */
+  @Input()
+  set limit(limit: number) {
+    this._limit = limit;
+  }
+
   @HostBinding('class.td-notification-hidden')
   get hideHost(): boolean {
     return !this.show && !this._hasContent();
@@ -89,8 +101,8 @@ export class TdNotificationCountComponent implements AfterContentInit {
    * Anything over 99 gets set as 99+
    */
   get notificationsDisplay(): string {
-    if (this._notifications > 99) {
-      return '99+';
+    if (this._notifications > this._limit) {
+      return `${this._limit}+`;
     }
     return this._notifications.toString();
   }


### PR DESCRIPTION
## Description
Limit attribute is added to the td-notification-count component. When the notification count exceeds the limit set, it would display as {limit}+. It was initially hard coded as 99. Now it defaults to 99 but can be overridden by the user of this component.

### What's included?
<!-- List features included in this PR -->
- limit attribute added


#### Test Steps
<!-- Add instructions on how to test your changes -->
- [x] `npm run serve`

#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
