### PR TITLE
feat(search): added blur event on search-box

### DIFF
--- a/src/platform/core/search/search-box/README.md
+++ b/src/platform/core/search/search-box/README.md
@@ -32,6 +32,9 @@
 + clear?: string
   + Event emitted after the clear icon has been clicked.
   + Emits [void].
++ blur: function
+  + Event emitted after the blur event has been called in underlying input.
+  + Emits [void].
 
 ## Setup
 
@@ -54,6 +57,6 @@ export class MyModule {}
 Example for HTML usage:
 
 ```html
-  <td-search-box backIcon="arrow_back" placeholder="Search here" [(ngModel)]="searchInputTerm" [showUnderline]="false|true" [debounce]="500" [alwaysVisible]="false|true" (searchDebounce)="searchInputTerm = $event" (search)="searchInputTerm = $event" (clear)="searchInputTerm = ''">
+  <td-search-box backIcon="arrow_back" placeholder="Search here" [(ngModel)]="searchInputTerm" [showUnderline]="false|true" [debounce]="500" [alwaysVisible]="false|true" (searchDebounce)="searchInputTerm = $event" (search)="searchInputTerm = $event" (clear)="searchInputTerm = ''" (blur)="onBlurEvent()">
   </td-search-box>
 ```

--- a/src/platform/core/search/search-box/search-box.component.html
+++ b/src/platform/core/search/search-box/search-box.component.html
@@ -12,6 +12,7 @@
                    [clearIcon]="clearIcon"
                    (searchDebounce)="handleSearchDebounce($event)"
                    (search)="handleSearch($event)"
-                   (clear)="handleClear(); toggleVisibility()">
+                   (clear)="handleClear(); toggleVisibility()"
+                   (blur)="handleBlur()">
   </td-search-input>
 </div>

--- a/src/platform/core/search/search-box/search-box.component.ts
+++ b/src/platform/core/search/search-box/search-box.component.ts
@@ -110,6 +110,12 @@ export class TdSearchBoxComponent extends _TdSearchBoxMixinBase implements ICont
    */
   @Output('clear') onClear: EventEmitter<void> = new EventEmitter<void>();
 
+  /**
+   * blur: function()
+   * Event emitted after the blur event has been called in underlying input.
+   */
+  @Output('blur') onBlur: EventEmitter<void> = new EventEmitter<void>();
+
   constructor(_changeDetectorRef: ChangeDetectorRef) {
     super(_changeDetectorRef);
   }
@@ -144,4 +150,7 @@ export class TdSearchBoxComponent extends _TdSearchBoxMixinBase implements ICont
     this.onClear.emit(undefined);
   }
 
+  handleBlur(): void {
+    this.onBlur.emit(undefined);
+  }
 }


### PR DESCRIPTION
## Description
Added (blur) event on Search Box. Closes #796

### What's included?
- Added (blur) event to Search Box
- Search-Input already had the blur event, so I just sent it through Search-Box
- Added the event to the documentation page, see http://localhost:4200/#/components/search

#### Test Steps
- [ ] Open file `covalent/src/app/components/components/search/search.component.html`
- [ ] Add some (blur) event to td-search-box on lines 27 and 28
- [ ] `npm run serve`
- [ ] Open http://localhost:4200/#/components/search
- [ ] Open the search box and click somewhere else
- [ ] See results of the (blur) event created on step 2
- [ ] Check new blur event documentation on `TdSearchBoxComponent: td-search-box` API Summary and usage sections

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
