### PR TITLE
fix(http): make appended/multiple value params work (closes #1385)

### DIFF
--- a/src/platform/http/actions/http.mixin.spec.ts
+++ b/src/platform/http/actions/http.mixin.spec.ts
@@ -127,7 +127,7 @@ describe('Decorators: Http', () => {
     }),
   ));
 
-  it('expect to do a query with parameters succesfully',
+  it('expect to do a query with HttpParams parameters succesfully',
     async(inject([BasicTestRESTService, HttpTestingController],
                  (service: BasicTestRESTService, httpTestingController: HttpTestingController) => {
       let success: boolean = false;
@@ -135,6 +135,7 @@ describe('Decorators: Http', () => {
       let queryParams: HttpParams = new HttpParams()
         .set('firstParam', '1')
         .set('second-Param', '2')
+        .append('second-Param', '3')
         .set('thirdParam', 'false');
       service.queryWithParams(queryParams).subscribe((data: string) => {
         expect(data).toBe('success');
@@ -148,6 +149,39 @@ describe('Decorators: Http', () => {
       let req: TestRequest = httpTestingController.match(() => true)[0];
       expect(req.request.method).toEqual('GET');
       expect(req.request.params).toEqual(queryParams);
+      expect(req.request.url).toEqual(TEST_URL + '/');
+      req.flush('success', {
+        status: 200,
+        statusText: 'OK',
+      });
+      httpTestingController.verify();
+
+      expect(success).toBe(true, 'on success didnt execute with observables');
+      expect(complete).toBe(true, 'on complete didnt execute with observables');
+    }),
+  ));
+
+  it('expect to do a query with object parameters succesfully',
+    async(inject([BasicTestRESTService, HttpTestingController],
+                 (service: BasicTestRESTService, httpTestingController: HttpTestingController) => {
+      let success: boolean = false;
+      let complete: boolean = false;
+      service.queryWithParams(<any>{
+        firstParam: 1,
+        secondParam: [2, 3],
+        thirdParam: false,
+      }).subscribe((data: string) => {
+        expect(data).toBe('success');
+        success = true;
+      }, () => {
+        fail('on error executed when it shouldnt have with observables');
+      }, () => {
+        complete = true;
+      });
+
+      let req: TestRequest = httpTestingController.match(() => true)[0];
+      expect(req.request.method).toEqual('GET');
+      expect(req.request.params.toString()).toEqual('firstParam=1&secondParam=2&secondParam=3&thirdParam=false');
       expect(req.request.url).toEqual(TEST_URL + '/');
       req.flush('success', {
         status: 200,

--- a/src/platform/http/actions/methods/abstract-method.decorator.ts
+++ b/src/platform/http/actions/methods/abstract-method.decorator.ts
@@ -20,14 +20,30 @@ export function parseParams(target: HttpParams, source: HttpParams | {[key: stri
     source.keys().forEach((key: string) => {
       // skip if value is undefined
       if ((<HttpParams>source).get(key) !== undefined) {
-        queryParams = queryParams.set(key, (<HttpParams>source).get(key));
+        (<HttpParams>source).getAll(key).forEach((value: string, index: number) => {
+          if (index === 0) {
+            queryParams = queryParams.set(key, value);
+          } else {
+            queryParams = queryParams.append(key, value);
+          }
+        });
       }
     });
   } else {
     for (let key in source) {
       // skip if value is undefined
       if (<any>source[key] !== undefined) {
-        queryParams = queryParams.set(key, <any>source[key]);
+        if (source[key] instanceof Array) {
+          (<string[]>source[key]).forEach((value: string, index: number) => {
+            if (index === 0) {
+              queryParams = queryParams.set(key, value);
+            } else {
+              queryParams = queryParams.append(key, value);
+            }
+          });
+        } else {
+          queryParams = queryParams.set(key, <any>source[key]);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
This PR makes sure we support appended parameters or multiple values for queryParams.

#### Test Steps
There is no way to test while serving the application, but added unit tests to validate.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

closes https://github.com/Teradata/covalent/issues/1385
