### PR TITLE
fix(flavored-markdown): Prevent breakage from invalid table

### DIFF
--- a/src/platform/flavored-markdown/flavored-markdown.component.ts
+++ b/src/platform/flavored-markdown/flavored-markdown.component.ts
@@ -202,9 +202,12 @@ export class TdFlavoredMarkdownComponent implements AfterViewInit {
                                                       .map((s: string) => { return s.trim(); });
         let row: any = {};
         columns.forEach((col: string, index: number) => {
-          row[col.toLowerCase().trim()] = rowSplit[index].replace(/`(.*)`/, (m: string, value: string) => {
-            return value;
-          });
+          const rowSplitCell: string = rowSplit[index];
+          if (rowSplitCell) {
+            row[col.toLowerCase().trim()] = rowSplitCell.replace(/`(.*)`/, (m: string, value: string) => {
+              return value;
+            });
+          }
         });
         data.push(row);
       }


### PR DESCRIPTION
## Description

Currently the `code-editor` docs page is broken (stuck in a loop, so careful navigating there). The issue is due to an improperly formatted table in https://github.com/Teradata/covalent-code-editor/blob/develop/docs/API.md 

### What's included?

Checks that the cell is valid so it does not break due to invalid tables.

### TODO

Update the code-editor markdown

#### Test Steps
- [ ] `npm run serve`
- [ ] Check that the `code-editor` docs page render.s

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![localhost_4200_ 3](https://user-images.githubusercontent.com/7193975/50193422-68c7b780-02eb-11e9-992f-b0c8df0912c3.png)
