### PR TITLE
fix(): a11y visual fixes layout

### DIFF
--- a/src/app/components/layouts/overview/overview.component.html
+++ b/src/app/components/layouts/overview/overview.component.html
@@ -46,9 +46,9 @@
       <div class="md-padding">
         <p>Horizontal row container:</p>
         <div layout="row">
-          <div flex class="bgc-teal-600 tc-teal-50">child</div>
-          <div flex class="bgc-indigo-600 tc-indigo-50">child</div>
-          <div flex class="bgc-purple-600 tc-purple-50">child</div>
+          <div flex class="bgc-teal-700 tc-white">child</div>
+          <div flex class="bgc-indigo-700 tc-white">child</div>
+          <div flex class="bgc-purple-700 tc-white">child</div>
         </div>
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
@@ -67,9 +67,9 @@
         </div>
         <p>Vertical column container:</p>
         <div layout="column">
-          <div flex class="bgc-teal-600 tc-teal-50">child</div>
-          <div flex class="bgc-indigo-600 tc-indigo-50">child</div>
-          <div flex class="bgc-purple-600 tc-purple-50">child</div>
+          <div flex class="bgc-teal-700 tc-white">child</div>
+          <div flex class="bgc-indigo-700 tc-white">child</div>
+          <div flex class="bgc-purple-700 tc-white">child</div>
         </div>
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
@@ -89,9 +89,9 @@
       <div class="md-padding">
         <p>Layout margin</p>
         <div layout="row" layout-margin>
-          <div flex class="bgc-teal-600 tc-teal-50">child</div>
-          <div flex class="bgc-indigo-600 tc-indigo-50">child</div>
-          <div flex class="bgc-purple-600 tc-purple-50">child</div>
+          <div flex class="bgc-teal-700 tc-white">child</div>
+          <div flex class="bgc-indigo-700 tc-white">child</div>
+          <div flex class="bgc-purple-700 tc-white">child</div>
         </div>
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
@@ -110,9 +110,9 @@
         </div>
         <p>Layout padding</p>
         <div layout="row" layout-padding>
-          <div flex class="bgc-teal-600 tc-teal-50">child</div>
-          <div flex class="bgc-indigo-600 tc-indigo-50">child</div>
-          <div flex class="bgc-purple-600 tc-purple-50">child</div>
+          <div flex class="bgc-teal-700 tc-white">child</div>
+          <div flex class="bgc-indigo-700 tc-white">child</div>
+          <div flex class="bgc-purple-700 tc-white">child</div>
         </div>
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
@@ -132,9 +132,9 @@
       <div class="md-padding">
         <p>40/flex/30 (notice how <code>flex</code> fills remaining space):</p>
         <div layout="row" layout-padding>
-          <div flex="40" class="bgc-teal-600 tc-teal-50">child</div>
-          <div flex class="bgc-indigo-600 tc-indigo-50">child</div>
-          <div flex="30" class="bgc-purple-600 tc-purple-50">child</div>
+          <div flex="40" class="bgc-teal-700 tc-white">child</div>
+          <div flex class="bgc-indigo-700 tc-white">child</div>
+          <div flex="30" class="bgc-purple-700 tc-white">child</div>
         </div>
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
@@ -153,9 +153,9 @@
         </div>
         <p>Responsive widths (will change as you resize browser):</p>
         <div layout="row" layout-padding>
-          <div flex-gt-xs="40" flex-md="50" class="bgc-teal-600 tc-teal-50">child</div>
-          <div flex class="bgc-indigo-600 tc-indigo-50">child</div>
-          <div flex-gt-xs="30" flex-md="20" flex-lg="10" class="bgc-purple-600 tc-purple-50">child</div>
+          <div flex-gt-xs="40" flex-md="50" class="bgc-teal-700 tc-white">child</div>
+          <div flex class="bgc-indigo-700 tc-white">child</div>
+          <div flex-gt-xs="30" flex-md="20" flex-lg="10" class="bgc-purple-700 tc-white">child</div>
         </div>
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
@@ -174,8 +174,8 @@
         </div>
         <p>Typical responsive layout (just collapse on xs which is mobile)</p>
         <div layout-gt-xs="row">
-          <div flex-gt-xs="60" class="bgc-teal-600 tc-teal-50">child</div>
-          <div flex-gt-xs="40" class="bgc-purple-600 tc-purple-50">child</div>
+          <div flex-gt-xs="60" class="bgc-teal-700 tc-white">child</div>
+          <div flex-gt-xs="40" class="bgc-purple-700 tc-white">child</div>
         </div>
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>


### PR DESCRIPTION
## Description
- Increase contrast on flexbox demo layout

#### Test Steps
- [ ] `npm run a11y`
- [ ] Expect errors (Steven is working on these code errrors)
- [ ] Verify no contrast related errors (ctrl + f > search contrast) except those already resolved in previous PRs (i.e. theme accent color contrast, top nav contrast, higlight contrast)
- [ ] `npm run serve`
- [ ] Verify design matches screenshots below

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1671" alt="screen shot 2019-03-05 at 4 23 20 pm" src="https://user-images.githubusercontent.com/17860952/53841691-0e8dd880-3f63-11e9-9569-d5980294dbf7.png">
