### PR TITLE
fix(http): remove aot warning compilation

### DIFF
--- a/src/platform/http/http.module.ts
+++ b/src/platform/http/http.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, ModuleWithProviders, Injector, InjectionToken, Provider } from '@angular/core';
 import { HttpClientModule, HttpHandler } from '@angular/common/http';
 
-import { TdHttpService, ITdHttpInterceptorConfig } from './interceptors/http.service';
+import { TdHttpService, TdInterceptorBehaviorService, ITdHttpInterceptorConfig } from './interceptors/http.service';
 import { TdURLRegExpInterceptorMatcher } from './interceptors/url-regexp-interceptor-matcher.class';
 
 export const HTTP_CONFIG: InjectionToken<HttpConfig> = new InjectionToken<HttpConfig>('HTTP_CONFIG');
@@ -9,7 +9,10 @@ export const HTTP_CONFIG: InjectionToken<HttpConfig> = new InjectionToken<HttpCo
 export type HttpConfig = {interceptors: ITdHttpInterceptorConfig[]};
 
 export function httpFactory(handler: HttpHandler, injector: Injector, config: HttpConfig): TdHttpService {
-  return new TdHttpService(handler, injector, new TdURLRegExpInterceptorMatcher(), config.interceptors);
+  return new TdHttpService(
+              handler,
+              new TdInterceptorBehaviorService(injector, new TdURLRegExpInterceptorMatcher(), config.interceptors),
+            );
 }
 
 export const HTTP_INTERCEPTOR_PROVIDER: Provider = {

--- a/src/platform/http/public-api.ts
+++ b/src/platform/http/public-api.ts
@@ -1,6 +1,6 @@
 export * from './http.module';
 export * from './interceptors/url-regexp-interceptor-matcher.class';
-export * from './interceptors/http.service';
+export { ITdHttpInterceptorConfig, TdHttpService } from './interceptors/http.service';
 export * from './interceptors/http-interceptor.interface';
 export * from './interceptors/http-interceptor-matcher.interface';
 export * from './interceptors/http-interceptor-mapping.interface';


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Since the TdHttpService is extending HttpClient, there were AoT issues since @Injectable is added into HttpClient.

#### Test Steps
- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

