### PR TITLE
Add user avatar to navigation drawer

### DIFF
--- a/src/app/components/style-guide/logo/logo.component.html
+++ b/src/app/components/style-guide/logo/logo.component.html
@@ -3,7 +3,7 @@
   <mat-divider></mat-divider>
   <mat-card-content>
     <p class="mat-body-1">Your company logo can be implemented with <code>mat-icon</code>.</p>
-    
+
     <p class="mat-body-1">For example:</p>
     <td-highlight lang="html">
       <![CDATA[
@@ -97,5 +97,53 @@
   <mat-divider></mat-divider>
   <mat-card-actions>
     <a mat-button color="primary" [routerLink]="['/design-patterns', 'navigation-drawer']" class="text-upper">Navigation Drawer</a>
+  </mat-card-actions>
+</mat-card>
+
+<mat-card>
+  <mat-card-title>Navigation Drawer (Sidenav) Avatar Placement</mat-card-title>
+  <mat-card-subtitle>place the avatar in the sidenav toolbar next to the title, above the user info</mat-card-subtitle>
+  <mat-divider></mat-divider>
+  <mat-card-content>
+    <div class="md-padding bgc-grey-200">
+      <td-layout mode="side" opened="true">
+        <td-navigation-drawer flex sidenavTitle="App Title" name="Firstname Lastname"
+                              email="firstname.lastname@company.com"
+                              avatar="assets/icons/covalent.svg">
+          <div class="pad">
+            sidenav content
+          </div>
+        </td-navigation-drawer>
+        <div td-sidenav-content class="td-layout-footer pad">
+          <span class="mat-caption tc-grey-500">&copy;{{year}} Teradata. All Rights Reserved</span>
+        </div>
+        <div class="pad">
+          main content
+        </div>
+      </td-layout>
+    </div>
+    <div class="pad-top pad-bottom">
+      <mat-divider></mat-divider>
+    </div>
+    <td-highlight lang="html">
+      <![CDATA[
+      <td-layout>
+        <td-navigation-drawer flex sidenavTitle="App Title" name="Firstname Lastname"
+                              email="firstname.lastname@company.com"
+                              avatar="assets/icons/covalent.svg">
+          sidenav content
+        </td-navigation-drawer>
+        <div td-sidenav-content class="td-layout-footer pad">
+          <span class="mat-caption tc-grey-500">&copy;{ {year} } Teradata. All Rights Reserved</span>
+        </div>
+        main content
+      </td-layout>
+      ]]>
+    </td-highlight>
+  </mat-card-content>
+  <mat-divider></mat-divider>
+  <mat-card-actions>
+    <a mat-button color="primary" [routerLink]="['/design-patterns', 'navigation-drawer']" class="text-upper">Navigation
+      Drawer</a>
   </mat-card-actions>
 </mat-card>

--- a/src/platform/core/layout/README.md
+++ b/src/platform/core/layout/README.md
@@ -99,6 +99,9 @@ See [theming](https://teradata.github.io/covalent/#/docs/theme) in the covalent 
 + logo: string
   + Logo icon name to be displayed before the title. 
   + If [icon] is set, then this will not be shown.
++ avatar: string
+  + Avatar url to be displayed before the title.
+  + If [icon] or [logo] are set, then this will not be shown.
 + color: string
   + Optional sidenav toolbar color.
 + navigationRoute: string

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.html
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.html
@@ -4,12 +4,13 @@
              class="td-nagivation-drawer-toolbar">
   <ng-content select="[td-navigation-drawer-toolbar]"></ng-content>
   <ng-container *ngIf="!isCustomToolbar">
-    <div *ngIf="icon || logo || sidenavTitle"
+    <div *ngIf="icon || logo || sidenavTitle || avatar"
           class="td-navigation-drawer-toolbar-content"
           [class.cursor-pointer]="routerEnabled"
           (click)="handleNavigationClick()">
       <mat-icon *ngIf="icon">{{icon}}</mat-icon>
       <mat-icon *ngIf="logo && !icon" class="mat-icon-logo" [svgIcon]="logo"></mat-icon>
+      <img *ngIf="avatar && !logo && !icon" class="td-nagivation-drawer-toolbar-avatar" [attr.src]="avatar" />
       <span *ngIf="sidenavTitle" class="td-navigation-drawer-title">{{sidenavTitle}}</span>
     </div>
     <div class="td-navigation-drawer-name" *ngIf="email && name">{{name}}</div>

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.scss
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.scss
@@ -27,6 +27,13 @@
       align-content: center;
       max-width: 100%;
       justify-content: flex-start;
+
+      .td-nagivation-drawer-toolbar-avatar {
+        border-radius: 50%;
+        height: 60px;
+        width: 60px;
+        margin: 0 12px 12px 0;
+      }
     }
     .td-navigation-drawer-menu-toggle {
       // [layout="row"]

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
@@ -72,13 +72,6 @@ export class TdNavigationDrawerComponent implements OnInit, OnDestroy {
   @Input('sidenavTitle') sidenavTitle: string;
 
   /**
-   * avatar?: string
-   *
-   * avatar url to be displayed before the title
-   */
-  @Input('avatar') avatar: string;
-
-  /**
    * icon?: string
    *
    * icon name to be displayed before the title
@@ -92,6 +85,14 @@ export class TdNavigationDrawerComponent implements OnInit, OnDestroy {
    * If [icon] is set, then this will not be shown.
    */
   @Input('logo') logo: string;
+
+  /**
+   * avatar?: string
+   *
+   * avatar url to be displayed before the title
+   * If [icon] or [logo] are set, then this will not be shown.
+   */
+  @Input('avatar') avatar: string;
 
   /**
    * color?: string

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
@@ -72,6 +72,13 @@ export class TdNavigationDrawerComponent implements OnInit, OnDestroy {
   @Input('sidenavTitle') sidenavTitle: string;
 
   /**
+   * avatar?: string
+   *
+   * avatar url to be displayed before the title
+   */
+  @Input('avatar') avatar: string;
+
+  /**
    * icon?: string
    *
    * icon name to be displayed before the title


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

I've added support for showing an avatar in the navigation drawer when there is no logo or icon. 

Please let me know if you'd like to see any changes in this PR, I would love to see this land in this amazing project!


### What's included?
<!-- List features included in this PR -->

- Adds a the option to show a user avatar in the navigation drawer.
- The avatar is shown when there is no logo or icon.
- Fixes #998.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- `npm run serve`
- Navigate to http://localhost:4200/#/style-guide

#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

![image](https://user-images.githubusercontent.com/36491/60391191-ee24f380-9ae8-11e9-9348-3a15b6ab49a7.png)
