### PR TITLE
fix(data-table): Cell alignment 

### DIFF
--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -24,10 +24,10 @@
             </thead>
             <tbody>
               <tr td-data-table-row *ngFor="let row of basicData">
-                <td td-data-table-cell [align]='column.align' *ngFor="let column of columns" [numeric]="column.numeric">
+                <td td-data-table-cell *ngFor="let column of columns" [numeric]="column.numeric">
                   {{column.format ? column.format(row[column.name]) : row[column.name]}}
                 </td>
-                <td td-data-table-cell (click)="openPrompt(row, 'comments')">
+                <td td-data-table-cell (click)="openPrompt(row, 'comments')" align="start">
                   <button mat-button [class.mat-accent]="!row['comments']">{{row['comments'] || 'Add Comment'}}</button>
                 </td>
               </tr>
@@ -59,7 +59,7 @@
                   <td td-data-table-cell *ngFor="let column of columns" [numeric]="column.numeric">
                     { {column.format ? column.format(row[column.name]) : row[column.name]}}
                   </td>
-                  <td td-data-table-cell (click)="openPrompt(row, 'comments')">
+                  <td td-data-table-cell (click)="openPrompt(row, 'comments')" align="start">
                     <button mat-button [class.mat-accent]="!row['comments']">{ {row['comments'] || 'Add Comment'}}</button>
                   </td>
                 </tr>
@@ -80,7 +80,7 @@
               columns: ITdDataTableColumn[] = [
                 { name: 'first_name',  label: 'First Name' },
                 { name: 'last_name', label: 'Last Name' },
-                { name: 'gender', label: 'Gender', align: 'start'},
+                { name: 'gender', label: 'Gender'},
                 { name: 'email', label: 'Email' },
                 { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },
               ];
@@ -671,7 +671,6 @@
                   [sortOrder]="'ASC'|'DESC'"
                   [active]="true|false"
                   [numeric]="true|false"
-                  [align]="'start'|'center'|'end'"
                   (sortChange)="function($event)">
                 ...
               </th>

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -80,7 +80,7 @@
               columns: ITdDataTableColumn[] = [
                 { name: 'first_name',  label: 'First Name' },
                 { name: 'last_name', label: 'Last Name' },
-                { name: 'gender', label: 'Gender', cellAlign: 'left'},
+                { name: 'gender', label: 'Gender', cellAlign: 'start'},
                 { name: 'email', label: 'Email' },
                 { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },
               ];

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -671,7 +671,7 @@
                   [sortOrder]="'ASC'|'DESC'"
                   [active]="true|false"
                   [numeric]="true|false"
-                  [cellAlign]="'center'|'left'|'right'"
+                  [cellAlign]="'start'|'center'|'end'"
                   (sortChange)="function($event)">
                 ...
               </th>
@@ -681,7 +681,7 @@
             <tr td-data-table-row>
               <td td-data-table-cell
                   [numeric]="true|false"
-                  [cellAlign]="'center'|'left'|'right'"
+                  [cellAlign]="'start'|'center'|'end'"
                   >
                 ...
               </td>

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -24,7 +24,7 @@
             </thead>
             <tbody>
               <tr td-data-table-row *ngFor="let row of basicData">
-                <td td-data-table-cell [cellAlign]='column.cellAlign' *ngFor="let column of columns" [numeric]="column.numeric">
+                <td td-data-table-cell [align]='column.align' *ngFor="let column of columns" [numeric]="column.numeric">
                   {{column.format ? column.format(row[column.name]) : row[column.name]}}
                 </td>
                 <td td-data-table-cell (click)="openPrompt(row, 'comments')">
@@ -80,7 +80,7 @@
               columns: ITdDataTableColumn[] = [
                 { name: 'first_name',  label: 'First Name' },
                 { name: 'last_name', label: 'Last Name' },
-                { name: 'gender', label: 'Gender', cellAlign: 'start'},
+                { name: 'gender', label: 'Gender', align: 'start'},
                 { name: 'email', label: 'Email' },
                 { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },
               ];
@@ -671,7 +671,7 @@
                   [sortOrder]="'ASC'|'DESC'"
                   [active]="true|false"
                   [numeric]="true|false"
-                  [cellAlign]="'start'|'center'|'end'"
+                  [align]="'start'|'center'|'end'"
                   (sortChange)="function($event)">
                 ...
               </th>
@@ -681,7 +681,7 @@
             <tr td-data-table-row>
               <td td-data-table-cell
                   [numeric]="true|false"
-                  [cellAlign]="'start'|'center'|'end'"
+                  [align]="'start'|'center'|'end'"
                   >
                 ...
               </td>

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -24,7 +24,7 @@
             </thead>
             <tbody>
               <tr td-data-table-row *ngFor="let row of basicData">
-                <td td-data-table-cell *ngFor="let column of columns" [numeric]="column.numeric">
+                <td td-data-table-cell [cellAlign]='column.cellAlign' *ngFor="let column of columns" [numeric]="column.numeric">
                   {{column.format ? column.format(row[column.name]) : row[column.name]}}
                 </td>
                 <td td-data-table-cell (click)="openPrompt(row, 'comments')">
@@ -80,7 +80,7 @@
               columns: ITdDataTableColumn[] = [
                 { name: 'first_name',  label: 'First Name' },
                 { name: 'last_name', label: 'Last Name' },
-                { name: 'gender', label: 'Gender' },
+                { name: 'gender', label: 'Gender', cellAlign: 'left'},
                 { name: 'email', label: 'Email' },
                 { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },
               ];
@@ -671,6 +671,7 @@
                   [sortOrder]="'ASC'|'DESC'"
                   [active]="true|false"
                   [numeric]="true|false"
+                  [cellAlign]="'center'|'left'|'right'"
                   (sortChange)="function($event)">
                 ...
               </th>
@@ -679,7 +680,9 @@
           <tbody>
             <tr td-data-table-row>
               <td td-data-table-cell
-                  [numeric]="true|false">
+                  [numeric]="true|false"
+                  [cellAlign]="'center'|'left'|'right'"
+                  >
                 ...
               </td>
             </tr>

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit, HostBinding, ViewChild } from '@angular/core';
 import { slideInDownAnimation } from '../../../app.animations';
 
 import { TdDataTableSortingOrder, TdDataTableService, TdDataTableComponent,
-  ITdDataTableSortChangeEvent, ITdDataTableColumn, TdPagingBarComponent, TdDataTableCellAlign } from '../../../../platform/core';
+  ITdDataTableSortChangeEvent, ITdDataTableColumn, TdPagingBarComponent } from '../../../../platform/core';
 import { IPageChangeEvent } from '../../../../platform/core';
 import { TdDialogService } from '../../../../platform/core';
 
@@ -33,8 +33,8 @@ export class DataTableDemoComponent implements OnInit {
   },
   {
     description: `Aligns cell text/content to desired position. Defaults to 'start'. Overrides numeric property`,
-    name: 'cellAlign',
-    type: `['start' | 'center' | 'end'] or TdDataTableCellAlign`,
+    name: 'align',
+    type: `'start' | 'center' | 'end'`,
   },
 ];
 
@@ -69,8 +69,8 @@ export class DataTableDemoComponent implements OnInit {
   }, 
   {
     description: `Aligns cell text/content to desired position. Defaults to 'start'. Overrides numeric property`,
-    name: 'cellAlign',
-    type: `['start' | 'center' | 'end'] or TdDataTableCellAlign`,
+    name: 'align',
+    type: `'start' | 'center' | 'end'`,
   },
   {
     description: `Event emitted when the column headers are clicked. [sortable] needs to be enabled.
@@ -105,7 +105,7 @@ export class DataTableDemoComponent implements OnInit {
   columns: ITdDataTableColumn[] = [
     { name: 'first_name',  label: 'First Name', sortable: true, width: 150,  },
     { name: 'last_name', label: 'Last Name', filter: true, sortable: false },
-    { name: 'gender', label: 'Gender', hidden: false, cellAlign: 'start' },
+    { name: 'gender', label: 'Gender', hidden: false, align: 'start' },
     { name: 'email', label: 'Email', sortable: true, width: 250 },
     { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },
   ];

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -68,11 +68,6 @@ export class DataTableDemoComponent implements OnInit {
     type: `boolean`,
   }, 
   {
-    description: `Aligns cell text/content to desired position. Defaults to 'start'. Overrides numeric property`,
-    name: 'align',
-    type: `'start' | 'center' | 'end'`,
-  },
-  {
     description: `Event emitted when the column headers are clicked. [sortable] needs to be enabled.
                   Emits an [ITdDataTableSortChangeEvent] implemented object.`,
     name: 'sortChange',
@@ -105,7 +100,7 @@ export class DataTableDemoComponent implements OnInit {
   columns: ITdDataTableColumn[] = [
     { name: 'first_name',  label: 'First Name', sortable: true, width: 150,  },
     { name: 'last_name', label: 'Last Name', filter: true, sortable: false },
-    { name: 'gender', label: 'Gender', hidden: false, align: 'start' },
+    { name: 'gender', label: 'Gender', hidden: false },
     { name: 'email', label: 'Email', sortable: true, width: 250 },
     { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },
   ];

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit, HostBinding, ViewChild } from '@angular/core';
 import { slideInDownAnimation } from '../../../app.animations';
 
 import { TdDataTableSortingOrder, TdDataTableService, TdDataTableComponent,
-  ITdDataTableSortChangeEvent, ITdDataTableColumn, TdPagingBarComponent } from '../../../../platform/core';
+  ITdDataTableSortChangeEvent, ITdDataTableColumn, TdPagingBarComponent, TdDataTableCellAlign } from '../../../../platform/core';
 import { IPageChangeEvent } from '../../../../platform/core';
 import { TdDialogService } from '../../../../platform/core';
 
@@ -30,7 +30,13 @@ export class DataTableDemoComponent implements OnInit {
     description: `Makes cell follow the numeric data-table specs. Defaults to 'false'`,
     name: 'numeric',
     type: `boolean`,
-  }];
+  },
+  {
+    description: `Aligns cell text/content to desired position. Defaults to 'left'. Overrides numeric property`,
+    name: 'cellAlign',
+    type: `['center' | 'left' | 'right'] or TdDataTableCellAlign`,
+  },
+];
 
   columnAttrs: Object[] = [{
     description: `Sets unique column [name] for [sortable] events.`,
@@ -60,7 +66,13 @@ export class DataTableDemoComponent implements OnInit {
     description: `Makes cell follow the numeric data-table specs. Defaults to 'false'`,
     name: 'numeric',
     type: `boolean`,
-  }, {
+  }, 
+  {
+    description: `Aligns cell text/content to desired position. Defaults to 'left'. Overrides numeric property`,
+    name: 'cellAlign',
+    type: `['center' | 'left' | 'right'] or TdDataTableCellAlign`,
+  },
+  {
     description: `Event emitted when the column headers are clicked. [sortable] needs to be enabled.
                   Emits an [ITdDataTableSortChangeEvent] implemented object.`,
     name: 'sortChange',
@@ -91,9 +103,9 @@ export class DataTableDemoComponent implements OnInit {
   ];
 
   columns: ITdDataTableColumn[] = [
-    { name: 'first_name',  label: 'First Name', sortable: true, width: 150 },
+    { name: 'first_name',  label: 'First Name', sortable: true, width: 150,  },
     { name: 'last_name', label: 'Last Name', filter: true, sortable: false },
-    { name: 'gender', label: 'Gender', hidden: false },
+    { name: 'gender', label: 'Gender', hidden: false, cellAlign: 'left' },
     { name: 'email', label: 'Email', sortable: true, width: 250 },
     { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },
   ];

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -32,9 +32,9 @@ export class DataTableDemoComponent implements OnInit {
     type: `boolean`,
   },
   {
-    description: `Aligns cell text/content to desired position. Defaults to 'left'. Overrides numeric property`,
+    description: `Aligns cell text/content to desired position. Defaults to 'start'. Overrides numeric property`,
     name: 'cellAlign',
-    type: `['center' | 'left' | 'right'] or TdDataTableCellAlign`,
+    type: `['start' | 'center' | 'end'] or TdDataTableCellAlign`,
   },
 ];
 
@@ -68,9 +68,9 @@ export class DataTableDemoComponent implements OnInit {
     type: `boolean`,
   }, 
   {
-    description: `Aligns cell text/content to desired position. Defaults to 'left'. Overrides numeric property`,
+    description: `Aligns cell text/content to desired position. Defaults to 'start'. Overrides numeric property`,
     name: 'cellAlign',
-    type: `['center' | 'left' | 'right'] or TdDataTableCellAlign`,
+    type: `['start' | 'center' | 'end'] or TdDataTableCellAlign`,
   },
   {
     description: `Event emitted when the column headers are clicked. [sortable] needs to be enabled.
@@ -105,7 +105,7 @@ export class DataTableDemoComponent implements OnInit {
   columns: ITdDataTableColumn[] = [
     { name: 'first_name',  label: 'First Name', sortable: true, width: 150,  },
     { name: 'last_name', label: 'Last Name', filter: true, sortable: false },
-    { name: 'gender', label: 'Gender', hidden: false, cellAlign: 'left' },
+    { name: 'gender', label: 'Gender', hidden: false, cellAlign: 'start' },
     { name: 'email', label: 'Email', sortable: true, width: 250 },
     { name: 'balance', label: 'Balance', numeric: true, format: DECIMAL_FORMAT },
   ];

--- a/src/platform/core/data-table/README.md
+++ b/src/platform/core/data-table/README.md
@@ -125,7 +125,7 @@ export class Demo {
   ];
   private columns: ITdDataTableColumn[] = [
     { name: 'sku', label: 'SKU #', tooltip: 'Stock Keeping Unit', sortable: true },
-    { name: 'item', label: 'Item name', width: 200, cellAlign: 'right' },
+    { name: 'item', label: 'Item name', width: 200, cellAlign: 'start' },
     { name: 'price', label 'Price (US$)', numeric: true, format: v => v.toFixed(2), width: { min: 100, max: 400 } },
   ];
   compareWith(row: any: model: any): boolean {

--- a/src/platform/core/data-table/README.md
+++ b/src/platform/core/data-table/README.md
@@ -75,7 +75,6 @@ export interface ITdDataTableColumn {
   label: string;
   tooltip?: string; // used to add a tooltip into the column header
   numeric?: boolean; // used to right align elements if they are numeric
-  align?: string // used to align cell content, overrides numeric property
   format?: (value: any) => any; // used to format the cell values
   nested?: boolean; // when this is true, the `.` characters will be taken as key separators for nested values
   sortable?: boolean; // used to make a particular column sortable

--- a/src/platform/core/data-table/README.md
+++ b/src/platform/core/data-table/README.md
@@ -75,6 +75,7 @@ export interface ITdDataTableColumn {
   label: string;
   tooltip?: string; // used to add a tooltip into the column header
   numeric?: boolean; // used to right align elements if they are numeric
+  cellAlign?: TdDataTableCellAlign | string // used to align cell content, overrides numeric property
   format?: (value: any) => any; // used to format the cell values
   nested?: boolean; // when this is true, the `.` characters will be taken as key separators for nested values
   sortable?: boolean; // used to make a particular column sortable
@@ -124,7 +125,7 @@ export class Demo {
   ];
   private columns: ITdDataTableColumn[] = [
     { name: 'sku', label: 'SKU #', tooltip: 'Stock Keeping Unit', sortable: true },
-    { name: 'item', label: 'Item name', width: 200 },
+    { name: 'item', label: 'Item name', width: 200, cellAlign: 'right' },
     { name: 'price', label 'Price (US$)', numeric: true, format: v => v.toFixed(2), width: { min: 100, max: 400 } },
   ];
   compareWith(row: any: model: any): boolean {

--- a/src/platform/core/data-table/README.md
+++ b/src/platform/core/data-table/README.md
@@ -75,7 +75,7 @@ export interface ITdDataTableColumn {
   label: string;
   tooltip?: string; // used to add a tooltip into the column header
   numeric?: boolean; // used to right align elements if they are numeric
-  cellAlign?: TdDataTableCellAlign | string // used to align cell content, overrides numeric property
+  align?: string // used to align cell content, overrides numeric property
   format?: (value: any) => any; // used to format the cell values
   nested?: boolean; // when this is true, the `.` characters will be taken as key separators for nested values
   sortable?: boolean; // used to make a particular column sortable
@@ -125,7 +125,7 @@ export class Demo {
   ];
   private columns: ITdDataTableColumn[] = [
     { name: 'sku', label: 'SKU #', tooltip: 'Stock Keeping Unit', sortable: true },
-    { name: 'item', label: 'Item name', width: 200, cellAlign: 'start' },
+    { name: 'item', label: 'Item name', width: 200, align: 'start' },
     { name: 'price', label 'Price (US$)', numeric: true, format: v => v.toFixed(2), width: { min: 100, max: 400 } },
   ];
   compareWith(row: any: model: any): boolean {

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.html
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.html
@@ -1,4 +1,8 @@
 <div class="td-data-table-cell-content-wrapper"
-     [class.td-data-table-cell-numeric]="numeric">
+     [class.td-data-table-cell-numeric]="numeric"
+     [class.td-data-table-cell-align-center]="cellAlign === 'center'"
+     [class.td-data-table-cell-align-right]="cellAlign === 'right'"
+     [class.td-data-table-cell-align-left]="cellAlign === 'left'"
+     >
   <ng-content></ng-content>
 </div>

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.html
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.html
@@ -1,8 +1,8 @@
 <div class="td-data-table-cell-content-wrapper"
      [class.td-data-table-cell-numeric]="numeric"
-     [class.td-data-table-cell-align-center]="cellAlign === 'center'"
-     [class.td-data-table-cell-align-end]="cellAlign === 'end'"
-     [class.td-data-table-cell-align-start]="cellAlign === 'start'"
+     [class.td-data-table-cell-align-center]="align === 'center'"
+     [class.td-data-table-cell-align-end]="align === 'end'"
+     [class.td-data-table-cell-align-start]="align === 'start'"
      >
   <ng-content></ng-content>
 </div>

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.html
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.html
@@ -1,8 +1,8 @@
 <div class="td-data-table-cell-content-wrapper"
      [class.td-data-table-cell-numeric]="numeric"
      [class.td-data-table-cell-align-center]="cellAlign === 'center'"
-     [class.td-data-table-cell-align-right]="cellAlign === 'right'"
-     [class.td-data-table-cell-align-left]="cellAlign === 'left'"
+     [class.td-data-table-cell-align-end]="cellAlign === 'end'"
+     [class.td-data-table-cell-align-start]="cellAlign === 'start'"
      >
   <ng-content></ng-content>
 </div>

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.scss
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.scss
@@ -18,18 +18,17 @@
     &.td-data-table-cell-numeric {
       // [layout-align="end center"]
       justify-content: flex-end;
-    };
-    &.td-data-table-cell-align-left{
+    }
+    &.td-data-table-cell-align-left {
       justify-content: start;
     }
-    &.td-data-table-cell-align-right{
+    &.td-data-table-cell-align-right {
       justify-content: flex-end;
     }
-    &.td-data-table-cell-align-center{
+    &.td-data-table-cell-align-center {
       justify-content: center;
     }
   }
-
 
   &:first-child > .td-data-table-cell-content-wrapper {
     @include rtl(padding-left, 24px, initial);

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.scss
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.scss
@@ -19,10 +19,10 @@
       // [layout-align="end center"]
       justify-content: flex-end;
     }
-    &.td-data-table-cell-align-left {
+    &.td-data-table-cell-align-start {
       justify-content: start;
     }
-    &.td-data-table-cell-align-right {
+    &.td-data-table-cell-align-end {
       justify-content: flex-end;
     }
     &.td-data-table-cell-align-center {

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.scss
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.scss
@@ -18,8 +18,18 @@
     &.td-data-table-cell-numeric {
       // [layout-align="end center"]
       justify-content: flex-end;
+    };
+    &.td-data-table-cell-align-left{
+      justify-content: start;
+    }
+    &.td-data-table-cell-align-right{
+      justify-content: flex-end;
+    }
+    &.td-data-table-cell-align-center{
+      justify-content: center;
     }
   }
+
 
   &:first-child > .td-data-table-cell-content-wrapper {
     @include rtl(padding-left, 24px, initial);

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
@@ -2,8 +2,8 @@ import { Component, Input, Renderer2, ElementRef, HostBinding } from '@angular/c
 
 export enum TdDataTableCellAlign {
   Center = 'center',
-  Left = 'left',
-  Right = 'right',
+  Start = 'start',
+  End = 'end',
 }
 
 @Component({
@@ -24,7 +24,7 @@ export class TdDataTableCellComponent {
   @Input('numeric') numeric: boolean = false;
 
   /**
-   * cellAlign?: 'center' | 'right' | 'left'
+   * cellAlign?: 'start' | 'center' | 'end'
    * Makes cell content align on demand
    * Defaults to 'left', overrides numeric
    */

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
@@ -1,11 +1,5 @@
 import { Component, Input, Renderer2, ElementRef, HostBinding } from '@angular/core';
 
-export enum TdDataTableCellAlign {
-  Center = 'center',
-  Start = 'start',
-  End = 'end',
-}
-
 @Component({
   /* tslint:disable-next-line */
   selector: 'td[td-data-table-cell]',
@@ -14,7 +8,7 @@ export enum TdDataTableCellAlign {
 })
 export class TdDataTableCellComponent {
 
-  private _cellAlign: TdDataTableCellAlign;
+  private _align: 'start' | 'center' | 'end';
 
   /**
    * numeric?: boolean
@@ -24,16 +18,16 @@ export class TdDataTableCellComponent {
   @Input('numeric') numeric: boolean = false;
 
   /**
-   * cellAlign?: 'start' | 'center' | 'end'
+   * align?: 'start' | 'center' | 'end'
    * Makes cell content align on demand
    * Defaults to 'left', overrides numeric
    */
   @Input() 
-  set cellAlign(cellAlign: TdDataTableCellAlign) {
-    this._cellAlign = cellAlign;
+  set align(align: 'start' | 'center' | 'end') {
+    this._align = align;
   }
-  get cellAlign(): TdDataTableCellAlign {
-    return this._cellAlign;    
+  get align(): 'start' | 'center' | 'end' {
+    return this._align;    
   }
 
   @HostBinding('class.mat-numeric')

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input, Renderer2, ElementRef, HostBinding } from '@angular/core';
 
+export type TdDataTableCellAlign = 'start' | 'center' | 'end';
+
 @Component({
   /* tslint:disable-next-line */
   selector: 'td[td-data-table-cell]',
@@ -8,7 +10,7 @@ import { Component, Input, Renderer2, ElementRef, HostBinding } from '@angular/c
 })
 export class TdDataTableCellComponent {
 
-  private _align: 'start' | 'center' | 'end';
+  private _align: TdDataTableCellAlign;
 
   /**
    * numeric?: boolean
@@ -23,10 +25,10 @@ export class TdDataTableCellComponent {
    * Defaults to 'left', overrides numeric
    */
   @Input() 
-  set align(align: 'start' | 'center' | 'end') {
+  set align(align: TdDataTableCellAlign) {
     this._align = align;
   }
-  get align(): 'start' | 'center' | 'end' {
+  get align(): TdDataTableCellAlign {
     return this._align;    
   }
 

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
@@ -1,5 +1,11 @@
 import { Component, Input, Renderer2, ElementRef, HostBinding } from '@angular/core';
 
+export enum TdDataTableCellAlign {
+  Center = 'center',
+  Left = 'left',
+  Right = 'right',
+}
+
 @Component({
   /* tslint:disable-next-line */
   selector: 'td[td-data-table-cell]',
@@ -8,12 +14,27 @@ import { Component, Input, Renderer2, ElementRef, HostBinding } from '@angular/c
 })
 export class TdDataTableCellComponent {
 
+  private _cellAlign: TdDataTableCellAlign;
+
   /**
    * numeric?: boolean
    * Makes cell follow the numeric data-table specs.
    * Defaults to 'false'
    */
   @Input('numeric') numeric: boolean = false;
+
+  /**
+   * cellAlign?: 'center' | 'right' | 'left'
+   * Makes cell content align on demand
+   * Defaults to 'left', overrides numeric
+   */
+  @Input() 
+  set cellAlign(cellAlign: TdDataTableCellAlign) {
+    this._cellAlign = cellAlign;
+  }
+  get cellAlign(): TdDataTableCellAlign {
+    return this._cellAlign;    
+  }
 
   @HostBinding('class.mat-numeric')
   get bindNumeric(): boolean {

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -38,7 +38,6 @@ export interface ITdDataTableColumn {
   hidden?: boolean;
   filter?: boolean;
   width?: ITdDataTableColumnWidth | number;
-  align?: string;
 }
 
 export interface ITdDataTableSelectEvent {

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -11,7 +11,6 @@ import { ENTER, SPACE, UP_ARROW, DOWN_ARROW } from '@angular/cdk/keycodes';
 import { Observable, Subscription, Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
-import { TdDataTableCellAlign } from './data-table-cell/data-table-cell.component';
 import { TdDataTableRowComponent } from './data-table-row/data-table-row.component';
 import { ITdDataTableSortChangeEvent, TdDataTableColumnComponent } from './data-table-column/data-table-column.component';
 import { TdDataTableTemplateDirective } from './directives/data-table-template.directive';
@@ -39,7 +38,7 @@ export interface ITdDataTableColumn {
   hidden?: boolean;
   filter?: boolean;
   width?: ITdDataTableColumnWidth | number;
-  cellAlign?: TdDataTableCellAlign | string;
+  align?: string;
 }
 
 export interface ITdDataTableSelectEvent {

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -11,6 +11,7 @@ import { ENTER, SPACE, UP_ARROW, DOWN_ARROW } from '@angular/cdk/keycodes';
 import { Observable, Subscription, Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
+import { TdDataTableCellAlign } from './data-table-cell/data-table-cell.component';
 import { TdDataTableRowComponent } from './data-table-row/data-table-row.component';
 import { ITdDataTableSortChangeEvent, TdDataTableColumnComponent } from './data-table-column/data-table-column.component';
 import { TdDataTableTemplateDirective } from './directives/data-table-template.directive';
@@ -38,6 +39,7 @@ export interface ITdDataTableColumn {
   hidden?: boolean;
   filter?: boolean;
   width?: ITdDataTableColumnWidth | number;
+  cellAlign?: TdDataTableCellAlign | string;
 }
 
 export interface ITdDataTableSelectEvent {


### PR DESCRIPTION
### Description
Added properties 'cellAlign' on atomic components TdDataTableColumn and TdDataTableCell to align cell content.

Fixes #871 

### What's included?

- align: input property

#### Test Steps
- [ ] Open file covalent/src/app/components/components/data-table/data-table.component.html
- [ ]   (Line 30) Change property align="start" to align="end"
- [ ] `npm run serve`
- [ ] Open http://localhost:4200/#/components/data-table
- [ ] Scroll to card  **Custom Data Table** on "comments" column, check cells content aligns to 'end'
- [ ] In toolbar click on **More - Icon button** (Last button from left to right, next to notification button)
- [ ] Click on LTR
- [ ] On "comments" column from Step 5, check cell content still aligns to 'end' in the context of RTL

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
