### PR TITLE
feat(docs): Add link to github repo to toolbar

### DIFF
--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -12,6 +12,9 @@
       <a class="push-right text-nodecoration" [routerLink]="['/design-patterns']" [routerLinkActive]="['active']"><span hide-md>Design</span> Patterns</a>
       <a class="push-right text-nodecoration" [routerLink]="['/templates']" [routerLinkActive]="['active']">Templates</a>
     </nav>
+    <a mat-icon-button matTooltip="Github" href="https://github.com/teradata/covalent" target="_blank">
+      <mat-icon svgIcon="assets:github"></mat-icon>
+    </a>
     <button class="overflow-visible" mat-icon-button [matMenuTriggerFor]="notificationsMenu">
       <td-notification-count color="accent" [notifications]="updates.length + 3">
         <mat-icon>notifications</mat-icon>


### PR DESCRIPTION
## Description

Add link to the Github repo in the toolbar so it is quickly accessible throughout the docs
Closes #966 

### What's included?
<!-- List features included in this PR -->
- A link to the Github repo in the toolbar

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Navigate to the home page
- [ ] Click on the button with the Github icon in the toolbar


#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

![localhost_4200_ ipad](https://user-images.githubusercontent.com/7193975/48871591-371a0a00-ed9a-11e8-9f9d-4daf0e46f5ee.png)

