### PR TITLE
fix(): a11y code batch 0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,7 +78,7 @@ After:
 import { HttpInterceptorService, CovalentHttpModule } from '@covalent/http-deprec';
 ```
 
-Our new `http` module has a different usage and uses `@angular/common/http` under the covers. You can find more about it by clicking [here](https://teradata.github.io/covalent/#/components/http).
+Our new `http` module has a different usage and uses `@angular/common/http` under the covers. You can find more about it by clicking [here](https://teradata.github.io/covalent/components/http).
 
 * **animations:** remove deprecated animation functions ([#1297](https://github.com/teradata/covalent/issues/1297)) ([f37ce0c](https://github.com/teradata/covalent/commit/f37ce0c))
 
@@ -96,7 +96,7 @@ After:
 tdCollapseAnimation
 ```
 
-Usage info [here](https://teradata.github.io/covalent/#/components/animations)
+Usage info [here](https://teradata.github.io/covalent/components/animations)
 
 * **expansion-panel:** add multi input, openAll(), and closeAll() ([#1306](https://github.com/teradata/covalent/issues/1306)) ([1521137](https://github.com/teradata/covalent/commit/1521137))
 
@@ -226,7 +226,7 @@ html:
 <div [@tdFadeInOut]="boolean">
 ```
 
-more information about animations [here](https://teradata.github.io/covalent/#/components/animations)
+more information about animations [here](https://teradata.github.io/covalent/components/animations)
 
 ### Bug Fixes
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -129,7 +129,7 @@ This also includes the `material icons` by default.
 
 #### Not interested in using ALL the CSS?
 
-Click [here](https://teradata.github.io/covalent/#/docs/utility-sass-mixins) if you want to cherry pick the utility classes instead of loading the `platform.css`
+Click [here](https://teradata.github.io/covalent/docs/utility-sass-mixins) if you want to cherry pick the utility classes instead of loading the `platform.css`
 
 ----
 

--- a/docs/UTILITY_MIXINS.md
+++ b/docs/UTILITY_MIXINS.md
@@ -29,7 +29,7 @@ $mat-font-url: '../node_modules/@covalent/core/common/styles/font/';
 
 ### Covalent Utilities Mixin
 
-To include [utility classes](https://teradata.github.io/covalent/#/style-guide/utility-styles), add the following:
+To include [utility classes](https://teradata.github.io/covalent/style-guide/utility-styles), add the following:
 
 ```css
 // Include covalent utility classes
@@ -38,7 +38,7 @@ To include [utility classes](https://teradata.github.io/covalent/#/style-guide/u
 
 ### Flex Layout Mixin
 
-To include [flex layout v1](https://teradata.github.io/covalent/#/layouts), add the following:
+To include [flex layout v1](https://teradata.github.io/covalent/layouts), add the following:
 
 ```css
 // Include flex layout classes
@@ -47,7 +47,7 @@ To include [flex layout v1](https://teradata.github.io/covalent/#/layouts), add 
 
 ### Colors Mixin
 
-To include the [color classes](https://teradata.github.io/covalent/#/style-guide/colors), add the following:
+To include the [color classes](https://teradata.github.io/covalent/style-guide/colors), add the following:
 
 ```css
 // Include covalent color classes
@@ -56,7 +56,7 @@ To include the [color classes](https://teradata.github.io/covalent/#/style-guide
 
 ### Example including every single mixin
 
-If you want to include everything, include the following snippet (or just include the `platform.css` as described in the [getting started](http://localhost:4200/#/docs) docs)
+If you want to include everything, include the following snippet (or just include the `platform.css` as described in the [getting started](http://localhost:4200/docs) docs)
 
 ```css
 @import '~@covalent/core/theming/all-theme';

--- a/scripts/a11y/a11y.sh
+++ b/scripts/a11y/a11y.sh
@@ -57,7 +57,7 @@ wait_for $server
 for route in $(cat ${routes});
 do
   route=$(echo $route|tr -d '\n')
-  ./node_modules/.bin/pa11y ${server}/\#/${route};
+  ./node_modules/.bin/pa11y ${server}/${route};
 done
 
 # stop the ng server process.

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -35,6 +35,5 @@ export const appRoutingProviders: any[] = [
 ];
 
 export const appRoutes: any = RouterModule.forRoot(routes, {
-  useHash: true,
   preloadingStrategy: SelectivePreloadingStrategyService,
 });

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -12,7 +12,7 @@
       <a class="push-right text-nodecoration" [routerLink]="['/design-patterns']" [routerLinkActive]="['active']"><span hide-md>Design</span> Patterns</a>
       <a class="push-right text-nodecoration" [routerLink]="['/templates']" [routerLinkActive]="['active']">Templates</a>
     </nav>
-    <a mat-icon-button matTooltip="Github" href="https://github.com/teradata/covalent" target="_blank">
+    <a mat-icon-button matTooltip="Github" href="https://github.com/teradata/covalent" target="_blank" aria-label="Covalent GitHub link">
       <mat-icon svgIcon="assets:github"></mat-icon>
     </a>
     <button class="overflow-visible" mat-icon-button [matMenuTriggerFor]="notificationsMenu">

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/src/platform/core/README.md
+++ b/src/platform/core/README.md
@@ -36,6 +36,6 @@ export class MyModule {}
 
 ## Styles, Icons and Theming
 
-See [theming](https://teradata.github.io/covalent/#/docs/theme) in the covalent docs for more info
+See [theming](https://teradata.github.io/covalent/docs/theme) in the covalent docs for more info
 
 Core Teradata UI Platform comes with a base CSS file `@covalent/core/common/platform.css` (includes icons). 

--- a/src/platform/core/layout/README.md
+++ b/src/platform/core/layout/README.md
@@ -80,7 +80,7 @@ export class MyModule {}
 
 ### Theming
 
-See [theming](https://teradata.github.io/covalent/#/docs/theme) in the covalent docs for more info.
+See [theming](https://teradata.github.io/covalent/docs/theme) in the covalent docs for more info.
 
 
 ## TdNavigationDrawerComponent - td-navigation-drawer

--- a/src/test-bed/test-bed.routes.ts
+++ b/src/test-bed/test-bed.routes.ts
@@ -14,5 +14,4 @@ export const appRoutingProviders: any[] = [
 ];
 
 export const appRoutes: any = RouterModule.forRoot(routes, {
-  useHash: true,
 });


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
This PR merges into a feature branch: `feature/a11y-code-fixes`

Batch-0: Of code related a11y issue fixes reported by pa11y, Jenn is resolving the visual side of a11y/pa11y issues in a different feature branch.

### What's included?
<!-- List features included in this PR -->
- [ ] Problem: pa11y was reporting "G124.NoSuchID" https://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/#sc2_4_1 a11y issue.
       Solution: use recommended PathLocationStrategy — the default "HTML5 pushState" style rather than HashLocationStrategy—the "hash URL" style in Angular routing strategy
- [ ] Change link schema being tested by pa11y
- [ ] No lang set on html for a11y devices
- [ ] Icon link with no info for a11y devices to read from

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] Primarily want code review b/c will take a long time to run `npm run a11y` every batch PR. When all the batches get merged into feature branch - the last batch PR we will run `npm run a11y` and it should not report any issues.
- [ ] Sanity check
  - [ ] `nuke node_modules`
  - [ ] `npm install` (b/c of recent updates - next prs don't have to do this)
  - [ ] `npm run serve`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
