### PR TITLE
feat(http): create http-deprec package for `@angular/http` use

### DIFF
--- a/scripts/build-release
+++ b/scripts/build-release
@@ -25,6 +25,9 @@ cp -r deploy/platform/core src/platform/node_modules/@covalent
 ./node_modules/.bin/ng-packagr -p src/platform/highlight/ng-package.js
 # BUILD: @covalent/http primary entrypoint
 ./node_modules/.bin/ng-packagr -p src/platform/http/ng-package.js
+# **DEPRECATED** TODO Remove on 3.0.0
+# BUILD: @covalent/http-deprec primary entrypoint
+./node_modules/.bin/ng-packagr -p src/platform/http-deprec/ng-package.js
 # BUILD: @covalent/markdown primary entrypoint
 ./node_modules/.bin/ng-packagr -p src/platform/markdown/ng-package.js
 

--- a/src/platform/http-deprec/README.md
+++ b/src/platform/http-deprec/README.md
@@ -1,0 +1,58 @@
+# RESTService (deprecated)
+
+Abstract class provided with methods that wraps http services to facilitate REST API calls with `@angular/http`.
+
+## API Summary
+
+#### Methods
+
++ query: function(query?: IRestQuery, transform?: IRestTransform)
+  + Creates a GET request to the generated endpoint URL.
++ get: function(id: string | number, transform?: IRestTransform)
+  + Creates a GET request to the generated endpoint URL, adding the ID at the end.
++ create: function(obj: T, transform?: IRestTransform)
+  + Creates a POST request to the generated endpoint URL.
++ update: function(id: string | number, obj: T, transform?: IRestTransform)
+  + Creates a PATCH request to the generated endpoint URL, adding the ID at the end.
++ delete: function(id: string | number, transform?: IRestTransform)
+  + Creates a DELETE request to the generated endpoint URL, adding the ID at the end.
++ buildUrl: function(id?: string | number, query?: IRestQuery)
+  + Builds the endpoint URL with the configured properties and arguments passed in the method.
+
+## Usage
+
+Example:
+
+```typescript
+import { Injectable } from '@angular/core';
+import { Response, Http, Headers } from '@angular/http';
+import { RESTService, HttpInterceptorService } from '@covalent/http-deprec';
+
+@Injectable()
+export class CustomRESTService extends RESTService<any> {
+
+  constructor(private _http: Http /* or HttpInterceptorService */) {
+    super(_http, {
+      baseUrl: 'www.api.com',
+      path: '/path/to/endpoint',
+      headers: new Headers(),
+      dynamicHeaders: () => new Headers(),
+      transform: (res: Response): any => res.json(),
+    });
+  }
+}
+
+```
+Note: the constructor takes any object that implements the methods in [IHttp] interface. This can be the @angular [Http] service, the covalent [HttpInterceptorService] or a custom service.</p>
+
+```typescript
+export interface IHttp {
+  delete: (url: string, options?: RequestOptionsArgs) => Observable<Response>;
+  get: (url: string, options?: RequestOptionsArgs) => Observable<Response>;
+  head: (url: string, options?: RequestOptionsArgs) => Observable<Response>;
+  patch: (url: string, body: any, options?: RequestOptionsArgs) => Observable<Response>;
+  post: (url: string, body: any, options?: RequestOptionsArgs) => Observable<Response>;
+  put: (url: string, body: any, options?: RequestOptionsArgs) => Observable<Response>;
+  request: (url: string | Request, options: RequestOptionsArgs) => Observable<Response>;
+}
+```

--- a/src/platform/http-deprec/http-rest.service.spec.ts
+++ b/src/platform/http-deprec/http-rest.service.spec.ts
@@ -1,0 +1,655 @@
+import {
+  TestBed,
+  inject,
+  async,
+} from '@angular/core/testing';
+import { Injectable } from '@angular/core';
+import { XHRBackend, Response, ResponseOptions, Headers, RequestMethod } from '@angular/http';
+import { MockBackend, MockConnection } from '@angular/http/testing';
+import { HttpModule, Http } from '@angular/http';
+import { RESTService } from './http-rest.service';
+
+@Injectable()
+export class BasicTestRESTService extends RESTService<any> {
+
+  constructor(http: Http) {
+    super(http, {
+      baseUrl: 'www.url.com',
+      path: 'path/to/endpoint',
+    });
+  }
+
+}
+
+@Injectable()
+export class BaseHeadersTestRESTService extends RESTService<any> {
+
+  constructor(http: Http) {
+    super(http, {
+      baseUrl: 'www.url.com',
+      path: 'path/to/endpoint',
+      baseHeaders: new Headers({'header': 'value'}),
+    });
+  }
+}
+
+@Injectable()
+export class DynamicHeadersTestRESTService extends RESTService<any> {
+
+  constructor(http: Http) {
+    super(http, {
+      baseUrl: 'www.url.com',
+      path: 'path/to/endpoint',
+      dynamicHeaders: () => {
+        return new Headers({'header': 'value'});
+      },
+    });
+  }
+}
+
+@Injectable()
+export class TransformTestRESTService extends RESTService<any> {
+
+  constructor(http: Http) {
+    super(http, {
+      baseUrl: 'www.url.com',
+      path: 'path/to/endpoint',
+      transform: (res: Response) => {
+        return { data: res.json(), transformFrom: 'service'};
+      },
+    });
+  }
+}
+
+describe('Service: RESTService', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpModule,
+      ],
+      providers: [
+        MockBackend, {
+          provide: XHRBackend,
+          useExisting: MockBackend,
+        },
+        BasicTestRESTService,
+        BaseHeadersTestRESTService,
+        DynamicHeadersTestRESTService,
+        TransformTestRESTService,
+      ],
+    });
+  }));
+
+  it('expect to do a query succesfully',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.url).toBe('www.url.com/path/to/endpoint',  'url doesnt match expected url');
+        expect(connection.request.method).toBe(RequestMethod.Get, 'request didnt have GET method');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.query().subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    }),
+  ));
+
+  it('expect to do a query and use the service transform() and then override it with a method transform()',
+    async(inject([TransformTestRESTService, MockBackend],
+                 (service: TransformTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.query().subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('service');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+      success = false;
+      error = false;
+      complete = false;
+      service.query(undefined, (res: Response) => {
+        return { data: res.json(), transformFrom: 'method'};
+      }).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('method');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+    }),
+  ));
+
+  it('expect to do a query failure',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Error('error'));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.query().subscribe(() => {
+        success = true;
+      }, (err: Error) => {
+        expect(err.message).toBe('error');
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
+      expect(error).toBe(true, 'on error didnt execute with observables');
+      expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
+    }),
+  ));
+
+  it('expect to do a query with parameters succesfully',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.url)
+        .toBe('www.url.com/path/to/endpoint?firstParam=1&second-Param=value&thirdParam=false',
+              'url with query parameters didnt match the expected url');
+        expect(connection.request.method).toBe(RequestMethod.Get, 'request didnt have GET method');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.query({
+        firstParam: 1,
+        'second-Param': 'value',
+        thirdParam: false,
+      }).subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    }),
+  ));
+
+  it('expect to do a get succesfully',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.url)
+        .toBe('www.url.com/path/to/endpoint/id-of-something',
+              'url with :id didnt match the expected url');
+        expect(connection.request.method).toBe(RequestMethod.Get, 'request didnt have GET method');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.get('id-of-something').subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    }),
+  ));
+
+  it('expect to do a get and use the service transform() and then override it with a method transform()',
+    async(inject([TransformTestRESTService, MockBackend],
+                 (service: TransformTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.get('id-of-something').subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('service');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+      success = false;
+      error = false;
+      complete = false;
+      service.get('id-of-something', (res: Response) => {
+        return { data: res.json(), transformFrom: 'method'};
+      }).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('method');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+    }),
+  ));
+
+  it('expect to do a get failure',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Error('error'));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.get('id-of-something').subscribe(() => {
+        success = true;
+      }, (err: Error) => {
+        expect(err.message).toBe('error');
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
+      expect(error).toBe(true, 'on error didnt execute with observables');
+      expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
+    }),
+  ));
+
+  it('expect to do a create succesfully',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.url)
+        .toBe('www.url.com/path/to/endpoint',
+              'url didnt match the expected url');
+        expect(connection.request.method).toBe(RequestMethod.Post, 'request didnt have POST method');
+        expect(connection.request.getBody()).toBe('data', 'request didnt have the body');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 201,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.create('data').subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    }),
+  ));
+
+  it('expect to do a create and use the service transform() and then override it with a method transform()',
+    async(inject([TransformTestRESTService, MockBackend],
+                 (service: TransformTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 201,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.create({}).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('service');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+      success = false;
+      error = false;
+      complete = false;
+      service.create({}, (res: Response) => {
+        return { data: res.json(), transformFrom: 'method'};
+      }).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('method');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+    }),
+  ));
+
+  it('expect to do a create failure',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Error('error'));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.create({data: 'value'}).subscribe(() => {
+        success = true;
+      }, (err: Error) => {
+        expect(err.message).toBe('error');
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
+      expect(error).toBe(true, 'on error didnt execute with observables');
+      expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
+    }),
+  ));
+
+  it('expect to do an update succesfully',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.url)
+        .toBe('www.url.com/path/to/endpoint/id-of-something',
+              'url with :id didnt match the expected url');
+        expect(connection.request.method).toBe(RequestMethod.Patch, 'request didnt have PATCH method');
+        expect(connection.request.getBody()).toBe('data', 'request didnt have the body');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.update('id-of-something', 'data').subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    }),
+  ));
+
+  it('expect to do an update and use the service transform() and then override it with a method transform()',
+    async(inject([TransformTestRESTService, MockBackend],
+                 (service: TransformTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.update('id-of-something', {}).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('service');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+      success = false;
+      error = false;
+      complete = false;
+      service.update('id-of-something', {}, (res: Response) => {
+        return { data: res.json(), transformFrom: 'method'};
+      }).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('method');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+    }),
+  ));
+
+  it('expect to do a update failure',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Error('error'));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.update('id-of-something', 'data').subscribe((data: string) => {
+        success = true;
+      }, (err: Error) => {
+        expect(err.message).toBe('error');
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
+      expect(error).toBe(true, 'on error didnt execute with observables');
+      expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
+    }),
+  ));
+
+  it('expect to do a delete succesfully with observables',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.url)
+        .toBe('www.url.com/path/to/endpoint/id-of-something',
+              'url with :id didnt match the expected url');
+        expect(connection.request.method).toBe(RequestMethod.Delete, 'request didnt have DELETE method');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.delete('id-of-something').subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    }),
+  ));
+
+  it('expect to do a delete and use the service transform() and then override it with a method transform()',
+    async(inject([TransformTestRESTService, MockBackend],
+                 (service: TransformTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.delete('id-of-something').subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('service');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+      success = false;
+      error = false;
+      complete = false;
+      service.delete('id-of-something', (res: Response) => {
+        return { data: res.json(), transformFrom: 'method'};
+      }).subscribe((data: any) => {
+        expect(data.data).toBe('success');
+        expect(data.transformFrom).toBe('method');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+
+    }),
+  ));
+
+  it('expect to do a delete failure',
+    async(inject([BasicTestRESTService, MockBackend], (service: BasicTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Error('error'));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.delete('id-of-something').subscribe((data: string) => {
+        success = true;
+      }, (err: Error) => {
+        expect(err.message).toBe('error');
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
+      expect(error).toBe(true, 'on error didnt execute with observables');
+      expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
+    }),
+  ));
+
+  it('expect to do a query succesfully with baseHeaders',
+    async(inject([BaseHeadersTestRESTService, MockBackend],
+                 (service: BaseHeadersTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.headers.get('header')).toBe('value', 'request didnt have baseHeaders');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.query().subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    }),
+  ));
+
+  it('expect to do a query succesfully with dynamicHeaders',
+    async(inject([DynamicHeadersTestRESTService, MockBackend],
+                 (service: DynamicHeadersTestRESTService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.headers.get('header')).toBe('value', 'request didnt have dynamicHeaders');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.query().subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    }),
+  ));
+});

--- a/src/platform/http-deprec/http-rest.service.ts
+++ b/src/platform/http-deprec/http-rest.service.ts
@@ -1,0 +1,210 @@
+import { Headers, RequestOptionsArgs, Response, Request } from '@angular/http';
+import { map, catchError } from 'rxjs/operators';
+import { Observable, Subscriber } from 'rxjs';
+
+export interface IRestTransform {
+  (response: Response): any;
+}
+
+export interface IRestConfig {
+  baseHeaders?: Headers;
+  dynamicHeaders?: () => Headers;
+  baseUrl: string;
+  path?: string;
+  transform?: IRestTransform;
+}
+
+export interface IRestQuery {
+  [key: string]: any;
+}
+
+export interface IHttp {
+  delete: (url: string, options?: RequestOptionsArgs) => Observable<Response>;
+  get: (url: string, options?: RequestOptionsArgs) => Observable<Response>;
+  head: (url: string, options?: RequestOptionsArgs) => Observable<Response>;
+  patch: (url: string, body: any, options?: RequestOptionsArgs) => Observable<Response>;
+  post: (url: string, body: any, options?: RequestOptionsArgs) => Observable<Response>;
+  put: (url: string, body: any, options?: RequestOptionsArgs) => Observable<Response>;
+  request: (url: string | Request, options?: RequestOptionsArgs) => Observable<Response>;
+}
+
+export abstract class RESTService<T> {
+
+  private _path: string;
+  private _base: string;
+  private _baseHeaders: Headers;
+  private _dynamicHeaders: () => Headers;
+
+  protected transform: IRestTransform;
+  protected http: IHttp;
+
+  constructor(http: IHttp, config: IRestConfig) {
+    this.http = http;
+    this._base = config.baseUrl.replace(/\/$/, '');
+    this._path = config.path.replace(/^\//, '');
+    this._baseHeaders = config.baseHeaders ? config.baseHeaders : new Headers();
+    this._dynamicHeaders = config.dynamicHeaders ? config.dynamicHeaders : () => new Headers();
+    this.transform = config.transform ? config.transform : (response: Response): any => response.json();
+  }
+
+  public query(query?: IRestQuery, transform?: IRestTransform): Observable<any> {
+    let request: Observable<Response> = this.http.get(this.buildUrl(undefined, query), this.buildRequestOptions());
+    return request.pipe(
+      catchError((error: Response) => {
+        return new Observable<any>((subscriber: Subscriber<any>) => {
+          try {
+            subscriber.error(this.transform(error));
+          } catch (err) {
+            subscriber.error(error);
+          }
+        });
+      }),
+      map((res: Response) => {
+        if (transform) {
+          return transform(res);
+        }
+        return this.transform(res);
+      }),
+    );
+  }
+
+  public get(id: string | number, transform?: IRestTransform): Observable<any> {
+    let request: Observable<Response> = this.http.get(this.buildUrl(id), this.buildRequestOptions());
+    return request.pipe(
+      catchError((error: Response) => {
+        return new Observable<any>((subscriber: Subscriber<any>) => {
+          try {
+            subscriber.error(this.transform(error));
+          } catch (err) {
+            subscriber.error(error);
+          }
+        });
+      }),
+      map((res: Response) => {
+        if (transform) {
+          return transform(res);
+        }
+        return this.transform(res);
+      }),
+    );
+  }
+
+  public create(obj: T, transform?: IRestTransform): Observable<any> {
+    let requestOptions: RequestOptionsArgs = this.buildRequestOptions();
+    let request: Observable<Response> = this.http.post(this.buildUrl(), obj, requestOptions);
+    return request.pipe(
+      catchError((error: Response) => {
+        return new Observable<any>((subscriber: Subscriber<any>) => {
+          try {
+            subscriber.error(this.transform(error));
+          } catch (err) {
+            subscriber.error(error);
+          }
+        });
+      }),
+      map((res: Response) => {
+        if (res.status === 201) {
+          if (transform) {
+            return transform(res);
+          }
+          return this.transform(res);
+        } else {
+          return res;
+        }
+      }),
+    );
+  }
+
+  public update(id: string | number, obj: T, transform?: IRestTransform): Observable<any> {
+    let requestOptions: RequestOptionsArgs = this.buildRequestOptions();
+    let request: Observable<Response> = this.http.patch(this.buildUrl(id), obj, requestOptions);
+    return request.pipe(
+      catchError((error: Response) => {
+        return new Observable<any>((subscriber: Subscriber<any>) => {
+          try {
+            subscriber.error(this.transform(error));
+          } catch (err) {
+            subscriber.error(error);
+          }
+        });
+      }),
+      map((res: Response) => {
+        if (res.status === 200) {
+          if (transform) {
+            return transform(res);
+          }
+          return this.transform(res);
+        } else {
+          return res;
+        }
+      }),
+    );
+  }
+
+  public delete(id: string | number, transform?: IRestTransform): Observable<any> {
+    let request: Observable<Response> = this.http.delete(this.buildUrl(id), this.buildRequestOptions());
+    return request.pipe(
+      catchError((error: Response) => {
+        return new Observable<any>((subscriber: Subscriber<any>) => {
+          try {
+            subscriber.error(this.transform(error));
+          } catch (err) {
+            subscriber.error(error);
+          }
+        });
+      }),
+      map((res: Response) => {
+        if (res.status === 200) {
+          if (transform) {
+            return transform(res);
+          }
+          return this.transform(res);
+        } else {
+          return res;
+        }
+      }),
+    );
+  }
+
+  protected buildRequestOptions(): RequestOptionsArgs {
+    let requestHeaders: Headers = new Headers();
+    this._baseHeaders.forEach((value: string[], key: string) => {
+      requestHeaders.set(key, value);
+    });
+    this._dynamicHeaders().forEach((value: string[], key: string) => {
+      requestHeaders.set(key, value);
+    });
+    let requestOptions: RequestOptionsArgs = {
+      headers: requestHeaders,
+    };
+    return requestOptions;
+  }
+
+  protected buildUrl(id?: string | number, query?: IRestQuery): string {
+    let url: string = this._path ? this._path : '';
+    if (id) {
+      url += `/${id}`;
+    }
+    if (query) {
+      url += this.buildQuery(query);
+    }
+    url = `${this._base}/${url}`;
+    return url;
+  }
+
+  protected buildQuery(query: IRestQuery): string {
+    let url: string = '';
+    if (query) {
+      url += '?';
+      let params: string[] = [];
+      for (let key in query) {
+        let value: string | number | boolean = query[key];
+        if (value !== undefined) {
+          params.push(`${key}=${value}`);
+        }
+      }
+      url += params.join('&');
+    }
+    return url;
+  }
+}

--- a/src/platform/http-deprec/http.module.ts
+++ b/src/platform/http-deprec/http.module.ts
@@ -1,0 +1,38 @@
+import { NgModule, ModuleWithProviders, Injector, InjectionToken, Provider } from '@angular/core';
+import { HttpModule, Http } from '@angular/http';
+
+import { HttpInterceptorService, IHttpInterceptorConfig } from './interceptors/http-interceptor.service';
+import { URLRegExpInterceptorMatcher } from './interceptors/url-regexp-interceptor-matcher.class';
+
+export const HTTP_CONFIG: InjectionToken<HttpConfig> = new InjectionToken<HttpConfig>('HTTP_CONFIG');
+
+export type HttpConfig = {interceptors: IHttpInterceptorConfig[]};
+
+export function httpFactory(http: Http, injector: Injector, config: HttpConfig): HttpInterceptorService {
+  return new HttpInterceptorService(http, injector, new URLRegExpInterceptorMatcher(), config.interceptors);
+}
+
+export const HTTP_INTERCEPTOR_PROVIDER: Provider = {
+  provide: HttpInterceptorService,
+  useFactory: httpFactory,
+  deps: [Http, Injector, HTTP_CONFIG],
+};
+
+@NgModule({
+  imports: [
+    HttpModule,
+  ],
+})
+export class CovalentHttpModule {
+  static forRoot(config: HttpConfig = {interceptors: []}): ModuleWithProviders {
+    return {
+      ngModule: CovalentHttpModule,
+      providers: [{
+          provide: HTTP_CONFIG,
+          useValue: config,
+        },
+        HTTP_INTERCEPTOR_PROVIDER,
+      ],
+    };
+  }
+}

--- a/src/platform/http-deprec/index.ts
+++ b/src/platform/http-deprec/index.ts
@@ -1,0 +1,1 @@
+export * from './public-api';

--- a/src/platform/http-deprec/interceptors/README.md
+++ b/src/platform/http-deprec/interceptors/README.md
@@ -1,0 +1,166 @@
+# HttpInterceptorService (deprecated)
+
+Service provided with methods that wrap the @angular [Http] service and provide an easier experience for interceptor implementation.
+
+## API Summary
+
+#### Methods
+
++ delete: function(url: string, options: RequestOptionsArgs)
+  + Uses underlying @angular [http] to request a DELETE method to a URL, executing the interceptors as part of the request pipeline.
++ get: function(url: string, options: RequestOptionsArgs)
+  + Uses underlying @angular [http] to request a GET method to a URL, executing the interceptors as part of the request pipeline.
++ head: function(url: string, options: RequestOptionsArgs)
+  + Uses underlying @angular [http] to request a HEAD method to a URL, executing the interceptors as part of the request pipeline.
++ patch: function(url: string, data: any, options: RequestOptionsArgs)
+  + Uses underlying @angular [http] to request a PATCH method to a URL, executing the interceptors as part of the request pipeline.
++ post: function(url: string, data: any, options: RequestOptionsArgs)
+  + Uses underlying @angular [http] to request a POST method to a URL, executing the interceptors as part of the request pipeline.
++ put: function(url: string, data: any, options: RequestOptionsArgs)
+  + Uses underlying @angular [http] to request a PUT method to a URL, executing the interceptors as part of the request pipeline.
++ request: function(url: string | Request, options: RequestOptionsArgs)
+  + Uses underlying @angular [http] to request a generic request to a URL, executing the interceptors as part of the request pipeline.
+
+## Usage
+
+To add a desired interceptor, it needs to implement the [IHttpInterceptor] interface.
+
+```typescript
+export interface IHttpInterceptor {
+  onRequest?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
+  onRequestError?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
+  onResponse?: (response: Response) => Response;
+  onResponseError?: (error: Response) => Response;
+}
+```
+Every method is optional, so you can just implement the ones that are needed.
+
+## Setup
+
+Create your custom interceptors by implementing [IHttpInterceptor]:
+
+```typescript
+import { Injectable } from '@angular/core';
+import { IHttpInterceptor } from '@covalent/http-deprec';
+
+@Injectable()
+export class CustomInterceptor implements IHttpInterceptor {
+
+   onRequest(requestOptions: RequestOptionsArgs): RequestOptionsArgs {
+    ... // do something to requestOptions before a request
+    ... // if something is wrong, throw an error to execute onRequestError (if there is an onRequestError hook)
+    if (/*somethingWrong*/) {
+      throw new Error('error message for subscription error callback');
+    }
+    return requestOptions;
+  }
+
+  onRequestError(requestOptions: RequestOptionsArgs): RequestOptionsArgs {
+    ... // do something to try and recover from an error thrown `onRequest` 
+    ... // and return the requestOptions needed for the request
+    ... // else return 'undefined' or throw an error to execute the error callback of the subscription
+    if (cantRecover) {
+      throw new Error('error message for subscription error callback'); // or return undefined;
+    }
+    return requestOptions;
+  }
+
+  onResponse(response: Response): Response {
+    ... // check response status and do something
+    return response;
+  }
+
+  onResponseError(error: Response): Response {
+    ... // check error status and do something
+    return error;
+  }
+}
+
+```
+
+Then, import the [CovalentHttpModule] using the forRoot() method with the desired interceptors and paths to intercept in your NgModule:
+
+```typescript
+import { NgModule, Type } from '@angular/core';
+import { HttpModule } from '@angular/http';
+import { CovalentHttpModule, IHttpInterceptor } from '@covalent/http-deprec';
+import { CustomInterceptor } from 'dir/to/interceptor';
+
+const httpInterceptorProviders: Type<IHttpInterceptor>[] = [
+  CustomInterceptor,
+  ...
+];
+
+@NgModule({
+  imports: [
+    HttpModule,
+    CovalentHttpModule.forRoot({
+      interceptors: [{
+        interceptor: CustomInterceptor, paths: ['**'],
+      }],
+    }),
+    ...
+  ],
+  providers: [
+    httpInterceptorProviders,
+    ...
+  ],
+  ...
+})
+export class MyModule {}
+```
+
+After that, just inject [HttpInterceptorService] and use it for your requests.
+
+## Paths
+
+The following characters are accepted as a path to intercept
+- `**` is a wildcard for `[a-zA-Z0-9-_]` (including `/`)
+- `*` is a wildcard for `[a-zA-Z0-9-_]` (excluding `/`)
+- `[a-zA-Z0-9-_]`
+
+#### Examples
+
+Example 1
+
+`/users/*/groups` intercepts:
+- `www.url.com/users/id-of-user/groups`
+- `www.url.com/users/id/groups`
+
+`/users/*/groups` DOES NOT intercept:
+- `www.url.com/users/id-of-user/groups/path`
+- `www.url.com/users/id-of-user/path/groups`
+- `www.url.com/users/groups`
+
+Example 2
+
+`/users/**/groups` intercepts:
+- `www.url.com/users/id-of-user/groups`
+- `www.url.com/users/id/groups`
+- `www.url.com/users/id-of-user/path/groups`
+
+`/users/**/groups` DOES NOT intercept:
+- `www.url.com/users/id-of-user/groups/path`
+- `www.url.com/users/groups`
+
+Example 3
+
+`/users/**` intercepts:
+- `www.url.com/users/id-of-user/groups`
+- `www.url.com/users/id/groups`
+- `www.url.com/users/id-of-user/path/groups`
+- `www.url.com/users/id-of-user/groups/path`
+- `www.url.com/users/groups`
+
+`/users/**` DOES NOT intercept:
+- `www.url.com/users`
+
+Example 4
+
+`/users**` intercepts:
+- `www.url.com/users/id-of-user/groups`
+- `www.url.com/users/id/groups`
+- `www.url.com/users/id-of-user/path/groups`
+- `www.url.com/users/id-of-user/groups/path`
+- `www.url.com/users/groups`
+- `www.url.com/users`

--- a/src/platform/http-deprec/interceptors/http-interceptor-mapping.interface.ts
+++ b/src/platform/http-deprec/interceptors/http-interceptor-mapping.interface.ts
@@ -1,0 +1,10 @@
+import { IHttpInterceptor } from './http-interceptor.interface';
+
+/**
+ * Interface for http interceptor mappings.
+ * Maps the interceptor with the desired interception rule.
+ */
+export interface IHttpInterceptorMapping {
+  interceptor: IHttpInterceptor;
+  paths: string[];
+}

--- a/src/platform/http-deprec/interceptors/http-interceptor-matcher.interface.ts
+++ b/src/platform/http-deprec/interceptors/http-interceptor-matcher.interface.ts
@@ -1,0 +1,13 @@
+import { RequestOptionsArgs } from '@angular/http';
+
+import { IHttpInterceptorMapping } from './http-interceptor-mapping.interface';
+
+/**
+ * Interface for http interceptor matchers.
+ * Implement a class to set the behavior of how the interceptors are matched with the requests.
+ */
+export interface IHttpInterceptorMatcher {
+
+  matches(options: RequestOptionsArgs, mapping: IHttpInterceptorMapping): boolean;
+
+}

--- a/src/platform/http-deprec/interceptors/http-interceptor.interface.ts
+++ b/src/platform/http-deprec/interceptors/http-interceptor.interface.ts
@@ -1,0 +1,12 @@
+import { RequestOptionsArgs, Response } from '@angular/http';
+
+/**
+ * Interface for http interceptors.
+ * Implement the methods you want to be executed in the request pipeline on interception.
+ */
+export interface IHttpInterceptor {
+  onRequest?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
+  onRequestError?: (requestOptions: RequestOptionsArgs) => RequestOptionsArgs;
+  onResponse?: (response: Response) => Response;
+  onResponseError?: (error: Response) => Response;
+}

--- a/src/platform/http-deprec/interceptors/http-interceptor.service.spec.ts
+++ b/src/platform/http-deprec/interceptors/http-interceptor.service.spec.ts
@@ -1,0 +1,435 @@
+import {
+  TestBed,
+  inject,
+  async,
+} from '@angular/core/testing';
+import { Injector, Injectable, Type } from '@angular/core';
+import { Headers, XHRBackend, Response, ResponseOptions, RequestOptionsArgs } from '@angular/http';
+import { Observable, forkJoin } from 'rxjs';
+import { MockBackend, MockConnection } from '@angular/http/testing';
+import { HttpModule, Http } from '@angular/http';
+import { HttpInterceptorService, HttpConfig, CovalentHttpModule, IHttpInterceptor } from '../';
+import { URLRegExpInterceptorMatcher } from './url-regexp-interceptor-matcher.class';
+import { map } from 'rxjs/operators';
+
+@Injectable()
+export class ResponseOverrideInterceptor {
+
+  onResponse(response: Response): Response {
+    return new Response(new ResponseOptions({body: JSON.stringify('override'), status: 200}));
+  }
+}
+
+@Injectable()
+export class RequestAuthInterceptor {
+  onRequest(request: RequestOptionsArgs): RequestOptionsArgs {
+    if (!request.headers) {
+      request.headers = new Headers();
+    }
+    request.headers.set('auth', 'test-auth');
+    return request;
+  }
+}
+
+@Injectable()
+export class RequestFailureInterceptor {
+  onRequest(request: RequestOptionsArgs): RequestOptionsArgs {
+    throw new Error('error');
+  }
+}
+
+@Injectable()
+export class RequestRecoveryInterceptor {
+  onRequest(request: RequestOptionsArgs): RequestOptionsArgs {
+    throw new Error('error');
+  }
+
+  onRequestError(request: RequestOptionsArgs): RequestOptionsArgs {
+    if (!request.headers) {
+      request.headers = new Headers();
+    }
+    request.headers.set('recovered', 'yes');
+    return request;
+  }
+
+  onResponse(response: Response): Response {
+    return new Response(new ResponseOptions({body: JSON.stringify('recovered'), status: 200}));
+  }
+}
+
+describe('Service: HttpInterceptor', () => {
+
+  let config: HttpConfig = {
+    interceptors: [{
+      interceptor: ResponseOverrideInterceptor, paths: ['/url**'],
+    }, {
+      interceptor: RequestAuthInterceptor, paths: ['**'],
+    }, {
+      interceptor: RequestFailureInterceptor, paths: ['/error'],
+    }, {
+      interceptor: RequestRecoveryInterceptor, paths: ['/recovery/*/fromerror'],
+    }],
+  };
+
+  const httpInterceptorProviders: Type<IHttpInterceptor>[] = [
+    ResponseOverrideInterceptor,
+    RequestAuthInterceptor,
+    RequestFailureInterceptor,
+    RequestRecoveryInterceptor,
+  ];
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CovalentHttpModule.forRoot(config),
+      ],
+      providers: [
+        MockBackend, {
+          provide: XHRBackend,
+          useExisting: MockBackend,
+        },
+        httpInterceptorProviders,
+      ],
+    });
+  }));
+
+  it('expect to intercept only the route with `/recovery/*/fromerror` and recover from a failure',
+    async(inject([HttpInterceptorService, MockBackend], (service: HttpInterceptorService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        if (connection.request.url === 'http://www.test.com/recovery/id/fromerror') {
+          expect(connection.request.headers.get('recovered')).toBe('yes', 'did not execute onRequestError when failed');
+        } else {
+          expect(connection.request.headers.get('recovered'))
+          .toBeNull('did execute onRequestError when failed when it shouldnt');
+        }
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      service.patch('http://www.test.com/recovery/id/id2/fromerror', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('success', '/error/*/fromerror was intercepted');
+        });
+ 
+      service.patch('http://www.test.com/recovery/id/fromerror', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('recovered', '/error/*/fromerror was not intercepted');
+        });
+    }),
+  ));
+
+  it('expect to intercept only the route with `/error` and fail',
+    async(inject([HttpInterceptorService, MockBackend], (service: HttpInterceptorService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+
+      service.patch('http://www.test.com/error', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeUndefined('/error was not intercepted so request didnt fail');
+        }, (error: Error) => {
+          expect(error.message).toBe('error');
+        });
+    }),
+  ));
+
+  it('expect to intercept all routes and add an `auth=test-auth` header',
+    async(inject([HttpInterceptorService, MockBackend], (service: HttpInterceptorService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        expect(connection.request.headers.get('auth')).toBe('test-auth', 'didnt add `auth` header on all routes');
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+
+      service.post('http://www.test.com/url/with/any-path/another-path?query=1&query=2', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
+
+      service.post('http://www.test.com/any_path?query=1&query=2', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
+
+      service.get('http://www.test.com/url/any-path/111').pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
+
+      service.get('http://www.test.com/anypath/url').pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
+
+      service.delete('http://www.test.com/any_path?', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
+
+      service.delete('http://www.test.com', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
+
+      service.patch('http://www.test.com/any_path/111/url/another_path', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
+
+      service.patch('http://www.test.com/any-path/111/another_path/', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBeTruthy();
+        });
+    }),
+  ));
+
+  it('expect to intercept routes that contain `/url` in them and override responses body with `override`',
+    async(inject([HttpInterceptorService, MockBackend], (service: HttpInterceptorService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+
+      service.post('http://www.test.com/url/with/any-path/another-path?query=1&query=2', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('override', 'didnt intercept url with `/url`');
+        });
+
+      service.post('http://www.test.com/any_path?query=1&query=2', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+        expect(data).toBe('success', 'intercepted url without `/url`');
+      });
+
+      service.get('http://www.test.com/url/any-path/111').pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+        expect(data).toBe('override', 'didnt intercept url with `/url`');
+      });
+
+      service.get('http://www.test.com/anypath/url').pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('override', 'didnt intercept url with `/url`');
+        });
+
+      service.delete('http://www.test.com/any_path?', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('success', 'intercepted url without `/url`');
+        });
+
+      service.delete('http://www.test.com', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('success', 'intercepted url without `/url`');
+        });
+
+      service.patch('http://www.test.com/any_path/111/url/another_path', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('override', 'didnt intercept url with `/url`');
+        });
+
+      service.patch('http://www.test.com/any-path/111/another_path/', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('success', 'intercepted url without `/url`');
+        });
+    }),
+  ));
+
+});
+
+describe('Service: HttpInterceptor', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpModule,
+      ],
+      providers: [
+        MockBackend, {
+          provide: XHRBackend,
+          useExisting: MockBackend,
+        }, {
+          provide: HttpInterceptorService,
+          useFactory: (http: Http, injector: Injector): HttpInterceptorService => {
+            return new HttpInterceptorService(http, injector, new URLRegExpInterceptorMatcher(), []);
+          },
+          deps: [Http, Injector],
+        },
+      ],
+    });
+  }));
+
+  it('expect to do a forkJoin get succesfully with observables',
+    async(inject([HttpInterceptorService, MockBackend], (service: HttpInterceptorService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+
+      forkJoin(
+        service.get('testurl'),
+        service.get('testurl'))
+      .subscribe((response: Response[]) => {
+        success = true;
+      }, () => {
+        error = true;
+      }, () => {
+        complete = true;
+      });
+
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    }),
+  ));
+
+  it('expect to do a post succesfully with observables',
+    async(inject([HttpInterceptorService, MockBackend], (service: HttpInterceptorService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.post('testurl', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe((data: string) => {
+          expect(data).toBe('success');
+          success = true;
+        }, () => {
+          error = true;
+        }, () => {
+          complete = true;
+        });
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(error).toBe(false, 'on error executed when it shouldnt have with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    }),
+  ));
+
+  it('expect to do a post failure with observables',
+    async(inject([HttpInterceptorService, MockBackend], (service: HttpInterceptorService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Error('error'));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      let complete: boolean = false;
+      service.post('testurl', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).subscribe(() => {
+          success = true;
+        }, (err: Error) => {
+          expect(err.message).toBe('error');
+          error = true;
+        }, () => {
+          complete = true;
+        });
+      expect(success).toBe(false, 'on success execute when it shouldnt have with observables');
+      expect(error).toBe(true, 'on error didnt execute with observables');
+      expect(complete).toBe(false, 'on complete execute when it shouldnt have with observables');
+    }),
+  ));
+
+  it('expect to do a post succesfully with promises',
+    async(inject([HttpInterceptorService, MockBackend], (service: HttpInterceptorService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+            status: 200,
+            body: JSON.stringify('success')},
+        )));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      service.post('testurl', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).toPromise().then((data: string) => {
+          expect(data).toBe('success');
+          success = true;
+        }, () => {
+          error = true;
+        });
+      setTimeout(() => {
+        expect(success).toBe(true, 'on success didnt execute with promises');
+        expect(error).toBe(false, 'on error executed when it shouldnt have with promises');
+      });
+    }),
+  ));
+
+  it('expect to do a post failure with promises',
+    async(inject([HttpInterceptorService, MockBackend], (service: HttpInterceptorService, mockBackend: MockBackend) => {
+      mockBackend.connections.subscribe((connection: MockConnection) => {
+        connection.mockError(new Error('error'));
+      });
+      let success: boolean = false;
+      let error: boolean = false;
+      service.post('testurl', {}).pipe(
+        map(
+          (res: Response) => res.json(),
+        )).toPromise().then(() => {
+          success = true;
+        }, (err: Error) => {
+          expect(err.message).toBe('error');
+          error = true;
+        });
+      setTimeout(() => {
+        expect(success).toBe(false, 'on success execute when it shouldnt have with promises');
+        expect(error).toBe(true, 'on error didnt execute with promises');
+      });
+    }),
+  ));
+});

--- a/src/platform/http-deprec/interceptors/http-interceptor.service.ts
+++ b/src/platform/http-deprec/interceptors/http-interceptor.service.ts
@@ -1,0 +1,147 @@
+import { Injectable, Type, Injector } from '@angular/core';
+import { Http, RequestOptionsArgs, Response, Request, RequestMethod } from '@angular/http';
+
+import { Observable, Subscriber } from 'rxjs';
+
+import { IHttpInterceptor } from './http-interceptor.interface';
+import { IHttpInterceptorMatcher } from './http-interceptor-matcher.interface';
+import { IHttpInterceptorMapping } from './http-interceptor-mapping.interface';
+
+export interface IHttpInterceptorConfig {
+  interceptor: Type<any>;
+  paths: string[];
+}
+
+export class HttpInterceptorService {
+
+  private _requestInterceptors: IHttpInterceptorMapping[] = [];
+
+  constructor(private _http: Http,
+              private _injector: Injector,
+              private _httpInterceptorMatcher: IHttpInterceptorMatcher,
+              requestInterceptorConfigs: IHttpInterceptorConfig[]) {
+    requestInterceptorConfigs.forEach((config: IHttpInterceptorConfig) => {
+      this._requestInterceptors.push({
+        interceptor: <IHttpInterceptor>_injector.get(config.interceptor),
+        paths: config.paths,
+      });
+    });
+  }
+
+  public delete(url: string, requestOptions: RequestOptionsArgs = {}): Observable<Response> {
+    requestOptions.url = url;
+    requestOptions.method = RequestMethod.Delete;
+    return this.request(url, requestOptions);
+  }
+
+  public get(url: string, requestOptions: RequestOptionsArgs = {}): Observable<Response> {
+    requestOptions.url = url;
+    requestOptions.method = RequestMethod.Get;
+    return this.request(url, requestOptions);
+  }
+
+  public head(url: string, requestOptions: RequestOptionsArgs = {}): Observable<Response> {
+    requestOptions.url = url;
+    requestOptions.method = RequestMethod.Head;
+    return this.request(url, requestOptions);
+  }
+
+  public patch(url: string, data: any, requestOptions: RequestOptionsArgs = {}): Observable<Response> {
+    requestOptions.url = url;
+    requestOptions.method = RequestMethod.Patch;
+    requestOptions.body = data;
+    return this.request(url, requestOptions);
+  }
+
+  public post(url: string, data: any, requestOptions: RequestOptionsArgs = {}): Observable<Response> {
+    requestOptions.url = url;
+    requestOptions.method = RequestMethod.Post;
+    requestOptions.body = data;
+    return this.request(url, requestOptions);
+  }
+
+  public put(url: string, data: any, requestOptions: RequestOptionsArgs = {}): Observable<Response> {
+    requestOptions.url = url;
+    requestOptions.method = RequestMethod.Put;
+    requestOptions.body = data;
+    return this.request(url, requestOptions);
+  }
+
+  public request(url: string | Request, requestOptions: RequestOptionsArgs = {}): Observable<Response> {
+    let requestUrl: string;
+    if (url instanceof Request) {
+      requestUrl = url.url ? url.url : requestOptions.url;
+    } else {
+      requestUrl = url;
+    }
+    if (!requestOptions.url) {
+      requestOptions.url = requestUrl;
+    }
+    let interceptors: IHttpInterceptor[] = this._requestInterceptors.filter((mapping: IHttpInterceptorMapping) => {
+      return this._httpInterceptorMatcher.matches(requestOptions, mapping);
+    }).map((mapping: IHttpInterceptorMapping) => {
+      return mapping.interceptor;
+    });
+    return this._setupRequest(url, requestOptions, interceptors);
+  }
+
+  private _setupRequest(url: string | Request,
+                        requestOptions: RequestOptionsArgs,
+                        interceptors: IHttpInterceptor[]): Observable<Response> {
+    try {
+      requestOptions = this._requestResolve(requestOptions, interceptors);
+    } catch (e) {
+      return new Observable<any>((subscriber: Subscriber<any>) => {
+        subscriber.error(e);
+      });
+    }
+    return new Observable<any>((subscriber: Subscriber<any>) => {
+      this._http.request(url, requestOptions)
+      .subscribe((response: Response) => {
+        subscriber.next(this._responseResolve(response, interceptors));
+        subscriber.complete();
+      }, (error: Response) => {
+        subscriber.error(this._responseErrorResolve(error, interceptors));
+      });
+    });
+  }
+
+  private _requestResolve(requestOptions: RequestOptionsArgs, interceptors: IHttpInterceptor[]): RequestOptionsArgs {
+    interceptors.forEach((interceptor: IHttpInterceptor) => {
+      if (interceptor.onRequest) {
+        try {
+          requestOptions = interceptor.onRequest(requestOptions);
+        } catch (e) {
+          if (interceptor.onRequestError) {
+            requestOptions = interceptor.onRequestError(requestOptions);
+            if (!requestOptions) {
+              throw e;
+            }
+          } else {
+            throw e;
+          }
+        }
+      }
+    });
+    return requestOptions;
+  }
+
+  private _responseResolve(response: Response, interceptors: IHttpInterceptor[]): Response {
+    interceptors.reverse().forEach((interceptor: IHttpInterceptor) => {
+      if (interceptor.onResponse) {
+        response = interceptor.onResponse(response);
+      }
+    });
+    return response;
+  }
+
+  private _responseErrorResolve(error: Response, interceptors: IHttpInterceptor[]): Response {
+    interceptors.reverse().forEach((interceptor: IHttpInterceptor) => {
+      if (interceptor.onResponseError) {
+        error = interceptor.onResponseError(error);
+      }
+    });
+    return error;
+  }
+
+}

--- a/src/platform/http-deprec/interceptors/url-regexp-interceptor-matcher.class.spec.ts
+++ b/src/platform/http-deprec/interceptors/url-regexp-interceptor-matcher.class.spec.ts
@@ -1,0 +1,147 @@
+import { URLRegExpInterceptorMatcher } from './url-regexp-interceptor-matcher.class';
+
+describe('Http: URLRegExpInterceptorMatcher', () => {
+  let matcher: URLRegExpInterceptorMatcher;
+
+  beforeEach(() => {
+    matcher = new URLRegExpInterceptorMatcher();
+  });
+
+  it('should match all URLs', () => {
+    expect(matcher.matches(
+      {url: 'www.google.com/path/1_1_-_1/ano111_ther/11-22?query=1&query=2'},
+      {interceptor: undefined, paths: ['**']},
+    )).toBeTruthy();
+    expect(matcher.matches(
+      {url: 'www.google.com/path/111/another/11-22'},
+      {interceptor: undefined, paths: ['**']},
+    )).toBeTruthy();
+    expect(matcher.matches(
+      {url: 'www.google.com/path'},
+      {interceptor: undefined, paths: ['**']},
+    )).toBeTruthy();
+    expect(matcher.matches(
+      {url: 'www.google.com?'},
+      {interceptor: undefined, paths: ['**']},
+    )).toBeTruthy();
+    expect(matcher.matches(
+      {url: 'www.google.com/path/1_1_-_1/?query=1&query=2'},
+      {interceptor: undefined, paths: ['**']},
+    )).toBeTruthy();
+  });
+
+  it('should match routes that contain with /apps or /sys', () => {
+    expect(matcher.matches(
+      {url: 'www.google.com/apps/1_1_-_1/ano111_ther/11-22?query=1&query=2'},
+      {interceptor: undefined, paths: ['/apps**', '/sys**']},
+    )).toBeTruthy();
+    expect(matcher.matches(
+      {url: 'www.google.com/path/111/sys/11-22'},
+      {interceptor: undefined, paths: ['/apps**', '/sys**']},
+    )).toBeTruthy();
+    expect(matcher.matches(
+      {url: 'www.google.com/apps'},
+      {interceptor: undefined, paths: ['/apps**', '/sys**']},
+    )).toBeTruthy();
+    expect(matcher.matches(
+      {url: 'www.google.com?'},
+      {interceptor: undefined, paths: ['/apps**', '/sys**']},
+    )).toBeFalsy();
+    expect(matcher.matches(
+      {url: 'www.google.com/path/1_1_-_1/?query=1&query=2'},
+      {interceptor: undefined, paths: ['/apps**', '/sys**']},
+    )).toBeFalsy();
+  });
+
+  it('should match routes that end with /apps', () => {
+    expect(matcher.matches(
+      {url: 'www.google.com/apps/1_1_-_1/ano111_ther/11-22?query=1&query=2'},
+      {interceptor: undefined, paths: ['/apps']},
+    )).toBeFalsy();
+    expect(matcher.matches(
+      {url: 'www.google.com/path/111/sys/11-22'},
+      {interceptor: undefined, paths: ['/apps']},
+    )).toBeFalsy();
+    expect(matcher.matches(
+      {url: 'www.google.com/apps'},
+      {interceptor: undefined, paths: ['/apps']},
+    )).toBeTruthy();
+    expect(matcher.matches(
+      {url: 'www.google.com?'},
+      {interceptor: undefined, paths: ['/apps']},
+    )).toBeFalsy();
+    expect(matcher.matches(
+      {url: 'www.google.com/path/1_1_-_1/?query=1&query=2'},
+      {interceptor: undefined, paths: ['/apps']},
+    )).toBeFalsy();
+  });
+
+  it('should match routes that end with /apps/* (only with extra path)', () => {
+    expect(matcher.matches(
+      {url: 'www.google.com/apps/1_1_-_1/ano111_ther/11-22?query=1&query=2'},
+      {interceptor: undefined, paths: ['/apps/*']},
+    )).toBeFalsy();
+    expect(matcher.matches(
+      {url: 'www.google.com/path/111/apps/11-22'},
+      {interceptor: undefined, paths: ['/apps/*']},
+    )).toBeTruthy();
+    expect(matcher.matches(
+      {url: 'www.google.com/apps'},
+      {interceptor: undefined, paths: ['/apps/*']},
+    )).toBeFalsy();
+    expect(matcher.matches(
+      {url: 'www.google.com?'},
+      {interceptor: undefined, paths: ['/apps/*']},
+    )).toBeFalsy();
+    expect(matcher.matches(
+      {url: 'www.google.com/path/1_1_-_1/?query=1&query=2'},
+      {interceptor: undefined, paths: ['/apps/*']},
+    )).toBeFalsy();
+  });
+
+  it('should match routes that end with /apps/*/path (only one path in the middle)', () => {
+    expect(matcher.matches(
+      {url: 'www.google.com/apps/1_1_-_1/path?query=1&query=2'},
+      {interceptor: undefined, paths: ['/apps/*/path']},
+    )).toBeTruthy();
+    expect(matcher.matches(
+      {url: 'www.google.com/apps/111/path/11-22'},
+      {interceptor: undefined, paths: ['/apps/*/path']},
+    )).toBeFalsy();
+    expect(matcher.matches(
+      {url: 'www.google.com/apps'},
+      {interceptor: undefined, paths: ['/apps/*/path']},
+    )).toBeFalsy();
+    expect(matcher.matches(
+      {url: 'www.google.com?'},
+      {interceptor: undefined, paths: ['/apps/*/path']},
+    )).toBeFalsy();
+    expect(matcher.matches(
+      {url: 'www.google.com/path/1_1_-_1/?query=1&query=2'},
+      {interceptor: undefined, paths: ['/apps/*/path']},
+    )).toBeFalsy();
+  });
+
+  it('should match routes that end with /apps/**/path (any number of paths in the middle)', () => {
+    expect(matcher.matches(
+      {url: 'www.google.com/apps/1_1_-_1/path?query=1&query=2'},
+      {interceptor: undefined, paths: ['/apps/**/path']},
+    )).toBeTruthy();
+    expect(matcher.matches(
+      {url: 'www.google.com/apps/111/122/path'},
+      {interceptor: undefined, paths: ['/apps/**/path']},
+    )).toBeTruthy();
+    expect(matcher.matches(
+      {url: 'www.google.com/apps'},
+      {interceptor: undefined, paths: ['/apps/**/path']},
+    )).toBeFalsy();
+    expect(matcher.matches(
+      {url: 'www.google.com?'},
+      {interceptor: undefined, paths: ['/apps/**/path']},
+    )).toBeFalsy();
+    expect(matcher.matches(
+      {url: 'www.google.com/path/1_1_-_1/?query=1&query=2'},
+      {interceptor: undefined, paths: ['/apps/**/path']},
+    )).toBeFalsy();
+  });
+});

--- a/src/platform/http-deprec/interceptors/url-regexp-interceptor-matcher.class.ts
+++ b/src/platform/http-deprec/interceptors/url-regexp-interceptor-matcher.class.ts
@@ -1,0 +1,25 @@
+import { RequestOptionsArgs } from '@angular/http';
+
+import { IHttpInterceptorMapping } from './http-interceptor-mapping.interface';
+import { IHttpInterceptorMatcher } from './http-interceptor-matcher.interface';
+
+/**
+ * Concrete implementation for http interceptor matchers.
+ * This implementation uses regex to check mapping paths vs request url.
+ */
+export class URLRegExpInterceptorMatcher implements IHttpInterceptorMatcher {
+
+  matches(options: RequestOptionsArgs, mapping: IHttpInterceptorMapping): boolean {
+    return mapping.paths.filter((path: string) => {
+      path = path.replace(/\*\*/gi, '<>')
+                .replace(/\*/gi, '[a-zA-Z0-9\\-_]+')
+                .replace(/<>/gi, '[a-zA-Z0-9\\-_\/]*');
+      if (path) {
+        path += '(\\?{1}.*)?$';
+        return new RegExp(path).test(options.url);
+      }
+      return false;
+    }).length > 0;
+  }
+
+}

--- a/src/platform/http-deprec/ng-package.js
+++ b/src/platform/http-deprec/ng-package.js
@@ -1,0 +1,3 @@
+let ngPackageSettings = require('../ng-package-common.js');
+ngPackageSettings["dest"] = "../../../deploy/platform/http-deprec"
+module.exports = ngPackageSettings;

--- a/src/platform/http-deprec/package.json
+++ b/src/platform/http-deprec/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@covalent/http-deprec",
+  "version": "0.0.0-COVALENT",
+  "description": "Teradata UI Platform Http Helper Module (deprecated)",
+  "keywords": [
+    "angular",
+    "components",
+    "reusable",
+    "http",
+    "rest",
+    "interceptor",
+    "deprecated"
+  ],
+  "scripts": {
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/teradata/covalent.git"
+  },
+  "bugs": {
+    "url": "https://github.com/teradata/covalent/issues"
+  },
+  "license": "MIT",
+  "author": "Teradata UX",
+  "contributors": [
+    "Kyle Ledbetter <kyle.ledbetter@teradata.com>",
+    "Richa Vyas <richa.vyas@teradata.com>",
+    "Ed Morales <eduardo.morales@teradata.com>",
+    "Jason Weaver <jason.weaver@teradata.com>",
+    "Jeremy Wilken <jeremy.wilken@teradata.com>",
+    "Jeremy Smartt <jeremy.smartt@teradata.com>",
+    "Steven Ov <steven.ov@teradata.com>"
+  ],
+  "peerDependencies": {
+    "@angular/core": "^0.0.0-NG",
+    "@angular/http": "^0.0.0-NG"
+  }
+}

--- a/src/platform/http-deprec/public-api.ts
+++ b/src/platform/http-deprec/public-api.ts
@@ -1,0 +1,7 @@
+export * from './http.module';
+export * from './http-rest.service';
+export * from './interceptors/url-regexp-interceptor-matcher.class';
+export * from './interceptors/http-interceptor.service';
+export * from './interceptors/http-interceptor.interface';
+export * from './interceptors/http-interceptor-matcher.interface';
+export * from './interceptors/http-interceptor-mapping.interface';


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Since `@angular/http` has been deprecated for a long time.. we need to use `HttpClient` under the covers on our `http` package. Since most people wont be able to migrate in a single release, we are going to create an additional package called `http-deprec` with will have the "old" http module wrapping `@angular/http`.. and we will add a new `http` module that uses `HttpClient`.

### What's included?
<!-- List features included in this PR -->
- @covalent/http-deprec module for `@angular/http` compatibility.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
