### PR TITLE
perf(virtual-scroll): leverage scroll event to check bottom reached

### DIFF
--- a/src/app/components/components/virtual-scroll/virtual-scroll.component.ts
+++ b/src/app/components/components/virtual-scroll/virtual-scroll.component.ts
@@ -58,7 +58,6 @@ export class VirtualScrollDemoComponent implements OnInit {
       )
       .subscribe((results: any[]) => {
         this.infiniteData = this.infiniteData.concat(results);
-        this._changeDetectorRef.detectChanges();
       });
   }
 }

--- a/src/platform/core/virtual-scroll/README.md
+++ b/src/platform/core/virtual-scroll/README.md
@@ -17,6 +17,7 @@
 
 + bottom?: function
   + Method to be executed when user scrolled to the last item of the list. No value is emitted.
+  + An [ITdVirtualScrollBottomEvent] event is emitted
 
 #### Methods
 
@@ -53,7 +54,7 @@ Example for HTML usage:
 <td-virtual-scroll-container [style.height.px]="400"
                              [data]="data"
                              [trackBy]="trackByFn"
-                             (bottom)="myEvent()">
+                             (bottom)="fetchMoreData()">
   <ng-template let-row="row"
                let-index="index"
                let-first="first"


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Making some performance enhancements to check if the bottom has been reached only when scrolling.

Also making sure there are no memory leaks in the observables.

README updates for the bottom event.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
