### PR TITLE
fix(data-table): reset scroll when hiding element (closes #1189)

### DIFF
--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -493,6 +493,11 @@ export class TdDataTableComponent extends _TdDataTableMixinBase implements ICont
    * Checks hosts native elements widths to see if it has changed (resize check)
    */
   ngAfterContentChecked(): void {
+    // check if the scroll has been reset when element is hidden
+    if (this._scrollVerticalOffset - this._scrollableDiv.nativeElement.scrollTop > 5) {
+      // scroll back to the top if element has been reset
+      this._onVerticalScroll.next(0);
+    }
     if (this._elementRef.nativeElement) {
       let newHostWidth: number = this._elementRef.nativeElement.getBoundingClientRect().width;
       // if the width has changed then we throw a resize event.


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Since hidden elements reset their scroll by design, we need to check when that happens internally.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to data-table last demo and do the steps described in https://github.com/Teradata/covalent/issues/1189

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

closes #1189