### PR TITLE
fix(data-table): atomic sorting icon animation

### DIFF
--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -250,7 +250,7 @@
 <mat-card>
   <mat-card-content>
     <h3 class="mat-title">Atomic Data Table</h3>
-    <h4 class="mat-subheading-2">sorting on a date or firt name column</h4>
+    <h4 class="mat-subheading-2">sorting on a date or first name column</h4>
     <mat-divider></mat-divider>
     <mat-tab-group mat-stretch-tabs>
       <mat-tab>

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -249,6 +249,115 @@
 </mat-card>
 <mat-card>
   <mat-card-content>
+    <h3 class="mat-title">Atomic Data Table</h3>
+    <h4 class="mat-subheading-2">sorting on a date or firt name column</h4>
+    <mat-divider></mat-divider>
+    <mat-tab-group mat-stretch-tabs>
+      <mat-tab>
+        <ng-template matTabLabel>Demo</ng-template>
+        <table td-data-table>
+          <thead>
+            <tr td-data-table-column-row>
+              <th td-data-table-column [name]="'date'"
+                                        [sortable]="true"
+                                        [active]="atomicSortBy == 'date'"
+                                        (sortChange)="sortAtomic($event)"
+                                        [sortOrder]="atomicSortOrder">Date</th>
+              <th td-data-table-column [name]="'first_name'"
+                                        [sortable]="true"
+                                        [active]="atomicSortBy == 'first_name'"
+                                        (sortChange)="sortAtomic($event)"
+                                        [sortOrder]="atomicSortOrder">First Name</th>
+              <th td-data-table-column [name]="'last_name'">Last Name</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr td-data-table-row *ngFor="let item of atomicData">
+              <td td-data-table-cell>{{item.date}}</td>
+              <td td-data-table-cell>{{item.first_name}}</td>
+              <td td-data-table-cell>{{item.last_name}}</td>
+            </tr>
+          </tbody>
+        </table>
+      </mat-tab>
+      <mat-tab>
+        <ng-template matTabLabel>Code</ng-template>
+        <p>HTML:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <table td-data-table>
+              <thead>
+                <tr td-data-table-column-row>
+                  <th td-data-table-column [name]="'date'"
+                                            [sortable]="true"
+                                            [active]="atomicSortBy == 'date'"
+                                            (sortChange)="sortAtomic($event)"
+                                            [sortOrder]="atomicSortOrder">Date</th>
+                  <th td-data-table-column [name]="'first_name'"
+                                            [sortable]="true"
+                                            [active]="atomicSortBy == 'first_name'"
+                                            (sortChange)="sortAtomic($event)"
+                                            [sortOrder]="atomicSortOrder">First Name</th>
+                  <th td-data-table-column [name]="'last_name'">Last Name</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr td-data-table-row *ngFor="let item of atomicData">
+                  <td td-data-table-cell>{ {item.date} }</td>
+                  <td td-data-table-cell>{ {item.first_name} }</td>
+                  <td td-data-table-cell>{ {item.last_name} }</td>
+                </tr>
+              </tbody>
+            </table>
+          ]]>
+        </td-highlight>
+        <p>Typescript:</p>
+        <td-highlight lang="typescript">
+          <![CDATA[
+            export class Demo implements OnInit {
+              atomicData: any[];
+              atomicSortBy: string = 'date';
+              atomicSortOrder: TdDataTableSortingOrder = TdDataTableSortingOrder.Descending;
+
+              sortAtomic(sortEvent: ITdDataTableSortChangeEvent): void {
+                this._sortOrder = this._sortOrder === TdDataTableSortingOrder.Ascending ?
+                  TdDataTableSortingOrder.Descending : TdDataTableSortingOrder.Ascending;
+                this.atomicSortBy = sortEvent.name;
+                this.filterAtomicData();
+              }
+
+              ...
+
+              filterAtomicData(): void {
+                this.atomicData = Array.from(this.atomicData); // Change the array reference to trigger OnPush
+                this.atomicData = this.atomicData.sort((a: any, b: any) => {
+                  let direction: number = 0;
+                  if (this.atomicSortOrder === TdDataTableSortingOrder.Descending) {
+                    direction = 1;
+                  } else if (this.atomicSortOrder === TdDataTableSortingOrder.Ascending) {
+                    direction = -1;
+                  }
+                  if (a[this.atomicSortBy] < b[this.atomicSortBy]) {
+                    return direction;
+                  } else if (a[this.atomicSortBy] > b[this.atomicSortBy]) {
+                    return -direction;
+                  } else {
+                    return direction;
+                  }
+                });
+              }
+            }
+          ]]>
+        </td-highlight>
+        <p>Data:</p>
+        <td-highlight lang="json" [content]="dateSortData | json">
+        </td-highlight>
+      </mat-tab>
+    </mat-tab-group>
+  </mat-card-content>
+</mat-card>
+<mat-card>
+  <mat-card-content>
     <h3 class="mat-title">Data Table with components</h3>
     <h4 class="mat-subheading-2">Paging Bar / Search Box / Sortable components</h4>
     <mat-divider></mat-divider>

--- a/src/app/components/components/data-table/data-table.component.ts
+++ b/src/app/components/components/data-table/data-table.component.ts
@@ -114,6 +114,7 @@ export class DataTableDemoComponent implements OnInit {
   data: any[];
   basicData: any[];
   dateSortData: any[];
+  atomicData: any[];
   selectable: boolean = true;
   clickable: boolean = false;
   multiple: boolean = true;
@@ -131,6 +132,8 @@ export class DataTableDemoComponent implements OnInit {
   sortBy: string = 'first_name';
   sortOrder: TdDataTableSortingOrder = TdDataTableSortingOrder.Descending;
   dateSortOrder: TdDataTableSortingOrder = TdDataTableSortingOrder.Descending;
+  atomicSortBy: string = 'date';
+  atomicSortOrder: TdDataTableSortingOrder = TdDataTableSortingOrder.Descending;
 
   constructor(private _dataTableService: TdDataTableService,
               private _internalDocsService: InternalDocsService,
@@ -158,6 +161,8 @@ export class DataTableDemoComponent implements OnInit {
       row.date = randomDate;
       return row;
     });
+
+    this.atomicData = [].concat(this.dateSortData);
     this.filterDateData();
   }
 
@@ -170,6 +175,13 @@ export class DataTableDemoComponent implements OnInit {
   sortDates(sortEvent: ITdDataTableSortChangeEvent): void {
     this.dateSortOrder = sortEvent.order;
     this.filterDateData();
+  }
+
+  sortAtomic(sortEvent: ITdDataTableSortChangeEvent): void {
+    this.atomicSortOrder = this.atomicSortOrder === TdDataTableSortingOrder.Ascending ?
+      TdDataTableSortingOrder.Descending : TdDataTableSortingOrder.Ascending;
+    this.atomicSortBy = sortEvent.name;
+    this.filterAtomicData();
   }
 
   search(searchTerm: string): void {
@@ -213,6 +225,25 @@ export class DataTableDemoComponent implements OnInit {
       if (a.date < b.date) {
         return direction;
       } else if (a.date > b.date) {
+        return -direction;
+      } else {
+        return direction;
+      }
+    });
+  }
+
+  filterAtomicData(): void {
+    this.atomicData = Array.from(this.atomicData); // Change the array reference to trigger OnPush
+    this.atomicData = this.atomicData.sort((a: any, b: any) => {
+      let direction: number = 0;
+      if (this.atomicSortOrder === TdDataTableSortingOrder.Descending) {
+        direction = 1;
+      } else if (this.atomicSortOrder === TdDataTableSortingOrder.Ascending) {
+        direction = -1;
+      }
+      if (a[this.atomicSortBy] < b[this.atomicSortBy]) {
+        return direction;
+      } else if (a[this.atomicSortBy] > b[this.atomicSortBy]) {
         return -direction;
       } else {
         return direction;

--- a/src/platform/core/data-table/data-table-column/data-table-column.component.html
+++ b/src/platform/core/data-table/data-table-column/data-table-column.component.html
@@ -2,8 +2,8 @@
   <mat-icon 
     class="td-data-table-sort-icon" 
     *ngIf="sortable && numeric"
-    [class.mat-asc]="(!(active) || isAscending())"
-    [class.mat-desc]="(active && isDescending())">
+    [class.mat-asc]="isAscending()"
+    [class.mat-desc]="isDescending()">
     arrow_upward
   </mat-icon>
   <span>
@@ -12,8 +12,8 @@
   <mat-icon 
     class="td-data-table-sort-icon" 
     *ngIf="sortable && !numeric"
-    [class.mat-asc]="(!(active) || isAscending())"
-    [class.mat-desc]="(active && isDescending())">
+    [class.mat-asc]="isAscending()"
+    [class.mat-desc]="isDescending()">
     arrow_upward
   </mat-icon>
 </span>


### PR DESCRIPTION
## Description
Fixed the animation of atomic data table sorting icons by making the 'active' property optional.

This PR closes #532 

### What's included?
- Updated `th[td-data-table-column]` html
- Added new demo on Data Table docs
- Active prop is now optional. It is only used to make the highlight the columns, but the animation works without it

#### Test Steps
- [ ] `npm run serve`
- [ ] Open http://localhost:4200/#/components/data-table
- [ ] Scroll down to `Data Table with custom sort`
- [ ] Sort the date column and check if sorting and animation are still working
- [ ] Scroll down to `Atomic Data Table`
- [ ] Sort the date & first name columns and check if sorting and animation are still working
- [ ] Remove `[active]` input from lines 263 and 268 of file `src/app/components/components/data-table/data-table.component.html`
- [ ] Reload the page
- [ ] Test `Atomic Data Table` demo again
- [ ] The columns won't be highlighted but the animation will still work
- [ ] Check the demo code in the `Code` tab

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
