### PR TITLE
fix(http): fix injection on aot (again)

### DIFF
--- a/src/platform/http/actions/http.mixin.ts
+++ b/src/platform/http/actions/http.mixin.ts
@@ -1,5 +1,5 @@
 import { Type, Injectable, Injector, ɵReflectionCapabilities, InjectFlags, Optional,
-  SkipSelf, Self, Inject, InjectionToken } from '@angular/core';
+  SkipSelf, Self, Inject, InjectionToken, inject, INJECTOR } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { TdHttpService } from '../interceptors/http.service';
 
@@ -58,6 +58,17 @@ function injectArgs(types: (Type<any>| InjectionToken<any>| any[])[], injector: 
   return args;
 }
 
+export function getInjector(): Injector {
+  try {
+    return inject(INJECTOR);
+  } catch (e) {
+    if (!InternalHttpService._injector) {
+      throw new Error('Please add CovalentHttpModule into your imports.');
+    }
+    return InternalHttpService._injector;
+  }
+}
+
 /** 
  * Mixin to augment a service with http helpers.
  * @internal
@@ -70,11 +81,10 @@ export function mixinHttp(base: any,
    * a way to inject services from the constructor of the underlying service
    * @internal
    */
-  @Injectable()
   abstract class HttpInternalClass extends base {
-    constructor(public _injector: Injector) {
-      super(...injectArgs(new ɵReflectionCapabilities().parameters(base), _injector || InternalHttpService._injector));
-      this._injector = _injector || InternalHttpService._injector;
+    constructor(...args: any) {
+      super(...(args && args.length > 0 ? args : injectArgs(new ɵReflectionCapabilities().parameters(base), getInjector())));
+      this._injector = getInjector();
       this.buildConfig();
     }
     abstract buildConfig(): void;


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Fix constructor service injection for certain usecases (aot)

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
