### PR TITLE
refactor(data-table): simplify service provider

### DIFF
--- a/src/platform/core/data-table/data-table.module.ts
+++ b/src/platform/core/data-table/data-table.module.ts
@@ -12,8 +12,6 @@ import { TdDataTableRowComponent, TdDataTableColumnRowComponent } from './data-t
 import { TdDataTableTableComponent } from './data-table-table/data-table-table.component';
 import { TdDataTableTemplateDirective } from './directives/data-table-template.directive';
 
-import { DATA_TABLE_PROVIDER } from './services/data-table.service';
-
 const TD_DATA_TABLE: Type<any>[] = [
   TdDataTableComponent,
   TdDataTableTemplateDirective,
@@ -38,9 +36,6 @@ const TD_DATA_TABLE: Type<any>[] = [
   ],
   exports: [
     TD_DATA_TABLE,
-  ],
-  providers: [
-    DATA_TABLE_PROVIDER,
   ],
 })
 export class CovalentDataTableModule {

--- a/src/platform/core/data-table/services/data-table.service.ts
+++ b/src/platform/core/data-table/services/data-table.service.ts
@@ -1,8 +1,10 @@
-import { Injectable, Provider, SkipSelf, Optional } from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import { TdDataTableSortingOrder, ITdDataTableColumn } from '../data-table.component';
+import { TdDataTableSortingOrder } from '../data-table.component';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class TdDataTableService {
 
   /**
@@ -76,15 +78,3 @@ export class TdDataTableService {
     return data;
   }
 }
-
-export function DATA_TABLE_PROVIDER_FACTORY(
-    parent: TdDataTableService): TdDataTableService {
-  return parent || new TdDataTableService();
-}
-
-export const DATA_TABLE_PROVIDER: Provider = {
-  // If there is already a service available, use that. Otherwise, provide a new one.
-  provide: TdDataTableService,
-  deps: [[new Optional(), new SkipSelf(), TdDataTableService]],
-  useFactory: DATA_TABLE_PROVIDER_FACTORY,
-};


### PR DESCRIPTION
* Simplify how the singletone service is provided. Since v6 angular provides a new way of registering singleton services
by means of the provide in root module pattern.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
