### PR TITLE
fix(dialog): make sure tdDialogService is not singleton (closes #1327)

### DIFF
--- a/src/platform/core/dialogs/dialogs.module.ts
+++ b/src/platform/core/dialogs/dialogs.module.ts
@@ -12,7 +12,7 @@ import { TdDialogComponent, TdDialogTitleDirective,
 import { TdAlertDialogComponent } from './alert-dialog/alert-dialog.component';
 import { TdConfirmDialogComponent } from './confirm-dialog/confirm-dialog.component';
 import { TdPromptDialogComponent } from './prompt-dialog/prompt-dialog.component';
-import { DIALOG_PROVIDER } from './services/dialog.service';
+import { TdDialogService } from './services/dialog.service';
 
 const TD_DIALOGS: Type<any>[] = [
   TdAlertDialogComponent,
@@ -45,7 +45,7 @@ const TD_DIALOGS_ENTRY_COMPONENTS: Type<any>[] = [
     TD_DIALOGS,
   ],
   providers: [
-    DIALOG_PROVIDER,
+    TdDialogService,
   ],
   entryComponents: [
     TD_DIALOGS_ENTRY_COMPONENTS,

--- a/src/platform/core/dialogs/services/dialog.service.ts
+++ b/src/platform/core/dialogs/services/dialog.service.ts
@@ -141,15 +141,3 @@ export class TdDialogService {
   }
 
 }
-
-export function DIALOG_PROVIDER_FACTORY(
-    parent: TdDialogService, dialog: MatDialog): TdDialogService {
-  return parent || new TdDialogService(dialog);
-}
-
-export const DIALOG_PROVIDER: Provider = {
-  // If there is already service available, use that. Otherwise, provide a new one.
-  provide: TdDialogService,
-  deps: [[new Optional(), new SkipSelf(), TdDialogService], MatDialog],
-  useFactory: DIALOG_PROVIDER_FACTORY,
-};


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Takes care of https://github.com/Teradata/covalent/issues/1327

Remove singleton creation for tdDialogService since we need to have access to the lowest provided matDialog instance.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.