### PR TITLE
fix(docs): fix typo in docs #1040

### DIFF
--- a/src/platform/core/loading/README.md
+++ b/src/platform/core/loading/README.md
@@ -22,7 +22,7 @@ Dont forget to add the asterisk syntax before the `tdLoading` directive if its n
 + tdLoadingColor?: "primary" | "accent" | "warn"
   + Sets the theme color of the loading component. 
   + Defaults to "primary"
-+ tdLoadingUtil?: any
++ tdLoadingUntil?: any
   + If its null, undefined or false it will be used to register requests to the mask.
   + Else if its any value that can be resolved as true, it will resolve the mask.
   + [name] is optional when using [until], but can still be used to register/resolve it manually.


### PR DESCRIPTION
## Description
fixes the typo mentioned in #1040

### What's included?
- changed `tdLoadingUtil` to `tdLoadingUntil`

#### Test Steps
- [x] `npm run serve`

#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

