### PR TITLE
fix(dynamic-forms):  added missing hints for checkboxes, slide-toggles and sliders

### DIFF
--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
@@ -90,13 +90,13 @@ export class DynamicFormsDemoComponent {
     name: 'number',
     label: 'Number',
     type: TdDynamicType.Number,
-    hint: 'this is an input hint',
     required: true,
     min: 18,
     max: 70,
   }, {
     name: 'slider',
     type: TdDynamicElement.Slider,
+    hint: 'this is a slider hint',
     min: 18,
     max: 70,
   }];
@@ -105,14 +105,17 @@ export class DynamicFormsDemoComponent {
     name: 'boolean',
     label: 'Boolean Label',
     type: TdDynamicType.Boolean,
+    hint: 'this is a boolean',
     default: false,
   }, {
     name: 'slide-toggle',
     type: TdDynamicElement.SlideToggle,
+    hint: 'this is a slide toggle', 
     default: true,
   }, {
     name: 'checkbox',
     type: TdDynamicElement.Checkbox,
+    hint: 'this is a checkbox',
   }];
 
   arrayElements: ITdDynamicElementConfig[] = [{

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-checkbox/dynamic-checkbox.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-checkbox/dynamic-checkbox.component.html
@@ -4,5 +4,5 @@
                 [required]="required">
     {{label}}
   </mat-checkbox>
-  <span class="td-dynamic-elemenet-hint">{{hint}}</span>
+  <span class="mat-hint td-dynamic-element-hint">{{hint}}</span>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-checkbox/dynamic-checkbox.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-checkbox/dynamic-checkbox.component.html
@@ -4,4 +4,5 @@
                 [required]="required">
     {{label}}
   </mat-checkbox>
+  <span class="hint">{{hint}}</span>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-checkbox/dynamic-checkbox.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-checkbox/dynamic-checkbox.component.html
@@ -4,5 +4,5 @@
                 [required]="required">
     {{label}}
   </mat-checkbox>
-  <span class="hint">{{hint}}</span>
+  <span class="td-dynamic-elemenet-hint">{{hint}}</span>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-checkbox/dynamic-checkbox.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-checkbox/dynamic-checkbox.component.ts
@@ -14,6 +14,8 @@ export class TdDynamicCheckboxComponent {
 
   name: string = '';
 
+  hint: string = '';
+
   required: boolean = false;
 
 }

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-slide-toggle/dynamic-slide-toggle.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-slide-toggle/dynamic-slide-toggle.component.html
@@ -4,5 +4,5 @@
                     [required]="required">
     {{label}}
   </mat-slide-toggle>
-  <span class="hint">{{hint}}</span>
+  <span class="td-dynamic-elemenet-hint">{{hint}}</span>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-slide-toggle/dynamic-slide-toggle.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-slide-toggle/dynamic-slide-toggle.component.html
@@ -4,4 +4,5 @@
                     [required]="required">
     {{label}}
   </mat-slide-toggle>
+  <span class="hint">{{hint}}</span>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-slide-toggle/dynamic-slide-toggle.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-slide-toggle/dynamic-slide-toggle.component.html
@@ -4,5 +4,5 @@
                     [required]="required">
     {{label}}
   </mat-slide-toggle>
-  <span class="td-dynamic-elemenet-hint">{{hint}}</span>
+  <span class="mat-hint td-dynamic-element-hint">{{hint}}</span>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-slide-toggle/dynamic-slide-toggle.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-slide-toggle/dynamic-slide-toggle.component.ts
@@ -14,6 +14,8 @@ export class TdDynamicSlideToggleComponent {
 
   name: string = '';
 
+  hint: string = '';
+
   required: boolean = false;
 
 }

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-slider/dynamic-slider.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-slider/dynamic-slider.component.html
@@ -19,5 +19,5 @@
                 (blur)="_handleBlur()">
     </mat-slider>
   </div>  
-  <span class="hint">{{hint}}</span>
+  <span class="td-dynamic-elemenet-hint">{{hint}}</span>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-slider/dynamic-slider.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-slider/dynamic-slider.component.html
@@ -19,4 +19,5 @@
                 (blur)="_handleBlur()">
     </mat-slider>
   </div>  
+  <span class="hint">{{hint}}</span>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-slider/dynamic-slider.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-slider/dynamic-slider.component.html
@@ -19,5 +19,5 @@
                 (blur)="_handleBlur()">
     </mat-slider>
   </div>  
-  <span class="td-dynamic-elemenet-hint">{{hint}}</span>
+  <span class="mat-hint td-dynamic-element-hint">{{hint}}</span>
 </div>

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-slider/dynamic-slider.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-slider/dynamic-slider.component.ts
@@ -16,6 +16,8 @@ export class TdDynamicSliderComponent {
 
   name: string = '';
 
+  hint: string = '';
+
   min: number = undefined;
 
   max: number = undefined;

--- a/src/platform/dynamic-forms/dynamic-forms.component.scss
+++ b/src/platform/dynamic-forms/dynamic-forms.component.scss
@@ -3,6 +3,11 @@
     .mat-form-field-infix {
       width: auto;
     }
+    .hint {
+      color: rgba(0, 0, 0, 0.54);
+      font-size: 75%;
+      display: block;
+    }
   }
   // [layout-wrap]
   flex-wrap: wrap;
@@ -21,11 +26,5 @@
     box-sizing: border-box;
     position: relative;
     padding: 4px 4px 8px;
-
-    .hint {
-      color: rgba(0, 0, 0, 0.54);
-      font-size: 10.5px;
-      display: block;
-    }
   }
 }

--- a/src/platform/dynamic-forms/dynamic-forms.component.scss
+++ b/src/platform/dynamic-forms/dynamic-forms.component.scss
@@ -3,8 +3,7 @@
     .mat-form-field-infix {
       width: auto;
     }
-    .td-dynamic-elemenet-hint {
-      color: rgba(0, 0, 0, 0.54);
+    .td-dynamic-element-hint {
       font-size: 75%;
       display: block;
     }

--- a/src/platform/dynamic-forms/dynamic-forms.component.scss
+++ b/src/platform/dynamic-forms/dynamic-forms.component.scss
@@ -3,7 +3,7 @@
     .mat-form-field-infix {
       width: auto;
     }
-    .hint {
+    .td-dynamic-elemenet-hint {
       color: rgba(0, 0, 0, 0.54);
       font-size: 75%;
       display: block;

--- a/src/platform/dynamic-forms/dynamic-forms.component.scss
+++ b/src/platform/dynamic-forms/dynamic-forms.component.scss
@@ -21,5 +21,11 @@
     box-sizing: border-box;
     position: relative;
     padding: 4px 4px 8px;
+
+    .hint {
+      color: rgba(0, 0, 0, 0.54);
+      font-size: 10.5px;
+      display: block;
+    }
   }
 }


### PR DESCRIPTION
## Description
Added hints in for those elements that don't have built in `<mat-hint></mat-hint>` (ie. checkboxes, slide-toggles and sliders).

### What's included?
- Added hints to checkboxes
- Added hints to slide-toggles (booleans)
- Added hints to sliders

#### Test Steps
- [ ] `npm run serve`
- [ ] Go to http://localhost:4200/#/components/dynamic-forms and verify that hints show under `Dynamic Number Elements` and `Dynamic Boolean Elements`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1436" alt="screen shot 2018-11-13 at 1 06 19 pm" src="https://user-images.githubusercontent.com/437977/48443171-1bcd5000-e745-11e8-8870-ff8805e6df93.png">
