### PR TITLE
fix(flavored-markdown): Support '-' and '*' as list item symbols.

### DIFF
--- a/src/platform/flavored-markdown/flavored-markdown.component.ts
+++ b/src/platform/flavored-markdown/flavored-markdown.component.ts
@@ -235,14 +235,14 @@ export class TdFlavoredMarkdownComponent implements AfterViewInit {
   }
 
   private _replaceLists(markdown: string): string {
-    let listRegExp: RegExp = /(?:^|\n)(( *\+)[ |\t](.*)\n)+/g;
+    let listRegExp: RegExp = /(?:^|\n)(( *([+-\\*]))[ |\t](.*)\n)+/g;
     return this._replaceComponent(markdown, TdFlavoredListComponent, listRegExp,
       (componentRef: ComponentRef<TdFlavoredListComponent>, match: string) => {
-        let lineTexts: string[] = match.split(new RegExp('\\n {' + (match.indexOf('+') - 1).toString() + '}\\+[ |\\t]'));
+        let lineTexts: string[] = match.split(new RegExp('\\n {' + '0' + '}[+-\\\\*][ |\\t]'));
         lineTexts.shift();
         let lines: IFlavoredListItem[] = [];
         lineTexts.forEach((text: string, index: number) => {
-          let sublineTexts: string[] = text.split(/\n *\+ /);
+          let sublineTexts: string[] = text.split(/\n *[+-\\*] /);
           lines.push({
             line: sublineTexts.shift(),
             sublines: sublineTexts.map((subline: string) => {


### PR DESCRIPTION
## Description

Flavored markdown should also support `-` and `*` as list item symbols. 


#### Test Steps
- [ ] `npm run serve`
- [ ] Edit the flavored-markdown docs page and test out the new supported symbols. 

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
