### PR TITLE
docs(): add components that start with f's and s's

### DIFF
--- a/src/app/content/components/component-demos/file-input/file-input.component.html
+++ b/src/app/content/components/component-demos/file-input/file-input.component.html
@@ -78,5 +78,3 @@
     </mat-tab>
   </mat-tab-group>
 </mat-card>
-
-<td-readme-loader resourceUrl="platform/core/file/file-input/README.md"></td-readme-loader>

--- a/src/app/content/components/component-demos/file-input/file-input.module.ts
+++ b/src/app/content/components/component-demos/file-input/file-input.module.ts
@@ -1,30 +1,45 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes, Route } from '@angular/router';
 
-import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatTabsModule } from '@angular/material/tabs';
 
 import { ComponentDetailsModule } from 'app/components/shared/component-details/component-details.module';
-import { CovalentBreadcrumbsModule } from '@covalent/core/breadcrumbs';
+import { CovalentFileModule } from '@covalent/core/file';
+import { CovalentHighlightModule } from '@covalent/highlight';
 import { setComponentRoutes } from 'app/content/components/components';
 import { FileInputDemoComponent } from './file-input.component';
 
 const routes: Routes = setComponentRoutes({
   overviewDemoComponent: FileInputDemoComponent,
-  id: 'breadcrumbs',
+  id: 'file-input',
 });
 
 @NgModule({
   declarations: [FileInputDemoComponent],
   imports: [
     CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
     // Material
-    MatSelectModule,
+    MatButtonModule,
+    MatCardModule,
+    MatDividerModule,
+    MatFormFieldModule,
     MatIconModule,
+    MatInputModule,
+    MatTabsModule,
     ComponentDetailsModule,
     // Covalent
-    CovalentBreadcrumbsModule,
+    CovalentFileModule,
+    CovalentHighlightModule,
     // Docs
     // Routes
     RouterModule.forChild(routes),

--- a/src/app/content/components/component-demos/flavored-markdown/flavored-markdown.component.html
+++ b/src/app/content/components/component-demos/flavored-markdown/flavored-markdown.component.html
@@ -88,8 +88,9 @@
     <mat-tab-group mat-stretch-tabs>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
-        <td-flavored-markdown-loader [url]="'https://github.com/angular/angular/blob/master/README.md'">
-        </td-flavored-markdown-loader>
+        <td-flavored-markdown-loader
+          [url]="'https://github.com/angular/angular/blob/master/README.md'"
+        ></td-flavored-markdown-loader>
       </mat-tab>
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
@@ -101,5 +102,3 @@
     </mat-tab-group>
   </mat-card-content>
 </mat-card>
-
-<td-readme-loader resourceUrl="platform/flavored-markdown/README.md"></td-readme-loader>

--- a/src/app/content/components/component-demos/flavored-markdown/flavored-markdown.module.ts
+++ b/src/app/content/components/component-demos/flavored-markdown/flavored-markdown.module.ts
@@ -2,17 +2,19 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Routes, Route } from '@angular/router';
 
-import { MatSelectModule } from '@angular/material/select';
-import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatTabsModule } from '@angular/material/tabs';
 
 import { ComponentDetailsModule } from 'app/components/shared/component-details/component-details.module';
-import { CovalentBreadcrumbsModule } from '@covalent/core/breadcrumbs';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
+import { CovalentHighlightModule } from '@covalent/highlight';
 import { setComponentRoutes } from 'app/content/components/components';
 import { FlavoredMarkdownDemoComponent } from './flavored-markdown.component';
 
 const routes: Routes = setComponentRoutes({
   overviewDemoComponent: FlavoredMarkdownDemoComponent,
-  id: 'breadcrumbs',
+  id: 'flavored-markdown',
 });
 
 @NgModule({
@@ -20,11 +22,13 @@ const routes: Routes = setComponentRoutes({
   imports: [
     CommonModule,
     // Material
-    MatSelectModule,
-    MatIconModule,
+    MatCardModule,
+    MatDividerModule,
+    MatTabsModule,
     ComponentDetailsModule,
     // Covalent
-    CovalentBreadcrumbsModule,
+    CovalentFlavoredMarkdownModule,
+    CovalentHighlightModule,
     // Docs
     // Routes
     RouterModule.forChild(routes),

--- a/src/app/content/components/component-demos/search/search.component.html
+++ b/src/app/content/components/component-demos/search/search.component.html
@@ -5,12 +5,14 @@
   <mat-card-content>
     <div class="field-container" layout="row" layout-align="start center">
       <mat-button-toggle-group name="mode" (change)="modeChange()" [(ngModel)]="debounce">
-        <mat-button-toggle matTooltip="Enter/Clear Events" [value]="0"
-          ><mat-icon>search</mat-icon> Enter/Clear</mat-button-toggle
-        >
-        <mat-button-toggle matTooltip="Debounce Events" [value]="1"
-          ><mat-icon>keyboard</mat-icon> Debounce</mat-button-toggle
-        >
+        <mat-button-toggle matTooltip="Enter/Clear Events" [value]="0">
+          <mat-icon>search</mat-icon>
+          Enter/Clear
+        </mat-button-toggle>
+        <mat-button-toggle matTooltip="Debounce Events" [value]="1">
+          <mat-icon>keyboard</mat-icon>
+          Debounce
+        </mat-button-toggle>
       </mat-button-toggle-group>
     </div>
     <div class="field-container" layout="row" layout-align="start center">
@@ -86,7 +88,3 @@
     <button mat-button color="primary" (click)="toggleAlwaysVisible()" class="text-upper">Always Visible</button>
   </mat-card-actions>
 </mat-card>
-
-<td-readme-loader resourceUrl="platform/core/search/search-input/README.md"></td-readme-loader>
-
-<td-readme-loader resourceUrl="platform/core/search/search-box/README.md"></td-readme-loader>

--- a/src/app/content/components/component-demos/search/search.module.ts
+++ b/src/app/content/components/component-demos/search/search.module.ts
@@ -1,12 +1,20 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes, Route } from '@angular/router';
 
-import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatToolbarModule } from '@angular/material/toolbar';
 
 import { ComponentDetailsModule } from 'app/components/shared/component-details/component-details.module';
-import { CovalentBreadcrumbsModule } from '@covalent/core/breadcrumbs';
+import { CovalentSearchModule } from '@covalent/core/search';
 import { setComponentRoutes } from 'app/content/components/components';
 import { SearchDemoComponent } from './search.component';
 
@@ -19,12 +27,21 @@ const routes: Routes = setComponentRoutes({
   declarations: [SearchDemoComponent],
   imports: [
     CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
     // Material
-    MatSelectModule,
+    MatButtonModule,
+    MatButtonToggleModule,
+    MatCardModule,
+    MatDividerModule,
+    MatFormFieldModule,
     MatIconModule,
+    MatInputModule,
+    MatRadioModule,
+    MatToolbarModule,
     ComponentDetailsModule,
     // Covalent
-    CovalentBreadcrumbsModule,
+    CovalentSearchModule,
     // Docs
     // Routes
     RouterModule.forChild(routes),

--- a/src/app/content/components/component-demos/search/search.module.ts
+++ b/src/app/content/components/component-demos/search/search.module.ts
@@ -20,7 +20,7 @@ import { SearchDemoComponent } from './search.component';
 
 const routes: Routes = setComponentRoutes({
   overviewDemoComponent: SearchDemoComponent,
-  id: 'breadcrumbs',
+  id: 'search',
 });
 
 @NgModule({

--- a/src/app/content/components/component-demos/sidesheet/sidesheet.component.html
+++ b/src/app/content/components/component-demos/sidesheet/sidesheet.component.html
@@ -64,5 +64,3 @@
     </mat-tab>
   </mat-tab-group>
 </mat-card>
-
-<td-readme-loader resourceUrl="platform/core/sidesheet/README.md"></td-readme-loader>

--- a/src/app/content/components/component-demos/sidesheet/sidesheet.module.ts
+++ b/src/app/content/components/component-demos/sidesheet/sidesheet.module.ts
@@ -2,11 +2,16 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Routes, Route } from '@angular/router';
 
-import { MatSelectModule } from '@angular/material/select';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatToolbarModule } from '@angular/material/toolbar';
 
 import { ComponentDetailsModule } from 'app/components/shared/component-details/component-details.module';
-import { CovalentBreadcrumbsModule } from '@covalent/core/breadcrumbs';
+import { CovalentHighlightModule } from '@covalent/highlight';
+import { CovalentSidesheetModule } from '@covalent/core/sidesheet';
 import { setComponentRoutes } from 'app/content/components/components';
 import { SidesheetDemoComponent } from './sidesheet.component';
 
@@ -20,11 +25,16 @@ const routes: Routes = setComponentRoutes({
   imports: [
     CommonModule,
     // Material
-    MatSelectModule,
+    MatCardModule,
+    MatDividerModule,
     MatIconModule,
+    MatSidenavModule,
+    MatTabsModule,
+    MatToolbarModule,
     ComponentDetailsModule,
     // Covalent
-    CovalentBreadcrumbsModule,
+    CovalentHighlightModule,
+    CovalentSidesheetModule,
     // Docs
     // Routes
     RouterModule.forChild(routes),

--- a/src/app/content/components/component-demos/sidesheet/sidesheet.module.ts
+++ b/src/app/content/components/component-demos/sidesheet/sidesheet.module.ts
@@ -17,7 +17,7 @@ import { SidesheetDemoComponent } from './sidesheet.component';
 
 const routes: Routes = setComponentRoutes({
   overviewDemoComponent: SidesheetDemoComponent,
-  id: 'breadcrumbs',
+  id: 'sidesheet',
 });
 
 @NgModule({

--- a/src/app/content/components/components.routes.ts
+++ b/src/app/content/components/components.routes.ts
@@ -12,8 +12,27 @@ const routes: Routes = [
           import('./component-demos/breadcrumbs/breadcrumbs.module').then((m) => m.BreadcrumbsDemoModule),
       },
       {
+        path: 'file-input',
+        loadChildren: () => import('./component-demos/file-input/file-input.module').then((m) => m.FileInputDemoModule),
+      },
+      {
+        path: 'flavored-markdown',
+        loadChildren: () =>
+          import('./component-demos/flavored-markdown/flavored-markdown.module').then(
+            (m) => m.FlavoredMarkdownDemoModule,
+          ),
+      },
+      {
         path: 'markdown-parser',
         loadChildren: () => import('./component-demos/markdown/markdown.module').then((m) => m.MarkdownDemoModule),
+      },
+      {
+        path: 'search',
+        loadChildren: () => import('./component-demos/search/search.module').then((m) => m.SearchDemoModule),
+      },
+      {
+        path: 'sidesheet',
+        loadChildren: () => import('./component-demos/sidesheet/sidesheet.module').then((m) => m.SidesheetDemoModule),
       },
     ],
   },

--- a/src/app/content/components/components.ts
+++ b/src/app/content/components/components.ts
@@ -7,9 +7,10 @@ export const componentRouteCategories = [
   { name: 'Navigation', nested: false },
   { name: 'Dialogs', nested: false },
   { name: 'Forms', nested: false },
+  { name: 'Markdown', nested: false },
 ];
 
-const [root, layout, buttons, nav, dialogs, forms] = componentRouteCategories;
+const [root, layout, buttons, nav, dialogs, forms, markdown] = componentRouteCategories;
 
 export const componentDetails: any = [
   {
@@ -26,6 +27,30 @@ export const componentDetails: any = [
     demos: [],
   },
   {
+    name: 'File Input',
+    id: 'file-input',
+    description: 'Text input for files',
+    apiDocUrl: 'platform/core/file/file-input/README.md',
+    overviewDocUrl: '',
+    showExampleTab: true,
+    showOverviewDemo: true,
+    icon: '',
+    category: buttons.name,
+    route: '/components/file-input',
+  },
+  {
+    name: 'Flavored Markdown Parser',
+    id: 'flavored-markdown',
+    description: 'Parse and render markdown code with a Material Design flavor',
+    apiDocUrl: 'platform/flavored-markdown/README.md',
+    overviewDocUrl: '',
+    showExampleTab: true,
+    showOverviewDemo: true,
+    icon: '',
+    category: markdown.name,
+    route: '/components/flavored-markdown',
+  },
+  {
     name: 'Loading Mask',
     id: 'loading-mask',
     description:
@@ -37,6 +62,30 @@ export const componentDetails: any = [
     icon: '',
     category: 'Buttons & Indicators',
     route: '/components/breadcrumbs',
+  },
+  {
+    name: 'Search',
+    id: 'search',
+    description: 'Search and filter items',
+    apiDocUrl: 'this one has two readmes that need to be consolidated',
+    overviewDocUrl: '',
+    showExampleTab: true,
+    showOverviewDemo: true,
+    icon: '',
+    category: buttons.name,
+    route: '/components/search',
+  },
+  {
+    name: 'Sidesheet Content',
+    id: 'sidesheet',
+    description: 'Basic sidesheet content',
+    apiDocUrl: 'platform/core/sidesheet/README.md',
+    overviewDocUrl: '',
+    showExampleTab: true,
+    showOverviewDemo: true,
+    icon: '',
+    category: layout.name,
+    route: '/components/sidesheet',
   },
 ];
 


### PR DESCRIPTION
## Description

Added components that started with f's and s's

### What's included?
- file-input
- flavored-markdown
- search
- sidesheet

#### Test Steps
- Visit the pages for the components above

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
