### PR TITLE
feat(animations): remove deprecated animation functions *BREAKING CHANGE*

### DIFF
--- a/src/app/components/components/media/media.component.ts
+++ b/src/app/components/components/media/media.component.ts
@@ -2,14 +2,14 @@ import { Component, OnInit, NgZone, OnDestroy, HostBinding } from '@angular/core
 import { slideInDownAnimation } from '../../../app.animations';
 import { Subscription } from 'rxjs';
 
-import { TdMediaService, TdJelloAnimation } from '../../../../platform/core';
+import { TdMediaService, tdJelloAnimation } from '../../../../platform/core';
 
 @Component({
   selector: 'media-demo',
   styleUrls: ['./media.component.scss' ],
   templateUrl: './media.component.html',
   animations: [
-    TdJelloAnimation(),
+    tdJelloAnimation,
     slideInDownAnimation,
   ],
   preserveWhitespaces: true,

--- a/src/app/components/design-patterns/cards/cards.component.ts
+++ b/src/app/components/design-patterns/cards/cards.component.ts
@@ -1,7 +1,6 @@
 import { Component, HostBinding } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
-import { TdCollapseAnimation } from '@covalent/core/common';
 import { slideInDownAnimation } from '../../../app.animations';
 
 @Component({

--- a/src/app/components/design-patterns/management-list/management-list.component.ts
+++ b/src/app/components/design-patterns/management-list/management-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostBinding } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
-import { TdCollapseAnimation } from '@covalent/core/common';
+
 import { slideInDownAnimation } from '../../../app.animations';
 
 @Component({

--- a/src/platform/core/common/animations/bounce/bounce.animation.ts
+++ b/src/platform/core/common/animations/bounce/bounce.animation.ts
@@ -40,31 +40,3 @@ export const tdBounceAnimation: AnimationTriggerMetadata = trigger('tdBounce', [
     ]),
   ], { params: { duration: 500, delay: '0', ease: 'ease-out' }}),
 ]);
-
-/** @deprecated see tdBounceAnimation */
-export function TdBounceAnimation(bounceOptions: IAnimationOptions = {}): AnimationTriggerMetadata {
-  return trigger(bounceOptions.anchor || 'tdBounce', [
-    state('0', style({
-      transform: 'translate3d(0, 0, 0)',
-    })),
-    state('1',  style({
-      transform: 'translate3d(0, 0, 0)',
-    })),
-    transition('0 <=> 1', [
-      group([
-        query('@*', animateChild(), { optional: true }),
-        animate((bounceOptions.duration || 500) + 'ms ' + (bounceOptions.delay || 0) + 'ms', keyframes([
-          style({animationTimingFunction: 'cubic-bezier(0.215, 0.610, 0.355, 1.000)', transform: 'translate3d(0, 0, 0)', offset: 0}),
-          style({animationTimingFunction: 'cubic-bezier(0.215, 0.610, 0.355, 1.000)', transform: 'translate3d(0, 0, 0)', offset: 0.2}),
-          style({animationTimingFunction: 'cubic-bezier(0.755, 0.050, 0.855, 0.060)', transform: 'translate3d(0, -30px, 0)', offset: 0.4}),
-          style({animationTimingFunction: 'cubic-bezier(0.755, 0.050, 0.855, 0.060)', transform: 'translate3d(0, -30px, 0)', offset: 0.43}),
-          style({animationTimingFunction: 'cubic-bezier(0.215, 0.610, 0.355, 1.000)', transform: 'translate3d(0, 0, 0)', offset: 0.53}),
-          style({animationTimingFunction: 'cubic-bezier(0.755, 0.050, 0.855, 0.060)', transform: 'translate3d(0, -15px, 0)', offset: .7}),
-          style({animationTimingFunction: 'cubic-bezier(0.215, 0.610, 0.355, 1.000)', transform: 'translate3d(0, 0, 0)', offset: 0.8}),
-          style({transform: 'translate3d(0, -4px, 0)', offset: .9}),
-          style({animationTimingFunction: 'cubic-bezier(0.215, 0.610, 0.355, 1.000)', transform: 'translate3d(0, 0, 0)', offset: 1.0}),
-        ])),
-      ]),
-    ]),
-  ]);
-}

--- a/src/platform/core/common/animations/collapse/collapse.animation.ts
+++ b/src/platform/core/common/animations/collapse/collapse.animation.ts
@@ -56,33 +56,3 @@ export const tdCollapseAnimation: AnimationTriggerMetadata = trigger('tdCollapse
     ]),
   ], { params: { duration: 150, delay: '0', ease: 'ease-out' }}),
 ]);
-
-/** @deprecated see tdCollapseAnimation */
-export function TdCollapseAnimation(collapseOptions: ICollapseAnimation = {}): AnimationTriggerMetadata {
-  return trigger(collapseOptions.anchor || 'tdCollapse', [
-    state('1', style({
-      height: '0',
-      visibility: 'hidden',
-    })),
-    state('0',  style({
-      height: AUTO_STYLE,
-      visibility: AUTO_STYLE,
-    })),
-    transition('0 => 1', [
-      group([
-        query('@*', animateChild(), { optional: true }),
-        animate((collapseOptions.duration || 150) + 'ms ' +
-                (collapseOptions.delay || 0) + 'ms ' +
-                (collapseOptions.easeOnClose || 'ease-in')),
-      ]),
-    ]),
-    transition('1 => 0', [
-      group([
-        query('@*', animateChild(), { optional: true }),
-        animate((collapseOptions.duration || 150) + 'ms ' +
-                (collapseOptions.delay || 0) + 'ms ' +
-                (collapseOptions.easeOnOpen || 'ease-out')),
-      ]),
-    ]),
-  ]);
-}

--- a/src/platform/core/common/animations/fade/fadeInOut.animation.ts
+++ b/src/platform/core/common/animations/fade/fadeInOut.animation.ts
@@ -42,33 +42,3 @@ export const tdFadeInOutAnimation: AnimationTriggerMetadata = trigger('tdFadeInO
     ]),
   ], { params: { duration: 150, delay: '0', easeOnOut: 'ease-out' }}),
 ]);
-
-/** @deprecated see tdFadeInOutAnimation */
-export function TdFadeInOutAnimation(fadeInOut: IFadeInOutAnimation = {}): AnimationTriggerMetadata {
-  return trigger((fadeInOut.anchor || 'tdFadeInOut'), [
-    state('0', style({
-      opacity: '0',
-      visibility: 'hidden',
-    })),
-    state('1',  style({
-      opacity: AUTO_STYLE,
-      visibility: AUTO_STYLE,
-    })),
-    transition('0 => 1', [
-      group([
-        query('@*', animateChild(), { optional: true }),
-        animate((fadeInOut.duration || 150) + 'ms ' +
-                (fadeInOut.delay || 0) + 'ms ' +
-                (fadeInOut.easeOnIn || 'ease-in')),
-      ]),
-    ]),
-    transition('1 => 0', [
-      group([
-        query('@*', animateChild(), { optional: true }),
-        animate((fadeInOut.duration || 150) + 'ms ' +
-                (fadeInOut.delay || 0) + 'ms ' +
-                (fadeInOut.easeOnOut || 'ease-out')),
-      ]),
-    ]),
-  ]);
-}

--- a/src/platform/core/common/animations/flash/flash.animation.ts
+++ b/src/platform/core/common/animations/flash/flash.animation.ts
@@ -36,27 +36,3 @@ export const tdFlashAnimation: AnimationTriggerMetadata = trigger('tdFlash', [
     ]),
   ], { params: { duration: 500, delay: '0', ease: 'ease-out' }}),
 ]);
-
-/** @deprecated see tdFlashAnimation */
-export function TdFlashAnimation(flashOptions: IAnimationOptions = {}): AnimationTriggerMetadata {
-  return trigger(flashOptions.anchor || 'tdFlash', [
-    state('0', style({
-      opacity: 1,
-    })),
-    state('1',  style({
-      opacity: 1,
-    })),
-    transition('0 <=> 1', [
-      group([
-        query('@*', animateChild(), { optional: true }),
-        animate((flashOptions.duration || 500) + 'ms ' + (flashOptions.delay || 0) + 'ms', keyframes([
-          style({opacity: 1, offset: 0}),
-          style({opacity: 0, offset: 0.25}),
-          style({opacity: 1, offset: 0.5}),
-          style({opacity: 0, offset: 0.75}),
-          style({opacity: 1, offset: 1.0}),
-        ])),
-      ]),
-    ]),
-  ]);
-}

--- a/src/platform/core/common/animations/headshake/headshake.animation.ts
+++ b/src/platform/core/common/animations/headshake/headshake.animation.ts
@@ -37,28 +37,3 @@ export const tdHeadshakeAnimation: AnimationTriggerMetadata = trigger('tdHeadsha
     ]),
   ], { params: { duration: 500, delay: '0', ease: 'ease-out' }}),
 ]);
-
-/** @deprecated see tdHeadshakeAnimation */
-export function TdHeadshakeAnimation(headshakeOptions: IAnimationOptions = {}): AnimationTriggerMetadata {
-  return trigger(headshakeOptions.anchor || 'tdHeadshake', [
-    state('0', style({
-      transform: 'translateX(0)',
-    })),
-    state('1',  style({
-      transform: 'translateX(0)',
-    })),
-    transition('0 <=> 1', [
-      group([
-        query('@*', animateChild(), { optional: true }),
-        animate((headshakeOptions.duration || 500) + 'ms ' + (headshakeOptions.delay || 0) + 'ms', keyframes([
-          style({transform: 'translateX(0)', offset: 0}),
-          style({transform: 'translateX(-6px) rotateY(-9deg)', offset: 0.065}),
-          style({transform: 'translateX(5px) rotateY(7deg)', offset: 0.185}),
-          style({transform: 'translateX(-3px) rotateY(-5deg)', offset: 0.315}),
-          style({transform: 'translateX(2px) rotateY(3deg)', offset: 0.435}),
-          style({transform: 'translateX(0)', offset: 0.50}),
-        ])),
-      ]),
-    ]),
-  ]);
-}

--- a/src/platform/core/common/animations/jello/jello.animation.ts
+++ b/src/platform/core/common/animations/jello/jello.animation.ts
@@ -40,31 +40,3 @@ export const tdJelloAnimation: AnimationTriggerMetadata = trigger('tdJello', [
     ]),
   ], { params: { duration: 500, delay: '0', ease: 'ease-out' }}),
 ]);
-
-/** @deprecated see tdJelloAnimation */
-export function TdJelloAnimation(jelloOptions: IAnimationOptions = {}): AnimationTriggerMetadata {
-  return trigger(jelloOptions.anchor || 'tdJello', [
-    state('0', style({
-      transform: 'none',
-    })),
-    state('1',  style({
-      transform: 'none',
-    })),
-    transition('0 <=> 1', [
-      group([
-        query('@*', animateChild(), { optional: true }),
-        animate((jelloOptions.duration || 500) + 'ms ' + (jelloOptions.delay || 0) + 'ms', keyframes([
-          style({transform: 'none', offset: 0}),
-          style({transform: 'none', offset: 0.011}),
-          style({transform: 'skewX(-12.5deg) skewY(-12.5deg)', offset: 0.222}),
-          style({transform: 'skewX(6.25deg) skewY(6.25deg)', offset: 0.333}),
-          style({transform: 'skewX(-3.125deg) skewY(-3.125deg)', offset: 0.444}),
-          style({transform: 'skewX(1.5625deg) skewY(1.5625deg)', offset: 0.555}),
-          style({transform: 'skewX(-0.78125deg) skewY(-0.78125deg)', offset: 0.666}),
-          style({transform: 'skewX(0.390625deg) skewY(0.390625deg)', offset: 0.777}),
-          style({transform: 'skewX(-0.1953125deg) skewY(-0.1953125deg)', offset: 0.888}),
-        ])),
-      ]),
-    ]),
-  ]);
-}

--- a/src/platform/core/common/animations/pulse/pulse.animation.ts
+++ b/src/platform/core/common/animations/pulse/pulse.animation.ts
@@ -35,27 +35,3 @@ export const tdPulseAnimation: AnimationTriggerMetadata = trigger('tdPulse', [
     ]),
   ], { params: { duration: 500, delay: '0', ease: 'ease-out' }}),
 ]);
-
-/** @deprecated see tdPulseAnimation */
-export function TdPulseAnimation(pulseOptions: IAnimationOptions = {}): AnimationTriggerMetadata {
-  return trigger(pulseOptions.anchor || 'tdPulse', [
-    state('0', style({
-      transform: 'scale3d(1, 1, 1)',
-    })),
-    state('1',  style({
-      transform: 'scale3d(1, 1, 1)',
-    })),
-    transition('0 <=> 1', [
-      group([
-        query('@*', animateChild(), { optional: true }),
-        animate((pulseOptions.duration || 500) + 'ms ' + (pulseOptions.delay || 0) + 'ms',
-          keyframes([
-            style({ transform: 'scale3d(1, 1, 1)', offset: 0 }),
-            style({ transform: 'scale3d(1.05, 1.05, 1.05)', offset: 0.5 }),
-            style({ transform: 'scale3d(1, 1, 1)', offset: 1.0 }),
-          ]),
-        ),
-      ]),
-    ]),
-  ]);
-}

--- a/src/platform/core/common/animations/rotate/rotate.animation.ts
+++ b/src/platform/core/common/animations/rotate/rotate.animation.ts
@@ -39,23 +39,3 @@ export const tdRotateAnimation: AnimationTriggerMetadata = trigger('tdRotate', [
     ]),
   ], { params: { duration: 250, delay: '0', ease: 'ease-in' }}),
 ]);
-
-/** @deprecated see tdRotateAnimation */
-export function TdRotateAnimation(rotateOptions: IRotateAnimation = {}): AnimationTriggerMetadata {
-  return trigger(rotateOptions.anchor || 'tdRotate', [
-    state('0', style({
-      transform: 'rotate(0deg)',
-    })),
-    state('1',  style({
-      transform: 'rotate(' + (rotateOptions.degrees || 180) + 'deg)',
-    })),
-    transition('0 <=> 1', [
-      group([
-        query('@*', animateChild(), { optional: true }),
-        animate((rotateOptions.duration || 250) + 'ms ' +
-          (rotateOptions.delay || 0) + 'ms ' +
-          (rotateOptions.ease || 'ease-in')),
-      ]),
-    ]),
-  ]);
-}


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Remove deprecated animation functions.

NOTE: We need to have migration steps in the CHANGELOG

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
