### PR TITLE
chore(@covalent/code-editor): Bump to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@angular/platform-browser-dynamic": "7.0.0",
     "@angular/platform-server": "7.0.0",
     "@angular/router": "7.0.0",
-    "@covalent/code-editor": "2.0.0",
+    "@covalent/code-editor": "2.0.3",
     "@covalent/text-editor": "2.0.0",
     "@ngx-translate/core": "11.0.0",
     "@ngx-translate/http-loader": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,9 +211,10 @@
   dependencies:
     tslib "^1.9.0"
 
-"@covalent/code-editor@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@covalent/code-editor/-/code-editor-2.0.0.tgz#64c1364efa4f3cbdb2462d821879d605863f2f60"
+"@covalent/code-editor@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@covalent/code-editor/-/code-editor-2.0.3.tgz#c0b1c29850e0ec657c4263e761d95c4ba78286bd"
+  integrity sha512-5RpbuaZsIBCSAEqAVd9m+i7Nva37iaDyWZEWhoDP1HKAYuMHEWSE9iXE2sJbuM94KmFTbmPKEZQSTmZFIdILAA==
   dependencies:
     monaco-editor "^0.10.1"
     tslib "^1.9.0"


### PR DESCRIPTION
## Description

Bumps @covalent/code-editor to 2.0.3

#### Test Steps
- [ ] `yarn install`
- [ ] Go to http://localhost:4200/#/components/code-editor
- [ ] Make sure it is rendered correctly

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots

Before

![before](https://user-images.githubusercontent.com/7193975/51357967-26be9c80-1a76-11e9-82be-505e848000fe.gif)

After

![after](https://user-images.githubusercontent.com/7193975/51357969-29b98d00-1a76-11e9-8bdf-5df22c7f8b6b.gif)
