### PR TITLE
fix(build): remove schematics as dep from core

### DIFF
--- a/src/platform/core/package.json
+++ b/src/platform/core/package.json
@@ -33,10 +33,6 @@
     "Jeremy Smartt <jeremy.smartt@teradata.com>",
     "Steven Ov <steven.ov@teradata.com>"
   ],
-  "dependencies": {
-    "@angular-devkit/schematics": "^8.1.2",
-    "@angular/cdk": "^0.0.0-MATERIAL"
-  },
   "peerDependencies": {
     "@angular/common": "^0.0.0-NG",
     "@angular/core": "^0.0.0-NG",


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Remove `schematics` as dependency from covalent/core. This causes issues on installation and its not needed since angular/cli already has this as a hard dependency.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
