### PR TITLE
feat(nav-links): improve API contract + tweaks

### DIFF
--- a/src/platform/core/nav-links/nav-links.component.html
+++ b/src/platform/core/nav-links/nav-links.component.html
@@ -1,43 +1,58 @@
 <mat-nav-list dense *ngIf="links && links.length > 0">
-  <ng-template ngFor [ngForOf]="links" let-linkGroup let-indexGroup="index">
-    <td-expansion-panel
-      *ngIf="linkGroup.name && linkGroup.links.length"
-      class="td-nav-group"
-      [sublabel]="linkGroup.name"
-      [expand]="true"
-    >
-      <mat-divider></mat-divider>
-      <ng-template [ngTemplateOutlet]="links"></ng-template>
-    </td-expansion-panel>
-    <ng-template *ngIf="!linkGroup.name && linkGroup.links.length" [ngTemplateOutlet]="links"></ng-template>
-    <ng-template #links>
-      <ng-template ngFor [ngForOf]="linkGroup.links" let-link let-indexLink="index">
+  <ng-template ngFor [ngForOf]="links" let-link let-linkIndex="index">
+    <ng-container *ngIf="link.show === undefined || link.show">
+      <ng-container *ngIf="link.children?.length && !link.link">
+        <h3
+          [class.td-nav-link-cursor]="link.collapsable"
+          matSubheader
+          matRipple
+          [matRippleDisabled]="!link.collapsable"
+          (click)="link.collapsable && _toggle(link)"
+        >
+          <mat-icon *ngIf="link.icon" [fontSet]="link.icon?.fontSet">{{ link.icon?.name }}</mat-icon>
+          <span [style.width.%]="100">{{ link.label }}</span>
+          <mat-icon [@tdRotate]="!_isCollapsed(link)" *ngIf="link.collapsable">
+            keyboard_arrow_down
+          </mat-icon>
+        </h3>
+        <td-nav-links
+          [id]="id + '-' + linkIndex"
+          [@tdCollapse]="!!_isCollapsed(link)"
+          [links]="link.children"
+        ></td-nav-links>
+      </ng-container>
+      <ng-container *ngIf="link.link">
         <a
           mat-list-item
-          *ngIf="getHref(link) && (link.show === undefined || link.show)"
-          [href]="getHref(link)"
-          [target]="link.openInNewTab ? '_blank' : '_self'"
-          id="{{ id }}-{{ indexGroup }}-{{ indexLink }}"
+          *ngIf="_href(link)"
+          [href]="_href(link)"
+          [target]="link.link.openInNewTab ? '_blank' : undefined"
+          id="{{ id }}-{{ linkIndex }}"
           class="td-nav-link"
-          (click)="linkClicked(link)"
+          (click)="_linkClicked(link)"
         >
-          <mat-icon matListIcon [fontSet]="link.fontSet">{{ link.icon }}</mat-icon>
+          <mat-icon matListIcon [fontSet]="link.icon?.fontSet">{{ link.icon?.name }}</mat-icon>
           <span matLine>{{ link.label }}</span>
+          <mat-icon *ngIf="link.link.openInNewTab">
+            launch
+          </mat-icon>
         </a>
-
         <a
           mat-list-item
-          *ngIf="getRouterLink(link) && (link.show === undefined || link.show)"
-          [routerLink]="getRouterLink(link)"
-          [target]="link.openInNewTab ? '_blank' : null"
-          id="{{ id }}-{{ indexGroup }}-{{ indexLink }}"
+          *ngIf="_routerLink(link)"
+          [routerLink]="_routerLink(link)"
+          [target]="link.link.openInNewTab ? '_blank' : undefined"
+          id="{{ id }}-{{ linkIndex }}"
           class="td-nav-link"
-          (click)="linkClicked(link)"
+          (click)="_linkClicked(link)"
         >
-          <mat-icon matListIcon [fontSet]="link.fontSet">{{ link.icon }}</mat-icon>
+          <mat-icon matListIcon [fontSet]="link.icon?.fontSet">{{ link.icon?.name }}</mat-icon>
           <span matLine>{{ link.label }}</span>
+          <mat-icon *ngIf="link.link.openInNewTab">
+            launch
+          </mat-icon>
         </a>
-      </ng-template>
-    </ng-template>
+      </ng-container>
+    </ng-container>
   </ng-template>
 </mat-nav-list>

--- a/src/platform/core/nav-links/nav-links.component.scss
+++ b/src/platform/core/nav-links/nav-links.component.scss
@@ -2,6 +2,12 @@
   display: block;
   .mat-nav-list.mat-list-base {
     padding-top: 2px;
+    .td-nav-link-cursor {
+      cursor: pointer;
+    }
+    .mat-list-item {
+      height: 40px;
+    }
   }
   .mat-icon {
     margin-right: 0;

--- a/src/platform/core/nav-links/nav-links.component.spec.ts
+++ b/src/platform/core/nav-links/nav-links.component.spec.ts
@@ -2,11 +2,9 @@ import { async, ComponentFixture, TestBed, tick } from '@angular/core/testing';
 import { ChangeDetectorRef, DebugElement } from '@angular/core';
 
 import { TdNavLinksComponent } from './nav-links.component';
+import { CovalentNavLinksModule } from './nav-links.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
-import { MatIconModule } from '@angular/material/icon';
-import { MatListModule } from '@angular/material/list';
-import { CovalentExpansionPanelModule } from '@covalent/core/expansion-panel';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -19,15 +17,7 @@ describe('TdNavLinksComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [
-        BrowserModule,
-        RouterTestingModule,
-        NoopAnimationsModule,
-        CovalentExpansionPanelModule,
-        MatIconModule,
-        MatListModule,
-      ],
-      declarations: [TdNavLinksComponent],
+      imports: [BrowserModule, RouterTestingModule, NoopAnimationsModule, CovalentNavLinksModule],
     }).compileComponents();
   }));
 
@@ -47,14 +37,11 @@ describe('TdNavLinksComponent', () => {
   it('should display 1 href link', async () => {
     component.links = [
       {
-        links: [
-          {
-            // tslint:disable-next-line: no-duplicate-string
-            label: 'Duck Duck Go',
-            // tslint:disable-next-line: no-duplicate-string
-            linkTo: { href: 'https://duckduckgo.com/' },
-          },
-        ],
+        // tslint:disable-next-line: no-duplicate-string
+        label: 'Duck Duck Go',
+        // tslint:disable-next-line: no-duplicate-string
+        link: { href: 'https://duckduckgo.com/' },
+        icon: { name: 'apps' },
       },
     ];
     changeDetectorRef.detectChanges();
@@ -63,7 +50,7 @@ describe('TdNavLinksComponent', () => {
     // tslint:disable-next-line: no-duplicate-string
     const navLinks: DebugElement[] = fixture.debugElement.queryAll(By.css('.td-nav-link'));
     // tslint:disable-next-line: no-duplicate-string
-    const hrefLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-0-0'));
+    const hrefLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-0'));
     expect((<HTMLElement>hrefLink.nativeElement).hasAttribute('href')).toBeTruthy();
     expect((<HTMLElement>hrefLink.nativeElement).hasAttribute('ng-reflect-router-link')).toBeFalsy();
     expect(navLinks.length).toBe(1);
@@ -73,12 +60,9 @@ describe('TdNavLinksComponent', () => {
   it('should display 1 router link', async () => {
     component.links = [
       {
-        links: [
-          {
-            label: 'Duck Duck Go',
-            linkTo: { routerLink: 'https://duckduckgo.com/' },
-          },
-        ],
+        label: 'Duck Duck Go',
+        link: { routerLink: 'https://duckduckgo.com/' },
+        icon: { name: 'apps' },
       },
     ];
 
@@ -86,7 +70,7 @@ describe('TdNavLinksComponent', () => {
     await fixture.whenStable();
 
     const navLinks: DebugElement[] = fixture.debugElement.queryAll(By.css('.td-nav-link'));
-    const routerLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-0-0'));
+    const routerLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-0'));
     expect((<HTMLElement>routerLink.nativeElement).hasAttribute('href')).toBeTruthy();
     expect((<HTMLElement>routerLink.nativeElement).hasAttribute('ng-reflect-router-link')).toBeTruthy();
     expect(navLinks.length).toBe(1);
@@ -96,16 +80,14 @@ describe('TdNavLinksComponent', () => {
   it('should display 1 href link and 1 router link', async () => {
     component.links = [
       {
-        links: [
-          {
-            label: 'Duck Duck Go',
-            linkTo: { href: 'https://duckduckgo.com/' },
-          },
-          {
-            label: 'Home',
-            linkTo: { routerLink: ['/'] },
-          },
-        ],
+        label: 'Duck Duck Go',
+        link: { href: 'https://duckduckgo.com/' },
+        icon: { name: 'apps' },
+      },
+      {
+        label: 'Home',
+        link: { routerLink: ['/'] },
+        icon: { name: 'apps' },
       },
     ];
 
@@ -113,8 +95,8 @@ describe('TdNavLinksComponent', () => {
     await fixture.whenStable();
 
     const navLinks: DebugElement[] = fixture.debugElement.queryAll(By.css('.td-nav-link'));
-    const hrefLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-0-0'));
-    const routerLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-0-1'));
+    const hrefLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-0'));
+    const routerLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-1'));
 
     expect((<HTMLElement>hrefLink.nativeElement).hasAttribute('href')).toBeTruthy();
     expect((<HTMLElement>hrefLink.nativeElement).hasAttribute('ng-reflect-router-link')).toBeFalsy();
@@ -128,17 +110,15 @@ describe('TdNavLinksComponent', () => {
   it('should display 1 hidden href link and 1 router link', async () => {
     component.links = [
       {
-        links: [
-          {
-            label: 'Duck Duck Go',
-            linkTo: { href: 'https://duckduckgo.com/' },
-            show: false,
-          },
-          {
-            label: 'Home',
-            linkTo: { routerLink: ['/'] },
-          },
-        ],
+        label: 'Duck Duck Go',
+        link: { href: 'https://duckduckgo.com/' },
+        icon: { name: 'apps' },
+        show: false,
+      },
+      {
+        label: 'Home',
+        link: { routerLink: ['/'] },
+        icon: { name: 'apps' },
       },
     ];
 
@@ -146,8 +126,8 @@ describe('TdNavLinksComponent', () => {
     await fixture.whenStable();
 
     const navLinks: DebugElement[] = fixture.debugElement.queryAll(By.css('.td-nav-link'));
-    const hrefLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-0-0'));
-    const routerLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-0-1'));
+    const hrefLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-0'));
+    const routerLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-1'));
 
     expect(navLinks.length).toBe(1);
     expect(hrefLink).toBeFalsy();
@@ -157,15 +137,17 @@ describe('TdNavLinksComponent', () => {
   it('should display 1 group with 1 routelink and 1 href', async () => {
     component.links = [
       {
-        name: 'Group 1 Links',
-        links: [
+        label: 'Group 1 Links',
+        children: [
           {
             label: 'Duck Duck Go',
-            linkTo: { href: 'https://duckduckgo.com/' },
+            link: { href: 'https://duckduckgo.com/' },
+            icon: { name: 'apps' },
           },
           {
             label: 'Home',
-            linkTo: { routerLink: ['/'] },
+            link: { routerLink: ['/'] },
+            icon: { name: 'apps' },
           },
         ],
       },
@@ -175,7 +157,7 @@ describe('TdNavLinksComponent', () => {
     await fixture.whenStable();
 
     const navLinks: DebugElement[] = fixture.debugElement.queryAll(By.css('.td-nav-link'));
-    const navGroups: DebugElement[] = fixture.debugElement.queryAll(By.css('.td-nav-group'));
+    const navGroups: DebugElement[] = fixture.debugElement.queryAll(By.css('h3'));
     const hrefLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-0-0'));
     const routerLink: DebugElement = fixture.debugElement.query(By.css('#' + id + '-0-1'));
 
@@ -188,28 +170,32 @@ describe('TdNavLinksComponent', () => {
   it('should display 2 group and 4 links', async () => {
     component.links = [
       {
-        name: 'Group 1 Links',
-        links: [
+        label: 'Group 1 Links',
+        children: [
           {
             label: 'Duck Duck Go',
-            linkTo: { href: 'https://duckduckgo.com/' },
+            link: { href: 'https://duckduckgo.com/' },
+            icon: { name: 'apps' },
           },
           {
             label: 'Home',
-            linkTo: { routerLink: ['/'] },
+            link: { routerLink: ['/'] },
+            icon: { name: 'apps' },
           },
         ],
       },
       {
-        name: 'Group 2 Links',
-        links: [
+        label: 'Group 2 Links',
+        children: [
           {
             label: 'Duck Duck Go',
-            linkTo: { href: 'https://duckduckgo.com/' },
+            link: { href: 'https://duckduckgo.com/' },
+            icon: { name: 'apps' },
           },
           {
             label: 'Home',
-            linkTo: { routerLink: ['/'] },
+            link: { routerLink: ['/'] },
+            icon: { name: 'apps' },
           },
         ],
       },
@@ -219,7 +205,7 @@ describe('TdNavLinksComponent', () => {
     await fixture.whenStable();
 
     const navLinks: DebugElement[] = fixture.debugElement.queryAll(By.css('.td-nav-link'));
-    const navGroups: DebugElement[] = fixture.debugElement.queryAll(By.css('.td-nav-group'));
+    const navGroups: DebugElement[] = fixture.debugElement.queryAll(By.css('h3'));
 
     expect(navGroups.length).toBe(2);
 

--- a/src/platform/core/nav-links/nav-links.component.ts
+++ b/src/platform/core/nav-links/nav-links.component.ts
@@ -1,17 +1,23 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
 
-export interface ITdLinkGroup {
-  name?: string;
-  links: ITdLink[];
+import { tdCollapseAnimation, tdRotateAnimation } from '@covalent/core/common';
+
+export interface ITdNavNode {
+  label: string;
+  show?: boolean;
 }
 
-export interface ITdLink {
-  label: string;
-  linkTo: { href?: string } | { routerLink?: string | string[] };
-  openInNewTab?: boolean;
-  icon?: string;
-  show?: boolean;
-  fontSet?: string;
+export interface ITdNavHeader extends ITdNavNode {
+  children: ITdLink[];
+}
+
+export interface ITdNavExpansion extends ITdNavHeader {
+  collapsable?: boolean;
+}
+
+export interface ITdLink extends ITdNavNode {
+  link: { href: string; openInNewTab?: boolean } | { routerLink: string | string[]; openInNewTab?: boolean };
+  icon: { fontSet?: string; name: string };
 }
 
 let nextUniqueId: number = 0;
@@ -21,23 +27,56 @@ let nextUniqueId: number = 0;
   templateUrl: './nav-links.component.html',
   styleUrls: ['./nav-links.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [tdCollapseAnimation, tdRotateAnimation],
 })
 export class TdNavLinksComponent {
   private _uniqueId: string = `td-nav-links-${++nextUniqueId}`;
 
+  private _collapsedSet: Set<ITdNavExpansion> = new Set<ITdNavExpansion>();
+
   @Input() id: string = this._uniqueId;
-  @Input() links: ITdLinkGroup[];
-  @Output() afterClick: EventEmitter<ITdLink> = new EventEmitter<ITdLink>();
 
-  linkClicked(link: ITdLink): void {
-    this.afterClick.emit(link);
+  /**
+   * Links to be rendered by component.
+   */
+  /* tslint:disable-next-line */
+  @Input() links: Array<ITdNavExpansion | ITdNavHeader | ITdLink>;
+
+  /**
+   * Event trigger after a navigation click
+   */
+  @Output() afterNavigation: EventEmitter<ITdLink> = new EventEmitter<ITdLink>();
+
+  _linkClicked(link: ITdLink): void {
+    this.afterNavigation.emit(link);
   }
 
-  getHref(link: ITdLink): string {
-    return link.linkTo && (<{ href?: string }>link.linkTo).href;
+  _href(link: ITdLink): string {
+    return link.link && (<{ href?: string }>link.link).href;
   }
 
-  getRouterLink(link: ITdLink): string | string[] {
-    return link.linkTo && (<{ routerLink?: string | string[] }>link.linkTo).routerLink;
+  _routerLink(link: ITdLink): string | string[] {
+    return link.link && (<{ routerLink?: string | string[] }>link.link).routerLink;
+  }
+
+  /**
+   * @param link
+   * Toggles expand/collapse state of expansion link.
+   * Only applied when `collapsable` is true
+   */
+  _toggle(link: ITdNavExpansion): void {
+    if (this._isCollapsed(link)) {
+      this._collapsedSet.delete(link);
+    } else {
+      this._collapsedSet.add(link);
+    }
+  }
+
+  /**
+   * @param link
+   * Returns true if the state of provided expansion link is collapsed.
+   */
+  _isCollapsed(link: ITdNavExpansion): boolean {
+    return this._collapsedSet.has(link);
   }
 }

--- a/src/platform/core/nav-links/nav-links.module.ts
+++ b/src/platform/core/nav-links/nav-links.module.ts
@@ -3,9 +3,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
+import { MatRippleModule } from '@angular/material/core';
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatMenuModule } from '@angular/material/menu';
 
 import { CovalentCommonModule } from '@covalent/core/common';
 import { CovalentExpansionPanelModule } from '@covalent/core/expansion-panel';
@@ -19,6 +21,8 @@ import { TdNavLinksComponent } from './nav-links.component';
     CommonModule,
     CovalentCommonModule,
     CovalentExpansionPanelModule,
+    MatRippleModule,
+    MatMenuModule,
     MatListModule,
     MatIconModule,
     MatDividerModule,

--- a/src/test-bed/main/main.component.html
+++ b/src/test-bed/main/main.component.html
@@ -28,10 +28,45 @@
 </div>
 
 <td-nav-links
+  [style.width.px]="400"
   [links]="[
     {
-      name: 'test',
-      links: [{ label: 'test1', icon: 'apps', linkTo: { href: '/' } }, { label: 'test2', linkTo: { href: '/' } }]
+      label: 'expansion',
+      collapsable: true,
+      children: [
+        {
+          label: 'link',
+          link: { href: '/', openInNewTab: true },
+          icon: { name: 'apps' }
+        }
+      ]
+    },
+    {
+      label: 'header',
+      children: [
+        {
+          label: 'link',
+          link: { href: '/' },
+          icon: { name: 'apps' }
+        }
+      ]
+    },
+    {
+      label: 'link',
+      link: { href: '/' },
+      icon: { name: 'apps' },
+      children: [
+        {
+          label: 'header',
+          link: { href: '/', openInNewTab: true },
+          icon: { name: 'apps' }
+        },
+        {
+          label: 'link',
+          link: { href: '/' },
+          icon: { name: 'apps' }
+        }
+      ]
     }
   ]"
 ></td-nav-links>


### PR DESCRIPTION
## Description
Improve nav-links API to support more of a tree-like structure

### What's included?
<!-- List features included in this PR -->
- Improve API to support first level links rather than just nested.
- Make the collapsable groups visually more consistent and easier to use (no expansion panel).
- Make collapsable groups optional.
- Add launch icon depending if its opening a new tab or not

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve:experimental`
- [ ] Play with `links` input

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.