### PR TITLE
feat(http): add http decorators to experimental usage

### DIFF
--- a/scripts/build-release
+++ b/scripts/build-release
@@ -28,6 +28,11 @@ cp -r deploy/platform/core src/platform/node_modules/@covalent
 # BUILD: @covalent/markdown primary entrypoint
 ./node_modules/.bin/ng-packagr -p src/platform/markdown/ng-package.js
 
+# HACK (Remove in future): used to resolve ng-packagr current lack of support for Intra-package dependencies between primary entry points
+# HACK START
+cp -r deploy/platform/http src/platform/node_modules/@covalent
+# HACK END
+
 # BUILD: @covalent/experimental primary entrypoint
 ./node_modules/.bin/ng-packagr -p src/platform/experimental/ng-package.js
 

--- a/src/platform/experimental/http/README.md
+++ b/src/platform/experimental/http/README.md
@@ -1,0 +1,92 @@
+# Http Decorators
+
+It is a framework of decorators on top of the angular HttpClient to enhance your services and give them Http capabilities.
+
+## Usage
+
+Example:
+
+```typescript
+import { Injectable } from '@angular/core';
+import { HttpHeaders, HttpResponse } from '@angular/common/http';
+
+import { Observable } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+
+import {
+  TdHttp,
+  GET,
+  POST,
+  TdBody,
+  TdParam,
+  TdResponse,
+  TdQueryParams,
+} from '@covalent/experimental/http';
+
+@TdHttp({
+  baseUrl: 'www.mybaseurl.com',
+  baseHeaders: new HttpHeaders({ 'Accept': 'application/json' }),
+})
+@Injectable()
+export class TestHttpService {
+  /**
+   * Generates http request [www.mybaseurl.com/myitems] GET and returns an HttpResponse object
+   */
+  @GET({
+    path: '/myitems',
+    options: {
+      observe: 'response',
+    },
+  })
+  getResponse(): Observable<HttpResponse<any>> { return; }
+
+  /**
+   * Assuming queryParams = {q: 1}
+   * Generates http request [www.mybaseurl.com/myitems?q=1] GET and returns the response body parsed in JSON
+   */
+  @GET({
+    path: '/myitems',
+  })
+  getParsedResponse(@TdQueryParams() queryParams?: HttpParams): Observable<HttpResponse<any>> { return; }
+
+  /**
+   * Generates http request [www.mybaseurl.com/myitems] GET and returns the number of items after we use `map` of the response body
+   */
+  @GET({
+    path: '/myitems',
+  })
+  getMappedResponse(@TdResponse() response?: Observable<HttpResponse<any>>): Observable<number> {
+    return response.pipe(
+      map((data: any) => {
+        return data.items.length;
+      }),
+    );
+  }
+  
+  /**
+   * Assuming `id` = 1234
+   * Generates http request [www.mybaseurl.com/myitems/1234] GET and returns the response body parsed in JSON
+   */
+  @GET({
+    path: '/myitems/:id',
+  })
+  get(@TdParam('id') id: string,
+      @TdResponse() response?: Observable<HttpResponse<any>>): Observable<any> { return; }
+
+  /**
+   * Generates http request [www.mybaseurl.com/myitems] POST with a request body and returns the response body parsed in JSON
+   */
+  @POST({
+    path: '/myitems',
+  })
+  create(@TdBody() body: any,
+          @TdResponse() response?: Observable<HttpResponse<any>>): Observable<any> {
+    return response.pipe(
+      map((data: any) => {
+        return {
+          name: data.MyName,
+        };
+      }),
+    );
+  }
+}

--- a/src/platform/experimental/http/actions/class/http.decorator.ts
+++ b/src/platform/experimental/http/actions/class/http.decorator.ts
@@ -1,0 +1,12 @@
+import { mixinHttp, ITdHttpRESTConfig } from '../../http.mixin';
+
+/**
+ * Decorator used to give a service http capabilities
+ */
+export function TdHttp(config: ITdHttpRESTConfig): Function {
+  return function <T extends { new(...args: any[]): {} }>(constructor: any): any {
+    return class extends mixinHttp(constructor, config) {
+     
+    };
+  };
+}

--- a/src/platform/experimental/http/actions/index.ts
+++ b/src/platform/experimental/http/actions/index.ts
@@ -1,0 +1,12 @@
+export * from './methods/get.decorator';
+export * from './methods/post.decorator';
+export * from './methods/patch.decorator';
+export * from './methods/put.decorator';
+export * from './methods/delete.decorator';
+
+export * from './class/http.decorator';
+
+export * from './params/param.decorator';
+export * from './params/body.decorator';
+export * from './params/response.decorator';
+export * from './params/query-params.decorator';

--- a/src/platform/experimental/http/actions/methods/abstract-method.decorator.ts
+++ b/src/platform/experimental/http/actions/methods/abstract-method.decorator.ts
@@ -1,0 +1,104 @@
+import { HttpParams } from '@angular/common/http';
+
+import { TdHttpMethod, ITdHttpRESTOptions, ITdHttpRESTOptionsWithBody, NOOP_HTTP } from '../../http.mixin';
+import { TdParamType, tdHttpRESTParam } from '../params/abstract-param.decorator';
+
+declare const Reflect: any;
+
+/**
+ * Method used to copy parameters from an array or HttpParams object
+ * into a centrilized HttpParams object
+ * @internal
+ */
+export function parseParams(target: HttpParams, source: HttpParams | {[key: string]: string | string[]}): HttpParams {
+  let queryParams: HttpParams = target;
+  if (source instanceof HttpParams) {
+    source.keys().forEach((key: string) => {
+      // skip if value is undefined
+      if ((<HttpParams>source).get(key) !== undefined) {
+        queryParams = queryParams.set(key, (<HttpParams>source).get(key));
+      }
+    });
+  } else {
+    for (let key in source) {
+      // skip if value is undefined
+      if (<any>source[key] !== undefined) {
+        queryParams = queryParams.set(key, <any>source[key]);
+      }
+    }
+  }
+  return queryParams;
+}
+
+/**
+ * Abstract implementation of the http method decorator
+ * @internal
+ */
+export function TdAbstractMethod(config: {
+  method: TdHttpMethod,
+  path: string,
+  options?: ITdHttpRESTOptions,
+}): Function {
+  return function (target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function>): any {
+    let wrappedFunction: Function = descriptor.value;
+    // replace method call with our own and proxy it
+    descriptor.value = function (): any {
+      try {
+        let replacedPath: string = config.path;
+        let parameters: { index: number, param: string, type: TdParamType }[] = Reflect.getOwnMetadata(tdHttpRESTParam, target, propertyName);
+        let newArgs: any[] = [];
+        let body: any;
+        let queryParams: HttpParams = new HttpParams();
+        if (parameters) {
+          // map parameters and see which type they are to act on them
+          for (let parameter of parameters) {
+            if (parameter.type === 'param') {
+              newArgs[parameter.index] = arguments[parameter.index];
+              replacedPath = replacedPath.replace(':' + parameter.param, arguments[parameter.index]);
+            } else if (parameter.type === 'body') {
+              newArgs[parameter.index] = arguments[parameter.index];
+              body = arguments[parameter.index];
+            } else if (parameter.type === 'queryParams') {
+              newArgs[parameter.index] = arguments[parameter.index];
+              let qParams: HttpParams | {[key: string]: string | string[]} = arguments[parameter.index];
+              if (config.options && config.options.params) {
+                queryParams = parseParams(queryParams, config.options.params);
+              }
+              if (qParams) {
+                queryParams = parseParams(queryParams, qParams);
+              }
+            }
+          }
+        }
+        // tslint:disable-next-line
+        let url: string = this.baseUrl + replacedPath;
+        let options: ITdHttpRESTOptionsWithBody = Object.assign({}, config.options, {
+          body: body,
+          params: queryParams,
+        });
+        // tslint:disable-next-line
+        let request: any = this.buildRequest(config.method, url, options);
+        if (parameters) {
+          // see which one was the response parameter so we can set the request observable
+          for (let parameter of parameters) {
+            if (parameter.type === 'response') {
+              newArgs[parameter.index] = request;
+            }
+          }
+        }
+        // tslint:disable-next-line
+        let response: any = wrappedFunction.apply(this, newArgs);
+        // if the response is NOOP_HTTP or undefined, then we return the request as it is
+        // else we return the response from the inner function
+        if (response === NOOP_HTTP || response === undefined) {
+          return request;
+        } else {
+          return response;
+        }
+      } catch (error) {
+        // tslint:disable-next-line
+        console.error(error);
+      }
+    };
+  };
+}

--- a/src/platform/experimental/http/actions/methods/delete.decorator.ts
+++ b/src/platform/experimental/http/actions/methods/delete.decorator.ts
@@ -1,0 +1,14 @@
+import { ITdHttpRESTOptions } from '../../';
+import { TdAbstractMethod } from './abstract-method.decorator';
+
+/**
+ * Decorator that adds DELETE request capabilities to a method
+ */
+export function DELETE(config: {
+  path: string,
+  options?: ITdHttpRESTOptions,
+}): Function {
+  return TdAbstractMethod(<any>Object.assign({
+    method: 'DELETE',
+  }, config));
+}

--- a/src/platform/experimental/http/actions/methods/get.decorator.ts
+++ b/src/platform/experimental/http/actions/methods/get.decorator.ts
@@ -1,0 +1,14 @@
+import { ITdHttpRESTOptions } from '../../';
+import { TdAbstractMethod } from './abstract-method.decorator';
+
+/**
+ * Decorator that adds GET request capabilities to a method
+ */
+export function GET(config: {
+  path: string,
+  options?: ITdHttpRESTOptions,
+}): Function {
+  return TdAbstractMethod(<any>Object.assign({
+    method: 'GET',
+  }, config));
+}

--- a/src/platform/experimental/http/actions/methods/patch.decorator.ts
+++ b/src/platform/experimental/http/actions/methods/patch.decorator.ts
@@ -1,0 +1,14 @@
+import { ITdHttpRESTOptions } from '../../';
+import { TdAbstractMethod } from './abstract-method.decorator';
+
+/**
+ * Decorator that adds PATCH request capabilities to a method
+ */
+export function PATCH(config: {
+  path: string,
+  options?: ITdHttpRESTOptions,
+}): Function {
+  return TdAbstractMethod(<any>Object.assign({
+    method: 'PATCH',
+  }, config));
+}

--- a/src/platform/experimental/http/actions/methods/post.decorator.ts
+++ b/src/platform/experimental/http/actions/methods/post.decorator.ts
@@ -1,0 +1,14 @@
+import { ITdHttpRESTOptions } from '../../';
+import { TdAbstractMethod } from './abstract-method.decorator';
+
+/**
+ * Decorator that adds POST request capabilities to a method
+ */
+export function POST(config: {
+  path: string,
+  options?: ITdHttpRESTOptions,
+}): Function {
+  return TdAbstractMethod(<any>Object.assign({
+    method: 'POST',
+  }, config));
+}

--- a/src/platform/experimental/http/actions/methods/put.decorator.ts
+++ b/src/platform/experimental/http/actions/methods/put.decorator.ts
@@ -1,0 +1,14 @@
+import { ITdHttpRESTOptions } from '../../';
+import { TdAbstractMethod } from './abstract-method.decorator';
+
+/**
+ * Decorator that adds PUT request capabilities to a method
+ */
+export function PUT(config: {
+  path: string,
+  options?: ITdHttpRESTOptions,
+}): Function {
+  return TdAbstractMethod(<any>Object.assign({
+    method: 'PUT',
+  }, config));
+}

--- a/src/platform/experimental/http/actions/params/abstract-param.decorator.ts
+++ b/src/platform/experimental/http/actions/params/abstract-param.decorator.ts
@@ -1,0 +1,20 @@
+declare const Reflect: any;
+export type TdParamType = 'param' | 'response' | 'body' | 'queryParams';
+
+export const tdHttpRESTParam: Symbol = Symbol('TdHttpRESTParam');
+
+/**
+ * Abstract implementation of the http param decorator
+ * @internal
+ */
+export function TdAbstractParam(type: TdParamType, param?: string): Function {
+  return function (target: Object, propertyKey: string | symbol, parameterIndex: number): void {
+    let parameters: { index: number, param: string, type: TdParamType }[] = Reflect.getOwnMetadata(tdHttpRESTParam, target, propertyKey) || [];
+    parameters.push({
+      index: parameterIndex,
+      param: param,
+      type: type,
+    });
+    Reflect.defineMetadata(tdHttpRESTParam, parameters, target, propertyKey);
+  };
+}

--- a/src/platform/experimental/http/actions/params/body.decorator.ts
+++ b/src/platform/experimental/http/actions/params/body.decorator.ts
@@ -1,0 +1,8 @@
+import { TdAbstractParam } from './abstract-param.decorator';
+
+/**
+ * Decorator that is used to define which parameter is the http body in a method
+ */
+export function TdBody(): Function {
+  return TdAbstractParam('body');
+}

--- a/src/platform/experimental/http/actions/params/param.decorator.ts
+++ b/src/platform/experimental/http/actions/params/param.decorator.ts
@@ -1,0 +1,8 @@
+import { TdAbstractParam } from './abstract-param.decorator';
+
+/**
+ * Decorator that is used to define which parameter is an http parameter in a method
+ */
+export function TdParam(param: string): Function {
+  return TdAbstractParam('param', param);
+}

--- a/src/platform/experimental/http/actions/params/query-params.decorator.ts
+++ b/src/platform/experimental/http/actions/params/query-params.decorator.ts
@@ -1,0 +1,8 @@
+import { TdAbstractParam } from './abstract-param.decorator';
+
+/**
+ * Decorator that is used to define which parameter is the http query parameters in a method
+ */
+export function TdQueryParams(): Function {
+  return TdAbstractParam('queryParams');
+}

--- a/src/platform/experimental/http/actions/params/response.decorator.ts
+++ b/src/platform/experimental/http/actions/params/response.decorator.ts
@@ -1,0 +1,8 @@
+import { TdAbstractParam } from './abstract-param.decorator';
+
+/**
+ * Decorator that is used to define which parameter is the http response in a method
+ */
+export function TdResponse(): Function {
+  return TdAbstractParam('response');
+}

--- a/src/platform/experimental/http/http.mixin.ts
+++ b/src/platform/experimental/http/http.mixin.ts
@@ -1,0 +1,233 @@
+import { Type, Injectable, Injector, ɵReflectionCapabilities, InjectFlags, Optional,
+  SkipSelf, Self, Inject, InjectionToken } from '@angular/core';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Http, Response, Headers, URLSearchParams } from '@angular/http';
+import { HttpInterceptorService } from '@covalent/http';
+
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export type TdHttpMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'HEAD' | 'PUT' | 'OPTIONS';
+
+export type TdHttpRESTResponseType = 'arraybuffer' | 'blob' | 'json' | 'text';
+
+export type TdHttpRESTObserve = 'body' | 'response' | 'events';
+
+export interface ITdHttpRESTConfig {
+  baseHeaders?: HttpHeaders;
+  baseUrl: string;
+  defaultObserve?: TdHttpRESTObserve;
+  defaultResponseType?: TdHttpRESTResponseType;
+  httpServiceType?: Type<Http | HttpClient | HttpInterceptorService>;
+}
+
+export interface ITdHttpRESTOptions {
+  headers?: HttpHeaders | {
+    [header: string]: string | string[];
+  };
+  observe?: TdHttpRESTObserve;
+  params?: HttpParams | {
+    [param: string]: string | string[];
+  };
+  responseType?: TdHttpRESTResponseType;
+  reportProgress?: boolean;
+  withCredentials?: boolean;
+}
+
+export interface ITdHttpRESTOptionsWithBody extends ITdHttpRESTOptions {
+  body?: any;
+}
+
+export const NOOP_HTTP: Observable<any> = of(undefined);
+
+type Constructor<T> = new (...args: any[]) => T;
+
+/**
+ * DO NOT MODIFY
+ * Taken from angular since they dont expose this function
+ * This is used internally to inject services from the constructor of the base service using the mixinHttp
+ * @internal
+ */
+function injectArgs(types: (Type<any>| InjectionToken<any>| any[])[], injector: Injector): any[] {
+  const args: any[] = [];
+  for (let i: number = 0; i < types.length; i++) {
+    const arg: any = types[i];
+    if (Array.isArray(arg)) {
+      if (arg.length === 0) {
+        throw new Error('Arguments array must have arguments.');
+      }
+      let type: Type<any>|undefined = undefined;
+      let flags: InjectFlags = InjectFlags.Default;
+
+      for (let j: number = 0; j < arg.length; j++) {
+        const meta: any = arg[j];
+        if (meta instanceof Optional || meta.ngMetadataName === 'Optional') {
+          /* tslint:disable */
+          flags |= InjectFlags.Optional;
+        } else if (meta instanceof SkipSelf || meta.ngMetadataName === 'SkipSelf') {
+          flags |= InjectFlags.SkipSelf;
+        } else if (meta instanceof Self || meta.ngMetadataName === 'Self') {
+          flags |= InjectFlags.Self;
+        } else if (meta instanceof Inject) {
+          type = meta.token;
+        } else {
+          type = meta;
+        }
+        /* tslint:enable */
+      }
+
+      args.push(injector.get(type !, flags));
+    } else {
+      args.push(injector.get(arg));
+    }
+  }
+  return args;
+}
+
+/** 
+ * Mixin to augment a service with http helpers.
+ * @internal
+ */
+export function mixinHttp(base: any, config: ITdHttpRESTConfig): Constructor<any> {
+  /**
+   * Internal class used to get an instance of Injector for internal usage plus also
+   * a way to inject services from the constructor of the underlying service
+   * @internal
+   */
+  @Injectable()
+  abstract class HttpInternalClass extends base {
+    constructor(public _injector: Injector) {
+      super(...injectArgs(new ɵReflectionCapabilities().parameters(base), _injector));
+      this.buildConfig();
+    }
+    abstract buildConfig(): void;
+  }
+  /**
+   * Actuall class being returned with all the hooks for http usage
+   * @internal
+   */
+  return class extends HttpInternalClass {
+    private _baseUrl: string;
+    get baseUrl(): string {
+      return (typeof(this.basePath) === 'string' ?
+        this.basePath.replace(/\/$/, '') : '') + this._baseUrl;
+    }
+    private _baseHeaders: HttpHeaders;
+    private _defaultObserve?: TdHttpRESTObserve;
+    private _defaultResponseType?: TdHttpRESTResponseType;
+
+    http: HttpClient | HttpInterceptorService | Http;
+
+    /**
+     * Method used to setup the configuration parameters and get an instance of the http service
+     */
+    buildConfig(): void {
+      this.http = this._injector.get(config.httpServiceType || HttpClient);
+      this._baseUrl = config && config.baseUrl ? config.baseUrl.replace(/\/$/, '') : '';
+      this._baseHeaders = config && config.baseHeaders ? config.baseHeaders : new HttpHeaders();
+      this._defaultObserve = config && config.defaultObserve ? config.defaultObserve : 'body';
+      this._defaultResponseType = config && config.defaultResponseType ? config.defaultResponseType : 'json';
+    }
+
+    /**
+     * Method used to build the default headers using the base headers
+     */
+    buildHeaders(): HttpHeaders {
+      let headersObj: {[key: string]: any} = {};
+      this._baseHeaders.keys().forEach((key: any) => {
+        headersObj[key] = this._baseHeaders.get(key);
+      });
+      return new HttpHeaders(headersObj);
+    }
+
+    /* tslint:disable-next-line */
+    buildRequest<Response>(method: 'POST' | 'PUT' | 'PATCH', url: string, options?: ITdHttpRESTOptionsWithBody): Observable<Response>;
+    /* tslint:disable-next-line */
+    buildRequest<HttpResponse>(method: 'POST' | 'PUT' | 'PATCH', url: string, options?: ITdHttpRESTOptionsWithBody): Observable<HttpResponse>;
+    /* tslint:disable-next-line */
+    buildRequest<Response>(method: 'GET' | 'DELETE', url: string, options?: ITdHttpRESTOptions): Observable<Response>;
+    /* tslint:disable-next-line */
+    buildRequest<HttpResponse>(method: 'GET' | 'DELETE', url: string, options?: ITdHttpRESTOptions): Observable<HttpResponse>;
+    /* tslint:disable-next-line */
+    buildRequest<Response>(method: TdHttpMethod, url: string, options?: ITdHttpRESTOptionsWithBody): Observable<Response>;
+    /* tslint:disable-next-line */
+    buildRequest<HttpResponse>(method: TdHttpMethod, url: string, options?: ITdHttpRESTOptionsWithBody): Observable<HttpResponse> {
+      return this._buildRequest(method, url, options);
+    }
+
+    /**
+     * Method used to build the request depending on the `http` service and TdHttpMethod
+     */
+    private _buildRequest(method: TdHttpMethod, url: string, options: ITdHttpRESTOptionsWithBody = {}): Observable<any> {
+      if (!options.responseType) {
+        options.responseType = this._defaultResponseType;
+      }
+      if (!options.observe) {
+        options.observe = this._defaultObserve;
+      }
+      if (!options.headers) {
+        options.headers = this.buildHeaders();
+      } else {
+        let headers: HttpHeaders = this.buildHeaders();
+        if (options.headers instanceof HttpHeaders) {
+          (<HttpHeaders>options.headers).keys().forEach((key: any) => {
+            headers = headers.set(key, (<HttpHeaders>options.headers).get(key));
+          });
+        } else {
+          for (let key in options.headers) {
+            headers = headers.set(key, <any>options.headers[key]);
+          }
+        }
+        options.headers = headers;
+      }
+      if (this.http instanceof HttpInterceptorService || this.http instanceof Http) {
+        let headers: Headers = new Headers();
+        (<HttpHeaders>options.headers).keys().forEach((key: any) => {
+          headers.set(key, (<HttpHeaders>options.headers).get(key));
+        });
+        let params: URLSearchParams = new URLSearchParams();
+        if (options.params) {
+          if (options.params instanceof HttpParams) {
+            options.params.keys().forEach((key: string) => {
+              params.set(key, (<HttpParams>options.params).get(key));
+            });
+          } else {
+            for (let key in options.params) {
+              params.set(key, <any>options.params[key]);
+            }
+          }
+        }
+        let observable: Observable<Response> = (<HttpInterceptorService>this.http).request(url, {
+          headers: headers,
+          method: method,
+          body: options.body ? options.body : undefined,
+          params: params,
+        });
+        if (options.observe === 'body') {
+          if (options.responseType === 'json') {
+            return <any>observable.pipe(
+              map((response: Response) => response.json()),
+            );
+          } else if (options.responseType === 'text') {
+            return <any>observable.pipe(
+              map((response: Response) => response.text()),
+            );
+          } else if (options.responseType === 'blob') {
+            return <any>observable.pipe(
+              map((response: Response) => response.blob()),
+            );
+          } else if (options.responseType === 'arraybuffer') {
+            return <any>observable.pipe(
+              map((response: Response) => response.arrayBuffer()),
+            );
+          }
+        } else if (options.observe === 'events') {
+          throw Error('"events" not suppported in @angular/http');
+        }
+        return observable;
+      } else {
+        return (<HttpClient>this.http).request(method, url, options);
+      }
+    }
+  };
+}

--- a/src/platform/experimental/http/index.ts
+++ b/src/platform/experimental/http/index.ts
@@ -1,0 +1,1 @@
+export * from './public-api';

--- a/src/platform/experimental/http/package.json
+++ b/src/platform/experimental/http/package.json
@@ -1,0 +1,10 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "index.ts",
+      "umdModuleIds": {
+        "@covalent/http": "covalent.http"
+      }
+    }
+  }
+}

--- a/src/platform/experimental/http/public-api.ts
+++ b/src/platform/experimental/http/public-api.ts
@@ -1,0 +1,2 @@
+export * from './actions';
+export * from './http.mixin';

--- a/src/platform/experimental/package.json
+++ b/src/platform/experimental/package.json
@@ -16,6 +16,7 @@
   "peerDependencies": {
     "@angular/common": "^0.0.0-NG",
     "@angular/core": "^0.0.0-NG",
+    "@angular/http": "^0.0.0-NG",
     "@angular/cdk": "^0.0.0-MATERIAL",
     "@angular/material": "^0.0.0-MATERIAL"
   }

--- a/src/platform/experimental/package.json
+++ b/src/platform/experimental/package.json
@@ -16,8 +16,8 @@
   "peerDependencies": {
     "@angular/common": "^0.0.0-NG",
     "@angular/core": "^0.0.0-NG",
-    "@angular/http": "^0.0.0-NG",
     "@angular/cdk": "^0.0.0-MATERIAL",
-    "@angular/material": "^0.0.0-MATERIAL"
+    "@angular/material": "^0.0.0-MATERIAL",
+    "@covalent/http": "^0.0.0-COVALENT"
   }
 }

--- a/src/platform/experimental/public-api.ts
+++ b/src/platform/experimental/public-api.ts
@@ -2,3 +2,4 @@ export * from './template-rename-me-experiment-module/index';
 export * from './breadcrumbs/index';
 export * from './tab-select/index';
 export * from './nav-stepper/index';
+export * from './http/index';

--- a/src/test-bed/main/main.component.html
+++ b/src/test-bed/main/main.component.html
@@ -8,3 +8,6 @@
 <div class="pad">
   <a [routerLink]="'/navstepper'">Nav Stepper</a>
 </div>
+<div class="pad">
+  <a [routerLink]="'/http'">Http</a>
+</div>

--- a/src/test-bed/sandbox/http/http.component.html
+++ b/src/test-bed/sandbox/http/http.component.html
@@ -1,0 +1,22 @@
+<h3>Http Framework Test</h3>
+<h4>Response  with mapping</h4>
+<button (click)="httpTest()">
+  TEST HTTP CALL
+</button>
+<div>
+  {{response | json}}
+</div>
+<h4>Response with parsing</h4>
+<button (click)="httpTest2()">
+  TEST HTTP CALL
+</button>
+<div>
+  {{response2 | json}}
+</div>
+<h4>Response without parsing</h4>
+<button (click)="httpTest3()">
+  TEST HTTP CALL
+</button>
+<div>
+  {{response3 | json}}
+</div>

--- a/src/test-bed/sandbox/http/http.component.ts
+++ b/src/test-bed/sandbox/http/http.component.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import { HttpParams } from '@angular/common/http';
+
+import { TestHttpService } from './test-http.service';
+
+@Component({
+  selector: 'http-demo',
+  templateUrl: './http.component.html',
+  providers: [
+    TestHttpService,
+  ],
+})
+export class HttpDemoComponent {
+
+  private _queryParams: HttpParams = new HttpParams().set('q', 'repo:Teradata/covalent');
+
+  response: any;
+  response2: any;
+  response3: any;
+
+  constructor(private _http: TestHttpService) {
+    
+  }
+
+  async httpTest(): Promise<void> {
+    this.response = await this._http.getMappedResponse(this._queryParams).toPromise();
+  }
+
+  async httpTest2(): Promise<void> {
+    this.response2 = await this._http.getParsedResponse(this._queryParams).toPromise();
+  }
+
+  async httpTest3(): Promise<void> {
+    this.response3 = await this._http.getResponse(this._queryParams).toPromise();
+  }
+
+}

--- a/src/test-bed/sandbox/http/test-http.service.ts
+++ b/src/test-bed/sandbox/http/test-http.service.ts
@@ -1,0 +1,49 @@
+import { Injectable, Injector } from '@angular/core';
+import { HttpHeaders, HttpResponse, HttpClient, HttpParams } from '@angular/common/http';
+
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import {
+  TdHttp,
+  GET,
+  TdResponse,
+  TdQueryParams,
+} from '@covalent/experimental/http';
+
+@TdHttp({
+  baseUrl: 'https://api.github.com',
+  baseHeaders: new HttpHeaders({ 'Accept': 'application/json' }),
+})
+@Injectable()
+export class TestHttpService {
+
+  constructor(private _httpClient: HttpClient, private _injector: Injector) {
+    /* tslint:disable-next-line */
+    console.log(_httpClient, _injector); // dont remove, its to test if they get injected
+  }
+
+  @GET({
+    path: '/search/repositories',
+    options: {
+      observe: 'response',
+    },
+  })
+  getResponse(@TdQueryParams() queryParams?: HttpParams): Observable<HttpResponse<any>> { return; }
+
+  @GET({
+    path: '/search/repositories',
+  })
+  getParsedResponse(@TdQueryParams() queryParams?: HttpParams): Observable<HttpResponse<any>> { return; }
+
+  @GET({
+    path: '/search/repositories',
+  })
+  getMappedResponse(@TdQueryParams() queryParams?: HttpParams, @TdResponse() response?: Observable<HttpResponse<any>>): Observable<number> {
+    return response.pipe(
+      map((data: any) => {
+        return data.items.length > 0 ? data.items[0].stargazers_count : 0;
+      }),
+    );
+  }
+}

--- a/src/test-bed/test-bed.module.ts
+++ b/src/test-bed/test-bed.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -11,12 +12,14 @@ import { CovalentNavStepperModule } from '../platform/experimental/nav-stepper';
 import { TestBedComponent } from './test-bed/test-bed.component';
 import { MainComponent } from './main/main.component';
 import { NavStepperDemoComponent } from './sandbox/nav-stepper/nav-stepper.component';
+import { HttpDemoComponent } from './sandbox/http/http.component';
 import { appRoutes, appRoutingProviders } from './test-bed.routes';
 
 @NgModule({
   declarations: [
     TestBedComponent,
     NavStepperDemoComponent,
+    HttpDemoComponent,
     MainComponent,
   ],
   imports: [
@@ -24,6 +27,7 @@ import { appRoutes, appRoutingProviders } from './test-bed.routes';
     CommonModule,
     BrowserAnimationsModule,
     FormsModule,
+    HttpClientModule,
     MatDividerModule,
     MatToolbarModule,
     appRoutes,

--- a/src/test-bed/test-bed.routes.ts
+++ b/src/test-bed/test-bed.routes.ts
@@ -1,16 +1,19 @@
 import { Routes, RouterModule } from '@angular/router';
 
 import { NavStepperDemoComponent } from './sandbox/nav-stepper/nav-stepper.component';
+import { HttpDemoComponent } from './sandbox/http/http.component';
 import { MainComponent } from './main/main.component';
 
 const routes: Routes = [
   {
     component: MainComponent,
     path: '',
-  },
-  {
+  }, {
     component: NavStepperDemoComponent,
     path: 'navstepper',
+  }, {
+    component: HttpDemoComponent,
+    path: 'http',
   },
 ];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
       "@covalent/highlight": ["./platform/highlight"],
       "@covalent/http": ["./platform/http"],
       "@covalent/markdown": ["./platform/markdown"],
+      "@covalent/experimental/*": ["./platform/experimental/*"],
       "@covalent/flavored-markdown": ["./platform/flavored-markdown"]
     },
     "noUnusedParameters": false,


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Http Decorator Framework to simplify/hide the usage of `HttpClient` and make it easier to create http services.

Demo and Readme added to experimental.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve:experimental`
- [ ] click on http
- [ ] test requests

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
