### PR TITLE
feat(breadcrumbs): remove not needed elements from breadcrumbs

### DIFF
--- a/src/platform/core/breadcrumbs/breadcrumb/breadcrumb.component.html
+++ b/src/platform/core/breadcrumbs/breadcrumb/breadcrumb.component.html
@@ -1,4 +1,4 @@
-<span *ngIf="displayCrumb" class="td-breadcrumb">
+<ng-container *ngIf="displayCrumb">
   <ng-content></ng-content>
   <mat-icon *ngIf="_displayIcon"
             class="td-breadcrumb-separator-icon"
@@ -6,4 +6,4 @@
             (click)="_handleIconClick($event)">
     {{separatorIcon}}
   </mat-icon>
-</span>
+</ng-container>

--- a/src/platform/core/breadcrumbs/breadcrumb/breadcrumb.component.scss
+++ b/src/platform/core/breadcrumbs/breadcrumb/breadcrumb.component.scss
@@ -1,6 +1,6 @@
 :host {
-  .td-breadcrumb {
-    height: 48px;
+  &.td-breadcrumb {
+    display: inline-block;
     box-sizing: border-box;
     flex-direction: row;
     align-items: center;

--- a/src/platform/core/breadcrumbs/breadcrumb/breadcrumb.component.ts
+++ b/src/platform/core/breadcrumbs/breadcrumb/breadcrumb.component.ts
@@ -1,7 +1,6 @@
 import {
   Component,
   ElementRef,
-  Renderer2,
   HostBinding,
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -12,6 +11,10 @@ import {
   selector: 'td-breadcrumb, a[td-breadcrumb]',
   styleUrls: ['./breadcrumb.component.scss'],
   templateUrl: './breadcrumb.component.html',
+  /* tslint:disable-next-line */
+  host: {
+    class: 'mat-button td-breadcrumb',
+  },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TdBreadcrumbComponent implements AfterViewInit {
@@ -53,10 +56,7 @@ export class TdBreadcrumbComponent implements AfterViewInit {
   }
 
   constructor(private _elementRef: ElementRef,
-              private _renderer: Renderer2,
               private _changeDetectorRef: ChangeDetectorRef) {
-    this._renderer.addClass(this._elementRef.nativeElement, 'mat-button');
-    this._renderer.addClass(this._elementRef.nativeElement, 'td-breadcrumb');
   }
 
   ngAfterViewInit(): void {

--- a/src/platform/core/breadcrumbs/breadcrumb/breadcrumb.component.ts
+++ b/src/platform/core/breadcrumbs/breadcrumb/breadcrumb.component.ts
@@ -56,6 +56,7 @@ export class TdBreadcrumbComponent implements AfterViewInit {
               private _renderer: Renderer2,
               private _changeDetectorRef: ChangeDetectorRef) {
     this._renderer.addClass(this._elementRef.nativeElement, 'mat-button');
+    this._renderer.addClass(this._elementRef.nativeElement, 'td-breadcrumb');
   }
 
   ngAfterViewInit(): void {

--- a/src/platform/core/breadcrumbs/breadcrumbs.component.html
+++ b/src/platform/core/breadcrumbs/breadcrumbs.component.html
@@ -1,3 +1,1 @@
-<div class="td-breadcrumbs">
-  <ng-content></ng-content>
-</div>
+<ng-content></ng-content>

--- a/src/platform/core/breadcrumbs/breadcrumbs.component.scss
+++ b/src/platform/core/breadcrumbs/breadcrumbs.component.scss
@@ -1,7 +1,7 @@
 :host {
   display: block;
   width: 100%;
-  .td-breadcrumbs {
+  &.td-breadcrumbs {
     white-space: nowrap;
   }
 }

--- a/src/platform/core/breadcrumbs/breadcrumbs.component.ts
+++ b/src/platform/core/breadcrumbs/breadcrumbs.component.ts
@@ -10,7 +10,6 @@ import {
   ChangeDetectorRef,
   ElementRef,
   Input,
-  Renderer2,
 } from '@angular/core';
 
 import {
@@ -30,6 +29,10 @@ import { TdBreadcrumbComponent } from './breadcrumb/breadcrumb.component';
   selector: 'td-breadcrumbs',
   styleUrls: ['./breadcrumbs.component.scss'],
   templateUrl: './breadcrumbs.component.html',
+  /* tslint:disable-next-line */
+  host: {
+    class: 'td-breadcrumbs',
+  },
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TdBreadcrumbsComponent implements OnInit, DoCheck, AfterContentInit, OnDestroy {
@@ -49,9 +52,7 @@ export class TdBreadcrumbsComponent implements OnInit, DoCheck, AfterContentInit
   @Input('separatorIcon') separatorIcon: string = 'navigate_next';
 
   constructor(private _elementRef: ElementRef,
-              private _renderer: Renderer2,
               private _changeDetectorRef: ChangeDetectorRef) {
-    this._renderer.addClass(this._elementRef.nativeElement, 'td-breadcrumbs');
   }
 
   ngOnInit(): void {

--- a/src/platform/core/breadcrumbs/breadcrumbs.component.ts
+++ b/src/platform/core/breadcrumbs/breadcrumbs.component.ts
@@ -10,6 +10,7 @@ import {
   ChangeDetectorRef,
   ElementRef,
   Input,
+  Renderer2,
 } from '@angular/core';
 
 import {
@@ -47,7 +48,11 @@ export class TdBreadcrumbsComponent implements OnInit, DoCheck, AfterContentInit
    */
   @Input('separatorIcon') separatorIcon: string = 'navigate_next';
 
-  constructor(private _elementRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef) { }
+  constructor(private _elementRef: ElementRef,
+              private _renderer: Renderer2,
+              private _changeDetectorRef: ChangeDetectorRef) {
+    this._renderer.addClass(this._elementRef.nativeElement, 'td-breadcrumbs');
+  }
 
   ngOnInit(): void {
     this._resizeSubscription = merge(


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Make sure we remove unnecessary elements from the `td-breadcrumbs` DOM.

e.g.

before
```
<td-breadcrumbs>
  <div class="td-breadcrumbs">
    <td-breadcrumb>
      <span class="td-breadcrumb">
```

after
```
<td-breadcrumbs class="td-breadcrumbs">
    <td-breadcrumb class="td-breadcrumb">
```

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [x] `npm run serve`
- [x] See demo still working properly

#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build:lib` still works.
