### PR TITLE
fix(chips): mobile select

### DIFF
--- a/src/platform/core/chips/chips.component.ts
+++ b/src/platform/core/chips/chips.component.ts
@@ -71,6 +71,7 @@ export class TdChipsComponent extends _TdChipsMixinBase implements IControlValue
   private _chipRemoval: boolean = true;
   private _focused: boolean = false;
   private _tabIndex: number = 0;
+  private _touchendDebounce: number = 100;
 
   _internalClick: boolean = false;
   _internalActivateOption: boolean = false;
@@ -722,6 +723,7 @@ export class TdChipsComponent extends _TdChipsMixinBase implements IControlValue
         fromEvent(this._document, 'click'),
         fromEvent(this._document, 'touchend'),
       ).pipe(
+        debounceTime(this._touchendDebounce),
         filter(
           (event: MouseEvent) => {
             const clickTarget: HTMLElement = <HTMLElement>event.target;


### PR DESCRIPTION
## Description
Fixed select on Chips Autocomplete on mobile devices.
Closes #1044

### What's included?
* Modified: `src/platform/core/chips/chips.component.ts`

* Reason of the bug: `touchend` events is canceling `click` events on mobile
* Fix explanation: Added debounceTime to prevent both events from being fired together

#### Test Steps
- [ ] Go to Chips demo page
- [ ] Try selecting autocomplete on desktop
- [ ] Try selecting autocomplete on mobile view
- [ ] With ng serve --host 0.0.0.0, try on a real phone opening the application on port 4200

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
