### PR TITLE
feat(td-markdown): Add simpleLineBreaks input

### DIFF
--- a/src/app/components/components/text-editor/text-editor.component.html
+++ b/src/app/components/components/text-editor/text-editor.component.html
@@ -27,7 +27,7 @@
       <td-text-editor flex-gt-md [(ngModel)]="editorVal"></td-text-editor>
     </div>
     <div flex-gt-md="45" layout-gt-md="column" class="md-content pad-sm">
-      <td-markdown flex-gt-md [content]="editorVal"></td-markdown>
+      <td-markdown flex-gt-md [content]="editorVal" [simpleLineBreaks]="simpleLineBreaks"></td-markdown>
     </div>
   </div>
 </mat-card>

--- a/src/app/components/components/text-editor/text-editor.component.ts
+++ b/src/app/components/components/text-editor/text-editor.component.ts
@@ -34,4 +34,6 @@ Unordered lists can be started using the toolbar or by typing '* ', '- ', or '+ 
 ## What about images?
 ![Yes](https://i.imgur.com/sZlktY7.png)
 `;
+
+  simpleLineBreaks: boolean = true;
 }

--- a/src/platform/markdown/README.md
+++ b/src/platform/markdown/README.md
@@ -13,8 +13,12 @@ By default, `--dev` build will log the following message in the console to let y
 #### Inputs
 
 + content: string
-  + Markdown format content to be parsed as html markup. 
+  + Markdown format content to be parsed as html markup.
   + Used to load data dynamically. e.g. `README.md` content.
+
+ + simpleLineBreaks?: string
+   + Sets whether newline characters inside paragraphs and spans are parsed as <br/>.
+   + Defaults to false.
 
 #### Events
 
@@ -71,7 +75,7 @@ $theme: mat-light-theme($primary, $accent, $warn);
 
 ```html
 <td-markdown>
-  # Heading 
+  # Heading
   ## Sub Heading (H2)
   ### Steps (H2)
 </td-markdown>
@@ -79,7 +83,7 @@ $theme: mat-light-theme($primary, $accent, $warn);
 
 **Output:**
 
-# Heading 
+# Heading
 ## Sub Heading (H2)
 ### Steps (H2)
 

--- a/src/platform/markdown/markdown.component.spec.ts
+++ b/src/platform/markdown/markdown.component.spec.ts
@@ -19,7 +19,8 @@ describe('Component: Markdown', () => {
         TdMarkdownEmptyStaticContentTestRenderingComponent,
         TdMarkdownStaticContentTestRenderingComponent,
         TdMarkdownDymanicContentTestRenderingComponent,
-        
+        TdMarkdownSimpleLineBreaksTestRenderingComponent,
+
         TdMarkdownEmptyStaticContentTestEventsComponent,
         TdMarkdownStaticContentTestEventsComponent,
         TdMarkdownDynamicContentTestEventsComponent,
@@ -68,15 +69,59 @@ describe('Component: Markdown', () => {
       });
     }));
 
+    it('should render newlines as <br/> if simpleLineBreaks is true', async(() => {
+
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownSimpleLineBreaksTestRenderingComponent);
+      let component: TdMarkdownSimpleLineBreaksTestRenderingComponent = fixture.debugElement.componentInstance;
+      component.simpleLineBreaks = true;
+      let element: HTMLElement = fixture.nativeElement;
+
+      expect(fixture.debugElement.query(By.css('td-markdown')).nativeElement.textContent.trim())
+        .toBe(`
+        first line
+        second line
+        third line
+        `.trim());
+      expect(fixture.debugElement.query(By.css('td-markdown div'))).toBeFalsy();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(fixture.debugElement.query(By.css('td-markdown div'))).toBeTruthy();
+        expect(element.querySelector('td-markdown').querySelectorAll('br').length).toBe(2);
+      });
+    }));
+
+    it('should not render newlines as <br/> if simpleLineBreaks is false', async(() => {
+
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownSimpleLineBreaksTestRenderingComponent);
+      let component: TdMarkdownSimpleLineBreaksTestRenderingComponent = fixture.debugElement.componentInstance;
+      component.simpleLineBreaks = false;
+      let element: HTMLElement = fixture.nativeElement;
+
+      expect(fixture.debugElement.query(By.css('td-markdown')).nativeElement.textContent.trim())
+        .toBe(`
+        first line
+        second line
+        third line
+        `.trim());
+      expect(fixture.debugElement.query(By.css('td-markdown div'))).toBeFalsy();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(fixture.debugElement.query(By.css('td-markdown div'))).toBeTruthy();
+        expect(element.querySelector('td-markdown').querySelectorAll('br').length).toBe(0);
+      });
+    }));
+
     it('should render markup from dynamic content', async(() => {
 
       let fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownDymanicContentTestRenderingComponent);
       let component: TdMarkdownDymanicContentTestRenderingComponent = fixture.debugElement.componentInstance;
       component.content = `
       # another title
-      
+
       ## subtitle
-      
+
       \`\`\`
       pseudo code
       \`\`\``;
@@ -101,7 +146,7 @@ describe('Component: Markdown', () => {
       let component: TdMarkdownDymanicContentTestRenderingComponent = fixture.debugElement.componentInstance;
       component.content = `
       # another title
-      
+
         ## subtitle`;
       let element: HTMLElement = fixture.nativeElement;
 
@@ -122,14 +167,14 @@ describe('Component: Markdown', () => {
   describe('Event bindings: ', () => {
 
     describe('contentReady event: ', () => {
-  
+
       it('should be fired only once after display renders empty static content', async(() => {
-  
+
         let fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownEmptyStaticContentTestEventsComponent);
         let component: TdMarkdownEmptyStaticContentTestEventsComponent = fixture.debugElement.componentInstance;
-  
+
         let eventSpy: jasmine.Spy = spyOn(component, 'tdMarkdownContentIsReady');
-  
+
         fixture.detectChanges();
         fixture.whenStable().then(() => {
           fixture.detectChanges();
@@ -141,9 +186,9 @@ describe('Component: Markdown', () => {
 
         let fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownStaticContentTestEventsComponent);
         let component: TdMarkdownStaticContentTestEventsComponent = fixture.debugElement.componentInstance;
-  
+
         let eventSpy: jasmine.Spy = spyOn(component, 'tdMarkdownContentIsReady');
-  
+
         fixture.detectChanges();
         fixture.whenStable().then(() => {
           fixture.detectChanges();
@@ -151,7 +196,7 @@ describe('Component: Markdown', () => {
         });
       }));
 
-      it('should be fired only once after display renders inital markup from dynamic content', async(() => {
+      it('should be fired only once after display renders initial markup from dynamic content', async(() => {
 
         let fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownDynamicContentTestEventsComponent);
         let component: TdMarkdownDynamicContentTestEventsComponent = fixture.debugElement.componentInstance;
@@ -160,9 +205,9 @@ describe('Component: Markdown', () => {
         // Inital dynamic content
         component.content = `
         # another title
-        
+
         ## subtitle
-        
+
         \`\`\`
         pseudo code
         \`\`\``;
@@ -174,7 +219,7 @@ describe('Component: Markdown', () => {
         });
       }));
 
-      it(`should be fired twice after changing the inital rendered markup dynamic content`, async(() => {
+      it(`should be fired twice after changing the initial rendered markup dynamic content`, async(() => {
 
         let fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownDynamicContentTestEventsComponent);
         let component: TdMarkdownDynamicContentTestEventsComponent = fixture.debugElement.componentInstance;
@@ -182,9 +227,9 @@ describe('Component: Markdown', () => {
 
         component.content = `
         # another title
-        
+
         ## subtitle
-        
+
         \`\`\`
         pseudo code
         \`\`\``;
@@ -192,10 +237,10 @@ describe('Component: Markdown', () => {
         fixture.detectChanges();
 
         component.content = `
-        # changed title 
-        
+        # changed title
+
         ## changed subtitle
-        
+
         \`\`\`
         changed pseudo code
         \`\`\``;
@@ -237,6 +282,20 @@ class TdMarkdownStaticContentTestRenderingComponent { }
 })
 class TdMarkdownDymanicContentTestRenderingComponent {
   content: string;
+}
+
+@Component({
+  template: `
+      <td-markdown [simpleLineBreaks]="simpleLineBreaks">
+        first line
+        second line
+        third line
+      </td-markdown>
+      `,
+      preserveWhitespaces: true,
+})
+class TdMarkdownSimpleLineBreaksTestRenderingComponent {
+  simpleLineBreaks: boolean;
 }
 
 // Use the 3 components below to test event binding requirements of the TdMarkdown component.

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -13,6 +13,7 @@ let showdown: any = require('showdown/dist/showdown.js');
 export class TdMarkdownComponent implements AfterViewInit {
 
   private _content: string;
+  private _simpleLineBreaks: boolean = false;
 
   /**
    * content?: string
@@ -25,6 +26,18 @@ export class TdMarkdownComponent implements AfterViewInit {
   @Input('content')
   set content(content: string) {
     this._content = content;
+    this._loadContent(this._content);
+  }
+
+  /**
+   * simpleLineBreaks?: string
+   *
+   * Sets whether newline characters inside paragraphs and spans are parsed as <br/>.
+   * Defaults to false.
+   */
+  @Input('simpleLineBreaks')
+  set simpleLineBreaks(simpleLineBreaks: boolean) {
+    this._simpleLineBreaks = simpleLineBreaks;
     this._loadContent(this._content);
   }
 
@@ -90,6 +103,7 @@ export class TdMarkdownComponent implements AfterViewInit {
     converter.setOption('ghCodeBlocks', true);
     converter.setOption('tasklists', true);
     converter.setOption('tables', true);
+    converter.setOption('simpleLineBreaks', this._simpleLineBreaks);
     let html: string = converter.makeHtml(markdownToParse);
     return html;
   }

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit, ElementRef, Input, Output, EventEmitter, Renderer2, SecurityContext } from '@angular/core';
+import { Component, AfterViewInit, ElementRef, Input, Output, EventEmitter, Renderer2, SecurityContext, OnChanges } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
 declare const require: any;
@@ -10,7 +10,7 @@ let showdown: any = require('showdown/dist/showdown.js');
   styleUrls: ['./markdown.component.scss'],
   templateUrl: './markdown.component.html',
 })
-export class TdMarkdownComponent implements AfterViewInit {
+export class TdMarkdownComponent implements OnChanges, AfterViewInit {
 
   private _content: string;
   private _simpleLineBreaks: boolean = false;
@@ -26,7 +26,6 @@ export class TdMarkdownComponent implements AfterViewInit {
   @Input('content')
   set content(content: string) {
     this._content = content;
-    this._loadContent(this._content);
   }
 
   /**
@@ -38,7 +37,6 @@ export class TdMarkdownComponent implements AfterViewInit {
   @Input('simpleLineBreaks')
   set simpleLineBreaks(simpleLineBreaks: boolean) {
     this._simpleLineBreaks = simpleLineBreaks;
-    this._loadContent(this._content);
   }
 
   /**
@@ -50,6 +48,10 @@ export class TdMarkdownComponent implements AfterViewInit {
   constructor(private _renderer: Renderer2,
               private _elementRef: ElementRef,
               private _domSanitizer: DomSanitizer) {}
+
+  ngOnChanges(): void {
+    this._loadContent(this._content);
+  }
 
   ngAfterViewInit(): void {
     if (!this._content) {


### PR DESCRIPTION
## Description

- Adds `simpleLineBreaks` input to `<td-markdown/>`.
- Decided to default to `false` so it would be backwards-compatible.
- Thoughts on default state and input name?
- Fixes #1290

### What's included?
- New `simpleLineBreaks` input
- Updates to `<td-text-editor/>` demo 
- New tests

#### Test Steps
- [ ] `npm run serve`
- [ ] Open markdown text editor demo
- [ ] Insert text that has new lines, for example
```
line 1
line 2
line 3
```
- [ ] Check that text still has new lines in markdown preview on right
- [ ] Set the simpleLineBreaks input of the `<td-markdown/>` component to `true` in the `<text-editor-component/>`
- [ ] Check that text no longer has new lines in markdown preview on right

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
 
![localhost_4200_](https://user-images.githubusercontent.com/7193975/49186747-4fe66a80-f31a-11e8-8338-9709307114d1.png)
