### PR TITLE
fix(breadcrumbs): consistently align separator icons independent of their font-set class

### DIFF
--- a/src/platform/experimental/breadcrumbs/breadcrumb/breadcrumb.component.html
+++ b/src/platform/experimental/breadcrumbs/breadcrumb/breadcrumb.component.html
@@ -1,6 +1,7 @@
 <span *ngIf="displayCrumb" class="td-breadcrumb">
   <ng-content></ng-content>
   <mat-icon *ngIf="_displayIcon"
+            class="td-breadcrumb-icon"
             [style.cursor]="'default'"
             (click)="_handleIconClick($event)">
     {{separatorIcon}}

--- a/src/platform/experimental/breadcrumbs/breadcrumb/breadcrumb.component.html
+++ b/src/platform/experimental/breadcrumbs/breadcrumb/breadcrumb.component.html
@@ -1,7 +1,7 @@
 <span *ngIf="displayCrumb" class="td-breadcrumb">
   <ng-content></ng-content>
   <mat-icon *ngIf="_displayIcon"
-            class="td-breadcrumb-icon"
+            class="td-breadcrumb-separator-icon"
             [style.cursor]="'default'"
             (click)="_handleIconClick($event)">
     {{separatorIcon}}

--- a/src/platform/experimental/breadcrumbs/breadcrumb/breadcrumb.component.scss
+++ b/src/platform/experimental/breadcrumbs/breadcrumb/breadcrumb.component.scss
@@ -11,7 +11,7 @@
       margin: 0 10px;
     }
   }
-  .td-breadcrumb-icon {
+  .td-breadcrumb-separator-icon {
     display: inline-flex;
     vertical-align: middle;
   }

--- a/src/platform/experimental/breadcrumbs/breadcrumb/breadcrumb.component.scss
+++ b/src/platform/experimental/breadcrumbs/breadcrumb/breadcrumb.component.scss
@@ -11,7 +11,7 @@
       margin: 0 10px;
     }
   }
-  mat-icon.material-icons.mat-icon {
+  .td-breadcrumb-icon {
     display: inline-flex;
     vertical-align: middle;
   }


### PR DESCRIPTION
* Add new css class
* Reduces specificity of css selector used to style
the separator icon. Now the style is applied to the newly added class.
This makes the styling independent of the font-set class
associated to the icon, which is currently not the case.

Closes #1254 

#### Test Steps
- [ ] `npm run serve`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.