### PR TITLE
fix(text-editor): import css properly

### DIFF
--- a/src/platform/text-editor/text-editor.component.scss
+++ b/src/platform/text-editor/text-editor.component.scss
@@ -1,0 +1,5 @@
+:host ::ng-deep {
+  // intentionally omitting file extension
+  // see: https://stackoverflow.com/questions/48806765/import-styles-in-angular-components-styles-with-ng-deep
+  @import '~simplemde/dist/simplemde.min';
+}

--- a/src/platform/text-editor/text-editor.component.ts
+++ b/src/platform/text-editor/text-editor.component.ts
@@ -1,13 +1,8 @@
-import { Component, Input, AfterViewInit, ViewChild, ElementRef, forwardRef, NgZone, Inject } from '@angular/core';
+import { Component, Input, AfterViewInit, ViewChild, ElementRef, forwardRef, NgZone } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
-import { DomSanitizer } from '@angular/platform-browser';
-import { DOCUMENT } from '@angular/common';
 import * as SimpleMDE from 'simplemde';
 // get access to the marked class under simplemde
 import * as marked from 'marked';
-declare const require: any;
-/* tslint:disable-next-line */
-let SimpleMDECss = require('simplemde/dist/simplemde.min.css');
 
 const noop: any = () => {
   // empty method
@@ -33,12 +28,7 @@ export class TdTextEditorComponent implements AfterViewInit, ControlValueAccesso
   @ViewChild('simplemde', { static: true }) textarea: ElementRef;
   @Input() options: any = {};
 
-  constructor(
-    private _elementRef: ElementRef,
-    private _zone: NgZone,
-    private _domSanitizer: DomSanitizer,
-    @Inject(DOCUMENT) private _document: any,
-  ) {}
+  constructor(private _zone: NgZone) {}
 
   /* tslint:disable-next-line */
   propagateChange = (_: any) => {};
@@ -83,11 +73,6 @@ export class TdTextEditorComponent implements AfterViewInit, ControlValueAccesso
   }
 
   ngAfterViewInit(): void {
-    if (this._document) {
-      let styleElement: HTMLElement = this._document.createElement('style');
-      styleElement.innerHTML = <string>this._domSanitizer.bypassSecurityTrustHtml(String(SimpleMDECss));
-      this._document.head.appendChild(styleElement);
-    }
     this.options.element = this.textarea.nativeElement;
 
     // If content entered is html then don't evaluate it, prevent xss vulnerabilities


### PR DESCRIPTION
## Description

When using in ac, the style tag inserted into the dom was:
```html
<style>
  SafeValue must use [property]=binding: [object Module] (see http://g.co/ng/security#xss)
</style>
```
Went with the route of just properly importing the css to fix the css issue. This also gets rid of a memory leak since the style tag was not being removed.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Visit http://localhost:4200/#/components/text-editor
- [ ] verify css is applied to component

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
