### PR TITLE
feat(functions): removed button padding

### DIFF
--- a/src/app/components/components/functions/functions.component.html
+++ b/src/app/components/components/functions/functions.component.html
@@ -16,7 +16,7 @@
             </mat-form-field>
           </div>
         </form>
-        <button mat-button color="primary" (click)="doCopyToClipboard()" class="text-upper pad-left-sm">
+        <button mat-button color="primary" (click)="doCopyToClipboard()" class="text-upper">
           Copy To Clipboard
         </button>
       </mat-tab>
@@ -83,7 +83,7 @@
         <p>Conversion function that takes a CSV representation of objects and converts them to JSON. The first row in the input must be the object keys. Custom key separator and line separator can be specified. Space indentation size for output JSON can be specified.</p>
         <h4>Input CSV:</h4>
         <td-highlight [content]="csv"></td-highlight>
-        <button mat-button color="primary" (click)="doConvertCSVToJSON()" class="text-upper pad-left-sm pad-top">
+        <button mat-button color="primary" (click)="doConvertCSVToJSON()" class="text-upper">
           Convert CSV
         </button>
         <h4>Output JSON:</h4>
@@ -92,7 +92,7 @@
         <p>Conversion function that takes an array of objects and converts them to CSV format. Custom key and line separators can be specified.</p>
         <h4>Input Objects:</h4>
         <td-highlight [content]="objectsString"></td-highlight>
-        <button mat-button color="primary" (click)="doConvertObjectsToCSV()" class="text-upper pad-left-sm pad-top">
+        <button mat-button color="primary" (click)="doConvertObjectsToCSV()" class="text-upper">
           Convert Objects
         </button>
         <h4>Output CSV:</h4>
@@ -178,28 +178,28 @@
         <p>Download CSV content to the specified file with .csv extension appended to the provided base file name.</p>
         <h4>CSV:</h4>
         <td-highlight [content]="csv"></td-highlight>
-        <button mat-button color="primary" (click)="doDownloadCSV()" class="text-upper pad-left-sm pad-top pad-bottom">
+        <button mat-button color="primary" (click)="doDownloadCSV()" class="text-upper">
           Download CSV
         </button>
         <h3 class="mat-title pad-top-lg">downloadJSON</h3>
         <p>Download JSON content to the specified file with .json extension appended to the provided base file name.</p>
         <h4>JSON:</h4>
         <td-highlight [content]="json"></td-highlight>
-        <button mat-button color="primary" (click)="doDownloadJSON()" class="text-upper pad-left-sm pad-top pad-bottom">
+        <button mat-button color="primary" (click)="doDownloadJSON()" class="text-upper">
           Download JSON
         </button>
         <h3 class="mat-title pad-top-lg">downloadObjectsToCSV</h3>
         <p>Convert objects to CSV format and download to file with .csv extension appended to the provided base file name. Custom key separator and line separator can be specified.</p>
         <h4>Objects:</h4>
         <td-highlight [content]="objectsString"></td-highlight>
-        <button mat-button color="primary" (click)="doDownloadObjectsToCSV()" class="text-upper pad-left-sm pad-top pad-bottom">
+        <button mat-button color="primary" (click)="doDownloadObjectsToCSV()" class="text-upper">
           Download To CSV
         </button>
         <h3 class="mat-title pad-top-lg">downloadObjectsToJSON</h3>
         <p>Convert objects to JSON format and download to file with .json extension appended to the provided base file name.</p>
         <h4>Objects:</h4>
         <td-highlight [content]="objectsString"></td-highlight>
-        <button mat-button color="primary" (click)="doDownloadObjectsToJSON()" class="text-upper pad-left-sm pad-top pad-bottom">
+        <button mat-button color="primary" (click)="doDownloadObjectsToJSON()" class="text-upper">
           Download To JSON
         </button>
         <h3 class="mat-title pad-top-lg">download</h3>
@@ -218,7 +218,7 @@
             </mat-form-field>
           </div>
         </form>
-        <button mat-button color="primary" (click)="doDownloadFile()" class="text-upper pad-left-sm pad-top">
+        <button mat-button color="primary" (click)="doDownloadFile()" class="text-upper">
           Download
         </button>
       </mat-tab>

--- a/src/app/components/components/functions/functions.component.html
+++ b/src/app/components/components/functions/functions.component.html
@@ -37,7 +37,7 @@
                   </mat-form-field>
                 </div>
               </form>
-              <button mat-button 
+              <button mat-button
                 color="primary"
                 (click)="doCopyToClipboard()"
                 class="text-upper">
@@ -52,13 +52,13 @@
 
               export class FunctionsDemoComponent {
                 copyText: string = 'Lorem Ipsum';
-          
+
                 constructor(private _snackBar: MatSnackBar) {}
-          
+
                 doCopyToClipboard(): void {
                   // Invoke utility function to copy input text to clipboard
                   copyToClipboard(this.copyText);
-          
+
                   // Show snackbar to indicate task complete
                   this._snackBar.open('Text copied!', undefined, {
                     duration: 2000,
@@ -83,7 +83,7 @@
         <p>Conversion function that takes a CSV representation of objects and converts them to JSON. The first row in the input must be the object keys. Custom key separator and line separator can be specified. Space indentation size for output JSON can be specified.</p>
         <h4>Input CSV:</h4>
         <td-highlight [content]="csv"></td-highlight>
-        <button mat-button color="primary" (click)="doConvertCSVToJSON()" class="text-upper">
+        <button mat-button color="primary" (click)="doConvertCSVToJSON()" class="text-upper push-top-sm">
           Convert CSV
         </button>
         <h4>Output JSON:</h4>
@@ -92,7 +92,7 @@
         <p>Conversion function that takes an array of objects and converts them to CSV format. Custom key and line separators can be specified.</p>
         <h4>Input Objects:</h4>
         <td-highlight [content]="objectsString"></td-highlight>
-        <button mat-button color="primary" (click)="doConvertObjectsToCSV()" class="text-upper">
+        <button mat-button color="primary" (click)="doConvertObjectsToCSV()" class="text-upper push-top-sm">
           Convert Objects
         </button>
         <h4>Output CSV:</h4>
@@ -105,14 +105,14 @@
           <![CDATA[
             <h4>Input CSV:</h4>
             <td-highlight [content]="csv"></td-highlight>
-            <button mat-button color="primary" (click)="doConvertCSVToJSON()" class="text-upper">
+            <button mat-button color="primary" (click)="doConvertCSVToJSON()" class="text-upper push-top-sm">
               Convert CSV
             </button>
             <h4>Output JSON:</h4>
             <td-highlight [content]="jsonOutput"></td-highlight>
             <h4>Input Objects:</h4>
             <td-highlight [content]="objectsString"></td-highlight>
-            <button mat-button color="primary" (click)="doConvertObjectsToCSV()" class="text-upper">
+            <button mat-button color="primary" (click)="doConvertObjectsToCSV()" class="text-upper push-top-sm">
               Convert Objects
             </button>
             <h4>Output CSV:</h4>
@@ -130,30 +130,30 @@
               objects: object[] = [ { 'name': 'user1', 'id': 123 }, { 'name': 'user2', 'id': 234 } ];
               objectsString: string;
               csvOutput: string = '';
-                        
+
               constructor(private _snackBar: MatSnackBar) {
                 this.objectsString = JSON.stringify(this.objects, undefined, 2);
               }
-                        
+
               doConvertCSVToJSON(): void {
                 // Invoke utility function to CSV value using
                 // comma as the key separator and carriage return line feed
                 // as the line separator into JSON format. Use two space
                 // indent to prettify output JSON.
                 this.jsonOutput = convertCSVToJSON(this.csv, ',', '\r\n', 2);
-                          
+
                 // Show snackbar to indicate task complete
                 this._snackBar.open('Objects converted!', undefined, {
                   duration: 2000,
                 });
               }
-                      
+
               doConvertObjectsToCSV(): void {
                 // Invoke utility function to convert objects array using
                 // comma as the key separator and carriage return line feed
                 // as the line separator.
                 this.csvOutput = convertObjectsToCSV(this.objects, ',', '\r\n');
-                            
+
                 // Show snackbar to indicate task complete
                 this._snackBar.open('Objects converted!', undefined, {
                   duration: 2000,
@@ -178,28 +178,28 @@
         <p>Download CSV content to the specified file with .csv extension appended to the provided base file name.</p>
         <h4>CSV:</h4>
         <td-highlight [content]="csv"></td-highlight>
-        <button mat-button color="primary" (click)="doDownloadCSV()" class="text-upper">
+        <button mat-button color="primary" (click)="doDownloadCSV()" class="text-upper push-top-sm">
           Download CSV
         </button>
         <h3 class="mat-title pad-top-lg">downloadJSON</h3>
         <p>Download JSON content to the specified file with .json extension appended to the provided base file name.</p>
         <h4>JSON:</h4>
         <td-highlight [content]="json"></td-highlight>
-        <button mat-button color="primary" (click)="doDownloadJSON()" class="text-upper">
+        <button mat-button color="primary" (click)="doDownloadJSON()" class="text-upper push-top-sm">
           Download JSON
         </button>
         <h3 class="mat-title pad-top-lg">downloadObjectsToCSV</h3>
         <p>Convert objects to CSV format and download to file with .csv extension appended to the provided base file name. Custom key separator and line separator can be specified.</p>
         <h4>Objects:</h4>
         <td-highlight [content]="objectsString"></td-highlight>
-        <button mat-button color="primary" (click)="doDownloadObjectsToCSV()" class="text-upper">
+        <button mat-button color="primary" (click)="doDownloadObjectsToCSV()" class="text-upper push-top-sm">
           Download To CSV
         </button>
         <h3 class="mat-title pad-top-lg">downloadObjectsToJSON</h3>
         <p>Convert objects to JSON format and download to file with .json extension appended to the provided base file name.</p>
         <h4>Objects:</h4>
         <td-highlight [content]="objectsString"></td-highlight>
-        <button mat-button color="primary" (click)="doDownloadObjectsToJSON()" class="text-upper">
+        <button mat-button color="primary" (click)="doDownloadObjectsToJSON()" class="text-upper push-top-sm">
           Download To JSON
         </button>
         <h3 class="mat-title pad-top-lg">download</h3>
@@ -229,22 +229,22 @@
           <![CDATA[
             <h4>CSV:</h4>
             <td-highlight [content]="csv"></td-highlight>
-            <button mat-button color="primary" (click)="doDownloadCSV()" class="text-upper">
+            <button mat-button color="primary" (click)="doDownloadCSV()" class="text-upper push-top-sm">
               Download CSV
             </button>
             <h4>JSON:</h4>
             <td-highlight [content]="json"></td-highlight>
-            <button mat-button color="primary" (click)="doDownloadJSON()" class="text-upper">
+            <button mat-button color="primary" (click)="doDownloadJSON()" class="text-upper push-top-sm">
               Download JSON
             </button>
             <h4>Objects:</h4>
             <td-highlight [content]="objectsString"></td-highlight>
-            <button mat-button color="primary" (click)="doDownloadObjectsToCSV()" class="text-upper">
-              Download To CSV 
+            <button mat-button color="primary" (click)="doDownloadObjectsToCSV()" class="text-upper push-top-sm">
+              Download To CSV
             </button>
             <h4>Objects:</h4>
             <td-highlight [content]="objectsString"></td-highlight>
-            <button mat-button color="primary" (click)="doDownloadObjectsToJSON()" class="text-upper">
+            <button mat-button color="primary" (click)="doDownloadObjectsToJSON()" class="text-upper push-top-sm">
               Download To JSON
             </button>
             <form>
@@ -263,7 +263,7 @@
             </form>
             <button mat-button color="primary" (click)="doDownloadFile()" class="text-upper">
               Download
-            </button>            
+            </button>
           ]]>
         </td-highlight>
         <p>Typescript:</p>
@@ -283,36 +283,36 @@
               constructor(private _snackBar: MatSnackBar) {
                 this.objectsString = JSON.stringify(this.objects, undefined, 2);
               }
-                        
+
               doDownloadCSV(): void {
                 // Invoke utility function to download CSV value into file
                 // with 'text/csv' mime type and '.csv' extension.
                 downloadCSV('csvsampledata', this.csv);
-              
+
                 // Show snackbar to indicate task complete
                 this._snackBar.open('CSV downloaded!', undefined, {
                   duration: 2000,
                 });
               }
-                        
+
               doDownloadJSON(): void {
                 // Invoke utility function to download JSON into file
                 // with 'application/json' mime type and '.json' extension.
                 // Request JSON to be prettied.
                 downloadJSON('jsonsampledata', this.json, true, 2);
-              
+
                 // Show snackbar to indicate task complete
                 this._snackBar.open('JSON downloaded!', undefined, {
                   duration: 2000,
                 });
               }
-                        
+
               doDownloadObjectsToCSV(): void {
                 // Invoke utility function to convert objects to CSV value
                 // and download into file with 'text/csv' mime type and
                 // '.csv' extension.
                 downloadObjectsToCSV('objtocsvsampledata', this.objects);
-              
+
                 // Show snackbar to indicate task complete
                 this._snackBar.open('JSON converted to CSV and downloaded!', undefined, {
                   duration: 2000,
@@ -324,7 +324,7 @@
                 // and download into file with 'application/json' mime type and
                 // '.json' extension.
                 downloadObjectsToJSON('objtojsonsampledata', this.objects);
-            
+
                 // Show snackbar to indicate task complete
                 this._snackBar.open('Objects converted to JSON and downloaded!', undefined, {
                   duration: 2000,
@@ -335,7 +335,7 @@
                 // Invoke utility function to write contents to specified
                 // file with desired mime type.
                 downloadFile(this.fileName, this.fileContent, this.mimeType);
-              
+
                 // Show snackbar to indicate task complete
                 this._snackBar.open('Content downloaded!', undefined, {
                   duration: 2000,


### PR DESCRIPTION
## Description

Quick styling fix removing pad from buttons

### What's included?
- Removed all pad styling from buttons in functions demo HTML.

#### Test Steps
- [ ] `npm run serve`
- [ ] Confirm functions demo page looks nice.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
