### PR TITLE
feat(schematics): include markdown navigator as part of ng-add

### DIFF
--- a/src/platform/core/schematics/ng-add/components.ts
+++ b/src/platform/core/schematics/ng-add/components.ts
@@ -84,3 +84,13 @@ export class CodeEditor implements IComponent {
     return '@covalent/code-editor';
   }
 }
+
+export class MarkdownNavigator implements IComponent {
+  public enabled(options: ISchema): boolean {
+    return options.markdownNavigator;
+  }
+
+  public dependency(): string {
+    return '@covalent/markdown-navigator';
+  }
+}

--- a/src/platform/core/schematics/ng-add/index.spec.ts
+++ b/src/platform/core/schematics/ng-add/index.spec.ts
@@ -39,6 +39,7 @@ describe('ng-add schematic', () => {
       markdown: true,
       flavoredMarkdown: true,
       echarts: true,
+      markdownNavigator: true,
     };
     const tree: Tree = await testRunner.runSchematicAsync('ng-add', dependencyOptions, appTree).toPromise();
     const packageJson: any = JSON.parse(getFileContent(tree, '/package.json'));
@@ -55,6 +56,7 @@ describe('ng-add schematic', () => {
     expectVersionToBe(dependencies, '@covalent/echarts', expectedCovalentVersion);
     expectVersionToBe(dependencies, '@covalent/text-editor', expectedCovalentVersion);
     expectVersionToBe(dependencies, '@covalent/code-editor', expectedCovalentVersion);
+    expectVersionToBe(dependencies, '@covalent/markdown-navigator', expectedCovalentVersion);
     expectVersionToBe(dependencies, '@angular/material', expectedMaterialVersion);
     expect(dependencies['@covalent/highlight']).not.toBeDefined();
 

--- a/src/platform/core/schematics/ng-add/index.ts
+++ b/src/platform/core/schematics/ng-add/index.ts
@@ -12,6 +12,7 @@ import {
   Echarts,
   TextEditor,
   CodeEditor,
+  MarkdownNavigator,
 } from './components';
 import { strings } from '@angular-devkit/core';
 import { getProjectFromWorkspace, getProjectTargetOptions } from '@angular/cdk/schematics';
@@ -33,6 +34,7 @@ export function addDependenciesAndFiles(options: ISchema): Rule {
         new Echarts(),
         new TextEditor(),
         new CodeEditor(),
+        new MarkdownNavigator(),
       ];
 
       components.forEach((component: IComponent) => {

--- a/src/platform/core/schematics/ng-add/schema.json
+++ b/src/platform/core/schematics/ng-add/schema.json
@@ -52,6 +52,12 @@
       "description": "Whether covalent code-editor should be set up.",
       "x-prompt": "Set up code editor?"
     },
+    "markdownNavigator": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether covalent markdown-navigator should be set up.",
+      "x-prompt": "Set up markdown navigator?"
+    },
     "styleSheetUtilities": {
       "type": "boolean",
       "default": true,

--- a/src/platform/core/schematics/ng-add/schema.ts
+++ b/src/platform/core/schematics/ng-add/schema.ts
@@ -23,6 +23,9 @@ export interface ISchema {
   /** Whether covalent code editor should be set up. */
   codeEditor: boolean;
 
+  /** Whether markdown navigator should be set up. */
+  markdownNavigator: boolean;
+
   /** Whether covalent utilities stylesheet should be added. */
   styleSheetUtilities: boolean;
 


### PR DESCRIPTION
## Description
Include `markdown-navigator` as part of ng add schematics. Takes care of #1493 

### What's included?
- Running ng add prompts user to setup markdown navigator
<img width="508" alt="markdown-navigator" src="https://user-images.githubusercontent.com/4469548/66222365-d8920d80-e685-11e9-859c-59b28a2c268b.png">
- If chosen yes, it adds `@covalent/markdown-navigator` as a dependency in package.json

#### Test Steps
- [x] Navigate to covalent/scripts directory
- [x] Run ./precommit-schematics.sh : this is the script to test this entire feature locally as we haven't published it to npm yet.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
