### PR TITLE
Feat(tslint): run on remaining files excluding platform

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -34,7 +34,6 @@ import 'web-animations-js';
  * By default, zone.js will patch all possible macroTask and DomEvents
  * user can disable parts of macroTask/DomEvents patch by setting following flags
  */
-
 // (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
 // (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
 // (window as any).__zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames

--- a/src/tests/utilities/covalent-tests.ts
+++ b/src/tests/utilities/covalent-tests.ts
@@ -55,6 +55,7 @@ export class CovalentTests {
   public static checkForErrorDialogs(): boolean {
     const elements: NodeList = document.querySelectorAll('[id^=cdk-overlay]');
     let foundErrorDialog: boolean = false;
+    // tslint:disable-next-line:prefer-for-of
     for (let index: number = 0; index < elements.length; index++) {
       if (elements[index].firstChild.textContent.indexOf('There was a problem') > -1) {
         foundErrorDialog = true;

--- a/src/universal-app/combat-training/combat-training.ts
+++ b/src/universal-app/combat-training/combat-training.ts
@@ -1,7 +1,6 @@
 import { Component, NgModule, OnInit } from '@angular/core';
 import { ServerModule } from '@angular/platform-server';
 import { BrowserModule } from '@angular/platform-browser';
-// import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 


### PR DESCRIPTION
## Description

run on remaining files excluding platform. Works off of #1541 

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
