### PR TITLE
fix(dynamic-forms): update template when manually adding errors to controls

### DIFF
--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.html
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.html
@@ -548,6 +548,68 @@
         </td-highlight>
       </mat-tab>
     </mat-tab-group>
+
+    <h4>Manual Validators</h4>
+    <mat-divider></mat-divider>
+    <mat-tab-group mat-stretch-tabs>
+      <mat-tab>
+        <ng-template matTabLabel>Demo</ng-template>
+        <td-dynamic-forms #manualValidateForm [elements]="manualValidatorElement">
+          <ng-template let-control="control" tdDynamicFormsError="vowelsElement">
+            <span *ngIf="control.touched || !control.pristine">
+              <span *ngIf="control.hasError('consonants')">{{ control.errors['consonants'] }}</span>
+            </span>
+          </ng-template>
+
+          <mat-card-actions>
+            <button mat-raised-button (click)="submitManualValidator()" color="primary" class="text-upper" [disabled]="!manualValidateForm.valid">
+              Submit
+            </button>
+          </mat-card-actions>
+        </td-dynamic-forms>
+      </mat-tab>
+      <mat-tab>
+        <ng-template matTabLabel>Code</ng-template>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <td-dynamic-forms #manualValidateForm [elements]="manualValidatorElement">
+              <ng-template let-control="control" tdDynamicFormsError="vowelsElement">
+                <span *ngIf="control.touched || !control.pristine">
+                  <span *ngIf="control.hasError('consonants')">{ { control.errors['consonants'] } }</span>
+                </span>
+              </ng-template>
+
+              <mat-card-actions>
+                <button mat-raised-button (click)="submitManualValidator()"
+                                          color="primary"
+                                          class="text-upper"
+                                          [disabled]="!manualValidateForm.valid">
+                  Submit
+                </button>
+              </mat-card-actions>
+            </td-dynamic-forms>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            manualValidatorElement: ITdDynamicElementConfig[] = [{
+              name: 'vowelsElement',
+              label: 'Vowels only',
+              type: TdDynamicType.Text,
+            }];
+
+            submitManualValidator(): void {
+              const control: AbstractControl = this.manualValidateForm.controls['vowelsElement'];
+              if (control.value.match(/[^aeiou]/)) {
+                this.manualValidateForm.controls['vowelsElement'].setErrors({ consonants: 'Only vowel characters. Do not use any consonants.' });
+              }
+            }
+          ]]>
+        </td-highlight>
+      </mat-tab>
+    </mat-tab-group>
   </mat-card-content>
 </mat-card>
 

--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, TemplateRef } from '@angular/core';
+import { Component, HostBinding, TemplateRef, ViewChild } from '@angular/core';
 import { AbstractControl, Validators } from '@angular/forms';
 import { tdCollapseAnimation } from '@covalent/core/common';
 import { slideInDownAnimation } from '../../../app.animations';
@@ -44,7 +44,7 @@ export class TdTestDynamicComponent {
   preserveWhitespaces: true,
 })
 export class DynamicFormsDemoComponent {
-
+  @ViewChild('manualValidateForm') manualValidateForm: TdDynamicFormsComponent;
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
 
@@ -262,6 +262,20 @@ export class DynamicFormsDemoComponent {
       validator: Validators.pattern(/^#[A-Fa-f0-9]{6}$/),
     }],
   }];
+
+  manualValidatorElement: ITdDynamicElementConfig[] = [{
+    name: 'vowelsElement',
+    label: 'Vowels only',
+    type: TdDynamicType.Text,
+    required: true,
+  }];
+
+  submitManualValidator(): void {
+    const control: AbstractControl = this.manualValidateForm.controls['vowelsElement'];
+    if (control.value.match(/[^aeiou]/)) {
+      this.manualValidateForm.controls['vowelsElement'].setErrors({ consonants: 'Only vowel characters. Do not use any consonants.' });
+    }
+  }
 
   isMinMaxSupported(type: TdDynamicElement | TdDynamicType): boolean {
     return type === TdDynamicElement.Slider || type === TdDynamicType.Number || this.isDate(type);

--- a/src/platform/dynamic-forms/dynamic-forms.component.spec.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.component.spec.ts
@@ -319,6 +319,35 @@ describe('Component: TdDynamicForms', () => {
     });
   })));
 
+  it('should render errors with manual validations', async(inject([], () => {
+    let fixture: ComponentFixture<any> = TestBed.createComponent(TdDynamicFormsTestComponent);
+    let component: TdDynamicFormsTestComponent = fixture.debugElement.componentInstance;
+
+    component.elements = [{
+      name: 'customElement',
+      label: 'Custom Element',
+      type: TdDynamicType.Text,
+    }];
+
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      let dynamicFormsComponent: TdDynamicFormsComponent =
+          fixture.debugElement.query(By.directive(TdDynamicFormsComponent)).componentInstance;
+
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        dynamicFormsComponent.controls['customElement'].markAsTouched();
+        dynamicFormsComponent.controls['customElement'].setErrors({ customError: 'CUSTOM_ERROR' });
+
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          expect(fixture.debugElement.queryAll(By.css('#custom-error')).length).toBe(1);
+          expect(fixture.debugElement.query(By.css('#custom-error')).nativeElement.textContent).toBe('CUSTOM_ERROR');
+        });
+      });
+    });
+  })));
+
   it('should render dynamic elements with one element disabled', async(inject([], () => {
     let fixture: ComponentFixture<any> = TestBed.createComponent(TdDynamicFormsTestComponent);
     let component: TdDynamicFormsTestComponent = fixture.debugElement.componentInstance;
@@ -345,7 +374,7 @@ describe('Component: TdDynamicForms', () => {
       expect(JSON.stringify(dynamicFormsComponent.value)).toBe(JSON.stringify({hexColor: '#F1F1F1'}));
     });
   })));
-  
+
   it('should render dynamic custom element', async(inject([], () => {
     let fixture: ComponentFixture<any> = TestBed.createComponent(TdDynamicFormsTestComponent);
     let component: TdDynamicFormsTestComponent = fixture.debugElement.componentInstance;
@@ -370,6 +399,9 @@ describe('Component: TdDynamicForms', () => {
 @Component({
   template: `
     <td-dynamic-forms [elements]="elements">
+      <ng-template let-control="control" tdDynamicFormsError="customElement">
+        <span id="custom-error" *ngIf="control.hasError('customError')">{{ control.errors['customError'] }}</span>
+      </ng-template>
     </td-dynamic-forms>`,
 })
 class TdDynamicFormsTestComponent {

--- a/src/platform/dynamic-forms/dynamic-forms.component.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.component.ts
@@ -1,11 +1,12 @@
 import { Component, Input, ChangeDetectionStrategy, ChangeDetectorRef, ContentChildren,
-         TemplateRef, QueryList, AfterContentInit } from '@angular/core';
+         TemplateRef, QueryList, AfterContentInit, OnDestroy } from '@angular/core';
 import { FormGroup, FormBuilder, AbstractControl } from '@angular/forms';
 
 import { TdDynamicFormsService, ITdDynamicElementConfig } from './services/dynamic-forms.service';
 import { TdDynamicFormsErrorTemplate } from './dynamic-element.component';
 
-import { timer } from 'rxjs';
+import { timer, Subject, Observable } from 'rxjs';
+import { takeUntil, filter } from 'rxjs/operators';
 
 @Component({
   selector: 'td-dynamic-forms',
@@ -13,11 +14,14 @@ import { timer } from 'rxjs';
   styleUrls: ['./dynamic-forms.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TdDynamicFormsComponent implements AfterContentInit {
+export class TdDynamicFormsComponent implements AfterContentInit, OnDestroy {
 
   private _renderedElements: ITdDynamicElementConfig[] = [];
   private _elements: ITdDynamicElementConfig[];
   private _templateMap: Map<string, TemplateRef<any>> = new Map<string, TemplateRef<any>>();
+  private _destroy$: Subject<any> = new Subject();
+  private _destroyControl$: Subject<string> = new Subject();
+
   @ContentChildren(TdDynamicFormsErrorTemplate) _errorTemplates: QueryList<TdDynamicFormsErrorTemplate>;
   dynamicForm: FormGroup;
 
@@ -100,6 +104,12 @@ export class TdDynamicFormsComponent implements AfterContentInit {
     this._updateErrorTemplates();
   }
 
+  ngOnDestroy(): void {
+    this._destroy$.next();
+    this._destroy$.complete();
+    this._destroyControl$.complete();
+  }
+
   /**
    * Refreshes the form and rerenders all validator/element modifications.
    */
@@ -176,6 +186,7 @@ export class TdDynamicFormsComponent implements AfterContentInit {
     }
     // remove elements that were removed from the array
     this._renderedElements.forEach((elem: ITdDynamicElementConfig) => {
+      this._destroyControl$.next(elem.name);
       this.dynamicForm.removeControl(elem.name);
     });
   }
@@ -183,6 +194,18 @@ export class TdDynamicFormsComponent implements AfterContentInit {
   // Updates component when manually adding errors to controls
   private _subscribeToControlStatusChanges(elementName: string): void {
     const control: AbstractControl = this.controls[elementName];
-    control.statusChanges.subscribe(() => this._changeDetectorRef.markForCheck());
+
+    const controlDestroyed$: Observable<any> = this._destroyControl$
+      .pipe(
+        filter((destroyedElementName: string) => destroyedElementName === elementName),
+      );
+
+    control.statusChanges
+      .pipe(
+        takeUntil(this._destroy$),
+        takeUntil(controlDestroyed$),
+      ).subscribe(() => {
+        this._changeDetectorRef.markForCheck();
+      });
   }
 }

--- a/src/platform/dynamic-forms/dynamic-forms.component.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.component.ts
@@ -20,7 +20,7 @@ export class TdDynamicFormsComponent implements AfterContentInit {
   private _templateMap: Map<string, TemplateRef<any>> = new Map<string, TemplateRef<any>>();
   @ContentChildren(TdDynamicFormsErrorTemplate) _errorTemplates: QueryList<TdDynamicFormsErrorTemplate>;
   dynamicForm: FormGroup;
- 
+
   /**
    * elements: ITdDynamicElementConfig[]
    * JS Object that will render the elements depending on its config.
@@ -141,6 +141,7 @@ export class TdDynamicFormsComponent implements AfterContentInit {
       let dynamicElement: AbstractControl = this.dynamicForm.get(elem.name);
       if (!dynamicElement) {
         this.dynamicForm.addControl(elem.name, this._dynamicFormsService.createFormControl(elem));
+        this._subscribeToControlStatusChanges(elem.name);
       } else {
         dynamicElement.setValue(elem.default);
         dynamicElement.markAsPristine();
@@ -177,5 +178,11 @@ export class TdDynamicFormsComponent implements AfterContentInit {
     this._renderedElements.forEach((elem: ITdDynamicElementConfig) => {
       this.dynamicForm.removeControl(elem.name);
     });
+  }
+
+  // Updates component when manually adding errors to controls
+  private _subscribeToControlStatusChanges(elementName: string): void {
+    const control: AbstractControl = this.controls[elementName];
+    control.statusChanges.subscribe(() => this._changeDetectorRef.markForCheck());
   }
 }


### PR DESCRIPTION
## Description
Display Dynamic Forms error messages when adding error to controls through control.setErrors(...).

### What's included?
- Added Status Changes subscription on controls so we can detect changes when updating the control from outside
- New documentation "Manual Validators"
- Unit test

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Open http://localhost:4200/#/components/dynamic-forms
- [ ] Scroll to "Manual Validators" (new section)
- [ ] Type 'asdgg' and click on Submit button
- [ ] See error message "Only vowel characters. Do not use any consonants."
- [ ] Type "aeiou" and click on Submit button
- [ ] Error message disapears
- [ ] View example source code


#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

This PR fixes #1130