### PR TITLE
fix(dark-mode): theme updates

### DIFF
--- a/src/theme.scss
+++ b/src/theme.scss
@@ -95,6 +95,8 @@ $theme: mat-light-theme($primary, $accent, $warn);
   $theme-dark: mat-dark-theme($primary-dark, $accent-dark, $warn-dark);
   @include angular-material-theme($theme-dark);
   @include covalent-theme($theme-dark);
+  @include covalent-markdown-theme($theme-dark);
+  @include teradata-brand($theme-dark);
 
   .tc-primary {
     color: mat-color($primary-dark);


### PR DESCRIPTION
## Description
Fixes dark mode

### What's included?
- modified:   src/theme.scss to add dark mode to markdown and teradata branding themes

#### Test Steps
- [ ] Checkout branch
- [ ] `npm run serve`
- [ ] go to http://localhost:4200/#/components/markdown and verify that contrast is good on `H3` elements

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1437" alt="screen shot 2018-10-29 at 2 45 54 pm" src="https://user-images.githubusercontent.com/437977/47682387-6ff30480-db89-11e8-975d-15daef26ec31.png">
