### PR TITLE
fix(tdCollapseAnimation): Set display to none

### DIFF
--- a/src/platform/core/common/animations/collapse/collapse.animation.ts
+++ b/src/platform/core/common/animations/collapse/collapse.animation.ts
@@ -24,21 +24,25 @@ export const tdCollapseAnimation: AnimationTriggerMetadata = trigger('tdCollapse
   state('1', style({
     height: '0',
     overflow: 'hidden',
+    display: 'none',
   })),
   state('0',  style({
     height: AUTO_STYLE,
     overflow: AUTO_STYLE,
+    display: AUTO_STYLE,
   })),
   transition('0 => 1', [
     style({
       overflow: 'hidden',
       height: AUTO_STYLE,
+      display: AUTO_STYLE,
     }),
     group([
       query('@*', animateChild(), { optional: true }),
       animate('{{ duration }}ms {{ delay }}ms {{ ease }}', style({
         height: '0',
         overflow: 'hidden',
+        display: 'none',
       })),
     ]),
   ], { params: { duration: 150, delay: '0', ease: 'ease-in' }}),
@@ -46,12 +50,14 @@ export const tdCollapseAnimation: AnimationTriggerMetadata = trigger('tdCollapse
     style({
       height: '0',
       overflow: 'hidden',
+      display: 'none',
     }),
     group([
       query('@*', animateChild(), { optional: true }),
       animate('{{ duration }}ms {{ delay }}ms {{ ease }}', style({
         overflow: 'hidden',
         height: AUTO_STYLE,
+        display: AUTO_STYLE,
       })),
     ]),
   ], { params: { duration: 150, delay: '0', ease: 'ease-out' }}),


### PR DESCRIPTION
## Description
 
Discovered an issue where horizontal `mat-dividers` inside collapsed expansion-content elements were still visible, even with `height: 0;` and `overflow: hidden;`. I tried using the `inset` directive, but it did not work for all cases. Setting display to none prevents any children with absolute position from being visible.

### What's included?

Adds `display: none` to the collapse animation.

#### Test Steps
- [ ] `npm run serve`
- [ ] Visit the [animations docs](http://localhost:4200/#/components/animations)
- [ ] Check that the animation behaves the same.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

###### Before (Notice the visible horizontal mat-dividers)
![localhost_4200_ 1](https://user-images.githubusercontent.com/7193975/50865390-6260b480-135a-11e9-881d-5225fecb2333.png)

###### After
![localhost_4200_](https://user-images.githubusercontent.com/7193975/50865387-61c81e00-135a-11e9-8bb1-bb7db9d7a549.png)

