### PR TITLE
fix(chips): long texts

### DIFF
--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -128,7 +128,8 @@
                   (inputChange)="filterObjects($event)"
                   requireMatch>
           <ng-template td-chip let-chip="chip">
-            <mat-icon>location_city</mat-icon> {{chip.city}}, (Pop: {{chip.population}})
+            <mat-icon>location_city</mat-icon>
+            <span class="text-truncate">{{chip.city}}, (Pop: {{chip.population}})</span>
           </ng-template>
           <ng-template td-autocomplete-option let-option="option">
             <div layout="row" layout-align="start center">
@@ -151,7 +152,8 @@
                       (inputChange)="filterObjects($event)"
                       requireMatch>
               <ng-template td-chip let-chip="chip">
-                <mat-icon>location_city</mat-icon> { {chip.city} }, (Pop: { {chip.population} })
+                <mat-icon>location_city</mat-icon>
+                <span class="text-truncate">{ {chip.city} }, (Pop: { {chip.population} })</span>
               </ng-template>
               <ng-template td-autocomplete-option let-option="option">
                 <div layout="row" layout-align="start center">
@@ -215,7 +217,8 @@
                   (inputChange)="filterAsync($event)"
                   requireMatch>
           <ng-template td-chip let-chip="chip">
-            <div class="tc-grey-100 bgc-teal-700" td-chip-avatar>{{chip.substring(0, 1).toUpperCase()}}</div> {{chip}}
+            <div class="tc-grey-100 bgc-teal-700" td-chip-avatar>{{chip.substring(0, 1).toUpperCase()}}</div>
+            <span class="text-truncate">{{chip}}</span>
           </ng-template>
           <mat-progress-bar [style.height.px]="2" *ngIf="filteringAsync" mode="indeterminate"></mat-progress-bar>
         </td-chips>
@@ -234,7 +237,8 @@
                       (inputChange)="filterAsync($event)"
                       requireMatch>
               <ng-template td-chip let-chip="chip">
-                <div class="tc-grey-100 bgc-teal-700" td-chip-avatar>{ {chip.substring(0, 1).toUpperCase()} }</div> { {chip} }
+                <div class="tc-grey-100 bgc-teal-700" td-chip-avatar>{ {chip.substring(0, 1).toUpperCase()} }</div>
+                <span class="text-truncate">{ {chip} }</span>
               </ng-template>
               <mat-progress-bar [style.height.px]="2" *ngIf="filteringAsync" mode="indeterminate"></mat-progress-bar>
             </td-chips>
@@ -302,7 +306,8 @@
                   inputPosition="before"
                   stacked>
           <ng-template td-chip let-chip="chip">
-            <div class="tc-grey-100 bgc-teal-700" td-chip-avatar>{{chip.substring(0, 1).toUpperCase()}}</div> {{chip}}
+            <div class="tc-grey-100 bgc-teal-700" td-chip-avatar>{{chip.substring(0, 1).toUpperCase()}}</div>
+            <span class="text-truncate">{{chip}}</span>
           </ng-template>
         </td-chips>
       </div>

--- a/src/platform/core/chips/chips.component.scss
+++ b/src/platform/core/chips/chips.component.scss
@@ -32,6 +32,8 @@
       align-items: center;
       align-content: center;
       justify-content: start;
+      // truncate content on flexbox children
+      min-width: 0;
       &.td-chip-stacked {
         // layout-align space-between center
         justify-content: space-between;
@@ -63,6 +65,9 @@
           width: 32px;
           @include rtl(margin, 0 8px 0 -12px, 0 -12px 0 8px);
           border-radius: 50%;
+          // emulate flex="none"
+          flex: 0 0 auto;
+          box-sizing: border-box;
         }
       }
       box-sizing: border-box;


### PR DESCRIPTION
## Description
Fixed long text inside chips
Closes #1102

### What's included?
**modified: src/platform/core/chips (multiple files modified)**

* Added `text-truncate` to chip content
* Added `min-width` to `.chip-content` to truncate flexbox children (see https://css-tricks.com/flexbox-truncated-text/)
* Simulated `flex="none"` to `.td-chip-content`

**modified: src/app/components/components/chips/chips.component.html (for truncate documentation)**
* Added `.text-truncate` class to docs

#### Test Steps
- [ ] Go to Chips page
- [ ] Inspect the text within one of the chips (EX: "stepper" text chip), it can be any chip
- [ ] Enter a long string inside `span` with class `.text-truncate` though the inspector
- [ ] Try the same with `chip-avatars` and close icons

- [ ] See the chip occupying 100% of the width of the parent container
- [ ] see the text is truncated 
- [ ] see the `chip-avatar` without distortion
- [ ] see the close icon still inside the chip

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

#### Screenshots or link to StackBlitz/Plunker

#### Before the fix:

![bug](https://user-images.githubusercontent.com/24550592/35303889-6b934250-0048-11e8-8a3b-0f7a900df941.gif)

#### After the fix:

![chip long text](https://user-images.githubusercontent.com/766365/46635875-3865df00-cb2c-11e8-8701-79a1452a216c.gif)
