### PR TITLE
fix(usability-bug): style updates to the last breadcrumb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5761,8 +5761,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5780,13 +5779,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5799,18 +5796,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5913,8 +5907,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5924,7 +5917,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5937,20 +5929,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5967,7 +5956,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6040,8 +6028,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6051,7 +6038,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6127,8 +6113,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6158,7 +6143,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6176,7 +6160,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6215,13 +6198,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/platform/core/breadcrumbs/_breadcrumbs-theme.scss
+++ b/src/platform/core/breadcrumbs/_breadcrumbs-theme.scss
@@ -3,7 +3,6 @@
 
   td-breadcrumb {
     &:last-of-type {
-      color: mat-color($foreground, text);
       font-weight: bold;
       cursor: default;
     }

--- a/src/platform/core/breadcrumbs/_breadcrumbs-theme.scss
+++ b/src/platform/core/breadcrumbs/_breadcrumbs-theme.scss
@@ -1,10 +1,10 @@
-
 @mixin td-breadcrumbs-theme($theme) {
   $foreground: map-get($theme, foreground);
 
   td-breadcrumb {
     &:last-of-type {
-      color: mat-color($foreground, disabled);
+      color: mat-color($foreground, text);
+      font-weight: bold;
       cursor: default;
     }
   }


### PR DESCRIPTION
## Description
Updated styling for the last breadcrumb due to usability concerns. Made the last breadcrumb or active breadcrumb more prominent.

### What's included?
<!-- List features included in this PR -->
- Style update to `breadcrumbs-theme.scss`

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="716" alt="Screen Shot 2019-04-09 at 10 37 59 AM" src="https://user-images.githubusercontent.com/34658520/55814122-9495c580-5ab3-11e9-99f4-184b274d56be.png">
