### PR TITLE
build(version-placeholders): add placeholders for a few packages

### DIFF
--- a/build.conf.js
+++ b/build.conf.js
@@ -5,6 +5,10 @@ module.exports = {
   echartsVersion: '4.2.1',
   angularVersion: '8.0.0',
   materialVersion: '8.0.0',
+  showdownVersion: '1.9.0',
+  highlightVersion: '9.13.1',
+  monacoVersion: '0.17.0',
+  simplemdeVersion: '1.11.2',
   paths: {
     PostNgPackngrBuildRequiredFiles: [
       '!src/platform/core/**/*.component.scss',

--- a/scripts/version-placeholders.js
+++ b/scripts/version-placeholders.js
@@ -18,13 +18,20 @@ const versionPlaceholderText = '0.0.0-COVALENT';
 const ngVersionPlaceholderText = '0.0.0-NG';
 const materialVersionPlaceholderText = '0.0.0-MATERIAL';
 const echartsVersionPlaceholderText = '0.0.0-ECHARTS';
+const showdownVersionPlaceholderText = '0.0.0-SHOWDOWN';
+const highlightVersionPlaceholderText = '0.0.0-HIGHLIGHT';
+const monacoVersionPlaceholderText = '0.0.0-MONACO';
+const simplemdeVersionPlaceholderText = '0.0.0-SIMPLEMDE';
 
 /** RegExp that matches version placeholders inside of a file. */
 const versionPlaceholderRegex = new RegExp(versionPlaceholderText, 'g');
 const ngVersionPlaceholderRegex = new RegExp(ngVersionPlaceholderText, 'g');
 const materialVersionPlaceholderRegex = new RegExp(materialVersionPlaceholderText, 'g');
 const echartsVersionPlaceholderRegex = new RegExp(echartsVersionPlaceholderText, 'g');
-
+const showdownVersionPlaceholderRegex = new RegExp(showdownVersionPlaceholderText, 'g');
+const highlightVersionPlaceholderRegex = new RegExp(highlightVersionPlaceholderText, 'g');
+const monacoVersionPlaceholderRegex = new RegExp(monacoVersionPlaceholderText, 'g');
+const simplemdeVersionPlaceholderRegex = new RegExp(simplemdeVersionPlaceholderText, 'g');
 /**
  * Walks through every file in a directory and replaces the version placeholders
  */
@@ -40,6 +47,10 @@ function replaceVersionPlaceholders(packageDir, projectVersion) {
       .replace(ngVersionPlaceholderRegex, buildConfig.angularVersion)
       .replace(materialVersionPlaceholderRegex, buildConfig.materialVersion)
       .replace(echartsVersionPlaceholderRegex, buildConfig.echartsVersion)
+      .replace(showdownVersionPlaceholderRegex, buildConfig.showdownVersion)
+      .replace(highlightVersionPlaceholderRegex, buildConfig.highlightVersion)
+      .replace(monacoVersionPlaceholderRegex, buildConfig.monacoVersion)
+      .replace(simplemdeVersionPlaceholderRegex, buildConfig.simplemdeVersion)
       .replace(versionPlaceholderRegex, projectVersion);
 
     writeFileSync(filePath, fileContent);

--- a/scripts/version-placeholders.js
+++ b/scripts/version-placeholders.js
@@ -9,33 +9,28 @@ const buildConfig = require('../build.conf');
 const packageJson = require('../package.json');
 
 gulp.task('version-placeholder', function(cb) {
-  replaceVersionPlaceholders(buildConfig.deployed, packageJson.version);
+  replaceVersionPlaceholders(buildConfig.deployed);
   cb();
 });
 
-/** Variable that is set to the string for version placeholders. */
-const versionPlaceholderText = '0.0.0-COVALENT';
-const ngVersionPlaceholderText = '0.0.0-NG';
-const materialVersionPlaceholderText = '0.0.0-MATERIAL';
-const echartsVersionPlaceholderText = '0.0.0-ECHARTS';
-const showdownVersionPlaceholderText = '0.0.0-SHOWDOWN';
-const highlightVersionPlaceholderText = '0.0.0-HIGHLIGHT';
-const monacoVersionPlaceholderText = '0.0.0-MONACO';
-const simplemdeVersionPlaceholderText = '0.0.0-SIMPLEMDE';
+const placeholders = [
+  ['0.0.0-COVALENT', packageJson.version],
+  ['0.0.0-NG', buildConfig.angularVersion],
+  ['0.0.0-MATERIAL', buildConfig.materialVersion],
+  ['0.0.0-ECHARTS', buildConfig.echartsVersion],
+  ['0.0.0-SHOWDOWN', buildConfig.showdownVersion],
+  ['0.0.0-HIGHLIGHT', buildConfig.highlightVersion],
+  ['0.0.0-MONACO', buildConfig.monacoVersion],
+  ['0.0.0-SIMPLEMDE', buildConfig.simplemdeVersion],
+];
 
-/** RegExp that matches version placeholders inside of a file. */
-const versionPlaceholderRegex = new RegExp(versionPlaceholderText, 'g');
-const ngVersionPlaceholderRegex = new RegExp(ngVersionPlaceholderText, 'g');
-const materialVersionPlaceholderRegex = new RegExp(materialVersionPlaceholderText, 'g');
-const echartsVersionPlaceholderRegex = new RegExp(echartsVersionPlaceholderText, 'g');
-const showdownVersionPlaceholderRegex = new RegExp(showdownVersionPlaceholderText, 'g');
-const highlightVersionPlaceholderRegex = new RegExp(highlightVersionPlaceholderText, 'g');
-const monacoVersionPlaceholderRegex = new RegExp(monacoVersionPlaceholderText, 'g');
-const simplemdeVersionPlaceholderRegex = new RegExp(simplemdeVersionPlaceholderText, 'g');
+/** RegExps that match version placeholders inside of a file. */
+const placeholderRegexes = placeholders.map((placeholder) => new RegExp(placeholder[0], 'g'));
+
 /**
  * Walks through every file in a directory and replaces the version placeholders
  */
-function replaceVersionPlaceholders(packageDir, projectVersion) {
+function replaceVersionPlaceholders(packageDir) {
   // Resolve files that contain version placeholders using Grep or Findstr since those are
   // extremely fast and also have a very simple usage.
   const files = findFilesWithPlaceholders(packageDir);
@@ -43,16 +38,10 @@ function replaceVersionPlaceholders(packageDir, projectVersion) {
   // Walk through every file that contains version placeholders and replace those with the current
   // version of the root package.json file.
   files.forEach((filePath) => {
-    const fileContent = readFileSync(filePath, 'utf-8')
-      .replace(ngVersionPlaceholderRegex, buildConfig.angularVersion)
-      .replace(materialVersionPlaceholderRegex, buildConfig.materialVersion)
-      .replace(echartsVersionPlaceholderRegex, buildConfig.echartsVersion)
-      .replace(showdownVersionPlaceholderRegex, buildConfig.showdownVersion)
-      .replace(highlightVersionPlaceholderRegex, buildConfig.highlightVersion)
-      .replace(monacoVersionPlaceholderRegex, buildConfig.monacoVersion)
-      .replace(simplemdeVersionPlaceholderRegex, buildConfig.simplemdeVersion)
-      .replace(versionPlaceholderRegex, projectVersion);
-
+    const fileContent = placeholderRegexes.reduce(
+      (accumulator, currentValue, currentIndex) => accumulator.replace(currentValue, placeholders[currentIndex][1]),
+      readFileSync(filePath, 'utf-8'),
+    );
     writeFileSync(filePath, fileContent);
   });
 }
@@ -71,20 +60,12 @@ function buildPlaceholderFindCommand(packageDir) {
   if (platform() === 'win32') {
     return {
       binary: 'findstr',
-      args: [
-        '/msi',
-        `${materialVersionPlaceholderText} ${ngVersionPlaceholderText} ${echartsVersionPlaceholderText} ${versionPlaceholderText}`,
-        `${packageDir}\\*`,
-      ],
+      args: ['/msi', placeholders.map((item) => item[0]).join(' '), `${packageDir}\\*`],
     };
   } else {
     return {
       binary: 'grep',
-      args: [
-        '-ril',
-        `${materialVersionPlaceholderText}\\|${echartsVersionPlaceholderText}\\|${ngVersionPlaceholderText}\\|${versionPlaceholderText}`,
-        packageDir,
-      ],
+      args: ['-ril', placeholders.map((item) => item[0]).join(`\\|`), packageDir],
     };
   }
 }

--- a/src/platform/code-editor/package.json
+++ b/src/platform/code-editor/package.json
@@ -32,7 +32,7 @@
     "Steven Ov <steven.ov@teradata.com>"
   ],
   "dependencies": {
-    "monaco-editor": "^0.10.1"
+    "monaco-editor": "^0.0.0-MONACO"
   },
   "peerDependencies": {
     "@angular/common": "^0.0.0-NG",

--- a/src/platform/flavored-markdown/package.json
+++ b/src/platform/flavored-markdown/package.json
@@ -31,8 +31,8 @@
     "Steven Ov <steven.ov@teradata.com>"
   ],
   "dependencies": {
-    "highlight.js": "9.11.0",
-    "showdown": "1.6.4"
+    "highlight.js": "^0.0.0-HIGHLIGHT",
+    "showdown": "^0.0.0-SHOWDOWN"
   },
   "peerDependencies": {
     "@angular/common": "^0.0.0-NG",

--- a/src/platform/highlight/package.json
+++ b/src/platform/highlight/package.json
@@ -29,7 +29,7 @@
     "Steven Ov <steven.ov@teradata.com>"
   ],
   "dependencies": {
-    "highlight.js": "9.11.0"
+    "highlight.js": "^0.0.0-HIGHLIGHT"
   },
   "peerDependencies": {
     "@angular/common": "^0.0.0-NG",

--- a/src/platform/markdown/package.json
+++ b/src/platform/markdown/package.json
@@ -27,7 +27,7 @@
     "Steven Ov <steven.ov@teradata.com>"
   ],
   "dependencies": {
-    "showdown": "1.6.4"
+    "showdown": "^0.0.0-SHOWDOWN"
   },
   "peerDependencies": {
     "@angular/common": "^0.0.0-NG",

--- a/src/platform/text-editor/package.json
+++ b/src/platform/text-editor/package.json
@@ -33,7 +33,7 @@
     "Julie Knowles <julie.knowles@teradata.com>"
   ],
   "dependencies": {
-    "simplemde": "^1.11.2"
+    "simplemde": "^0.0.0-SIMPLEMDE"
   },
   "peerDependencies": {
     "@angular/common": "^0.0.0-NG",


### PR DESCRIPTION
## Description

Adds placeholders to a few packages to keep consitent versioning.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run build:lib`
- [ ] inspect built packages and verify correct version was added to package.jsons

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
