### PR TITLE
fix(td-help): handle non raw image urls

### DIFF
--- a/src/platform/markdown/markdown.component.spec.ts
+++ b/src/platform/markdown/markdown.component.spec.ts
@@ -340,6 +340,7 @@ describe('Component: Markdown', () => {
           [`/${ROOT_IMG}`, `${RAW_LINK}${ROOT_IMG}`],
           [`${RAW_LINK}${ROOT_IMG}`, `${RAW_LINK}${ROOT_IMG}`],
           [`${EXTERNAL_IMG}`, `${EXTERNAL_IMG}`],
+          [`${NON_RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`, `${RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`],
         ];
 
       let markdown: string = '';

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -18,6 +18,7 @@ import {
   isAnchorLink,
   removeTrailingHash,
   rawGithubHref,
+  isGithubHref,
 } from './markdown-utils';
 
 declare const require: any;
@@ -28,7 +29,6 @@ let showdown: any = require('showdown/dist/showdown.js');
 // allow override somehow
 function generateAbsoluteHref(currentHref: string, relativeHref: string): string {
   if (currentHref && relativeHref) {
-
     const currentUrl: URL = new URL(currentHref);
     const path: string = currentUrl.pathname
       .split('/')
@@ -101,10 +101,13 @@ function normalizeImageSrcs(html: string, currentHref: string): string {
     document.querySelectorAll('img[src]').forEach((image: HTMLImageElement) => {
       const src: string = image.getAttribute('src');
       try {
-         /* tslint:disable-next-line:no-unused-expression */
+        /* tslint:disable-next-line:no-unused-expression */
         new URL(src);
+        if (isGithubHref(src)) {
+          image.src = rawGithubHref(src);
+        }
       } catch {
-        image.src = generateAbsoluteHref(rawGithubHref(currentHref), src);
+        image.src = generateAbsoluteHref(isGithubHref(currentHref) ? rawGithubHref(currentHref) : currentHref, src);
       }
     });
 


### PR DESCRIPTION
## Description

Handle non raw github image urls

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Visit http://localhost:4200/#/components/help
- [ ] Paste:
```
[
    {
        "url": "https://raw.githubusercontent.com/Teradata/product-help/master/Unity/Overview/MarkdownCheatsheet.md"
    }
]
```

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.


#### Before
<img width="592" alt="Screen Shot 2019-06-25 at 4 28 28 PM" src="https://user-images.githubusercontent.com/7193975/60140359-62b50680-9766-11e9-8647-46c5f2fc032f.png">


#### After
<img width="598" alt="Screen Shot 2019-06-25 at 4 27 36 PM" src="https://user-images.githubusercontent.com/7193975/60140356-5f217f80-9766-11e9-89a5-dcb974a83626.png">



##### Screenshots or link to StackBlitz/Plunker
