### PR TITLE
docs(): add components that start with n's and t's

### DIFF
--- a/src/app/content/components/component-demos/nav-steps/nav-steps.component.html
+++ b/src/app/content/components/component-demos/nav-steps/nav-steps.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<!-- <mat-card>
   <div class="pad-left pad-right bgc-grey-100" layout="row" layout-align="start center">
     <span flex></span>
     <button mat-icon-button matTooltip="View Source" (click)="toggleHorizontalDemoCode = !toggleHorizontalDemoCode">
@@ -159,4 +159,5 @@
   </nav>
 </mat-card>
 
-<td-readme-loader resourceUrl="platform/core/steps/nav/README.md"></td-readme-loader>
+<td-readme-loader resourceUrl="platform/core/steps/nav/README.md"></td-readme-loader> -->
+<h1>Nav steps is working!</h1>

--- a/src/app/content/components/component-demos/nav-steps/nav-steps.module.ts
+++ b/src/app/content/components/component-demos/nav-steps/nav-steps.module.ts
@@ -12,7 +12,7 @@ import { NavStepsDemoComponent } from './nav-steps.component';
 
 const routes: Routes = setComponentRoutes({
   overviewDemoComponent: NavStepsDemoComponent,
-  id: 'breadcrumbs',
+  id: 'nav-steps',
 });
 
 @NgModule({

--- a/src/app/content/components/component-demos/notifications/notifications.component.html
+++ b/src/app/content/components/component-demos/notifications/notifications.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<!-- <mat-card>
   <mat-card-title>Notifications</mat-card-title>
   <mat-card-subtitle>Notification count &amp; menu for toolbar</mat-card-subtitle>
   <mat-divider></mat-divider>
@@ -184,4 +184,6 @@
   </mat-card-content>
 </mat-card>
 
-<td-readme-loader resourceUrl="platform/core/notifications/README.md"></td-readme-loader>
+<td-readme-loader resourceUrl="platform/core/notifications/README.md"></td-readme-loader> -->
+
+<h1>Notifications are working!</h1>

--- a/src/app/content/components/component-demos/notifications/notifications.module.ts
+++ b/src/app/content/components/component-demos/notifications/notifications.module.ts
@@ -12,7 +12,7 @@ import { NotificationsDemoComponent } from './notifications.component';
 
 const routes: Routes = setComponentRoutes({
   overviewDemoComponent: NotificationsDemoComponent,
-  id: 'breadcrumbs',
+  id: 'notifications',
 });
 
 @NgModule({

--- a/src/app/content/components/component-demos/tab-select/tab-select.component.html
+++ b/src/app/content/components/component-demos/tab-select/tab-select.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<!-- <mat-card>
   <mat-card-title>Tab Select</mat-card-title>
   <mat-card-subtitle>bind values to tabs and use them as filters</mat-card-subtitle>
   <mat-divider></mat-divider>
@@ -49,4 +49,5 @@
   </mat-tab-group>
 </mat-card>
 
-<td-readme-loader resourceUrl="platform/core/tab-select/README.md"></td-readme-loader>
+<td-readme-loader resourceUrl="platform/core/tab-select/README.md"></td-readme-loader> -->
+<h1>Tab select is working!</h1>

--- a/src/app/content/components/component-demos/tab-select/tab-select.module.ts
+++ b/src/app/content/components/component-demos/tab-select/tab-select.module.ts
@@ -12,7 +12,7 @@ import { TabSelectDemoComponent } from './tab-select.component';
 
 const routes: Routes = setComponentRoutes({
   overviewDemoComponent: TabSelectDemoComponent,
-  id: 'breadcrumbs',
+  id: 'tab-select',
 });
 
 @NgModule({

--- a/src/app/content/components/component-demos/text-editor/text-editor.component.html
+++ b/src/app/content/components/component-demos/text-editor/text-editor.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<!-- <mat-card>
   <mat-card-title>Markdown Text Editor</mat-card-title>
   <mat-card-subtitle
     >Simple markdown text editor component (edit the markdown in the left editor for a real-time
@@ -22,4 +22,5 @@
   </div>
 </mat-card>
 
-<td-readme-loader resourceUrl="platform/text-editor/README.md"> </td-readme-loader>
+<td-readme-loader resourceUrl="platform/text-editor/README.md"> </td-readme-loader> -->
+<h1>Text editor is working!</h1>

--- a/src/app/content/components/component-demos/text-editor/text-editor.module.ts
+++ b/src/app/content/components/component-demos/text-editor/text-editor.module.ts
@@ -12,7 +12,7 @@ import { TextEditorDemoComponent } from './text-editor.component';
 
 const routes: Routes = setComponentRoutes({
   overviewDemoComponent: TextEditorDemoComponent,
-  id: 'breadcrumbs',
+  id: 'text-editor',
 });
 
 @NgModule({

--- a/src/app/content/components/components.routes.ts
+++ b/src/app/content/components/components.routes.ts
@@ -15,6 +15,24 @@ const routes: Routes = [
         path: 'markdown-parser',
         loadChildren: () => import('./component-demos/markdown/markdown.module').then((m) => m.MarkdownDemoModule),
       },
+      {
+        path: 'nav-steps',
+        loadChildren: () => import('./component-demos/nav-steps/nav-steps.module').then((m) => m.NavstepsDemoModule),
+      },
+      {
+        path: 'notifications',
+        loadChildren: () =>
+          import('./component-demos/notifications/notifications.module').then((m) => m.NotificationsDemoModule),
+      },
+      {
+        path: 'tab-select',
+        loadChildren: () => import('./component-demos/tab-select/tab-select.module').then((m) => m.TabSelectDemoModule),
+      },
+      {
+        path: 'text-editor',
+        loadChildren: () =>
+          import('./component-demos/text-editor/text-editor.module').then((m) => m.TextEditorDemoModule),
+      },
     ],
   },
 ];

--- a/src/app/content/components/components.ts
+++ b/src/app/content/components/components.ts
@@ -7,9 +7,10 @@ export const componentRouteCategories = [
   { name: 'Navigation', nested: false },
   { name: 'Dialogs', nested: false },
   { name: 'Forms', nested: false },
+  { name: 'Editors', nested: false },
 ];
 
-const [root, layout, buttons, nav, dialogs, forms] = componentRouteCategories;
+const [root, layout, buttons, nav, dialogs, forms, editors] = componentRouteCategories;
 
 export const componentDetails: any = [
   {
@@ -37,6 +38,55 @@ export const componentDetails: any = [
     icon: '',
     category: 'Buttons & Indicators',
     route: '/components/breadcrumbs',
+  },
+  {
+    name: 'Nav Steps',
+    id: 'nav-steps',
+    description:
+      'Navigate across a sequence of logical & numbered steps (shrink width of page to see responsive behavior)',
+    apiDocUrl: 'platform/core/steps/README.md',
+    overviewDocUrl: '',
+    showExampleTab: true,
+    showOverviewDemo: true,
+    icon: 'format_line_spacing',
+    category: nav.name,
+    route: '/components/nav-steps',
+  },
+  {
+    name: 'Notifications',
+    id: 'notifications',
+    description: 'Notification count & menu for toolbar',
+    apiDocUrl: 'platform/core/notifications/README.md',
+    overviewDocUrl: '',
+    showExampleTab: true,
+    showOverviewDemo: true,
+    icon: 'notifications',
+    category: buttons.name,
+    route: '/components/notifications',
+  },
+  {
+    name: 'Tab Select',
+    id: 'tab-select',
+    description: 'Bind values to tabs and use them as filters',
+    apiDocUrl: 'platform/core/tab-select/README.md',
+    overviewDocUrl: '',
+    showExampleTab: true,
+    showOverviewDemo: true,
+    icon: 'tab',
+    category: forms.name,
+    route: '/components/tab-select',
+  },
+  {
+    name: 'Text Editor',
+    id: 'text-editor',
+    description: 'Simple markdown text editor component (edit the markdown in the left editor for a real-time preview)',
+    apiDocUrl: 'platform/text-editor/README.md',
+    overviewDocUrl: '',
+    showExampleTab: true,
+    showOverviewDemo: true,
+    icon: 'tab',
+    category: editors.name,
+    route: '/components/text-editor',
   },
 ];
 


### PR DESCRIPTION
## Description

Added components that started with n's and t's

### What's included?
<!-- List features included in this PR -->
- nav-steps
- notifications
- tab-select
- text-editor

#### Test Steps

- Visit the pages for the components above

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
