### PR TITLE
fix(): a11y visual fixes styleguide

### DIFF
--- a/src/app/components/style-guide/colors/colors.component.html
+++ b/src/app/components/style-guide/colors/colors.component.html
@@ -3,7 +3,8 @@
   <mat-divider></mat-divider>
   <mat-card-content>
     <p>
-      Color in material design is inspired by bold hues juxtaposed with muted environments, deep shadows, and bright highlights.
+      Color in material design is inspired by bold hues juxtaposed with muted environments, deep shadows, and bright
+      highlights.
     </p>
     <p>
       Covalent comes with CSS utility styles for background, type and SVG fill colors.
@@ -11,12 +12,12 @@
   </mat-card-content>
   <mat-divider></mat-divider>
   <mat-card-actions>
-    <a mat-button color="primary" href="https://material.io/guidelines/style/color.html" target="_blank" class="text-upper">Color Spec</a>
+    <a mat-button color="primary" href="https://material.io/guidelines/style/color.html" target="_blank" class="text-upper">Color
+      Spec</a>
   </mat-card-actions>
 </mat-card>
-
 <mat-card>
-  <mat-card-title>Background Color Utilities</mat-card-title>
+  <mat-card-title>Color Utilities</mat-card-title>
   <mat-divider></mat-divider>
   <mat-tab-group mat-stretch-tabs>
     <mat-tab label="Default Colors">
@@ -27,53 +28,95 @@
             <div class="bgc-green-700">green background</div>
           ]]>
         </td-highlight>
-        <p>choose from any of the material colors, in hues from 50, 100, 200, 300, 400, 500, 600, 700, 800, 900 (and A100, A200, A400, A700 for all except brown, grey &amp; blue-grey)</p>
-        <div layout-gt-sm="row" layout-wrap>
-          <div flex-gt-sm="20" *ngFor="let color of colors">
-            <mat-card>
-              <div class="mat-caption pad-xs">class="bgc-{{color}}-"</div>
-              <div class="tc-grey-800">
-                <div class="bgc-{{color}}-50 pad-xs">50</div>
-                <div class="bgc-{{color}}-100 pad-xs">100</div>
-                <div class="bgc-{{color}}-200 pad-xs">200</div>
-                <div class="bgc-{{color}}-300 pad-xs">300</div>
-              </div>
-              <div class="tc-{{color}}-50">
-                <div class="bgc-{{color}}-400 pad-xs">400</div>
-                <div class="bgc-{{color}}-500 pad-xs">500</div>
-                <div class="bgc-{{color}}-600 pad-xs">600</div>
-                <div class="bgc-{{color}}-700 pad-xs">700</div>
-                <div class="bgc-{{color}}-800 pad-xs">800</div>
-                <div class="bgc-{{color}}-900 pad-xs">900</div>
-              </div>
-              <div class="tc-grey-800">
-                <div class="bgc-{{color}}-A100 pad-xs">A100</div>
-              </div>
-              <div class="tc-{{color}}-50">
-                <div class="bgc-{{color}}-A200 pad-xs">A200</div>
-                <div class="bgc-{{color}}-A400 pad-xs">A400</div>
-                <div class="bgc-{{color}}-A700 pad-xs">A700</div>
-              </div>
-            </mat-card>
+        <p>To manually color text, use our simple tc utility class:</p>
+        <td-highlight lang="html">
+          <![CDATA[
+            <div class="tc-green-700">green font</div>
+          ]]>
+        </td-highlight>
+        <p>choose from any of the material colors, in hues from 50, 100, 200, 300, 400, 500, 600, 700, 800, 900 (and
+          A100, A200, A400, A700 for all except brown, grey &amp; blue-grey)</p>
+        <div layout="row" class="text-center text-sm">
+          <div flex="10"></div>
+          <div flex>50</div>
+          <div flex>100</div>
+          <div flex>200</div>
+          <div flex>300</div>
+          <div flex>400</div>
+          <div flex>500</div>
+          <div flex>600</div>
+          <div flex>700</div>
+          <div flex>800</div>
+          <div flex>900</div>
+          <div flex>A100</div>
+          <div flex>A200</div>
+          <div flex>A400</div>
+          <div flex>A700</div>
+        </div>
+        <div flex *ngFor="let color of colors" class="text-sm">
+          <div layout="row">
+            <div class="text-right pad-right pad-bottom-xs pad-top-xs" flex="10">{{color}}</div>
+            <div class="bgc-{{color}}-50 pad-xs" flex matTooltip="{{color}}-50" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-100 pad-xs" flex matTooltip="{{color}}-100" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-200 pad-xs" flex matTooltip="{{color}}-200" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-300 pad-xs" flex matTooltip="{{color}}-300" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-400 pad-xs" flex matTooltip="{{color}}-400" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-500 pad-xs" flex matTooltip="{{color}}-500" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-600 pad-xs" flex matTooltip="{{color}}-600" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-700 pad-xs" flex matTooltip="{{color}}-700" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-800 pad-xs" flex matTooltip="{{color}}-800" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-900 pad-xs" flex matTooltip="{{color}}-900" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-A100 pad-xs" flex matTooltip="{{color}}-A100" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-A200 pad-xs" flex matTooltip="{{color}}-A200" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-A400 pad-xs" flex matTooltip="{{color}}-A400" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-A700 pad-xs" flex matTooltip="{{color}}-A700" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
           </div>
-          <div flex-gt-sm="20" *ngFor="let color of neutrals">
-            <mat-card>
-              <div class="mat-caption pad-xs">class="bgc-{{color}}-"</div>
-              <div class="tc-grey-800">
-                <div class="bgc-{{color}}-50 pad-xs">50</div>
-                <div class="bgc-{{color}}-100 pad-xs">100</div>
-                <div class="bgc-{{color}}-200 pad-xs">200</div>
-                <div class="bgc-{{color}}-300 pad-xs">300</div>
-              </div>
-              <div class="tc-{{color}}-50">
-                <div class="bgc-{{color}}-400 pad-xs">400</div>
-                <div class="bgc-{{color}}-500 pad-xs">500</div>
-                <div class="bgc-{{color}}-600 pad-xs">600</div>
-                <div class="bgc-{{color}}-700 pad-xs">700</div>
-                <div class="bgc-{{color}}-800 pad-xs">800</div>
-                <div class="bgc-{{color}}-900 pad-xs">900</div>
-              </div>
-            </mat-card>
+        </div>
+        <div flex *ngFor="let color of neutrals" class="text-sm">
+          <div layout="row">
+            <div class="text-right pad-right pad-bottom-xs pad-top-xs" flex="10">{{color}}</div>
+            <div class="bgc-{{color}}-50 pad-xs" flex matTooltip="{{color}}-50" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-100 pad-xs" flex matTooltip="{{color}}-100" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-200 pad-xs" flex matTooltip="{{color}}-200" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-300 pad-xs" flex matTooltip="{{color}}-300" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-400 pad-xs" flex matTooltip="{{color}}-400" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-500 pad-xs" flex matTooltip="{{color}}-500" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-600 pad-xs" flex matTooltip="{{color}}-600" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-700 pad-xs" flex matTooltip="{{color}}-700" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-800 pad-xs" flex matTooltip="{{color}}-800" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-900 pad-xs" flex matTooltip="{{color}}-900" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-A100 pad-xs" flex matTooltip="{{color}}-A100" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-A200 pad-xs" flex matTooltip="{{color}}-A200" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-A400 pad-xs" flex matTooltip="{{color}}-A400" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-{{color}}-A700 pad-xs" flex matTooltip="{{color}}-A700" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
           </div>
         </div>
       </mat-card-content>
@@ -86,146 +129,61 @@
             <div class="bgc-dark-green-700">dark green background</div>
           ]]>
         </td-highlight>
-        <p>choose from any of the dark material colors, in hues from 500, B100, B65, B40, B30 &amp; B15</p>
-        <div layout-gt-sm="row" layout-wrap>
-          <div flex-gt-sm="25" *ngFor="let color of colors">
-            <mat-card>
-              <div class="mat-caption pad-xs">class="bgc-dark-{{color}}-"</div>
-              <div class="tc-white">
-                <div class="bgc-dark-{{color}}-500 pad-xs">500</div>
-                <div class="bgc-dark-{{color}}-B100 pad-xs tc-black">B100</div>
-                <div class="bgc-dark-{{color}}-B65 pad-xs">B65</div>
-                <div class="bgc-dark-{{color}}-B40 pad-xs">B40</div>
-                <div class="bgc-dark-{{color}}-B30 pad-xs">B30</div>
-                <div class="bgc-dark-{{color}}-B15 pad-xs">B15</div>
-              </div>
-            </mat-card>
-          </div>
-          <div flex-gt-sm="25" *ngFor="let color of neutrals">
-            <mat-card>
-              <div class="mat-caption pad-xs">class="bgc-dark-{{color}}-"</div>
-              <div class="tc-white">
-                <div class="bgc-dark-{{color}}-500 pad-xs">500</div>
-                <div class="bgc-dark-{{color}}-B100 pad-xs tc-black">B100</div>
-                <div class="bgc-dark-{{color}}-B65 pad-xs">B65</div>
-                <div class="bgc-dark-{{color}}-B40 pad-xs">B40</div>
-                <div class="bgc-dark-{{color}}-B30 pad-xs">B30</div>
-                <div class="bgc-dark-{{color}}-B15 pad-xs">B15</div>
-              </div>
-            </mat-card>
-          </div>
-        </div>
-      </mat-card-content>
-    </mat-tab>
-  </mat-tab-group>
-</mat-card>
 
-<mat-card>
-  <mat-card-title>CSS Font Colors</mat-card-title>
-  <mat-divider></mat-divider>
-  <mat-tab-group mat-stretch-tabs>
-    <mat-tab label="Default Colors">
-      <mat-card-content>
-        <p>To manually color a font color, use our simple tc utility class:</p>
-        <td-highlight lang="html">
-          <![CDATA[
-            <div class="tc-green-700">green font</div>
-          ]]>
-        </td-highlight>
-        <p>choose from any of the material colors, in hues from 50, 100, 200, 300, 400, 500, 600, 700, 800, 900 (and
-          A100, A200, A400, A700 for all except brown, grey &amp; blue-grey)</p>
-        <div layout-gt-sm="row" layout-wrap>
-          <div flex-gt-sm="20" *ngFor="let color of colors">
-            <mat-card>
-              <div class="mat-caption pad-xs">class="tc-{{color}}-"</div>
-              <div class="bgc-grey-800">
-                <div class="tc-{{color}}-50 pad-xs">50</div>
-                <div class="tc-{{color}}-100 pad-xs">100</div>
-                <div class="tc-{{color}}-200 pad-xs">200</div>
-                <div class="tc-{{color}}-300 pad-xs">300</div>
-                <div class="tc-{{color}}-400 pad-xs">400</div>
-              </div>
-              <div class="bgc-{{color}}-50">
-                <div class="tc-{{color}}-500 pad-xs">500</div>
-                <div class="tc-{{color}}-600 pad-xs">600</div>
-                <div class="tc-{{color}}-700 pad-xs">700</div>
-                <div class="tc-{{color}}-800 pad-xs">800</div>
-                <div class="tc-{{color}}-900 pad-xs">900</div>
-              </div>
-              <div class="bgc-grey-800">
-                <div class="tc-{{color}}-A100 pad-xs">A100</div>
-                <div class="tc-{{color}}-A200 pad-xs">A200</div>
-              </div>
-              <div class="bgc-{{color}}-50">
-                <div class="tc-{{color}}-A400 pad-xs">A400</div>
-                <div class="tc-{{color}}-A700 pad-xs">A700</div>
-              </div>
-            </mat-card>
-          </div>
-          <div flex-gt-sm="20" *ngFor="let color of neutrals">
-            <mat-card>
-              <div class="mat-caption pad-xs">class="tc-{{color}}-"</div>
-              <div class="bgc-grey-800">
-                <div class="tc-{{color}}-50 pad-xs">50</div>
-                <div class="tc-{{color}}-100 pad-xs">100</div>
-                <div class="tc-{{color}}-200 pad-xs">200</div>
-                <div class="tc-{{color}}-300 pad-xs">300</div>
-                <div class="tc-{{color}}-400 pad-xs">400</div>
-              </div>
-              <div class="bgc-{{color}}-50">
-                <div class="tc-{{color}}-500 pad-xs">500</div>
-                <div class="tc-{{color}}-600 pad-xs">600</div>
-                <div class="tc-{{color}}-700 pad-xs">700</div>
-                <div class="tc-{{color}}-800 pad-xs">800</div>
-                <div class="tc-{{color}}-900 pad-xs">900</div>
-              </div>
-            </mat-card>
-          </div>
-        </div>
-      </mat-card-content>
-    </mat-tab>
-    <mat-tab label="Dark Colors">
-      <mat-card-content>
-        <p>To manually color a font color, use our simple tc utility class:</p>
+        <p>To manually color text, use our simple bgc utility class:</p>
         <td-highlight lang="html">
           <![CDATA[
             <div class="tc-dark-green-700">dark green font</div>
           ]]>
         </td-highlight>
         <p>choose from any of the dark material colors, in hues from 500, B100, B65, B40, B30 &amp; B15</p>
-        <div layout-gt-sm="row" layout-wrap>
-          <div flex-gt-sm="20" *ngFor="let color of colors">
-            <mat-card>
-              <div class="mat-caption pad-xs">class="tc-dark-{{color}}-"</div>
-              <div class="bgc-{{color}}-100">
-                <div class="tc-dark-{{color}}-500 pad-xs">500</div>
-                <div class="tc-dark-{{color}}-B100 pad-xs">B100</div>
-                <div class="tc-dark-{{color}}-B65 pad-xs">B65</div>
-                <div class="tc-dark-{{color}}-B40 pad-xs">B40</div>
-                <div class="tc-dark-{{color}}-B30 pad-xs">B30</div>
-                <div class="tc-dark-{{color}}-B15 pad-xs">B15</div>
-              </div>
-            </mat-card>
+        <div layout="row" class="text-center text-sm">
+          <div flex="10"></div>
+          <div flex>500</div>
+          <div flex>B100</div>
+          <div flex>B65</div>
+          <div flex>B40</div>
+          <div flex>B30</div>
+          <div flex>B15</div>
+        </div>
+        <div flex *ngFor="let color of colors" class="text-sm">
+          <div layout="row">
+            <div class="text-right pad-right pad-bottom-xs pad-top-xs" flex="10">dark-{{color}}</div>
+            <div class="bgc-dark-{{color}}-500 pad-xs" flex matTooltip="dark-{{color}}-500" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-dark-{{color}}-B100 pad-xs" flex matTooltip="dark-{{color}}-B100" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-dark-{{color}}-B65 pad-xs" flex matTooltip="dark-{{color}}-B65" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-dark-{{color}}-B40 pad-xs" flex matTooltip="dark-{{color}}-B40" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-dark-{{color}}-B30 pad-xs" flex matTooltip="dark-{{color}}-B30" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-dark-{{color}}-B15 pad-xs" flex matTooltip="dark-{{color}}-B15" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
           </div>
-          <div flex-gt-sm="20" *ngFor="let color of neutrals">
-            <mat-card>
-              <div class="mat-caption pad-xs">class="tc-dark-{{color}}-"</div>
-              <div class="bgc-{{color}}-100">
-                <div class="tc-dark-{{color}}-500 pad-xs">500</div>
-                <div class="tc-dark-{{color}}-B100 pad-xs">B100</div>
-                <div class="tc-dark-{{color}}-B65 pad-xs">B65</div>
-                <div class="tc-dark-{{color}}-B40 pad-xs">B40</div>
-                <div class="tc-dark-{{color}}-B30 pad-xs">B30</div>
-                <div class="tc-dark-{{color}}-B15 pad-xs">B15</div>
-              </div>
-            </mat-card>
+        </div>
+        <div flex *ngFor="let color of neutrals" class="text-sm">
+          <div layout="row">
+            <div class="text-right pad-right pad-bottom-xs pad-top-xs" flex="10">{{color}}</div>
+            <div class="bgc-dark-{{color}}-500 pad-xs" flex matTooltip="dark-{{color}}-500" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-dark-{{color}}-B100 pad-xs" flex matTooltip="dark-{{color}}-B100" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-dark-{{color}}-B65 pad-xs" flex matTooltip="dark-{{color}}-B65" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-dark-{{color}}-B40 pad-xs" flex matTooltip="dark-{{color}}-B40" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-dark-{{color}}-B30 pad-xs" flex matTooltip="dark-{{color}}-B30" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
+            <div class="bgc-dark-{{color}}-B15 pad-xs" flex matTooltip="dark-{{color}}-B15" matTooltipPosition="right"
+              matTooltipDeplay="500"></div>
           </div>
         </div>
       </mat-card-content>
     </mat-tab>
   </mat-tab-group>
 </mat-card>
-
 <mat-card>
   <mat-card-title>Icon (Font or SVG) Colors</mat-card-title>
   <mat-divider></mat-divider>
@@ -356,7 +314,8 @@
       <span matLine>Material Design Colors</span>
     </a>
     <mat-divider></mat-divider>
-    <a mat-list-item href="https://www.google.com/design/spec-wear/style/color.html#color-dark-color-palette-for-wear" target="_blank">
+    <a mat-list-item href="https://www.google.com/design/spec-wear/style/color.html#color-dark-color-palette-for-wear"
+      target="_blank">
       <mat-icon>launch</mat-icon>
       <span matLine>Material Design Dark Color Palette</span>
     </a>

--- a/src/app/components/style-guide/logo/logo.component.html
+++ b/src/app/components/style-guide/logo/logo.component.html
@@ -15,7 +15,7 @@
     <div class="pad-top pad-bottom">
       <mat-divider></mat-divider>
     </div>
-    <td-message class="push-bottom" sublabel="Tip: if you need a custom logo size use this snippet with your logo size in /src/styles.scss" color="light-blue" icon="info"></td-message>
+    <td-message class="push-bottom" sublabel="Tip: if you need a custom logo size use this snippet with your logo size in /src/styles.scss" color="accent" icon="info"></td-message>
     <td-highlight lang="css">
       <![CDATA[
         mat-toolbar .mat-icon.mat-icon-logo { width: 100px; height: 100px; }
@@ -70,7 +70,7 @@
           </div>
         </td-navigation-drawer>
         <div td-sidenav-content class="td-layout-footer pad">
-          <span class="mat-caption tc-grey-500">&copy;{{year}} Teradata. All Rights Reserved</span>
+          <span class="mat-caption tc-grey-700">&copy;{{year}} Teradata. All Rights Reserved</span>
         </div>
         <div class="pad">
           main content
@@ -87,7 +87,7 @@
             sidenav content
           </td-navigation-drawer>
           <div td-sidenav-content class="td-layout-footer pad">
-            <span class="mat-caption tc-grey-500">&copy;{ {year} } Teradata. All Rights Reserved</span>
+            <span class="mat-caption tc-grey-700">&copy;{ {year} } Teradata. All Rights Reserved</span>
           </div>
           main content
         </td-layout>


### PR DESCRIPTION
## Description
Rework layout for color demo to avoid text on top of colored background to improve usability and resolve a11y errors.  

### What's included?
- Combine background and font color demos into single, simple grid of available colors with tooltip

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR
- [ ] `npm run serve`
- [ ] Verify design matches screenshots below

##### Screenshots or link to StackBlitz/Plunker
Before
<img width="957" alt="Screen Shot 2019-03-20 at 11 06 49 AM" src="https://user-images.githubusercontent.com/17860952/54700185-7cf49e00-4b00-11e9-9fcd-e41bbd12c82d.png">


After
<img width="961" alt="Screen Shot 2019-03-20 at 11 06 23 AM" src="https://user-images.githubusercontent.com/17860952/54700192-80882500-4b00-11e9-8451-4d1d7999cb9c.png">

