### PR TITLE
Bug Fix: JSON Formatter property name should not be centered when value is large

### DIFF
--- a/src/platform/core/json-formatter/json-formatter.component.html
+++ b/src/platform/core/json-formatter/json-formatter.component.html
@@ -6,16 +6,14 @@
      (keydown.enter)="toggle()"
      (click)="toggle()">
     <mat-icon class="td-node-icon" *ngIf="hasChildren()">{{open? 'keyboard_arrow_down' : (isRTL ? 'keyboard_arrow_left' : 'keyboard_arrow_right')}}</mat-icon>
-    <div layout="row" layout-align="center start">
-      <span *ngIf="key" class="key">{{key}}:</span>
-      <span class="value">
-        <span [class.td-empty]="!hasChildren()" *ngIf="isObject()" [matTooltip]="getPreview()" matTooltipPosition="after">
-          <span class="td-object-name">{{getObjectName()}}</span>
-          <span class="td-array-length" *ngIf="isArray()">[{{data.length}}]</span>
-        </span>
-        <span *ngIf="!isObject()" [class]="getType(data)">{{getValue(data)}}</span>
-      </span>  
-    </div>
+    <span *ngIf="key" class="key">{{key}}:</span>
+    <span class="value">
+      <span [class.td-empty]="!hasChildren()" *ngIf="isObject()" [matTooltip]="getPreview()" matTooltipPosition="after">
+        <span class="td-object-name">{{getObjectName()}}</span>
+        <span class="td-array-length" *ngIf="isArray()">[{{data.length}}]</span>
+      </span>
+      <span *ngIf="!isObject()" [class]="getType(data)">{{getValue(data)}}</span>
+    </span>
   </a>
   <div class="td-object-children" [@tdCollapse]="!(hasChildren() && open)">
     <ng-template let-key ngFor [ngForOf]="children">

--- a/src/platform/core/json-formatter/json-formatter.component.html
+++ b/src/platform/core/json-formatter/json-formatter.component.html
@@ -6,14 +6,16 @@
      (keydown.enter)="toggle()"
      (click)="toggle()">
     <mat-icon class="td-node-icon" *ngIf="hasChildren()">{{open? 'keyboard_arrow_down' : (isRTL ? 'keyboard_arrow_left' : 'keyboard_arrow_right')}}</mat-icon>
-    <span *ngIf="key" class="key">{{key}}:</span>
-    <span class="value">
-      <span [class.td-empty]="!hasChildren()" *ngIf="isObject()" [matTooltip]="getPreview()" matTooltipPosition="after">
-        <span class="td-object-name">{{getObjectName()}}</span>
-        <span class="td-array-length" *ngIf="isArray()">[{{data.length}}]</span>
-      </span>
-      <span *ngIf="!isObject()" [class]="getType(data)">{{getValue(data)}}</span>
-    </span>
+    <div layout="row" layout-align="center start">
+      <span *ngIf="key" class="key">{{key}}:</span>
+      <span class="value">
+        <span [class.td-empty]="!hasChildren()" *ngIf="isObject()" [matTooltip]="getPreview()" matTooltipPosition="after">
+          <span class="td-object-name">{{getObjectName()}}</span>
+          <span class="td-array-length" *ngIf="isArray()">[{{data.length}}]</span>
+        </span>
+        <span *ngIf="!isObject()" [class]="getType(data)">{{getValue(data)}}</span>
+      </span>  
+    </div>
   </a>
   <div class="td-object-children" [@tdCollapse]="!(hasChildren() && open)">
     <ng-template let-key ngFor [ngForOf]="children">

--- a/src/platform/core/json-formatter/json-formatter.component.scss
+++ b/src/platform/core/json-formatter/json-formatter.component.scss
@@ -11,7 +11,7 @@
     // [layout="row"]
     flex-direction: row;
     // [layout-align="start center"]
-    align-items: center;
+    align-items: flex-start;
     align-content: center;
     max-width: 100%;
     justify-content: start;


### PR DESCRIPTION
## Description
Top aligning key in json formatter if value is large.
Fix for https://github.com/Teradata/covalent/issues/1323

### What's included?
- One
- Two
- Three

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] `Go To JSON Formatter`
- [ ] `Make sure one of key contain a large value`
- [ ] `Key should be top aligned for larger value`

#### General Tests for Every PR

- [X] `npm run serve:prod` still works.
- [X] `npm run tslint` passes.
- [X] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [X] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![image](https://user-images.githubusercontent.com/4894148/50587426-ea9b1180-0ea3-11e9-9e2f-f680d98cc954.png)
