### PR TITLE
feat(search): tweak styles/layout on appearance

### DIFF
--- a/src/app/components/components/search/search.component.html
+++ b/src/app/components/components/search/search.component.html
@@ -32,8 +32,8 @@
         <div layout="row" layout-align="start center" class="push-left push-right">
           <span class="mat-title">Card</span>
           <span flex></span>
-          <td-search-box *ngIf="debounce" [appearance]="appearance" placeholder="Search here" [alwaysVisible]="alwaysVisible" (searchDebounce)="searchBoxTerm = $event" flex></td-search-box>
-          <td-search-box *ngIf="!debounce" [appearance]="appearance" placeholder="Search here" [alwaysVisible]="alwaysVisible" (search)="searchBoxTerm = $event" (clear)="searchBoxTerm = ''" flex></td-search-box>
+          <td-search-box *ngIf="debounce" placeholder="Search here" [alwaysVisible]="alwaysVisible" (searchDebounce)="searchBoxTerm = $event" flex></td-search-box>
+          <td-search-box *ngIf="!debounce" placeholder="Search here" [alwaysVisible]="alwaysVisible" (search)="searchBoxTerm = $event" (clear)="searchBoxTerm = ''" flex></td-search-box>
         </div>
         <mat-divider></mat-divider>
         <mat-card-content>card content</mat-card-content>

--- a/src/app/components/components/search/search.component.ts
+++ b/src/app/components/components/search/search.component.ts
@@ -102,7 +102,7 @@ export class SearchDemoComponent {
   debounce: number = 0;
   alwaysVisible: boolean = false;
   appearanceOptions: MatFormFieldAppearance[] = ['fill', 'legacy', 'outline', 'standard'];
-  appearance: MatFormFieldAppearance = undefined;
+  appearance: MatFormFieldAppearance = 'legacy';
 
   modeChange(): void {
     this.searchInputTerm = '';

--- a/src/platform/core/search/search-box/README.md
+++ b/src/platform/core/search/search-box/README.md
@@ -20,8 +20,6 @@
   + Sets if the input should always be visible. Defaults to 'false'.
 + placeholder?: string
   + Placeholder for the underlying input component.
-+ appearance?: MatFormFieldAppearance
-  + Appearance style for the underlying input component.
 
 #### Events
 
@@ -59,6 +57,6 @@ export class MyModule {}
 Example for HTML usage:
 
 ```html
-  <td-search-box appearance="legacy|standard|fill|outline" backIcon="arrow_back" placeholder="Search here" [(ngModel)]="searchInputTerm" [showUnderline]="false|true" [debounce]="500" [alwaysVisible]="false|true" (searchDebounce)="searchInputTerm = $event" (search)="searchInputTerm = $event" (clear)="searchInputTerm = ''" (blur)="onBlurEvent()">
+  <td-search-box backIcon="arrow_back" placeholder="Search here" [(ngModel)]="searchInputTerm" [showUnderline]="false|true" [debounce]="500" [alwaysVisible]="false|true" (searchDebounce)="searchInputTerm = $event" (search)="searchInputTerm = $event" (clear)="searchInputTerm = ''" (blur)="onBlurEvent()">
   </td-search-box>
 ```

--- a/src/platform/core/search/search-box/search-box.component.html
+++ b/src/platform/core/search/search-box/search-box.component.html
@@ -10,7 +10,6 @@
                    [showUnderline]="showUnderline"
                    [placeholder]="placeholder"
                    [clearIcon]="clearIcon"
-                   [appearance]="appearance"
                    (searchDebounce)="handleSearchDebounce($event)"
                    (search)="handleSearch($event)"
                    (clear)="handleClear(); toggleVisibility()"

--- a/src/platform/core/search/search-box/search-box.component.scss
+++ b/src/platform/core/search/search-box/search-box.component.scss
@@ -15,6 +15,7 @@
   .td-search-icon {
     // [flex="none"]
     flex: 0 0 auto;
+    align-self: center;
   }
   td-search-input {
     margin-left: 12px;

--- a/src/platform/core/search/search-box/search-box.component.scss
+++ b/src/platform/core/search/search-box/search-box.component.scss
@@ -23,5 +23,10 @@
       margin-right: 12px;
       margin-left: 0 !important;
     }
+    ::ng-deep .mat-form.field.mat-form-field-appearance-legacy {
+      .mat-form-field-wrapper {
+        padding-bottom: 1em;
+      }
+    }
   }
 }

--- a/src/platform/core/search/search-box/search-box.component.ts
+++ b/src/platform/core/search/search-box/search-box.component.ts
@@ -1,7 +1,6 @@
 import { Component, ViewChild, Input, Output, EventEmitter, ChangeDetectionStrategy, ChangeDetectorRef, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { trigger, state, style, transition, animate, AUTO_STYLE } from '@angular/animations';
-import { MatFormFieldAppearance } from '@angular/material/form-field';
 
 import { TdSearchInputComponent } from '../search-input/search-input.component';
 import { IControlValueAccessor, mixinControlValueAccessor } from '@covalent/core/common';
@@ -47,12 +46,6 @@ export class TdSearchBoxComponent extends _TdSearchBoxMixinBase implements ICont
   get searchVisible(): boolean {
     return this._searchVisible;
   }
-
-  /**
-   * appearance?: MatFormFieldAppearance
-   * Appearance style for the underlying input component.
-   */
-  @Input('appearance') appearance: MatFormFieldAppearance;
 
   /**
    * backIcon?: string

--- a/src/platform/core/search/search-input/search-input.component.html
+++ b/src/platform/core/search/search-input/search-input.component.html
@@ -11,7 +11,18 @@
             (blur)="handleBlur()"
             (search)="stopPropagation($event)"
             (keyup.enter)="handleSearch($event)"/>
+    <span matSuffix *ngIf="appearance === 'fill' || appearance === 'outline' || appearance === 'standard'">
+      <ng-template
+        [ngTemplateOutlet]="clearButton">
+      </ng-template>
+    </span>
   </mat-form-field>
+  <ng-template
+    *ngIf="!appearance || appearance === 'legacy'"
+    [ngTemplateOutlet]="clearButton">
+  </ng-template>
+</div>
+<ng-template #clearButton>
   <button mat-icon-button
           class="td-search-input-clear"
           type="button"
@@ -19,4 +30,4 @@
           (click)="clearSearch()">
     <mat-icon>{{clearIcon}}</mat-icon>
   </button>
-</div>
+</ng-template>

--- a/src/platform/core/search/search-input/search-input.component.scss
+++ b/src/platform/core/search/search-input/search-input.component.scss
@@ -15,6 +15,38 @@
       flex: 1;
     }
     ::ng-deep mat-form-field {
+      &.mat-form-field-appearance-outline {
+        .mat-form-field-wrapper {
+          padding-bottom: 0;
+        }
+      }
+      &.mat-form-field-appearance-fill {
+        .mat-form-field-wrapper {
+          padding-bottom: 0;
+          .mat-form-field-flex {
+            height: 52px;
+          }
+          .mat-form-field-underline {
+            bottom: 0;
+          }
+        }
+      }
+      &.mat-form-field-appearance-standard {
+        .mat-form-field-wrapper {
+          padding-bottom: 0;
+          .mat-form-field-infix {
+            bottom: 0.4em;
+          }
+          .mat-form-field-underline {
+            bottom: 0;
+          }
+        }
+      }
+      &.mat-form-field-appearance-legacy {
+        .mat-form-field-infix {
+          align-self: center;
+        }
+      }
       .mat-input-element {
         caret-color: currentColor;
       }
@@ -25,6 +57,7 @@
     .td-search-input-clear {
       // [flex="none"]
       flex: 0 0 auto;
+      align-self: center;
     }
   }
 }


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Since now we expose appearance from `mat-form-field`.. we need to move the cancel button and tweak some styles depending on the appearance chosen to display a proper search layout.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to search demo
- [ ] See how styles change depending on appearance

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
