### PR TITLE
feat(td-chips): Add compareWith input prop

### DIFF
--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -392,7 +392,7 @@
         <td-highlight lang="typescript">
           <![CDATA[
             export class ChipsDemoComponent {
-              
+
             }
           ]]>
         </td-highlight>
@@ -400,6 +400,49 @@
     </mat-tab>
   </mat-tab-group>
 </mat-card>
+<mat-card>
+    <mat-card-title>Chips with a custom compareWith function</mat-card-title>
+    <mat-card-subtitle>Use a compareWith function to customize how chips are compared when attempting to add a new one</mat-card-subtitle>
+    <mat-divider></mat-divider>
+    <mat-tab-group mat-stretch-tabs dynamicHeight>
+      <mat-tab>
+        <ng-template matTabLabel>Demo</ng-template>
+        <div class="push">
+          <div class="mat-body-1">Try to add 2 chips with same characters but with different casing, such as 'test' and 'TEST'</div>
+          <td-chips
+            placeholder="Type here"
+            [compareWith]="compareWith"
+          >
+          </td-chips>
+        </div>
+      </mat-tab>
+      <mat-tab>
+        <ng-template matTabLabel>Code</ng-template>
+        <mat-card-content>
+          <p>HTML:</p>
+          <td-highlight lang="html">
+            <![CDATA[
+              <td-chips
+                placeholder="Type here"
+                [compareWith]="compareWith"
+              >
+              </td-chips>
+            ]]>
+          </td-highlight>
+          <p>Typescript:</p>
+          <td-highlight lang="typescript">
+            <![CDATA[
+              export class ChipsDemoComponent {
+                compareWith: (o1: any, o2: any) => boolean = (o1: any, o2: any) => {
+                  return o1.toUpperCase() === o2.toUpperCase();
+                }
+              }
+            ]]>
+          </td-highlight>
+        </mat-card-content>
+      </mat-tab>
+    </mat-tab-group>
+  </mat-card>
 <!-- chip with required attribute -->
 <mat-card>
   <mat-card-title>Chips with required attribute</mat-card-title>
@@ -426,7 +469,7 @@
         <td-highlight lang="typescript">
           <![CDATA[
             export class ChipsDemoComponent {
-              
+
             }
           ]]>
         </td-highlight>
@@ -512,5 +555,5 @@
     </mat-tab>
   </mat-tab-group>
 </mat-card>
-   
+
 <td-readme-loader resourceUrl="platform/core/chips/README.md"></td-readme-loader>

--- a/src/app/components/components/chips/chips.component.ts
+++ b/src/app/components/components/chips/chips.component.ts
@@ -67,6 +67,10 @@ export class ChipsDemoComponent implements OnInit {
 
   constructor(private _changeDetectorRef: ChangeDetectorRef) {}
 
+  compareWith: (o1: any, o2: any) => boolean = (o1: any, o2: any) => {
+    return o1.toUpperCase() === o2.toUpperCase();
+  }
+
   ngOnInit(): void {
     this.filterStrings('');
     this.filterObjects('');

--- a/src/platform/core/chips/README.md
+++ b/src/platform/core/chips/README.md
@@ -23,17 +23,20 @@ Leverage the templates to create your own chip or contact chip.
 + placeholder?: string
   + Placeholder for the autocomplete input.
 + required?: boolean
-  + Mandates at least one chip to be available in the component. Appends * to the placeholder text. 
+  + Mandates at least one chip to be available in the component. Appends * to the placeholder text.
   + It does not prevent the deletion of last chip but instead sets the input field to warn state
   + Defaults to false
 + disabled?: boolean
   + Sets disabled state and disabled addition/removal of chips.
 + chipAddition?: boolean
-  + Enables the ability to add chips. When setting disabled as true, this will be overriden. 
+  + Enables the ability to add chips. When setting disabled as true, this will be overriden.
 + chipRemoval?: boolean
-  + Enables the ability to remove chips. When setting disabled as true, this will be overriden. 
+  + Enables the ability to remove chips. When setting disabled as true, this will be overriden.
 + debounce?: number
   + Debounce timeout between keypresses. Defaults to 200.
++ compareWith? function
+  + Function used to check whether a chip value already exists.
+  + Defaults to strict equality comparison ===
 
 #### Events
 
@@ -74,9 +77,10 @@ Example for HTML usage:
           [items]="items"
           [inputPosition]="'before'"
           [(ngModel)]="model"
-          [disabled]="disabled" 
+          [disabled]="disabled"
           [chipAddition]="chipAddition"
           [chipRemoval]="chipRemoval"
+          [compareWith]="compareWith"
           (add)="addEvent($event)"
           (remove)="removeEvent($event)"
           (chipBlur)="handleChipBlur($event)"
@@ -91,5 +95,5 @@ Example for HTML usage:
     {{option}}
   </ng-template>
   // anything below it
-</td-chips>  
+</td-chips>
 ```

--- a/src/platform/core/chips/chips.component.spec.ts
+++ b/src/platform/core/chips/chips.component.spec.ts
@@ -128,7 +128,7 @@ describe('Component: Chips', () => {
 
     it('should have primary color', (done: DoneFn) => {
       fixture.detectChanges();
-      fixture.whenStable().then(() => {        
+      fixture.whenStable().then(() => {
         expect((<HTMLElement>chips.nativeElement).classList.contains('mat-primary')).toBeTruthy();
         done();
       });
@@ -306,6 +306,42 @@ describe('Component: Chips', () => {
               expect(fixture.debugElement.queryAll(By.directive(MatChip))[0].nativeElement.textContent).toContain('test');
               done();
             }, 200);
+          });
+        });
+      });
+    });
+
+    it('should use compareWith function if one is provided', (done: DoneFn) => {
+      chips.triggerEventHandler('focus', new Event('focus'));
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        (<TdChipsComponent>chips.componentInstance)._inputChild.value = 'test';
+
+        function ignoreCase(o1: any, o2: any): boolean {
+          return o1.toUpperCase() === o2.toUpperCase();
+        }
+
+        chips.componentInstance.compareWith = ignoreCase;
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          input.triggerEventHandler('keyup.enter', createFakeKeyboardEvent(ENTER));
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+              expect(chips.componentInstance.value.length).toBe(1);
+              expect(fixture.debugElement.queryAll(By.directive(MatChip)).length).toBe(1);
+              expect(fixture.debugElement.queryAll(By.directive(MatChip))[0].nativeElement.textContent).toContain('test');
+
+              (<TdChipsComponent>chips.componentInstance)._inputChild.value = 'TEST';
+              fixture.detectChanges();
+              fixture.whenStable().then(() => {
+                input.triggerEventHandler('keyup.enter', createFakeKeyboardEvent(ENTER));
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    expect(chips.componentInstance.value.length).toBe(1);
+                    expect(fixture.debugElement.queryAll(By.directive(MatChip)).length).toBe(1);
+                    done();
+                });
+              });
           });
         });
       });
@@ -855,7 +891,13 @@ class TdChipsA11yTestComponent {
 
 @Component({
   template: `
-      <td-chips [placeholder]="placeholder" [items]="filteredItems" [(ngModel)]="selectedItems" (inputChange)="filter($event)">
+      <td-chips
+        [placeholder]="placeholder"
+        [items]="filteredItems"
+        [compareWith]="compareWith"
+        [(ngModel)]="selectedItems"
+        (inputChange)="filter($event)"
+      >
       </td-chips>`,
 })
 class TdChipsBasicTestComponent {
@@ -871,6 +913,11 @@ class TdChipsBasicTestComponent {
     'pasta',
     'sushi',
   ];
+
+  compareWith(o1: any: o2: any): boolean {
+    return o1 === o2;
+  }
+
   filter(value: string): void {
     this.filteredItems = this.items.filter((item: any) => {
       return item.toLowerCase().indexOf(value.toLowerCase()) > -1;
@@ -882,7 +929,7 @@ class TdChipsBasicTestComponent {
 
 @Component({
   template: `
-      <td-chips [placeholder]="placeholder" [required]="true" [items]="items" 
+      <td-chips [placeholder]="placeholder" [required]="true" [items]="items"
           [(ngModel)]="items">
       </td-chips>`,
 })

--- a/src/platform/core/chips/chips.component.spec.ts
+++ b/src/platform/core/chips/chips.component.spec.ts
@@ -914,7 +914,7 @@ class TdChipsBasicTestComponent {
     'sushi',
   ];
 
-  compareWith(o1: any: o2: any): boolean {
+  compareWith(o1: any, o2: any): boolean {
     return o1 === o2;
   }
 

--- a/src/platform/core/chips/chips.component.spec.ts
+++ b/src/platform/core/chips/chips.component.spec.ts
@@ -337,9 +337,11 @@ describe('Component: Chips', () => {
                 input.triggerEventHandler('keyup.enter', createFakeKeyboardEvent(ENTER));
                 fixture.detectChanges();
                 fixture.whenStable().then(() => {
+                  setTimeout(() => {
                     expect(chips.componentInstance.value.length).toBe(1);
                     expect(fixture.debugElement.queryAll(By.directive(MatChip)).length).toBe(1);
                     done();
+                  }, 200);
                 });
               });
           });

--- a/src/platform/core/chips/chips.component.ts
+++ b/src/platform/core/chips/chips.component.ts
@@ -298,6 +298,15 @@ export class TdChipsComponent extends _TdChipsMixinBase implements IControlValue
   }
 
   /**
+   * compareWith? function
+   * Function used to check whether a chip value already exists.
+   * Defaults to strict equality comparison ===
+   */
+  @Input('compareWith') compareWith: (o1: any, o2: any) => boolean = (o1: any, o2: any) => {
+    return o1 === o2;
+  }
+
+  /**
    * Listens to host focus event to act on it
    */
   @HostListener('focus', ['$event'])
@@ -442,7 +451,7 @@ export class TdChipsComponent extends _TdChipsMixinBase implements IControlValue
      * add a debounce ms delay when reopening the autocomplete to give it time
      * to rerender the next list and at the correct spot
      */
-    
+
     this._closeAutocomplete();
     timer(this.debounce).toPromise().then(() => {
       this.setFocusedState();
@@ -452,7 +461,7 @@ export class TdChipsComponent extends _TdChipsMixinBase implements IControlValue
 
     this.inputControl.setValue('');
     // check if value is already part of the model
-    if (this.value.indexOf(value) > -1) {
+    if (this.value.findIndex((item: any) => this.compareWith(item, value)) > -1) {
       return false;
     }
 
@@ -478,7 +487,7 @@ export class TdChipsComponent extends _TdChipsMixinBase implements IControlValue
      * Else check if its not the last chip of the list to focus the next one.
      */
     if (index === (this._totalChips - 1) && index === 0) {
-      this._inputChild.focus();     
+      this._inputChild.focus();
     } else if (index < (this._totalChips - 1)) {
       this._focusChip(index + 1);
     } else if (index > 0) {

--- a/src/platform/core/common/behaviors/control-value-accesor.mixin.ts
+++ b/src/platform/core/common/behaviors/control-value-accesor.mixin.ts
@@ -24,7 +24,7 @@ export interface IHasChangeDetectorRef {
 export function mixinControlValueAccessor<T extends Constructor<IHasChangeDetectorRef>>
                 (base: T, initialValue?: any): Constructor<IControlValueAccessor> & T {
   return class extends base {
-    private _value: any = initialValue;
+    private _value: any = initialValue instanceof Array ? Object.assign([], initialValue) : initialValue;
     private _subjectValueChanges: Subject<any>;
     valueChanges: Observable<any>;
 


### PR DESCRIPTION
## Description

Adds a `compareWith` input function to `<td-chips/>`

Fixes #1071

### What's included?
- Adds a `compareWith` input function
- Updates documentation 
- Adds a demo.

#### Test Steps
- [ ] `npm run serve`
- [ ] Check out the Chips with a custom compareWith function demo 

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
