### PR TITLE
fix(td-markdown): fix anchor id creation

### DIFF
--- a/src/platform/markdown/markdown-utils.ts
+++ b/src/platform/markdown/markdown-utils.ts
@@ -14,7 +14,7 @@ export function removeTrailingHash(str: string): string {
 
 export function normalizeAnchor(str: string): string {
   if (str) {
-    return removeLeadingHash(str.replace(/\W+/g, '')).toLowerCase();
+    return removeLeadingHash(str.replace(/[^\p{Alphabetic}\p{Decimal_Number}]+/ug, '')).toLowerCase();
   }
   return undefined;
 }

--- a/src/platform/markdown/markdown-utils.ts
+++ b/src/platform/markdown/markdown-utils.ts
@@ -14,7 +14,7 @@ export function removeTrailingHash(str: string): string {
 
 export function normalizeAnchor(str: string): string {
   if (str) {
-    return removeLeadingHash(str.replace(/[^\p{Alphabetic}\p{Decimal_Number}]+/ug, '')).toLowerCase();
+    return removeLeadingHash(str.replace(/(_|-|\s)+/g, '')).toLowerCase();
   }
   return undefined;
 }
@@ -25,12 +25,12 @@ export function scrollToAnchor(element: HTMLElement, anchor: string): void {
     const parent: HTMLElement = element.parentElement;
 
     let headingToJumpTo: HTMLElement;
-    const headingWithinComponent: HTMLElement = element.querySelector(`#${normalizedAnchor}`);
+    const headingWithinComponent: HTMLElement = element.querySelector(`[id="${normalizedAnchor}"]`);
 
     if (headingWithinComponent) {
       headingToJumpTo = headingWithinComponent;
     } else if (parent) {
-      headingToJumpTo = parent.querySelector(`#${normalizedAnchor}`);
+      headingToJumpTo = parent.querySelector(`[id="${normalizedAnchor}"]`);
     }
     if (headingToJumpTo) {
       headingToJumpTo.scrollIntoView({ behavior: 'auto' });

--- a/src/platform/markdown/markdown.component.spec.ts
+++ b/src/platform/markdown/markdown.component.spec.ts
@@ -9,16 +9,39 @@ import { By } from '@angular/platform-browser';
 import { CovalentMarkdownModule } from './';
 
 function anchorTestMarkdown(): string {
-  let str: string = '* **[Heading 1](#heading-1)** \n * **[Heading 2](#heading-2)** \n';
+  const heading1: string = 'Heading 1';
+  const heading2: string = 'Heading 2';
+  let str: string = `* **[${heading1}](#heading-1)** \n * **[${heading2}](#heading-2)** \n`;
   const arr: number[] = Array(100).fill(0);
   arr.forEach(() => {
     str += '\n * item \n';
   });
-  str += '\n # Heading 1 \n';
+  str += `\n # ${heading1} \n`;
   arr.forEach(() => {
     str += '\n * item \n';
   });
-  str += '\n # Heading 2 \n';
+  str += `\n # ${heading2} \n`;
+  return str;
+}
+
+function anchorTestNonEnglishMarkdown(): string {
+  const heading1: string = 'L10Nテスト';
+  const heading2: string = 'すべてが楽しいです!';
+  const heading3: string = '誰もが一生に一度ローカライズする必要があります。';
+  let str: string = `* **[${heading1}](#${heading1})** \n * **[${heading2}](#${heading2})** \n * **[${heading3}](#${heading3})** \n`;
+  const arr: number[] = Array(100).fill(0);
+  arr.forEach(() => {
+    str += '\n * item \n';
+  });
+  str += `\n # ${heading1} \n`;
+  arr.forEach(() => {
+    str += '\n * item \n';
+  });
+  str += `\n # ${heading2} \n`;
+  arr.forEach(() => {
+    str += '\n * item \n';
+  });
+  str += `\n # ${heading3} \n`;
   return str;
 }
 
@@ -219,6 +242,44 @@ describe('Component: Markdown', () => {
       const fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownAnchorsTestEventsComponent);
       const component: TdMarkdownAnchorsTestEventsComponent = fixture.debugElement.componentInstance;
       component.content = anchorTestMarkdown();
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      window.scrollTo(0, 0);
+      const originalScrollPos: number = window.scrollY;
+      const headings: HTMLElement[] = fixture.debugElement.nativeElement.querySelectorAll('a');
+      const heading1: HTMLElement = headings[0];
+      const heading2: HTMLElement = headings[1];
+      heading1.click();
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const heading1ScrollPos: number = window.scrollY;
+      expect(heading1ScrollPos).toBeGreaterThanOrEqual(originalScrollPos);
+
+      heading2.click();
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const heading2ScrollPos: number = window.scrollY;
+      expect(heading2ScrollPos).toBeGreaterThan(heading1ScrollPos);
+
+      heading1.click();
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(window.scrollY).toBeLessThan(heading2ScrollPos);
+    }));
+
+    it('should jump to anchor if an anchor link is clicked regardless of lang', async(async () => {
+
+      const fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownAnchorsTestEventsComponent);
+      const component: TdMarkdownAnchorsTestEventsComponent = fixture.debugElement.componentInstance;
+      component.content = anchorTestNonEnglishMarkdown();
 
       fixture.detectChanges();
       await fixture.whenStable();

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -239,7 +239,8 @@ export class TdMarkdownComponent implements OnChanges, AfterViewInit, OnDestroy 
   private async handleAnchorClicks(event: Event): Promise<void> {
     event.preventDefault();
     const url: URL = new URL((<HTMLAnchorElement>event.target).href);
-    scrollToAnchor(this._elementRef.nativeElement, url.hash);
+    const hash: string = decodeURI(url.hash);
+    scrollToAnchor(this._elementRef.nativeElement, hash);
   }
 
   private attachAnchorListeners(): void {


### PR DESCRIPTION
## Description

There was an issue with the original regex `\W` which did not work for Jap or other lang chars so used a more general regex.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to help component page
- [ ] Try [https://raw.githubusercontent.com/Teradata/product-help/master/Unity/Overview/JPN/MarkdownCheatsheet.md](https://raw.githubusercontent.com/Teradata/product-help/master/Unity/Overview/JPN/MarkdownCheatsheet.md)
- [ ] verify it renders

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
