### PR TITLE
feat(): Add timeUntil pipe

### DIFF
--- a/src/app/components/components/pipes/pipes.component.html
+++ b/src/app/components/components/pipes/pipes.component.html
@@ -155,6 +155,33 @@
   </mat-card-content>
  </mat-card>
 
+ <mat-card>
+  <mat-card-title>Time Until</mat-card-title>
+  <mat-divider></mat-divider>
+  <mat-card-content>
+    <p class="mat-body-1">The <code>timeUntil</code> pipe takes a string, number or Date timestamp (example: <code>{{currentTimeStamp}}</code>) and tranforms it to the amount of time until that timestamp will be reached. </p>
+    <mat-list>
+      <mat-list-item *ngFor="let log of logs">
+        <h3 matLine>Timestamp: {{ log.expiration_date }} | {{ log.expiration_date | timeUntil:log.reference }}</h3>
+        <p *ngIf="log.reference" matLine>Reference: {{ log.reference }} </p>
+      </mat-list-item>
+    </mat-list>
+  <p>Usage:</p>
+    <td-highlight lang="html">
+        <![CDATA[
+          <mat-list>
+            <mat-list-item *ngFor="let log of logs">
+              <!-- original output -->
+              { { log.timestamp } } | 
+              <!-- output with timeUntil pipe -->
+              { { log.timestamp | timeUntil:reference } } //reference is optional
+            </mat-list-item>
+          </mat-list>
+        ]]>
+    </td-highlight>
+  </mat-card-content>
+ </mat-card>
+
   <mat-card>
   <mat-card-title>Time Difference</mat-card-title>
   <mat-divider></mat-divider>

--- a/src/app/components/components/pipes/pipes.component.ts
+++ b/src/app/components/components/pipes/pipes.component.ts
@@ -14,6 +14,9 @@ export class PipesComponent {
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
 
+  currentDate: Date = new Date();
+  currentTimeStamp: string = this.currentDate.toISOString();
+
   public logs: Object[] = [
     {
       bytes: 72452903343,
@@ -22,6 +25,7 @@ export class PipesComponent {
       reference: '2016-06-17T12:59:59.000Z',
       timestamp: '2016-01-29T17:59:59.000Z',
       timestampend: '2016-01-29T18:59:59.000Z',
+      expiration_date: '2016-06-17T13:00:02.000Z',
       text_value: 'https://test_source_cf433eb5_5a00_4f2b_afa4_4022b7b2aac3',
       truncate_length: 5,
     }, {
@@ -31,6 +35,7 @@ export class PipesComponent {
       reference: new Date(2016, 4, 17),
       timestamp: '2016-06-10T17:59:59.000Z',
       timestampend: '2016-11-29T18:59:59.000Z',
+      expiration_date: new Date(new Date(2016, 4, 17).getTime() + 120000).toISOString(),
       text_value: 'https://test_source_cf433eb5_5a00_4f2b_afa4_4022b7b2aac3',
       truncate_length: 10,
     }, {
@@ -39,6 +44,7 @@ export class PipesComponent {
       reference: new Date(2016, 4, 17).getTime(),
       timestamp: '2016-06-17T12:59:59.000Z',
       timestampend: '2016-06-17T13:00:00.000Z',
+      expiration_date: new Date(new Date(2016, 4, 17).getTime() + 7200000).toISOString(),
       text_value: 'https://test_source_cf433eb5_5a00_4f2b_afa4_4022b7b2aac3',
       truncate_length: 15,
     }, {
@@ -47,6 +53,7 @@ export class PipesComponent {
       reference: 'invalid',
       timestamp: '2016-06-17T12:59:59.000Z',
       timestampend: '2016-06-18T13:00:00.000Z',
+      expiration_date: new Date(this.currentDate.getTime() + 259200000).toISOString(),
       text_value: 'https://test_source_cf433eb5_5a00_4f2b_afa4_4022b7b2aac3',
       truncate_length: 20,
     }, {
@@ -54,6 +61,7 @@ export class PipesComponent {
       digits: 'Invalid Number',
       timestamp: '2016-06-17T12:59:59.000Z',
       timestampend: '2016-06-20T13:00:00.000Z',
+      expiration_date: new Date(this.currentDate.getTime() + 10519200000).toISOString(),
       text_value: 'https://test_source_cf433eb5_5a00_4f2b_afa4_4022b7b2aac3',
       truncate_length: 25,
     }, {
@@ -61,6 +69,7 @@ export class PipesComponent {
       digits: 3245234,
       timestamp: new Date(2016, 4, 17),
       timestampend: '2016-06-20T13:00:00.000Z',
+      expiration_date: new Date(this.currentDate.getTime() + 157788000000).toISOString(),
       text_value: 'https://test_source_cf433eb5_5a00_4f2b_afa4_4022b7b2aac3',
       truncate_length: 30,
     }, {
@@ -68,6 +77,7 @@ export class PipesComponent {
       digits: 3245234100.6,
       timestamp: new Date(2016, 4, 17).getTime(),
       timestampend: '2016-06-20T13:00:00.000Z',
+      expiration_date: new Date(this.currentDate.getTime() + 20000).toISOString(),
       text_value: 'https://test_source_cf433eb5_5a00_4f2b_afa4_4022b7b2aac3',
       truncate_length: 35,
     }, {
@@ -75,6 +85,7 @@ export class PipesComponent {
       digits: 3245234190076.9,
       timestamp: 'invalid',
       timestampend: '2016-06-20T13:00:00.000Z',
+      expiration_date: new Date(this.currentDate.getTime() + 30000).toISOString(),
       text_value: 'https://test_source_cf433eb5_5a00_4f2b_afa4_4022b7b2aac3',
       truncate_length: 40,
     },

--- a/src/platform/core/common/common.module.ts
+++ b/src/platform/core/common/common.module.ts
@@ -37,6 +37,7 @@ const TD_VALIDATORS: Type<any>[] = [
  */
 import { TdTimeAgoPipe } from './pipes/time-ago/time-ago.pipe';
 import { TdTimeDifferencePipe } from './pipes/time-difference/time-difference.pipe';
+import { TdTimeUntilPipe } from './pipes/time-until/time-until.pipe';
 import { TdBytesPipe } from './pipes/bytes/bytes.pipe';
 import { TdDecimalBytesPipe } from './pipes/decimal-bytes/decimal-bytes.pipe';
 import { TdDigitsPipe } from './pipes/digits/digits.pipe';
@@ -45,6 +46,7 @@ import { TdTruncatePipe } from './pipes/truncate/truncate.pipe';
 const TD_PIPES: Type<any>[] = [
   TdTimeAgoPipe,
   TdTimeDifferencePipe,
+  TdTimeUntilPipe,
   TdBytesPipe,
   TdDecimalBytesPipe,
   TdDigitsPipe,

--- a/src/platform/core/common/pipes/time-until/time-until.pipe.spec.ts
+++ b/src/platform/core/common/pipes/time-until/time-until.pipe.spec.ts
@@ -1,0 +1,47 @@
+import { TdTimeUntilPipe } from './time-until.pipe';
+
+describe('TdTimeUntilPipe', () => {
+  let pipe: TdTimeUntilPipe;
+  let time: number = Date.now();
+
+  beforeEach(() => {
+    pipe = new TdTimeUntilPipe();
+  });
+
+  it('should return "Invalid Date" with an invalid date', () => {
+    expect(pipe.transform(undefined, undefined)).toEqual('Invalid Date');
+    expect(pipe.transform(undefined, time)).toEqual('Invalid Date');
+    expect(pipe.transform('', undefined)).toEqual('Invalid Date');
+    expect(pipe.transform('', '')).toEqual('Invalid Date');
+    expect(pipe.transform({}, {})).toEqual('Invalid Date');
+    expect(pipe.transform('this is not a valid date', 'not a valid date either')).toEqual('Invalid Date');
+  });
+
+  it('should return a time ago string', () => {
+    let fixedTime: number = Date.parse('2017-01-01T00:00:00Z');
+    // 1 second
+    expect(pipe.transform(Date.parse('2017-01-01T00:00:01Z'), fixedTime)).toEqual('in 1 second');
+    // < 1 minute
+    expect(pipe.transform(Date.parse('2017-01-01T00:00:37Z'), fixedTime)).toEqual('in 37 seconds');
+    // 1 minute
+    expect(pipe.transform(Date.parse('2017-01-01T00:01:00Z'), fixedTime)).toEqual('in 1 minute');
+    // < 1 hour
+    expect(pipe.transform(Date.parse('2017-01-01T00:06:00Z'), fixedTime)).toEqual('in 6 minutes');
+    // 1 hours
+    expect(pipe.transform(Date.parse('2017-01-01T01:00:00Z'), fixedTime)).toEqual('in 1 hour');
+    // < 1 day
+    expect(pipe.transform(Date.parse('2017-01-01T13:00:00Z'), fixedTime)).toEqual('in 13 hours');
+    // 1 day
+    expect(pipe.transform(Date.parse('2017-01-02T00:00:00Z'), fixedTime)).toEqual('in 1 day');
+    // < 1 month
+    expect(pipe.transform(Date.parse('2017-01-18T00:00:00Z'), fixedTime)).toEqual('in 17 days');
+    // 1 month
+    expect(pipe.transform(Date.parse('2017-02-01T00:00:00Z'), fixedTime)).toEqual('in 1 month');
+    // < 1 year
+    expect(pipe.transform(Date.parse('2017-04-01T00:00:00Z'), fixedTime)).toEqual('in 3 months');
+    // 1 year
+    expect(pipe.transform(Date.parse('2018-01-01T00:00:00Z'), fixedTime)).toEqual('in 1 year');
+    // years
+    expect(pipe.transform(Date.parse('2021-01-01T00:00:00Z'), fixedTime)).toEqual('in 4 years');
+  });
+});

--- a/src/platform/core/common/pipes/time-until/time-until.pipe.ts
+++ b/src/platform/core/common/pipes/time-until/time-until.pipe.ts
@@ -1,0 +1,68 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'timeUntil',
+})
+export class TdTimeUntilPipe implements PipeTransform {
+  transform(time: any, reference?: any): string {
+    // Convert time to date object if not already
+    time = new Date(time);
+    let ref: Date = new Date(reference);
+
+    // If not a valid timestamp, return 'Invalid Date'
+    if (!time.getTime()) {
+      return 'Invalid Date';
+    }
+
+    // For unit testing, we need to be able to declare a static start time
+    // for calculations, or else speed of tests can bork.
+    let startTime: number = isNaN(ref.getTime()) ? Date.now() : ref.getTime();
+    let diff: number = Math.floor((time.getTime() - startTime) / 1000);
+
+    if (diff < 2) {
+      return 'in 1 second';
+    }
+    if (diff < 60) {
+      return 'in ' + Math.floor(diff) + ' seconds';
+    }
+    // Minutes
+    diff = diff / 60;
+    if (diff < 2) {
+      return 'in 1 minute';
+    }
+    if (diff < 60) {
+      return 'in ' + Math.floor(diff) + ' minutes';
+    }
+    // Hours
+    diff = diff / 60;
+    if (diff < 2) {
+      return 'in 1 hour';
+    }
+    if (diff < 24) {
+      return 'in ' + Math.floor(diff) + ' hours';
+    }
+    // Days
+    diff = diff / 24;
+    if (diff < 2) {
+      return 'in 1 day';
+    }
+    if (diff < 30) {
+      return 'in ' + Math.floor(diff) + ' days';
+    }
+    // Months
+    diff = diff / 30;
+    if (diff < 2) {
+      return 'in 1 month';
+    }
+    if (diff < 12) {
+      return 'in ' + Math.floor(diff) + ' months';
+    }
+    // Years
+    diff = diff / 12;
+    if (diff < 2) {
+      return 'in 1 year';
+    } else {
+      return 'in ' + Math.floor(diff) + ' years';
+    }
+  }
+}


### PR DESCRIPTION
## Description
Added timeUntil pipe
closes #430 

### What's included?
- new file:   src/platform/core/common/pipes/time-until/time-until.pipe.spec.ts
- new file:   src/platform/core/common/pipes/time-until/time-until.pipe.ts
- modified:   src/app/components/components/pipes/pipes.component.html
- modified:   src/app/components/components/pipes/pipes.component.ts
- modified:   src/platform/core/common/common.module.ts

#### Test Steps
- [ ] Checkout branch
- [ ] `npm run serve`
- [ ] go to http://localhost:4200/#/components/pipes
- [ ] See section about timeUntil pipe and the examples working

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![screen shot 2018-09-13 at 4 58 04 pm](https://user-images.githubusercontent.com/10502797/45522167-38b1cb00-b776-11e8-86c2-cf59c9a72bee.png)
