### PR TITLE
feat(layout): support autosize in layout #1230

### DIFF
--- a/src/platform/core/layout/README.md
+++ b/src/platform/core/layout/README.md
@@ -15,6 +15,9 @@
 + sidenavWidth: string
   + Sets the 'width' of the sidenav in either 'px' or '%'. 
   + Defaults to '320px'.
++ containerAutosize: boolean
+  + Sets 'autosize' of the sidenav-container.
+  + Defaults to 'false'.
 
 ## Usage
 

--- a/src/platform/core/layout/layout-manage-list/README.md
+++ b/src/platform/core/layout/layout-manage-list/README.md
@@ -16,6 +16,9 @@
 + sidenavWidth: string 
   + Sets the 'width' of the sidenav in either 'px' or '%'. 
   + Defaults to '257px'.
++ containerAutosize: boolean
+  + Sets 'autosize' of the sidenav-container.
+  + Defaults to 'false'.
 
 ## Usage
 

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.html
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.html
@@ -1,4 +1,4 @@
-<mat-sidenav-container fullscreen class="td-layout-manage-list">
+<mat-sidenav-container fullscreen [autosize]="containerAutosize" class="td-layout-manage-list">
   <mat-sidenav #sidenav
               position="start"
               [mode]="mode"

--- a/src/platform/core/layout/layout-manage-list/layout-manage-list.component.ts
+++ b/src/platform/core/layout/layout-manage-list/layout-manage-list.component.ts
@@ -47,6 +47,18 @@ export class TdLayoutManageListComponent implements ILayoutTogglable {
   @Input('sidenavWidth') sidenavWidth: string = '257px';
 
   /**
+   * containerAutosize?: boolean
+   *
+   * Sets "autosize" of the sidenav-container.
+   * Defaults to "false".
+   *
+   * See documentation for more info and potential performance risks.
+   * 
+   * https://github.com/angular/material2/blob/master/src/lib/sidenav/sidenav.md#resizing-an-open-sidenav
+   */
+  @Input('containerAutosize') containerAutosize: boolean = false;
+
+  /**
    * Checks if `ESC` should close the sidenav
    * Should only close it for `push` and `over` modes
    */

--- a/src/platform/core/layout/layout-nav-list/README.md
+++ b/src/platform/core/layout/layout-nav-list/README.md
@@ -29,6 +29,9 @@
 + sidenavWidth: string
   + Sets the 'width' of the sidenav in either 'px' or '%'. 
   + Defaults to '257px'.
++ containerAutosize: boolean
+  + Sets 'autosize' of the sidenav-container.
+  + Defaults to 'false'.
 
 ## Usage
 

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
@@ -1,5 +1,5 @@
 <div class="td-layout-nav-list-wrapper">
-  <mat-sidenav-container fullscreen class="td-layout-nav-list">
+  <mat-sidenav-container fullscreen [autosize]="containerAutosize" class="td-layout-nav-list">
     <mat-sidenav #sidenav
                 position="start"
                 [mode]="mode"

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.ts
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.ts
@@ -76,6 +76,18 @@ export class TdLayoutNavListComponent implements ILayoutTogglable {
   @Input('sidenavWidth') sidenavWidth: string = '350px';
 
   /**
+   * containerAutosize?: boolean
+   *
+   * Sets "autosize" of the sidenav-container.
+   * Defaults to "false".
+   *
+   * See documentation for more info and potential performance risks.
+   * 
+   * https://github.com/angular/material2/blob/master/src/lib/sidenav/sidenav.md#resizing-an-open-sidenav
+   */
+  @Input('containerAutosize') containerAutosize: boolean = false;
+  
+  /**
    * navigationRoute?: string
    *
    * option to set the combined route for the icon, logo, and toolbarTitle.

--- a/src/platform/core/layout/layout.component.html
+++ b/src/platform/core/layout/layout.component.html
@@ -1,4 +1,4 @@
-<mat-sidenav-container fullscreen>
+<mat-sidenav-container fullscreen [autosize]="containerAutosize">
   <mat-sidenav #sidenav
               class="td-layout-sidenav"
               [mode]="mode"

--- a/src/platform/core/layout/layout.component.ts
+++ b/src/platform/core/layout/layout.component.ts
@@ -47,6 +47,18 @@ export class TdLayoutComponent implements ILayoutTogglable {
   @Input('sidenavWidth') sidenavWidth: string = '320px';
 
   /**
+   * containerAutosize?: boolean
+   *
+   * Sets "autosize" of the sidenav-container.
+   * Defaults to "false".
+   *
+   * See documentation for more info and potential performance risks.
+   * 
+   * https://github.com/angular/material2/blob/master/src/lib/sidenav/sidenav.md#resizing-an-open-sidenav
+   */
+  @Input('containerAutosize') containerAutosize: boolean = false;
+
+  /**
    * Checks if `ESC` should close the sidenav
    * Should only close it for `push` and `over` modes
    */


### PR DESCRIPTION
## Description
Allows setting `autosize` of the sidenav-container (#1230). Enables users for example to develop a mininav (see screenshot). 

### What's included?
- containerAutosize added to `td-layout`
- containerAutosize added to `td-layout-manage-list`
- containerAutosize added to `td-layout-nav-list`


#### Test Steps
- [x] `npm run serve`

#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots
Using autosize for a mininav.
![autosize](https://user-images.githubusercontent.com/9257417/45155701-2bc43300-b1dc-11e8-9bf8-21b7933ec2f7.gif)
 