### PR TITLE
fix(animations): changing to overflow hidden instead of visibility hidden

### DIFF
--- a/src/platform/core/common/animations/collapse/collapse.animation.ts
+++ b/src/platform/core/common/animations/collapse/collapse.animation.ts
@@ -21,27 +21,41 @@ export interface ICollapseAnimation extends IAnimationOptions {
  * usage: [@tdCollapse]="{ value: true | false, params: { duration: 500 }}"
  */
 export const tdCollapseAnimation: AnimationTriggerMetadata = trigger('tdCollapse', [
-    state('1', style({
-      height: '0',
-      visibility: 'hidden',
-    })),
-    state('0',  style({
+  state('1', style({
+    height: '0',
+    overflow: 'hidden',
+  })),
+  state('0',  style({
+    height: AUTO_STYLE,
+    overflow: AUTO_STYLE,
+  })),
+  transition('0 => 1', [
+    style({
+      overflow: 'hidden',
       height: AUTO_STYLE,
-      visibility: AUTO_STYLE,
-    })),
-    transition('0 => 1', [
-      group([
-        query('@*', animateChild(), { optional: true }),
-        animate('{{ duration }}ms {{ delay }}ms {{ ease }}'),
-      ]),
-    ], { params: { duration: 150, delay: '0', ease: 'ease-in' }}),
-    transition('1 => 0', [
-      group([
-        query('@*', animateChild(), { optional: true }),
-        animate('{{ duration }}ms {{ delay }}ms {{ ease }}'),
-      ]),
-    ], { params: { duration: 150, delay: '0', ease: 'ease-out' }}),
-  ]);
+    }),
+    group([
+      query('@*', animateChild(), { optional: true }),
+      animate('{{ duration }}ms {{ delay }}ms {{ ease }}', style({
+        height: '0',
+        overflow: 'hidden',
+      })),
+    ]),
+  ], { params: { duration: 150, delay: '0', ease: 'ease-in' }}),
+  transition('1 => 0', [
+    style({
+      height: '0',
+      overflow: 'hidden',
+    }),
+    group([
+      query('@*', animateChild(), { optional: true }),
+      animate('{{ duration }}ms {{ delay }}ms {{ ease }}', style({
+        overflow: 'hidden',
+        height: AUTO_STYLE,
+      })),
+    ]),
+  ], { params: { duration: 150, delay: '0', ease: 'ease-out' }}),
+]);
 
 /** @deprecated see tdCollapseAnimation */
 export function TdCollapseAnimation(collapseOptions: ICollapseAnimation = {}): AnimationTriggerMetadata {


### PR DESCRIPTION
this way we actually reduce the height of the element to 0 instead of it taking height out of the page

Also solves an issue where items with absolute position would still show up.

e.g.

`mat-tab` inside `td-expansion-panel`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
