### PR TITLE
feat(highlight) deprecate lang input in favor of codeLang

### DIFF
--- a/src/app/components/components/animations/animations.component.html
+++ b/src/app/components/components/animations/animations.component.html
@@ -7,7 +7,7 @@
 
     <h3>Setup:</h3>
     <p>Import individual animation utilities as needed into the component that will contain the elements you want to animate.</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { tdAnimationUtility_A, tdAnimationUtility_B } from '@covalent/core/common';
 
@@ -45,7 +45,7 @@
       </button>
 
       <p>Typescript:</p>
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         <![CDATA[
           import { tdRotateAnimation } from '@covalent/core/common';
           ...
@@ -59,7 +59,7 @@
         ]]>
       </td-highlight>
       <p>HTML:</p>
-      <td-highlight lang="html">
+      <td-highlight codeLang="html">
         <![CDATA[
           <button mat-raised-button [@tdRotate]="triggerState" (click)="triggerState = !triggerState" color="accent">
             Rotate 180&deg;<mat-icon>mood</mat-icon>
@@ -77,7 +77,7 @@
       </button>
 
       <p>Typescript:</p>
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         <![CDATA[
           import { tdRotateAnimation } from '@covalent/core/common';
           ...
@@ -91,7 +91,7 @@
         ]]>
       </td-highlight>
       <p>HTML:</p>
-      <td-highlight lang="html">
+      <td-highlight codeLang="html">
         <![CDATA[
           <button mat-raised-button [@tdRotate]="{ value: rotateState2, params: { duration: 500, degreesEnd: -45 } }" (click)="triggerState = !triggerState" color="accent">
             Rotate -45&deg;<mat-icon [@tdRotate]="{ value: rotateState2, params: { duration: 750, degreesEnd: 545 } }">mood</mat-icon>
@@ -151,7 +151,7 @@
       </div>
 
       <p>Typescript:</p>
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         <![CDATA[
           import { tdCollapseAnimation } from '@covalent/core/common';
           ...
@@ -165,7 +165,7 @@
         ]]>
       </td-highlight>
       <p>HTML:</p>
-      <td-highlight lang="html">
+      <td-highlight codeLang="html">
         <![CDATA[
           <button mat-raised-button color="accent" (click)="triggerState = !triggerState">Collapse</button>
           <div [style.overflow]="'hidden'" [@tdCollapse]="{ value: triggerState, params: { duration: 500 }}">
@@ -225,7 +225,7 @@
       </div>
 
       <p>Typescript:</p>
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         <![CDATA[
           import { tdFadeInOutAnimation } from '@covalent/core/common';
           ...
@@ -239,7 +239,7 @@
         ]]>
       </td-highlight>
       <p>HTML:</p>
-      <td-highlight lang="html">
+      <td-highlight codeLang="html">
         <![CDATA[
            <button mat-raised-button color="accent" (click)="triggerState = !triggerState">Fade In</button>
             <div [@tdFadeInOut]="triggerState">
@@ -314,7 +314,7 @@
       </button>
 
       <p>Typescript:</p>
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         <![CDATA[
           import {
             tdBounceAnimation,
@@ -342,7 +342,7 @@
         ]]>
       </td-highlight>
       <p>HTML:</p>
-      <td-highlight lang="html">
+      <td-highlight codeLang="html">
         <![CDATA[
           <button mat-raised-button [@tdBounce]="bounceState" (click)="bounceState = !bounceState" color="accent">
             @tdBounce <mat-icon>mood</mat-icon>

--- a/src/app/components/components/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/components/components/breadcrumbs/breadcrumbs.component.html
@@ -27,7 +27,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-breadcrumbs>
               <a td-breadcrumb
@@ -78,7 +78,7 @@
     <mat-tab>
       <ng-template matTabLabel>Code</ng-template>
       <p>HTML:</p>
-      <td-highlight lang="html">
+      <td-highlight codeLang="html">
         <![CDATA[
           <td-breadcrumbs separatorIcon="motorcycle">
             <a td-breadcrumb

--- a/src/app/components/components/chips/chips.component.html
+++ b/src/app/components/components/chips/chips.component.html
@@ -23,7 +23,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-chips [chipAddition]="chipAddition"
                       [chipRemoval]="chipRemoval"
@@ -38,7 +38,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class ChipsDemoComponent {
               disabled: boolean = false;
@@ -143,7 +143,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-chips color="accent"
                       [items]="filteredObjects"
@@ -164,7 +164,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class ChipsDemoComponent {
               objects: any[] = [
@@ -228,7 +228,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-chips [items]="filteredAsync"
                       [debounce]="500"
@@ -245,7 +245,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class ChipsDemoComponent {
               filteringAsync: boolean = false;
@@ -316,7 +316,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-chips [items]="filteredStackedStrings"
                       [(ngModel)]="stackedStringsModel"
@@ -328,7 +328,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class ChipsDemoComponent {
 
@@ -383,13 +383,13 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-chips color="warn" placeholder="Enter any string"></td-chips>
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class ChipsDemoComponent {
 
@@ -420,7 +420,7 @@
         <ng-template matTabLabel>Code</ng-template>
         <mat-card-content>
           <p>HTML:</p>
-          <td-highlight lang="html">
+          <td-highlight codeLang="html">
             <![CDATA[
               <td-chips
                 placeholder="Type here"
@@ -430,7 +430,7 @@
             ]]>
           </td-highlight>
           <p>Typescript:</p>
-          <td-highlight lang="typescript">
+          <td-highlight codeLang="typescript">
             <![CDATA[
               export class ChipsDemoComponent {
                 compareWith: (o1: any, o2: any) => boolean = (o1: any, o2: any) => {
@@ -460,13 +460,13 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
           <td-chips placeholder="Enter any string" required [(ngModel)]="stackedStringsModel"></td-chips>
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class ChipsDemoComponent {
 
@@ -509,7 +509,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-chips [items]="filteredStrings"
                   [(ngModel)]="stringsModel"
@@ -524,7 +524,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class ChipsDemoComponent {
               events: string[] = [];

--- a/src/app/components/components/code-editor/code-editor.component.html
+++ b/src/app/components/components/code-editor/code-editor.component.html
@@ -21,7 +21,7 @@
     </div>
     <p>Editor Output:</p>
     <div layout="row" layout-align="start center">
-      <td-highlight flex [content]="editorVal" [lang]="editorLanguage"></td-highlight>
+      <td-highlight flex [content]="editorVal" [codeLang]="editorLanguage"></td-highlight>
     </div>
   </mat-card-content>
   <mat-divider></mat-divider>

--- a/src/app/components/components/data-table/data-table.component.html
+++ b/src/app/components/components/data-table/data-table.component.html
@@ -38,7 +38,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <table td-data-table>
               <thead>
@@ -68,7 +68,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { ITdDataTableColumn } from '@covalent/core/data-table';
             import { TdDialogService } from '@covalent/core/dialogs';
@@ -103,7 +103,7 @@
           ]]>
         </td-highlight>
         <p>Data:</p>
-        <td-highlight lang="json" [content]="basicData | json">
+        <td-highlight codeLang="json" [content]="basicData | json">
         </td-highlight>
       </mat-tab>
     </mat-tab-group>
@@ -126,7 +126,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-data-table
               [data]="basicData"
@@ -138,7 +138,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { ITdDataTableColumn } from '@covalent/core/data-table';
             ...
@@ -159,7 +159,7 @@
           ]]>
         </td-highlight>
         <p>Data:</p>
-        <td-highlight lang="json" [content]="basicData | json">
+        <td-highlight codeLang="json" [content]="basicData | json">
         </td-highlight>
       </mat-tab>
     </mat-tab-group>
@@ -183,7 +183,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-data-table
               [data]="dateSortData"
@@ -199,7 +199,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { ITdDataTableColumn } from '@covalent/core/data-table';
             ...
@@ -241,7 +241,7 @@
           ]]>
         </td-highlight>
         <p>Data:</p>
-        <td-highlight lang="json" [content]="dateSortData | json">
+        <td-highlight codeLang="json" [content]="dateSortData | json">
         </td-highlight>
       </mat-tab>
     </mat-tab-group>
@@ -283,7 +283,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <table td-data-table>
               <thead>
@@ -312,7 +312,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class Demo implements OnInit {
               atomicData: any[];
@@ -350,7 +350,7 @@
           ]]>
         </td-highlight>
         <p>Data:</p>
-        <td-highlight lang="json" [content]="dateSortData | json">
+        <td-highlight codeLang="json" [content]="dateSortData | json">
         </td-highlight>
       </mat-tab>
     </mat-tab-group>
@@ -397,7 +397,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="row" layout-align="start center" class="pad-left-sm pad-right-sm" [class.mat-selected-title]="selectedRows.length && selectable">
               <span *ngIf="!searchBox.searchVisible" class="push-left-sm">
@@ -411,7 +411,7 @@
               </button>
             </div>
             <mat-divider></mat-divider>
-            <td-data-table 
+            <td-data-table
               #dataTable
               [data]="filteredData"
               [columns]="columns"
@@ -442,7 +442,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { Component, OnInit, HostBinding, ViewChild } from '@angular/core';
 
@@ -514,7 +514,7 @@
               }];
 
               serviceAttrs: Object[] = [{
-                description: `Searches [data] parameter for [searchTerm] matches and returns a new array with them. 
+                description: `Searches [data] parameter for [searchTerm] matches and returns a new array with them.
                               Any column names passed in with [nonSearchAbleColumns] will be excluded in the search.`,
                 name: 'filterData',
                 type: `function(data: any[], searchTerm: string, ignoreCase: boolean, nonSearchAbleColumns: string[])`,
@@ -628,7 +628,7 @@
                 let newData: any[] = this.data;
                 let excludedColumns: string[] = await this.columns
                 .filter((column: ITdDataTableColumn) => {
-                  return ((column.filter === undefined && column.hidden === true) || 
+                  return ((column.filter === undefined && column.hidden === true) ||
                           (column.filter !== undefined && column.filter === false));
                 }).map((column: ITdDataTableColumn) => {
                   return column.name;
@@ -676,7 +676,7 @@
           ]]>
         </td-highlight>
         <p>Data:</p>
-        <td-highlight lang="json" [content]="filteredData | json">
+        <td-highlight codeLang="json" [content]="filteredData | json">
         </td-highlight>
       </mat-tab>
     </mat-tab-group>
@@ -769,7 +769,7 @@
     </mat-list>
     <h3>Example:</h3>
     <p>HTML:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <table td-data-table>
           <thead>

--- a/src/app/components/components/dialogs/dialogs.component.html
+++ b/src/app/components/components/dialogs/dialogs.component.html
@@ -29,7 +29,7 @@
     </mat-list>
     <h3>Example(after setup):</h3>
     <p>Typescript:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { ViewContainerRef } from '@angular/core';
         import { TdDialogService } from '@covalent/core/dialogs';
@@ -93,7 +93,7 @@
     </td-highlight>
     <h3>Setup:</h3>
     <p>Import the [CovalentDialogsModule] in your NgModule:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { CovalentDialogsModule } from '@covalent/core/dialogs';
 

--- a/src/app/components/components/directives/directives.component.html
+++ b/src/app/components/components/directives/directives.component.html
@@ -9,7 +9,7 @@
 
     <h3>Setup:</h3>
     <p>Import the [CovalentCommonModule] in your NgModule:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { CovalentCommonModule } from '@covalent/core/common';
         @NgModule({
@@ -41,7 +41,7 @@
       </mat-form-field>
     </div>
     <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
         <![CDATA[
           <mat-form-field>
             <input matInput tdAutoTrim [(ngModel)]="trim" placeholder="This will be autotrimmed"/>

--- a/src/app/components/components/dynamic-forms/dynamic-forms.component.html
+++ b/src/app/components/components/dynamic-forms/dynamic-forms.component.html
@@ -194,7 +194,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-dynamic-forms [elements]="textElements">
               <ng-template let-element ngFor [ngForOf]="textElements">
@@ -209,7 +209,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           {{textElements | json}}
         </td-highlight>
       </mat-tab>
@@ -237,7 +237,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-dynamic-forms [elements]="numberElements">
               <ng-template let-element ngFor [ngForOf]="numberElements">
@@ -252,7 +252,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           {{numberElements | json}}
         </td-highlight>
       </mat-tab>
@@ -274,14 +274,14 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-dynamic-forms [elements]="booleanElements">
             </td-dynamic-forms>
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           {{booleanElements | json}}
         </td-highlight>
       </mat-tab>
@@ -302,14 +302,14 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-dynamic-forms [elements]="dateElements">
             </td-dynamic-forms>
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           {{dateElements | json}}
         </td-highlight>
       </mat-tab>
@@ -330,14 +330,14 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-dynamic-forms [elements]="arrayElements">
             </td-dynamic-forms>
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           {{arrayElements | json}}
         </td-highlight>
       </mat-tab>
@@ -358,14 +358,14 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-dynamic-forms [elements]="fileElements">
             </td-dynamic-forms>
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           {{fileElements | json}}
         </td-highlight>
       </mat-tab>
@@ -397,7 +397,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-dynamic-forms [elements]="customValidationElements">
               <ng-template let-element ngFor [ngForOf]="customValidationElements">
@@ -414,7 +414,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             customValidationElements: ITdDynamicElementConfig[] = [{
               name: 'evenElement',
@@ -462,7 +462,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-dynamic-forms #customValidateForm [elements]="multipleValidatorTypes">
               <ng-template let-control="control" [tdDynamicFormsError]="'passwordElement'">
@@ -476,7 +476,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             multipleValidatorTypes: ITdDynamicElementConfig[] = [{
               name: 'passwordElement',
@@ -522,7 +522,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-dynamic-forms #customValidateForm [elements]="angularValidators">
               <ng-template let-control="control" tdDynamicFormsError="hexColorElement">
@@ -534,7 +534,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             angularValidators: ITdDynamicElementConfig[] = [{
               name: 'hexColorElement',
@@ -571,7 +571,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-dynamic-forms #manualValidateForm [elements]="manualValidatorElement">
               <ng-template let-control="control" tdDynamicFormsError="vowelsElement">
@@ -592,7 +592,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             manualValidatorElement: ITdDynamicElementConfig[] = [{
               name: 'vowelsElement',
@@ -634,7 +634,7 @@
         <ng-template matTabLabel>Code</ng-template>
         <h4>Setup</h4>
         <p>Custom Component:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { Component, TemplateRef } from '@angular/core';
             import { FormControl } from '@angular/forms';
@@ -666,7 +666,7 @@
           ]]>
         </td-highlight>
         <p>Module imports:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             @NgModule({
               declarations: [
@@ -684,11 +684,11 @@
               ],
             })
             export class ComponentsModule {}
-          ]]>          
+          ]]>
         </td-highlight>
         <h4>Usage:</h4>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-dynamic-forms [elements]="customElements">
               <ng-template let-element ngFor [ngForOf]="customElements">
@@ -702,7 +702,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             customElements: ITdDynamicElementConfig[] = [{
               name: 'custom',

--- a/src/app/components/components/expansion-panel/expansion-panel.component.html
+++ b/src/app/components/components/expansion-panel/expansion-panel.component.html
@@ -28,7 +28,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-expansion-panel label="Label goes here" sublabel="sublabel goes here" [disabled]="disabled">
               <div class="md-padding">
@@ -51,7 +51,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class ExpansionPanelDemoComponent {
               disabled: boolean = false;
@@ -121,7 +121,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-expansion-panel [expand]="true">
               <ng-template td-expansion-panel-label>
@@ -221,7 +221,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-expansion-panel disableRipple>
               <ng-template td-expansion-panel-header>
@@ -300,7 +300,7 @@
         <ng-template matTabLabel>Code</ng-template>
         <mat-card-content>
           <p>HTML:</p>
-          <td-highlight lang="html">
+          <td-highlight codeLang="html">
             <![CDATA[
               <td-expansion-panel-group [multi]="multi" #panelGroup>
                 <td-expansion-panel label="Label goes here">
@@ -322,7 +322,7 @@
             ]]>
           </td-highlight>
           <p>Typescript:</p>
-          <td-highlight lang="typescript">
+          <td-highlight codeLang="typescript">
             <![CDATA[
               export class ExpansionPanelDemoComponent {
                 multi: boolean = false;

--- a/src/app/components/components/file-input/file-input.component.html
+++ b/src/app/components/components/file-input/file-input.component.html
@@ -42,7 +42,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="row">
               <mat-form-field tdFileDrop
@@ -73,7 +73,7 @@
           ]]>
         </td-highlight>
         <p>CSS:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             .drop-zone {
               font-weight: 600;
@@ -84,7 +84,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class Demo {
               files: any;

--- a/src/app/components/components/file-upload/file-upload.component.html
+++ b/src/app/components/components/file-upload/file-upload.component.html
@@ -29,7 +29,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <p>Select Event: { {fileSelectMsg} }</p>
             <p>Upload Event: { {fileUploadMsg} }</p>
@@ -46,7 +46,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class Demo {
               fileSelectMsg: string = 'No file selected yet.';
@@ -107,7 +107,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <p>Select Event: { {fileSelectMultipleMsg} }</p>
             <p>Upload Event: { {fileUploadMultipleMsg} }</p>
@@ -127,7 +127,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class Demo {
               fileSelectMultipleMsg: string = 'No file(s) selected yet.';

--- a/src/app/components/components/flavored-markdown/flavored-markdown.component.html
+++ b/src/app/components/components/flavored-markdown/flavored-markdown.component.html
@@ -33,7 +33,7 @@
       </mat-tab>
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-flavored-markdown>
               ## Checkboxes
@@ -41,9 +41,9 @@
               - [x] My checkbox
               - [x] My second checkbox
               - [ ] My empty checkbox
-    
+
               ## List
-    
+
               + One
                 + subline
               + Two
@@ -88,15 +88,15 @@
       </mat-tab>
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-flavored-markdown>
               ## Inline
-  
+
               Inline piece of code `var obj: Type = bla;`
-  
+
               ## Snippet
-  
+
               ```typescript
                 @Component({
                   selector: 'demo',
@@ -133,7 +133,7 @@
       </mat-tab>
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-flavored-markdown>
               | Tables   |      Are      |  Cool |

--- a/src/app/components/components/highlight/highlight.component.html
+++ b/src/app/components/components/highlight/highlight.component.html
@@ -5,17 +5,17 @@
   <mat-card-content>
      <h3>Example:</h3>
      <p>HTML usage:</p>
-     <td-highlight lang="html">
+     <td-highlight codeLang="html">
       <![CDATA[
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <h1>hello world!</h1>
           <span>{ {property} }</span>
         </td-highlight>
       ]]>
     </td-highlight>
     <p>here's what CSS looks like:</p>
-    <td-highlight lang="css">    
-      <![CDATA[   
+    <td-highlight codeLang="css">
+      <![CDATA[
         pre {
           display: block;
           overflow-x: auto;
@@ -34,7 +34,7 @@
       ]]>
     </td-highlight>
     <p>and TypeScript (javascript):</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { Injectable } from '@angular/core';
         import { Observable, Subject } from 'rxjs';

--- a/src/app/components/components/json-formatter/json-formatter.component.html
+++ b/src/app/components/components/json-formatter/json-formatter.component.html
@@ -10,7 +10,7 @@
       <mat-divider></mat-divider>
     </div>
     <h3 class="mat-title">Original JSON Object:</h3>
-    <td-highlight lang="json">
+    <td-highlight codeLang="json">
       {{data | json}}
     </td-highlight>
   </mat-card-content>

--- a/src/app/components/components/loading/loading.component.html
+++ b/src/app/components/components/loading/loading.component.html
@@ -27,7 +27,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div *tdLoading="'overlayStarSyntax'; mode:'indeterminate'; type:'circle'; strategy:'overlay'; color:'accent'">
               <div layout="row">
@@ -47,7 +47,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { TdLoadingService } from '@covalent/core/loading';
             ...
@@ -106,7 +106,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <ng-template tdLoading="replaceTemplateSyntax" tdLoadingMode="determinate" tdLoadingType="linear" tdLoadingStrategy="replace" tdLoadingColor="warn">
               <div layout="row">
@@ -126,7 +126,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { TdLoadingService } from '@covalent/core/loading';
             ...
@@ -186,7 +186,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <mat-list>
               <ng-template let-item let-last="last" ngFor [ngForOf]="itemList">
@@ -206,7 +206,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             ...
             export class Demo {
@@ -247,7 +247,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div *tdLoading="let items until listObservable | async; type: circle; color: accent">
               <mat-list>
@@ -267,7 +267,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { Observable, Subscriber } from 'rxjs';
             ...
@@ -314,7 +314,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <ng-template tdLoading [tdLoadingUntil]="!loading" tdLoadingStrategy="overlay" tdLoadingType="linear">
               <div layout="row">
@@ -334,7 +334,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             ...
             export class Demo {
@@ -365,7 +365,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="row">
               <button mat-button color="primary" (click)="toggleDefaultFullscreenDemo()" class="text-upper">Toggle Loader</button>
@@ -373,7 +373,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { TdLoadingService } from '@covalent/core/loading';
             ...
@@ -411,7 +411,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="row">
               <button mat-button color="primary" (click)="toggleConfigFullscreenDemo()" class="text-upper">Toggle Loader</button>
@@ -419,7 +419,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { TdLoadingService } from '@covalent/core/loading';
             ...

--- a/src/app/components/components/markdown/markdown.component.html
+++ b/src/app/components/components/markdown/markdown.component.html
@@ -15,7 +15,7 @@
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
         <td-markdown>
-          # Heading (H1) 
+          # Heading (H1)
 
           ## Sub Heading (H2)
 
@@ -38,15 +38,15 @@
       </mat-tab>
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-markdown>
-              # Heading (H1) 
-                    
+              # Heading (H1)
+
               ## Sub Heading (H2)
 
               ### Steps (H3)
-                  
+
               ###List Items
 
               * One
@@ -95,7 +95,7 @@
       </mat-tab>
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-markdown>
               [I'm an inline-style link](https://teradata.github.io/)
@@ -145,7 +145,7 @@
       </mat-tab>
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-markdown>
               `this is an inline code snippet`
@@ -202,7 +202,7 @@
       </mat-tab>
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-markdown>
               > Blockquotes are very handy in email to emulate reply text.
@@ -214,8 +214,8 @@
             </td-markdown>
           ]]>
         </td-highlight>
-        
-        <td-highlight lang="html">
+
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-markdown>
               Three or more...

--- a/src/app/components/components/media/media.component.html
+++ b/src/app/components/components/media/media.component.html
@@ -18,7 +18,7 @@
         </mat-list-item>
         <mat-divider *ngIf="!last"></mat-divider>
       </ng-template>
-    </mat-list>    
+    </mat-list>
   </mat-card-content>
 </mat-card>
 <mat-card>
@@ -28,7 +28,7 @@
   <mat-card-content>
     <h2><code>TdMediaService</code></h2>
     <p>This service is designed to provide basic media query evaluation for responsive applications.</p>
-    <p>It has pre-programmed support for media queries that match the layout 
+    <p>It has pre-programmed support for media queries that match the layout
       <a href="https://material.google.com/layout/responsive-ui.html" target="_blank">breakpoints</a>:
     </p>
     <mat-list>
@@ -53,7 +53,7 @@
     </mat-list>
     <h3>Example:</h3>
     <p>Typescript:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { Component, NgZone, OnInit, OnDestroy } from '@angular/core';
         import { TdMediaService } from '@covalent/core/media';
@@ -64,7 +64,7 @@
           isSmallScreen: boolean = false;
           private _querySubscription: Subscription;
 
-          constructor(private _mediaService: TdMediaService, private _ngZone: NgZone) { 
+          constructor(private _mediaService: TdMediaService, private _ngZone: NgZone) {
           }
 
           checkScreen(): void {
@@ -95,7 +95,7 @@
     <p>A good way of doing it is in the <code>ngOnDestroy</code> component life-cycle hook provided by the [OnDestroy] interface.</p>
     <h3>Setup:</h3>
     <p>Import the [CovalentMediaModule] in your NgModule:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { CovalentMediaModule } from '@covalent/core/media';
         @NgModule({
@@ -130,9 +130,9 @@
     </mat-list>
     <h3>Example:</h3>
     <p>HTML:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
-        <div tdMediaToggle="sm" [mediaClasses]="['classOne', 'classTwo']" 
+        <div tdMediaToggle="sm" [mediaClasses]="['classOne', 'classTwo']"
           [mediaAttributes]="{title: 'tooltip'}" [mediaStyles]="{color: 'red'}">
           ...
         </div>

--- a/src/app/components/components/message/message.component.html
+++ b/src/app/components/components/message/message.component.html
@@ -33,7 +33,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <p class="mat-body-1">Standalone message:</p>
             <td-message label="Error!" sublabel="You did something wrong!" color="warn" icon="error"></td-message>
@@ -93,7 +93,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <p class="mat-body-1">Using <code>color</code>:</p>
             <td-message label="Purple!" sublabel="Simply add color=blah" color="purple" icon="error">

--- a/src/app/components/components/nav-steps/nav-steps.component.html
+++ b/src/app/components/components/nav-steps/nav-steps.component.html
@@ -14,7 +14,7 @@
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>HTML</ng-template>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <nav td-steps horizontal>
               <a td-step-link
@@ -118,7 +118,7 @@
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>HTML</ng-template>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <nav td-steps vertical>
               <a td-step-link

--- a/src/app/components/components/ngx-translate/ngx-translate.component.html
+++ b/src/app/components/components/ngx-translate/ngx-translate.component.html
@@ -40,7 +40,7 @@
       </mat-tab>
       <mat-tab [label]="'CODE_TAB' | translate">
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="column" layout-padding>
               <h3>{ { 'DEMO_BASIC.PIPE_MESSAGE' | translate } }</h3>
@@ -49,7 +49,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { TranslateService } from '@ngx-translate/core';
             ...
@@ -69,7 +69,7 @@
           ]]>
         </td-highlight>
         <p>JSON (en):</p>
-        <td-highlight lang="json">
+        <td-highlight codeLang="json">
           <![CDATA[
             {
               "DEMO_BASIC": {
@@ -80,7 +80,7 @@
           ]]>
         </td-highlight>
         <p>JSON (es):</p>
-        <td-highlight lang="json">
+        <td-highlight codeLang="json">
           <![CDATA[
             {
               "DEMO_BASIC": {
@@ -127,7 +127,7 @@
       </mat-tab>
       <mat-tab [label]="'CODE_TAB' | translate">
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="row" layout-align="start center" layout-padding>
               <mat-form-field flex="40">
@@ -150,7 +150,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { TranslateService } from '@ngx-translate/core';
             ...
@@ -170,7 +170,7 @@
           ]]>
         </td-highlight>
         <p>JSON (en):</p>
-        <td-highlight lang="json">
+        <td-highlight codeLang="json">
           <![CDATA[
             {
               "DEMO_ONE": {
@@ -188,7 +188,7 @@
           ]]>
         </td-highlight>
         <p>JSON (es):</p>
-        <td-highlight lang="json">
+        <td-highlight codeLang="json">
           <![CDATA[
             {
               "DEMO_ONE": {
@@ -238,7 +238,7 @@
       </mat-tab>
       <mat-tab [label]="'CODE_TAB' | translate">
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <mat-list>
               <mat-list-item>
@@ -257,7 +257,7 @@
           ]]>
         </td-highlight>
         <p>Typescript (NgModule):</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { LOCALE_ID } from '@angular/core';
             ...
@@ -269,11 +269,11 @@
                 // Configure LOCALE_ID depending on the language set in browser
                 provide: LOCALE_ID, useFactory: getSelectedLanguage, deps: [TranslateService],
               },
-            ], 
+            ],
           ]]>
         </td-highlight>
         <p>JSON (en):</p>
-        <td-highlight lang="json">
+        <td-highlight codeLang="json">
           <![CDATA[
             {
               "DEMO_TWO": {
@@ -283,7 +283,7 @@
           ]]>
         </td-highlight>
         <p>JSON (es):</p>
-        <td-highlight lang="json">
+        <td-highlight codeLang="json">
           <![CDATA[
             {
               "DEMO_TWO": {
@@ -314,13 +314,13 @@
       </mat-tab>
       <mat-tab [label]="'CODE_TAB' | translate">
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
            <button mat-button color="accent" (click)="openAlert()" class="text-upper">{ {'DEMO_THREE.OPEN_ALERT' | translate} }</button>
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { TranslateService } from '@ngx-translate/core';
             import { TdDialogService } from '@covalent/core/dialogs';
@@ -352,7 +352,7 @@
           ]]>
         </td-highlight>
         <p>JSON (en):</p>
-        <td-highlight lang="json">
+        <td-highlight codeLang="json">
           <![CDATA[
             "DEMO_THREE": {
               "OPEN_ALERT": "Open alert",
@@ -365,7 +365,7 @@
           ]]>
         </td-highlight>
         <p>JSON (es):</p>
-        <td-highlight lang="json">
+        <td-highlight codeLang="json">
           <![CDATA[
             "DEMO_THREE": {
               "OPEN_ALERT": "Abrir alerta",

--- a/src/app/components/components/notifications/notifications.component.html
+++ b/src/app/components/components/notifications/notifications.component.html
@@ -58,7 +58,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <mat-toolbar color="accent">
               <button mat-icon-button>
@@ -141,7 +141,7 @@
           <mat-tab>
             <ng-template matTabLabel>
               <div layout="row" layout-align="center center">
-                Chats 
+                Chats
                 <td-notification-count color="accent" [notifications]="12">
                 </td-notification-count>
               </div>
@@ -152,7 +152,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <mat-tab-group mat-stretch-tabs>
               <mat-tab>
@@ -176,7 +176,7 @@
               <mat-tab>
                 <ng-template matTabLabel>
                   <div layout="row" layout-align="center center">
-                    Chats 
+                    Chats
                     <td-notification-count color="accent" [notifications]="12">
                     </td-notification-count>
                   </div>
@@ -227,7 +227,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <mat-nav-list dense flex>
               <a mat-list-item>

--- a/src/app/components/components/paging/paging.component.html
+++ b/src/app/components/components/paging/paging.component.html
@@ -23,7 +23,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-paging-bar #pagingBar [firstLast]="firstLast" [pageSize]="100" [total]="1345" (change)="change($event)">
               { {pagingBar.range} } of { {pagingBar.total} }
@@ -31,7 +31,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { IPageChangeEvent } from '@covalent/core/paging';
             ...
@@ -91,7 +91,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-paging-bar #pagingBarPageSize [firstLast]="true" [pageSize]="pageSize" [total]="1345" (change)="changePageSize($event)">
               <span hide-xs>Rows per page:</span>
@@ -105,7 +105,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { IPageChangeEvent } from '@covalent/core/paging';
             ...
@@ -149,7 +149,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-paging-bar #pagingBarLinks pageLinkCount="5" [firstLast]="false" [pageSize]="100" [total]="1345" (change)="changeLinks($event)">
               <span hide-xs>{ {pagingBarLinks.range} } of { {pagingBarLinks.total} }</span>
@@ -157,7 +157,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { IPageChangeEvent } from '@covalent/core/paging';
             ...
@@ -211,7 +211,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-paging-bar #pagingBarInput pageLinkCount="5" [firstLast]="false" [pageSize]="100" [total]="1345" (change)="changeInput($event)">
               <p hide-xs>Go to:</p>
@@ -230,7 +230,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { IPageChangeEvent } from '@covalent/core/paging';
             ...
@@ -295,7 +295,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-paging-bar #pagingBarResponsive
                           [pageLinkCount]="(media.registerQuery('md') | async) ? 0 : 5"
@@ -325,7 +325,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { IPageChangeEvent } from '@covalent/core/paging';
             ...

--- a/src/app/components/components/pipes/pipes.component.html
+++ b/src/app/components/components/pipes/pipes.component.html
@@ -9,7 +9,7 @@
 
     <h3>Setup:</h3>
     <p>Import the [CovalentCommonModule] in your NgModule:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { CovalentCommonModule } from '@covalent/core/common';
         @NgModule({
@@ -45,7 +45,7 @@
       </mat-list-item>
     </mat-list>
   <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
         <![CDATA[
           <mat-list>
             <mat-list-item *ngFor="let log of logs">
@@ -78,7 +78,7 @@
       </mat-list-item>
     </mat-list>
   <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
         <![CDATA[
           <mat-list>
             <mat-list-item *ngFor="let log of logs">
@@ -111,7 +111,7 @@
       </mat-list-item>
     </mat-list>
   <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
         <![CDATA[
           <mat-list>
             <mat-list-item *ngFor="let log of logs">
@@ -140,12 +140,12 @@
       </mat-list-item>
     </mat-list>
   <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
         <![CDATA[
           <mat-list>
             <mat-list-item *ngFor="let log of logs">
               <!-- original output -->
-              { { log.timestamp } } | 
+              { { log.timestamp } } |
               <!-- output with timeAgo pipe -->
               { { log.timestamp | timeAgo:reference } } //reference is optional
             </mat-list-item>
@@ -167,12 +167,12 @@
       </mat-list-item>
     </mat-list>
   <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
         <![CDATA[
           <mat-list>
             <mat-list-item *ngFor="let log of logs">
               <!-- original output -->
-              { { log.timestamp } } | 
+              { { log.timestamp } } |
               <!-- output with timeUntil pipe -->
               { { log.timestamp | timeUntil:reference } } //reference is optional
             </mat-list-item>
@@ -199,7 +199,7 @@
     </mat-list>
     <p class="mat-body-1"><strong>Note: </strong> Using this pipe without arguments outputs the time difference relative to the current time. </p>
   <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
         <![CDATA[
           <mat-list>
             <mat-list-item *ngFor="let log of logs">
@@ -230,7 +230,7 @@
       </mat-list-item>
     </mat-list>
     <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
         <![CDATA[
           <mat-list>
             <mat-list-item *ngFor="let log of logs">
@@ -243,7 +243,7 @@
         ]]>
     </td-highlight>
     <p class="mat-body-1"><strong>Note: </strong>  If the last character in a returned output is a space, then that space is removed.</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
         <![CDATA[
           <!-- Both have the same output because -->
           <!-- the space is removed in the last example -->

--- a/src/app/components/components/steps/steps.component.html
+++ b/src/app/components/components/steps/steps.component.html
@@ -43,7 +43,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <td-steps>
               <td-step #step1 label="Basic Usage" sublabel="Toggle between active and inactive and emit events." [active]="true" [disabled]="disabled" (activated)="activeStep1Event()" (deactivated)="deactiveStep1Event()">
@@ -71,7 +71,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { StepState } from '@covalent/core/steps';
             ...
@@ -129,7 +129,7 @@
     </mat-list>
     <h3>Example:</h3>
     <p>HTML:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-steps (stepChange)="change($event)" mode="'vertical'|'horizontal'">
           <td-step>
@@ -140,7 +140,7 @@
       ]]>
     </td-highlight>
     <p>Typescript:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { IStepChangeEvent } from '@covalent/core/steps';
         ...
@@ -154,7 +154,7 @@
     </td-highlight>
     <h3>Setup:</h3>
     <p>Import the [CovalentStepsModule] in your NgModule:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { CovalentStepsModule } from '@covalent/core/steps';
         @NgModule({
@@ -193,7 +193,7 @@
     </mat-list>
     <h3>Example:</h3>
     <p>HTML:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-step #step label="Label" sublabel="Sublabel" [active]="active" [disabled]="disabled" [state]="state" (activated)="activeEvent()" (deactivated)="deactiveEvent()" [disableRipple]="false">
           <ng-template td-step-label>
@@ -211,7 +211,7 @@
       ]]>
     </td-highlight>
     <p>Typescript:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { StepState } from '@covalent/core/steps';
         ...

--- a/src/app/components/components/tab-select/tab-select.component.html
+++ b/src/app/components/components/tab-select/tab-select.component.html
@@ -40,7 +40,7 @@
       <ng-template matTabLabel>Code</ng-template>
       <mat-card-content>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
           <td-tab-select [(ngModel)]="value"
                           backgroundColor="accent"
@@ -63,7 +63,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             export class Demo {
               disabled: boolean = false;

--- a/src/app/components/components/virtual-scroll/virtual-scroll.component.html
+++ b/src/app/components/components/virtual-scroll/virtual-scroll.component.html
@@ -16,7 +16,7 @@
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>HTML</ng-template>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <mat-list>
               <mat-list-item>
@@ -39,14 +39,14 @@
       </mat-tab>
       <mat-tab>
         <ng-template matTabLabel>TS</ng-template>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { Component, OnInit } from '@angular/core';
             ...
             export class Demo implements OnInit {
-            
+
               data: any[] = [];
-            
+
               ngOnInit(): void {
                 for (let index: number = 1; index <= 1500; index++) {
                   this.data.push({index: index, name: 'element-' + index});
@@ -107,7 +107,7 @@
     <mat-tab-group mat-stretch-tabs dynamicHeight>
       <mat-tab>
         <ng-template matTabLabel>HTML</ng-template>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <mat-list>
               <mat-list-item>
@@ -131,7 +131,7 @@
       </mat-tab>
       <mat-tab>
         <ng-template matTabLabel>TS</ng-template>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { Component, OnInit } from '@angular/core';
             import { finalize } from 'rxjs/operators';

--- a/src/app/components/docs/build-tasks/build-tasks.component.html
+++ b/src/app/components/docs/build-tasks/build-tasks.component.html
@@ -8,14 +8,14 @@
      <p>
        First install the CLI
      </p>
-     <td-highlight lang="bash">
+     <td-highlight codeLang="bash">
        npm install -g @angular/cli@latest
      </td-highlight>
      <h4>Local server</h4>
      <p>
        Serve your app locally by navingating to the directory and running:
      </p>
-     <td-highlight lang="bash">
+     <td-highlight codeLang="bash">
        ng serve
      </td-highlight>
      <p>
@@ -25,7 +25,7 @@
      <p>
        You can use the <code>ng generate</code> (or just <code>ng g</code>)
      </p>
-     <td-highlight lang="bash">
+     <td-highlight codeLang="bash">
        ng g component my-new-component
      </td-highlight>
      <p>

--- a/src/app/components/docs/creating/creating.component.html
+++ b/src/app/components/docs/creating/creating.component.html
@@ -5,7 +5,7 @@
   <mat-card-content>
      <h3>Generate Component</h3>
      <p>Using the CLI, nagivate into the directory you want the new component, then simply:</p>
-     <td-highlight lang="html">
+     <td-highlight codeLang="html">
        ng generate component new-view
       </td-highlight>
       <p>The CLI will do the heavy lifting and create the following with corresponding names:</p>
@@ -20,25 +20,25 @@
         It will also attempt to update your app module file. Double check and make sure your new component is imported into app.module.ts:
       </p>
       <p>for example in app.module.ts:</p>
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         <![CDATA[
           import { NewViewComponent } from './new-view/new-view.component';
         ]]>
        </td-highlight>
        <p>And define those declarations/imports in @NgModule:</p>
-       <td-highlight lang="typescript">
+       <td-highlight codeLang="typescript">
          <![CDATA[
           imports: [ NewViewComponent ]
           ]]>
         </td-highlight>
         <p>next we'll need to create a route for this component, edit app.routes.ts:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
           import { NewViewComponent } from './new-view/new-view.component';
           ]]>
        </td-highlight>
        <p>and add a new path with the url you desire for this route:</p>
-       <td-highlight lang="typescript">
+       <td-highlight codeLang="typescript">
          <![CDATA[
           { path: 'new-view', component: NewViewComponent },
         ]]>

--- a/src/app/components/docs/deployment/deployment.component.html
+++ b/src/app/components/docs/deployment/deployment.component.html
@@ -5,14 +5,14 @@
   <mat-card-content>
     <h3>Creating a build</h3>
     <p>The build artifacts will be stored in the dist/ directory.</p>
-   <td-highlight lang="html">
+   <td-highlight codeLang="html">
      ng build
    </td-highlight>
 
     <h3>Building for production</h3>
     <p>Adding the <code>prod</code> flag to <code>ng build</code> will
       set the build target and environment to production, which will optimize the build.</p>
-   <td-highlight lang="html">
+   <td-highlight codeLang="html">
      ng build --prod
    </td-highlight>
 
@@ -22,7 +22,7 @@
       into native Javascript the browser can easily interpret instead of bundling the Angular compiler within
       the application and compiling everything in the browser. This will result in faster rendering,
       fewer asynchronous requests, smaller Angular framework size, and better security for your application.</p>
-   <td-highlight lang="html">
+   <td-highlight codeLang="html">
      ng build --prod --aot
    </td-highlight>
   </mat-card-content>

--- a/src/app/components/docs/icons/icons.component.html
+++ b/src/app/components/docs/icons/icons.component.html
@@ -5,7 +5,7 @@
   <mat-card-content>
     <h3>Font Icons</h3>
     <p>Font icons using ligatures are the default option and simple to use:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
     <![CDATA[ <mat-icon>home</mat-icon> ]]>
     </td-highlight>
     <p>
@@ -14,7 +14,7 @@
     <h3>SVG Icons (from Safe URLS)</h3>
     <p>SVG icons have to be sanitized before they can be used with [DomSanitizer] and then icons need to be registered in [MatIconRegistry] so it can be referred later on:</p>
     <p>Typescript:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
      <![CDATA[
        import { DomSanitizer } from '@angular/platform-browser';
        import { MatIconRegistry } from '@angular/material/icon';
@@ -28,7 +28,7 @@
      ]]>
     </td-highlight>
     <p>HTML:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[ <mat-icon svgIcon="assets:sun"></mat-icon> ]]>
     </td-highlight>
   </mat-card-content>

--- a/src/app/components/docs/mock-data/mock-data.component.html
+++ b/src/app/components/docs/mock-data/mock-data.component.html
@@ -11,13 +11,13 @@
         npm run start-api
       </td-highlight>
       <p>You should see the server running starting with:</p>
-      <td-highlight lang="bash">
-        INFO[0000] ################################################################## 
-        INFO[0000] ########                                                  ######## 
-        INFO[0000] ######## Teradata Covalent Atomic Data mock API server    ######## 
-        INFO[0000] ######## Copyright 2016 by Teradata. All rights reserved. ######## 
-        INFO[0000] ######## This software is covered under the MIT license.  ######## 
-        INFO[0000] ########                                                  ######## 
+      <td-highlight codeLang="bash">
+        INFO[0000] ##################################################################
+        INFO[0000] ########                                                  ########
+        INFO[0000] ######## Teradata Covalent Atomic Data mock API server    ########
+        INFO[0000] ######## Copyright 2016 by Teradata. All rights reserved. ########
+        INFO[0000] ######## This software is covered under the MIT license.  ########
+        INFO[0000] ########                                                  ########
         INFO[0000] ##################################################################
       </td-highlight>
       <p>The server is running as a background process so it's still possible to use the terminal for other commands.  To stop covalent data, type:</p>
@@ -28,7 +28,7 @@
       <h3>Customizing Mock Data Schema</h3>
       <p>You can easily modify or create new schemas for mock data in the <code>/mock-api/schemas/</code> directory.</p>
       <p>For example to modify the mock users , edit <code>mock-api/schemas/users.yaml</code></p>
-      <td-highlight lang="bash">
+      <td-highlight codeLang="bash">
         # this is a sample schema file for a user object.
 
         ---
@@ -45,7 +45,7 @@
       <h3>Modifying Mock Data</h3>
       <p>Dynamic data is wrapped in _underscores_ that match up to text files in <code>/mock-api/datum/</code>.</p>
       <p>For example the <code>_firstname_</code> in the yaml above just looks for <code>/mock-api/datum/firstname.txt</code>, and each value is on a single line:</p>
-      <td-highlight lang="bash">
+      <td-highlight codeLang="bash">
         Aaron
         Benjamin
         Carl
@@ -54,7 +54,7 @@
       </td-highlight>
       <h3>Consuming Mock Data Endpoints</h3>
       <p>The Mock API Server generates real endpoints that can be consumed in Angular services.</p>
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         <![CDATA[
         import { Injectable } from '@angular/core';
 

--- a/src/app/components/docs/testing/testing.component.html
+++ b/src/app/components/docs/testing/testing.component.html
@@ -5,7 +5,7 @@
   <mat-card-content>
     <h3>Install TSLint for TypeScript</h3>
      <p>First ensure you have Protractor and TSLint installed, setup for TypeScript and updated Webdriver</p>
-    <td-highlight lang="bash">
+    <td-highlight codeLang="bash">
       npm install -g tslint typescript
       npm install -g protractor
       webdriver-manager update
@@ -17,7 +17,7 @@
      <p>
       You can run tests a single time via --watch=false, and turn off building of the app via --build=false (useful for running it at the same time as ng serve).
     </p>
-    <td-highlight lang="bash">
+    <td-highlight codeLang="bash">
       ng test
     </td-highlight>
     <h3>Running end-to-end tests</h3>
@@ -27,13 +27,13 @@
       End-to-end tests are ran via Protractor.
     </p>
 
-    <td-highlight lang="bash">
+    <td-highlight codeLang="bash">
       ng e2e
     </td-highlight>
     <h3>Linting and formatting code</h3>
     <p>You can lint your app code by running ng lint. This will use the lint npm script that in generated projects uses tslint.
     </p>
-    <td-highlight lang="bash">
+    <td-highlight codeLang="bash">
       ng lint
     </td-highlight>
   </mat-card-content>

--- a/src/app/components/docs/theme/theme.component.html
+++ b/src/app/components/docs/theme/theme.component.html
@@ -5,7 +5,7 @@
   <mat-card-content>
     <h3>SCSS Variables</h3>
     <p>Simply edit the /theme.scss file and update these SCSS variables:</p>
-    <td-highlight lang="scss">
+    <td-highlight codeLang="scss">
       @import '~@angular/material/theming';
       @import '~@covalent/core/theming/all-theme';
       @import '~@covalent/markdown/markdown-theme';
@@ -63,7 +63,7 @@
     <h3 class="mat-title"><span class="tc-blue-700">Blue Primary</span> / <span class="tc-orange-700">Orange Accent</span></h3>
     <div layout-gt-xs="row" layout-margin>
       <div flex-gt-xs="50" class="pad-top-sm">
-        <td-highlight lang="scss">
+        <td-highlight codeLang="scss">
           .blue-orange {{ '{' }}
               $primary2: mat-palette($mat-blue, 700);
               $accent2:  mat-palette($mat-orange, 800);
@@ -105,7 +105,7 @@
     <h3 class="mat-title"><span class="tc-blue-grey-700">Blue Grey Primary</span> / <span class="tc-deep-orange-700">Deep Orange Accent</span></h3>
     <div layout-gt-xs="row" layout-margin>
       <div flex-gt-xs="50" class="pad-top-sm">
-        <td-highlight lang="scss">
+        <td-highlight codeLang="scss">
           .blue-grey-deep-orange {{ '{' }}
               $primary3: mat-palette($mat-blue-grey);
               $accent3:  mat-palette($mat-deep-orange);
@@ -114,7 +114,7 @@
               $blue-grey-deep-orange: mat-light-theme($primary3, $accent3, $warn3);
 
               @include angular-material-theme($blue-grey-deep-orange);
-              @include covalent-theme($blue-grey-deep-orange); 
+              @include covalent-theme($blue-grey-deep-orange);
           {{ '}' }}
         </td-highlight>
       </div>

--- a/src/app/components/layouts/card-over/card-over.component.html
+++ b/src/app/components/layouts/card-over/card-over.component.html
@@ -9,7 +9,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout-card-over cardTitle="Covalent" cardSubtitle="Card Over Layout Demo">
           Content goes here
@@ -46,7 +46,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout>
           <td-navigation-drawer flex sidenavTitle="Covalent" logo="teradata-dark" name="Firstname Lastname" email="firstname.lastname@company.com">
@@ -136,7 +136,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout>
           <td-navigation-drawer flex sidenavTitle="Covalent" logo="teradata-dark" name="Firstname Lastname" email="firstname.lastname@company.com">
@@ -197,7 +197,7 @@
       ]]>
     </td-highlight>
     <h3 class="mat-title">TypeScript:</h3>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { Component, ChangeDetectionStrategy } from '@angular/core';
 

--- a/src/app/components/layouts/manage-list/manage-list.component.html
+++ b/src/app/components/layouts/manage-list/manage-list.component.html
@@ -14,7 +14,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout-manage-list opened="true" mode="side">
           <mat-toolbar td-sidenav-content></mat-toolbar>
@@ -66,7 +66,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout>
           <td-navigation-drawer flex sidenavTitle="Covalent" logo="teradata-dark" name="Firstname Lastname" email="firstname.lastname@company.com">
@@ -129,7 +129,7 @@
           <a mat-icon-button matTooltip="Docs" href="https://teradata.github.io/covalent/" target="_blank"><mat-icon>chrome_reader_mode</mat-icon></a>
           <a mat-icon-button matTooltip="Github" href="https://github.com/teradata/covalent" target="_blank"><mat-icon svgIcon="assets:github"></mat-icon></a>
         </div>
-        <td-layout-manage-list #manageList 
+        <td-layout-manage-list #manageList
                 [opened]="media.registerQuery('gt-sm') | async"
                 [mode]="(media.registerQuery('gt-sm') | async) ? 'side' :  'over'"
                 [sidenavWidth]="(media.registerQuery('gt-xs') | async) ? '257px' : '100%'">
@@ -229,7 +229,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout>
           <td-navigation-drawer flex sidenavTitle="Covalent" logo="teradata-dark" name="Firstname Lastname" email="firstname.lastname@company.com">
@@ -253,7 +253,7 @@
               <a mat-icon-button matTooltip="Docs" href="https://teradata.github.io/covalent/" target="_blank"><mat-icon>chrome_reader_mode</mat-icon></a>
               <a mat-icon-button matTooltip="Github" href="https://github.com/teradata/covalent" target="_blank"><mat-icon svgIcon="assets:github"></mat-icon></a>
             </div>
-            <td-layout-manage-list #manageList 
+            <td-layout-manage-list #manageList
                     [opened]="media.registerQuery('gt-sm') | async"
                     [mode]="(media.registerQuery('gt-sm') | async) ? 'side' :  'over'"
                     [sidenavWidth]="(media.registerQuery('gt-xs') | async) ? '257px' : '100%'">
@@ -353,7 +353,7 @@
       ]]>
     </td-highlight>
     <h3 class="mat-title">TypeScript:</h3>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { Component, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
         import { TdMediaService } from '@covalent/core/media';

--- a/src/app/components/layouts/nav-list/nav-list.component.html
+++ b/src/app/components/layouts/nav-list/nav-list.component.html
@@ -12,7 +12,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout-nav-list logo="assets:teradata" toolbarTitle="Covalent" navigationRoute="/" opened="true" mode="side">
           <div td-sidenav-content>
@@ -58,7 +58,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout>
           <td-navigation-drawer flex sidenavTitle="Covalent" logo="teradata-dark" name="Firstname Lastname" email="firstname.lastname@company.com">
@@ -165,7 +165,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout>
           <td-navigation-drawer flex sidenavTitle="Covalent" logo="teradata-dark" name="Firstname Lastname" email="firstname.lastname@company.com">
@@ -237,7 +237,7 @@
       ]]>
     </td-highlight>
     <h3 class="mat-title">TypeScript:</h3>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { Component, HostBinding, ChangeDetectionStrategy } from '@angular/core';
         import { TdMediaService } from '@covalent/core/media';

--- a/src/app/components/layouts/nav-view/nav-view.component.html
+++ b/src/app/components/layouts/nav-view/nav-view.component.html
@@ -11,7 +11,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout-nav logo="assets:teradata" toolbarTitle="Covalent" navigationRoute="/">
           Content goes here
@@ -46,7 +46,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout>
           <td-navigation-drawer flex sidenavTitle="Covalent" logo="teradata-dark" name="Firstname Lastname" email="firstname.lastname@company.com">
@@ -169,7 +169,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
       <td-layout>
         <td-navigation-drawer flex sidenavTitle="Covalent" logo="teradata-dark" name="Firstname Lastname" email="firstname.lastname@company.com">
@@ -252,7 +252,7 @@
       ]]>
     </td-highlight>
     <h3 class="mat-title">TypeScript:</h3>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       <![CDATA[
         import { Component, ChangeDetectionStrategy } from '@angular/core';
 

--- a/src/app/components/layouts/overview/overview.component.html
+++ b/src/app/components/layouts/overview/overview.component.html
@@ -1,7 +1,7 @@
 <mat-card>
   <mat-card-title>Layout Options</mat-card-title>
   <mat-card-subtitle>We offer 4 Material Design layouts for you</mat-card-subtitle>
-  <mat-divider></mat-divider> 
+  <mat-divider></mat-divider>
   <mat-card-content hide-xs hide-sm>
     <p>For your entire app or for different sections of your app, select one of these Material Design layout options:</p>
     <div layout="row" layout-padding>
@@ -23,7 +23,7 @@
       </a>
       <mat-divider *ngIf="!last" [inset]="true"></mat-divider>
     </ng-template>
-  </mat-nav-list>  
+  </mat-nav-list>
 </mat-card>
 <td-readme-loader td-after-card resourceUrl="platform/core/layout/README.md"></td-readme-loader>
 <mat-card>
@@ -53,7 +53,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="row">
               <div flex>child</div>
@@ -74,7 +74,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="column">
               <div flex>child</div>
@@ -96,7 +96,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="row" layout-margin>
               <div flex>child</div>
@@ -117,7 +117,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="row" layout-padding>
               <div flex>child</div>
@@ -139,7 +139,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="row" layout-padding>
               <div flex="40">child</div>
@@ -160,7 +160,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="row" layout-padding>
               <div flex-gt-xs="40" flex-md="50">child</div>
@@ -180,7 +180,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout-gt-xs="row">
               <div flex-gt-xs="60">child</div>

--- a/src/app/components/style-guide/colors/colors.component.html
+++ b/src/app/components/style-guide/colors/colors.component.html
@@ -22,7 +22,7 @@
     <mat-tab label="Default Colors">
       <mat-card-content>
         <p>To manually color a background, use our simple bgc utility class:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div class="bgc-green-700">green background</div>
           ]]>
@@ -81,7 +81,7 @@
     <mat-tab label="Dark Colors">
       <mat-card-content>
         <p>To manually color a background, use our simple bgc utility class:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div class="bgc-dark-green-700">dark green background</div>
           ]]>
@@ -127,7 +127,7 @@
     <mat-tab label="Default Colors">
       <mat-card-content>
         <p>To manually color a font color, use our simple tc utility class:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div class="tc-green-700">green font</div>
           ]]>
@@ -187,7 +187,7 @@
     <mat-tab label="Dark Colors">
       <mat-card-content>
         <p>To manually color a font color, use our simple tc utility class:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div class="tc-dark-green-700">dark green font</div>
           ]]>
@@ -234,7 +234,7 @@
       <mat-card-content>
         <p>To manually color a fill or font color (depending if you're using a font icon or SVV icon), use our simple
           tc utility class:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             /* this will be a green font icon */
             <mat-icon class="tc-green-700">palette</mat-icon>
@@ -299,7 +299,7 @@
       <mat-card-content>
         <p>To manually color a fill or font color (depending if you're using a font icon or SVV icon), use our simple
           tc utility class:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             /* this will be a dark green font icon */
             <mat-icon class="tc-dark-green-700">palette</mat-icon>

--- a/src/app/components/style-guide/iconography/iconography.component.html
+++ b/src/app/components/style-guide/iconography/iconography.component.html
@@ -10,7 +10,7 @@
     <p>This entire library of icons is licensed under Creative Common Attribution 4.0 International License (CC-BY 4.0) and can be used within Teradata products with no attribution (the icon library just can't be sold standalone).</p>
     <h3 class="mat-title">Usage</h3>
     <p>Using font icon within the Teradata UI Plaform is extremely simple:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <mat-icon class="tc-green-700">thumb_up</mat-icon>
         <mat-icon>thumb_down</mat-icon>
@@ -21,7 +21,7 @@
     <mat-icon>thumb_down</mat-icon>
   </mat-card-content>
   <mat-divider></mat-divider>
-  <mat-card-actions> 
+  <mat-card-actions>
     <a mat-button color="primary" href="https://design.google.com/icons" target="_blank">
       Material Icons Library
     </a>
@@ -51,7 +51,7 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <![CDATA[
             <div layout="row" layout-align="center center" class="md-padding">
               <td-search-box placeholder="icon search" [alwaysVisible]="true" [showUnderline]="true" (searchDebounce)="query = $event; filter()" flex></td-search-box>
@@ -68,7 +68,7 @@
           ]]>
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           <![CDATA[
             import { IconService } from '../../../../platform/core/common/services/icon.service';
 

--- a/src/app/components/style-guide/logo/logo.component.html
+++ b/src/app/components/style-guide/logo/logo.component.html
@@ -3,9 +3,9 @@
   <mat-divider></mat-divider>
   <mat-card-content>
     <p class="mat-body-1">Your company logo can be implemented with <code>mat-icon</code>.</p>
-    
+
     <p class="mat-body-1">For example:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <mat-icon class="mat-icon-logo" svgIcon="teradata"></mat-icon>
       ]]>
@@ -16,7 +16,7 @@
       <mat-divider></mat-divider>
     </div>
     <td-message class="push-bottom" sublabel="Tip: if you need a custom logo size use this snippet with your logo size in /src/styles.scss" color="light-blue" icon="info"></td-message>
-    <td-highlight lang="css">
+    <td-highlight codeLang="css">
       <![CDATA[
         mat-toolbar .mat-icon.mat-icon-logo { width: 100px; height: 100px; }
       ]]>
@@ -41,7 +41,7 @@
     <div class="pad-top pad-bottom">
       <mat-divider></mat-divider>
     </div>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout-nav logo="teradata" toolbarTitle="App Title">
           <button mat-icon-button td-menu-button tdLayoutToggle>
@@ -80,7 +80,7 @@
     <div class="pad-top pad-bottom">
       <mat-divider></mat-divider>
     </div>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <td-layout>
           <td-navigation-drawer flex logo="teradata-dark" sidenavTitle="App Title" name="Firstname Lastname" email="firstname.lastname@company.com">

--- a/src/app/components/style-guide/product-icons/product-icons.component.html
+++ b/src/app/components/style-guide/product-icons/product-icons.component.html
@@ -34,7 +34,7 @@
     </div>
     <h3 class="mat-title">Usage</h3>
     <p class="mat-body-1">Use the <code>mat-icon</code> component to load an SVG instead of a typing font icon:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <![CDATA[
         <mat-icon svgIcon="appcenter"></mat-icon>
         /* to color an SVG icon use our utility material color fill class */

--- a/src/app/components/style-guide/utility-styles/utility-styles.component.html
+++ b/src/app/components/style-guide/utility-styles/utility-styles.component.html
@@ -9,7 +9,7 @@
 <mat-card>
   <mat-card-title>General Utilities</mat-card-title>
   <mat-card-content>
-    <td-highlight lang="css">
+    <td-highlight codeLang="css">
       .radius-none // no border radius
       .overflow-hidden // hide overflow
       .overflow-auto // normal overflow
@@ -27,7 +27,7 @@
 <mat-card>
   <mat-card-title>Sizing Utilities</mat-card-title>
   <mat-card-content>
-    <td-highlight lang="css">
+    <td-highlight codeLang="css">
       /* Sizing avail in 12 16 24 32 50 64 72 100 128 256 */
       .size-256 // 256 height and width
       .size-height-256 // 256 height and auto width
@@ -38,7 +38,7 @@
 <mat-card>
   <mat-card-title>Text Utilities</mat-card-title>
   <mat-card-content>
-    <td-highlight lang="css">
+    <td-highlight codeLang="css">
       .text-normal // normal font size
       .text-center // text align center
       .text-left // text align left
@@ -67,7 +67,7 @@
     <mat-card>
       <mat-card-title class="mat-subheading-2">Pad (Padding) Utilities</mat-card-title>
       <mat-card-content>
-        <td-highlight lang="css">
+        <td-highlight codeLang="css">
           .pad             // 16px
           .pad-xxl         // 56px
           .pad-xl          // 48px
@@ -120,7 +120,7 @@
     <mat-card>
       <mat-card-title class="mat-subheading-2">Push (Margin) Utilities</mat-card-title>
       <mat-card-content>
-        <td-highlight lang="css">
+        <td-highlight codeLang="css">
           .push             // 16px
           .push-xxl         // 56px
           .push-xl          // 48px
@@ -173,7 +173,7 @@
     <mat-card>
       <mat-card-title class="mat-subheading-2">Pull (Negative Margin) Utilities</mat-card-title>
       <mat-card-content>
-        <td-highlight lang="css">
+        <td-highlight codeLang="css">
           .pull             // 16px
           .pull-xxl         // 56px
           .pull-xl          // 48px

--- a/src/platform/flavored-markdown/flavored-markdown.component.ts
+++ b/src/platform/flavored-markdown/flavored-markdown.component.ts
@@ -160,7 +160,7 @@ export class TdFlavoredMarkdownComponent implements AfterViewInit {
     return this._replaceComponent(markdown, TdHighlightComponent, codeBlockRegExp,
                                   (componentRef: ComponentRef<TdHighlightComponent>, match: string, language: string, codeblock: string) => {
       if (language) {
-        componentRef.instance.language = language;
+        componentRef.instance.codeLang = language;
       }
       componentRef.instance.content = codeblock;
     });

--- a/src/platform/highlight/README.md
+++ b/src/platform/highlight/README.md
@@ -14,7 +14,7 @@ By default, `--dev` build will log the following message in the console to let y
 
 #### Inputs
 
-+ lang: string
++ codeLang: string
   + Language of the code content to be parsed as highlighted html.
 + content: string
   + Code content to be parsed as highlighted html. Used to load data dynamically. e.g. `.ts` content.
@@ -88,9 +88,9 @@ Also, to display model binding, add spaces between curly braces like: `{ { } }` 
 Example for **HTML** usage:
 
 ```html
-<td-highlight lang="html">
+<td-highlight codeLang="html">
   <![CDATA[
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <h1>hello world!</h1>
       <span>{ {property} }</span>
     </td-highlight>
@@ -101,7 +101,7 @@ Example for **HTML** usage:
 Example for **CSS** usage:
 
 ```html
-<td-highlight lang="css">    
+<td-highlight codeLang="css">    
   <![CDATA[   
     pre {
       display: block;
@@ -125,7 +125,7 @@ Example for **CSS** usage:
 Example for **Typescript**:
 
 ```html
-<td-highlight lang="typescript">
+<td-highlight codeLang="typescript">
   <![CDATA[
     import { Injectable } from '@angular/core';
     import { Observable, Subject } from 'rxjs';

--- a/src/platform/highlight/highlight.component.spec.ts
+++ b/src/platform/highlight/highlight.component.spec.ts
@@ -189,9 +189,9 @@ class TdHighlightEmptyStaticTestRenderingComponent {
 }
 
 @Component({
-  template: `<td-highlight lang="html">
+  template: `<td-highlight codeLang="html">
       <![CDATA[
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <h1>hello world!</h1>
           <span>{ {property} }</span>
         </td-highlight>
@@ -203,7 +203,7 @@ class TdHighlightStaticHtmlTestRenderingComponent {
 
 @Component({
   template: `
-    <td-highlight lang="css" [content]="content">
+    <td-highlight codeLang="css" [content]="content">
     </td-highlight>`,
 })
 class TdHighlightDynamicCssTestRenderingComponent {
@@ -212,7 +212,7 @@ class TdHighlightDynamicCssTestRenderingComponent {
 
 @Component({
   template: `
-    <td-highlight [lang]="lang">
+    <td-highlight [codeLang]="lang">
     </td-highlight>`,
 })
 class TdHighlightUndefinedLangTestRenderingComponent {
@@ -230,9 +230,9 @@ class TdHighlightEmptyStaticTestEventsComponent {
 }
 
 @Component({
-  template: `<td-highlight lang="html" (contentReady)="tdHighlightContentIsReady()">
+  template: `<td-highlight codeLang="html" (contentReady)="tdHighlightContentIsReady()">
       <![CDATA[
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           <h1>hello world!</h1>
           <span>{ {property} }</span>
         </td-highlight>
@@ -245,7 +245,7 @@ class TdHighlightStaticHtmlTestEventsComponent {
 
 @Component({
   template: `
-    <td-highlight lang="css" [content]="content" (contentReady)="tdHighlightContentIsReady()">
+    <td-highlight codeLang="css" [content]="content" (contentReady)="tdHighlightContentIsReady()">
     </td-highlight>`,
 })
 class TdHighlightDynamicCssTestEventsComponent {
@@ -255,7 +255,7 @@ class TdHighlightDynamicCssTestEventsComponent {
 
 @Component({
   template: `
-    <td-highlight [lang]="lang" (contentReady)="tdHighlightContentIsReady()">
+    <td-highlight [codeLang]="lang" (contentReady)="tdHighlightContentIsReady()">
     </td-highlight>`,
 })
 class TdHighlightUndefinedLangTestEventsComponent {

--- a/src/platform/highlight/highlight.component.spec.ts
+++ b/src/platform/highlight/highlight.component.spec.ts
@@ -19,7 +19,7 @@ describe('Component: Highlight', () => {
         TdHighlightEmptyStaticTestRenderingComponent,
         TdHighlightStaticHtmlTestRenderingComponent,
         TdHighlightDynamicCssTestRenderingComponent,
-        TdHighlightUndefinedLangTestRenderingComponent,
+        TdHighlightDynamicInputsTestRenderingComponent,
 
         TdHighlightEmptyStaticTestEventsComponent,
         TdHighlightStaticHtmlTestEventsComponent,
@@ -89,12 +89,68 @@ describe('Component: Highlight', () => {
       });
     }));
 
-    it('should throw error for undefined language', async(() => {
-      let fixture: ComponentFixture<any> = TestBed.createComponent(TdHighlightUndefinedLangTestRenderingComponent);
-      let component: TdHighlightUndefinedLangTestRenderingComponent = fixture.debugElement.componentInstance;
-      expect(function(): void {
-        fixture.detectChanges();
-      }).toThrowError();
+    it('should update code when the content input changes', async(async () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdHighlightDynamicInputsTestRenderingComponent);
+      let component: TdHighlightDynamicInputsTestRenderingComponent = fixture.debugElement.componentInstance;
+      const RED_BACKGROUND: string = 'background: red;';
+      const BLUE_BACKGROUND: string = 'background: blue;';
+      component.codeLang = 'css';
+      component.content = `
+        body {
+          ${RED_BACKGROUND}
+        }`;
+      const element: HTMLElement = fixture.debugElement.nativeElement;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(element.textContent).toContain(RED_BACKGROUND);
+      component.content = `
+        body {
+          ${BLUE_BACKGROUND}
+        }`;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(element.textContent).not.toContain(RED_BACKGROUND);
+      expect(element.textContent).toContain(BLUE_BACKGROUND);
+    }));
+
+    it('should update code when the codeLang input changes', async(async () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdHighlightDynamicInputsTestRenderingComponent);
+      let component: TdHighlightDynamicInputsTestRenderingComponent = fixture.debugElement.componentInstance;
+      component.content = `
+        body {
+          background: red;
+        }`;
+      component.codeLang = 'css';
+      let element: HTMLElement = fixture.nativeElement;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(element.querySelectorAll('.hljs-selector-tag').length).toBe(1);
+      expect(element.querySelectorAll('.hljs-attribute').length).toBe(1);
+      component.codeLang = 'typescript';
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(element.querySelectorAll('.hljs-selector-tag').length).toBe(0);
+      expect(element.querySelectorAll('.hljs-attribute').length).toBe(0);
+    }));
+
+    it('should update code when the deprecated lang input changes', async(async () => {
+      let fixture: ComponentFixture<any> = TestBed.createComponent(TdHighlightDynamicInputsTestRenderingComponent);
+      let component: TdHighlightDynamicInputsTestRenderingComponent = fixture.debugElement.componentInstance;
+      component.content = `
+        body {
+          background: red;
+        }`;
+      component.lang = 'css';
+      let element: HTMLElement = fixture.nativeElement;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(element.querySelectorAll('.hljs-selector-tag').length).toBe(1);
+      expect(element.querySelectorAll('.hljs-attribute').length).toBe(1);
+      component.lang = 'typescript';
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(element.querySelectorAll('.hljs-selector-tag').length).toBe(0);
+      expect(element.querySelectorAll('.hljs-attribute').length).toBe(0);
     }));
   });
 
@@ -212,10 +268,16 @@ class TdHighlightDynamicCssTestRenderingComponent {
 
 @Component({
   template: `
-    <td-highlight [codeLang]="lang">
+    <td-highlight
+      [codeLang]="codeLang"
+      [lang]="lang"
+      [content]="content"
+    >
     </td-highlight>`,
 })
-class TdHighlightUndefinedLangTestRenderingComponent {
+class TdHighlightDynamicInputsTestRenderingComponent {
+  content: string;
+  codeLang: string;
   lang: string;
 }
 

--- a/src/platform/highlight/highlight.component.ts
+++ b/src/platform/highlight/highlight.component.ts
@@ -33,14 +33,14 @@ export class TdHighlightComponent implements AfterViewInit {
   }
 
   /**
-   * lang?: string
+   * codeLang?: string
    *
    * Language of the code content to be parsed as highlighted html.
    * Defaults to `typescript`
    *
    * e.g. `typescript`, `html` , etc.
    */
-  @Input('lang') language: string = 'typescript';
+  @Input('codeLang') language: string = 'typescript';
 
   /**
    * contentReady?: function

--- a/src/platform/highlight/highlight.component.ts
+++ b/src/platform/highlight/highlight.component.ts
@@ -15,6 +15,7 @@ export class TdHighlightComponent implements AfterViewInit {
   private _initialized: boolean = false;
 
   private _content: string;
+  private _language: string;
 
   /**
    * content?: string
@@ -28,16 +29,21 @@ export class TdHighlightComponent implements AfterViewInit {
   set content(content: string) {
     this._content = content;
     if (this._initialized) {
-      this._loadContent(this._content);
+      this.refresh();
     }
   }
 
   /**
-   * Deprecated: due to a11y issues reported by pa11y
+   * @deprecated: due to a11y issues reported by pa11y
    * Please see @Input('codeLang') as its replacement
    */
-  @Input('lang') languageDeprecated: string = 'typescript';
-
+  @Input('lang')
+  set lang(deprecatedLang: string) {
+    this._language = deprecatedLang || this._language;
+    if (this._initialized) {
+      this.refresh();
+    }
+  }
   /**
    * codeLang?: string
    *
@@ -46,8 +52,13 @@ export class TdHighlightComponent implements AfterViewInit {
    *
    * e.g. `typescript`, `html` , etc.
    */
-  @Input('codeLang') language: string = this.languageDeprecated;
-
+  @Input('codeLang')
+  set codeLang(codeLang: string) {
+    this._language = codeLang || this._language;
+    if (this._initialized) {
+      this.refresh();
+    }
+  }
   /**
    * contentReady?: function
    * Event emitted after the highlight content rendering is finished.
@@ -59,15 +70,16 @@ export class TdHighlightComponent implements AfterViewInit {
               private _domSanitizer: DomSanitizer) {}
 
   ngAfterViewInit(): void {
-    if (!this.language) {
-      throw new Error('Error: language attribute must be defined in TdHighlightComponent.');
-    }
+    this.refresh();
+    this._initialized = true;
+  }
+
+  private refresh(): void {
     if (!this._content) {
       this._loadContent((<HTMLElement>this._elementRef.nativeElement).textContent);
     } else {
       this._loadContent(this._content);
     }
-    this._initialized = true;
   }
   /**
    * General method to parse a string of code into HTML Elements and load them into the container
@@ -119,7 +131,7 @@ export class TdHighlightComponent implements AfterViewInit {
     .replace(/&lt;/gi, '<').replace(/&gt;/gi, '>');  // replace with < and > to render HTML in Angular
 
     // Parse code with highlight.js depending on language
-    let highlightedCode: any = hljs.highlight(this.language, codeToParse, true);
+    let highlightedCode: any = hljs.highlight(this._language, codeToParse, true);
     highlightedCode.value = highlightedCode.value
       .replace(/=<span class="hljs-value">""<\/span>/gi, '')
       .replace('<head>', '')

--- a/src/platform/highlight/highlight.component.ts
+++ b/src/platform/highlight/highlight.component.ts
@@ -33,6 +33,12 @@ export class TdHighlightComponent implements AfterViewInit {
   }
 
   /**
+   * Deprecated: due to a11y issues reported by pa11y
+   * Please see @Input('codeLang') as its replacement
+   */
+  @Input('lang') languageDeprecated: string = 'typescript';
+
+  /**
    * codeLang?: string
    *
    * Language of the code content to be parsed as highlighted html.
@@ -40,7 +46,7 @@ export class TdHighlightComponent implements AfterViewInit {
    *
    * e.g. `typescript`, `html` , etc.
    */
-  @Input('codeLang') language: string = 'typescript';
+  @Input('codeLang') language: string = this.languageDeprecated;
 
   /**
    * contentReady?: function


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
This PR merges into a feature branch: `feature/a11y-code-fixes`

Batch-1: Of code related a11y issue fixes reported by pa11y, Jenn is resolving the visual side of a11y/pa11y issues in a different feature branch.

### What's included?
<!-- List features included in this PR -->
- [ ] td-highlight language input alias changed from lang to codeLang, depreciate lang input alias

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] Primarily want code review b/c will take a long time to run `npm run a11y` every batch PR. When all the batches get merged into feature branch - the last batch PR we will run `npm run a11y` and it should not report any issues.
- [ ] Sanity check
  - [ ] `npm run serve`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
