### PR TITLE
Handle file-input disabled state via reactive forms

### DIFF
--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
@@ -27,6 +27,7 @@
   </button>
   <td-file-input class="td-file-input"
                   #fileInput
+                  [disabled]="control?.disabled"
                   [formControl]="control">
     <mat-icon>folder</mat-icon>
     <span>{{ label }}</span>


### PR DESCRIPTION
## Description
Changes added here modify the `<td-file-input>` being used inside the `<td-dynamic-file-input>` component to use a `[disabled]` custom input property with the appropriate value to make it look and behave as the rest of the elements inside the dynamic component when it's in a *disabled* state.

### What's included?
<!-- List features included in this PR -->
- A fix for #1220

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] Run `npm run serve`
- [ ] Navigate to http://localhost:4200/#/components/dynamic-forms
- [ ] Add a new file-input element to the "Generated Form" panel using the "Form Builder" panel.
- [ ] Toggle the "disable" switch to set the disable property on and off in the component and then hit the "Update Form" button to see the changes reflected on the dynamically generated component.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

<img width="1075" alt="screen shot 2018-10-26 at 19 40 11" src="https://user-images.githubusercontent.com/1547648/47595470-ff64a180-d956-11e8-8f78-2a1d21748c09.png">
