### PR TITLE
feat(tslint): run on core breadcrumbs - data-table

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "webdriver-update": "bash ./node_modules/.bin/webdriver-manager update",
     "lint": "npm run tslint && npm run stylelint",
-    "tslint": "./node_modules/.bin/tslint -p ./tsconfig.json --format codeFrame -c ./tslint.json './src/**/*.ts' -e './src/platform/core/**'  -e './src/platform/echarts/**'",
+    "tslint": "./node_modules/.bin/tslint -p ./tsconfig.json --format codeFrame -c ./tslint.json './src/**/*.ts'  -e './src/platform/echarts/**' -e './src/platform/core/{expansion-panel,file,json-formatter,layout,loading,media,menu,message,nav-link,notifications,paging,schematics,search,sidesheet,steps,tab-select,themeing,typography,virtual-scroll}/**' ",
     "stylelint": "./node_modules/.bin/stylelint 'src/**/*.scss' '!**/_layout.scss' '!**/markdown.component.scss' --config stylelint.config.js --syntax scss",
     "preinstall": "rm -rf node_modules tmp deploy dist",
     "postinstall": "npm rebuild node-sass && webdriver-manager update",

--- a/src/platform/core/breadcrumbs/breadcrumbs.component.ts
+++ b/src/platform/core/breadcrumbs/breadcrumbs.component.ts
@@ -40,7 +40,7 @@ export class TdBreadcrumbsComponent implements OnInit, DoCheck, AfterContentInit
   /**
    * Sets the icon url shown between breadcrumbs. Defaults to 'chevron_right'.
    */
-  @Input('separatorIcon') separatorIcon: string = 'chevron_right';
+  @Input() separatorIcon: string = 'chevron_right';
 
   constructor(private _elementRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef) {}
 

--- a/src/platform/core/chips/chips.component.spec.ts
+++ b/src/platform/core/chips/chips.component.spec.ts
@@ -42,7 +42,7 @@ describe('Component: Chips', () => {
         {
           provide: OverlayContainer,
           useFactory: () => {
-            overlayContainerElement = document.createElement('div') as HTMLElement;
+            overlayContainerElement = document.createElement('div');
             overlayContainerElement.classList.add('cdk-overlay-container');
 
             document.body.appendChild(overlayContainerElement);
@@ -355,7 +355,7 @@ describe('Component: Chips', () => {
       chips.triggerEventHandler('focus', new Event('focus'));
       fixture.detectChanges();
       fixture.whenStable().then(() => {
-        const option: HTMLElement = <HTMLElement>overlayContainerElement.querySelector('mat-option');
+        const option: HTMLElement = overlayContainerElement.querySelector('mat-option');
         option.click();
         fixture.detectChanges();
         fixture.whenStable().then(() => {
@@ -371,7 +371,7 @@ describe('Component: Chips', () => {
       chips.triggerEventHandler('focus', new Event('focus'));
       fixture.detectChanges();
       fixture.whenStable().then(() => {
-        const option: HTMLElement = <HTMLElement>overlayContainerElement.querySelector('mat-option');
+        const option: HTMLElement = overlayContainerElement.querySelector('mat-option');
         option.click();
         fixture.detectChanges();
         fixture.whenStable().then(() => {
@@ -395,7 +395,7 @@ describe('Component: Chips', () => {
       chips.triggerEventHandler('focus', new Event('focus'));
       fixture.detectChanges();
       fixture.whenStable().then(() => {
-        const option: HTMLElement = <HTMLElement>overlayContainerElement.querySelector('mat-option');
+        const option: HTMLElement = overlayContainerElement.querySelector('mat-option');
         option.click();
         fixture.detectChanges();
         fixture.whenStable().then(() => {
@@ -415,7 +415,6 @@ describe('Component: Chips', () => {
 
   describe('panel usage and filtering: ', () => {
     let fixture: ComponentFixture<TdChipsBasicTestComponent>;
-    let input: DebugElement;
     let chips: DebugElement;
 
     beforeEach(() => {
@@ -491,7 +490,6 @@ describe('Component: Chips', () => {
 
   describe('panel usage and requireMatch usage: ', () => {
     let fixture: ComponentFixture<TdChipsObjectsRequireMatchTestComponent>;
-    let input: DebugElement;
     let chips: DebugElement;
 
     beforeEach(() => {
@@ -515,7 +513,7 @@ describe('Component: Chips', () => {
       fixture.whenStable().then(() => {
         fixture.detectChanges();
         fixture.whenStable().then(() => {
-          const option: HTMLElement = <HTMLElement>overlayContainerElement.querySelector('mat-option');
+          const option: HTMLElement = overlayContainerElement.querySelector('mat-option');
           option.click();
           fixture.detectChanges();
           fixture.whenStable().then(() => {
@@ -530,7 +528,6 @@ describe('Component: Chips', () => {
 
   describe('stacked usage: ', () => {
     let fixture: ComponentFixture<TdChipsStackedTestComponent>;
-    let input: DebugElement;
     let chips: DebugElement;
 
     beforeEach(() => {
@@ -562,7 +559,6 @@ describe('Component: Chips', () => {
 
   describe('position usage: ', () => {
     let fixture: ComponentFixture<TdChipsBeforeAfterTestComponent>;
-    let input: DebugElement;
     let chips: DebugElement;
 
     beforeEach(() => {

--- a/src/platform/core/chips/chips.component.ts
+++ b/src/platform/core/chips/chips.component.ts
@@ -258,13 +258,13 @@ export class TdChipsComponent extends _TdChipsMixinBase
    * placeholder?: string
    * Placeholder for the autocomplete input.
    */
-  @Input('placeholder') placeholder: string;
+  @Input() placeholder: string;
 
   /**
    * debounce?: number
    * Debounce timeout between keypresses. Defaults to 200.
    */
-  @Input('debounce') debounce: number = 200;
+  @Input() debounce: number = 200;
 
   /**
    * color?: 'primary' | 'accent' | 'warn'
@@ -288,35 +288,35 @@ export class TdChipsComponent extends _TdChipsMixinBase
    * Method to be executed when a chip is added.
    * Sends chip value as event.
    */
-  @Output('add') onAdd: EventEmitter<any> = new EventEmitter<any>();
+  @Output() add: EventEmitter<any> = new EventEmitter<any>();
 
   /**
    * remove?: function
    * Method to be executed when a chip is removed.
    * Sends chip value as event.
    */
-  @Output('remove') onRemove: EventEmitter<any> = new EventEmitter<any>();
+  @Output() remove: EventEmitter<any> = new EventEmitter<any>();
 
   /**
    * inputChange?: function
    * Method to be executed when the value in the autocomplete input changes.
    * Sends string value as event.
    */
-  @Output('inputChange') onInputChange: EventEmitter<string> = new EventEmitter<string>();
+  @Output() inputChange: EventEmitter<string> = new EventEmitter<string>();
 
   /**
    * chipFocus?: function
    * Method to be executed when a chip is focused.
    * Sends chip value as event.
    */
-  @Output('chipFocus') onChipFocus: EventEmitter<any> = new EventEmitter<any>();
+  @Output() chipFocus: EventEmitter<any> = new EventEmitter<any>();
 
   /**
    * blur?: function
    * Method to be executed when a chip is blurred.
    * Sends chip value as event.
    */
-  @Output('chipBlur') onChipBlur: EventEmitter<any> = new EventEmitter<any>();
+  @Output() chipBlur: EventEmitter<any> = new EventEmitter<any>();
 
   /**
    * Hostbinding to set the a11y of the TdChipsComponent depending on its state
@@ -341,7 +341,7 @@ export class TdChipsComponent extends _TdChipsMixinBase
    * Function used to check whether a chip value already exists.
    * Defaults to strict equality comparison ===
    */
-  @Input('compareWith') compareWith: (o1: any, o2: any) => boolean = (o1: any, o2: any) => {
+  @Input() compareWith: (o1: any, o2: any) => boolean = (o1: any, o2: any) => {
     return o1 === o2;
   };
 
@@ -417,7 +417,7 @@ export class TdChipsComponent extends _TdChipsMixinBase
     this._inputValueChangesSubs = this.inputControl.valueChanges
       .pipe(debounceTime(this.debounce))
       .subscribe((value: string) => {
-        this.onInputChange.emit(value ? value : '');
+        this.inputChange.emit(value ? value : '');
       });
     this._changeDetectorRef.markForCheck();
   }
@@ -510,7 +510,7 @@ export class TdChipsComponent extends _TdChipsMixinBase
     }
 
     this.value.push(value);
-    this.onAdd.emit(value);
+    this.add.emit(value);
     this.onChange(this.value);
     this._changeDetectorRef.markForCheck();
     return true;
@@ -538,7 +538,7 @@ export class TdChipsComponent extends _TdChipsMixinBase
       this._focusChip(index - 1);
     }
 
-    this.onRemove.emit(removedValues[0]);
+    this.remove.emit(removedValues[0]);
     this.onChange(this.value);
     this.inputControl.setValue('');
     this._changeDetectorRef.markForCheck();
@@ -549,7 +549,7 @@ export class TdChipsComponent extends _TdChipsMixinBase
    * Sets blur of chip and sends out event
    */
   _handleChipBlur(event: FocusEvent, value: any): void {
-    this.onChipBlur.emit(value);
+    this.chipBlur.emit(value);
   }
 
   /**
@@ -557,7 +557,7 @@ export class TdChipsComponent extends _TdChipsMixinBase
    */
   _handleChipFocus(event: FocusEvent, value: any): void {
     this.setFocusedState();
-    this.onChipFocus.emit(value);
+    this.chipFocus.emit(value);
   }
 
   _handleFocus(): boolean {

--- a/src/platform/core/common/configs/tslint/tslint.json
+++ b/src/platform/core/common/configs/tslint/tslint.json
@@ -42,7 +42,7 @@
     "no-arg": true,
     "no-bitwise": true,
     "no-conditional-assignment": true,
-    "no-consecutive-blank-lines": [true],
+    "no-consecutive-blank-lines": true,
     "no-console": [
       true,
       "assert",
@@ -79,7 +79,7 @@
     "no-namespace": true,
     "no-null-keyword": true,
     "no-require-imports": true,
-    "quotemark": { "options": [true, "single", "avoid-escape", "avoid-template"] },
+    "quotemark": [true, "single", "avoid-escape", "avoid-template"],
     "switch-default": true,
     "trailing-comma": {
       "options": {
@@ -125,11 +125,11 @@
 
     "max-classes-per-file": false,
     "no-floating-promises": false,
-
     "no-big-function": false,
     "no-duplicate-string": false,
     "no-identical-functions": false,
     "max-union-size": false,
-    "no-hardcoded-credentials": false
+    "no-hardcoded-credentials": false,
+    "cognitive-complexity": false
   }
 }

--- a/src/platform/core/common/forms/validators/validators.ts
+++ b/src/platform/core/common/forms/validators/validators.ts
@@ -2,25 +2,23 @@ import { Validators, AbstractControl, ValidatorFn } from '@angular/forms';
 
 export class CovalentValidators {
   static min(minValue: any): ValidatorFn {
-    const func: ValidatorFn = (c: AbstractControl): { [key: string]: any } => {
+    return (c: AbstractControl): { [key: string]: any } => {
       if (!!Validators.required(c) || (!minValue && minValue !== 0)) {
         return undefined;
       }
       const v: number = c.value;
       return v < minValue ? { min: { minValue, actualValue: v } } : undefined;
     };
-    return func;
   }
 
   static max(maxValue: any): ValidatorFn {
-    const func: ValidatorFn = (c: AbstractControl): { [key: string]: any } => {
+    return (c: AbstractControl): { [key: string]: any } => {
       if (!!Validators.required(c) || (!maxValue && maxValue !== 0)) {
         return undefined;
       }
       const v: number = c.value;
       return v > maxValue ? { max: { maxValue, actualValue: v } } : undefined;
     };
-    return func;
   }
 
   static numberRequired(c: AbstractControl): { [key: string]: any } {

--- a/src/platform/core/common/functions/convert.spec.ts
+++ b/src/platform/core/common/functions/convert.spec.ts
@@ -11,8 +11,8 @@ describe('Convert', () => {
 
       expect(convertObjectsToCSV(undefined)).toEqual('');
       expect(convertObjectsToCSV([])).toEqual('');
-      expect(convertObjectsToCSV(objects, undefined)).toEqual(expectedStr);
-      expect(convertObjectsToCSV(objects, '|', undefined)).toEqual(expectedStrCustomKeySeparator);
+      expect(convertObjectsToCSV(objects)).toEqual(expectedStr);
+      expect(convertObjectsToCSV(objects, '|')).toEqual(expectedStrCustomKeySeparator);
       expect(convertObjectsToCSV(objects, undefined, '|')).toEqual(expectedStrCustomLineSeparator);
       expect(convertObjectsToCSV(objects)).toEqual(expectedStr);
       expect(convertObjectsToCSV(objects, '|')).toEqual(expectedStrCustomKeySeparator);
@@ -32,8 +32,8 @@ describe('Convert', () => {
 
       expect(convertCSVToJSON(undefined)).toEqual('');
       expect(convertCSVToJSON('')).toEqual('');
-      expect(convertCSVToJSON(csv, undefined)).toEqual(expectedJSON);
-      expect(convertCSVToJSON(csvCustomKeySeparator, '|', undefined)).toEqual(expectedJSON);
+      expect(convertCSVToJSON(csv)).toEqual(expectedJSON);
+      expect(convertCSVToJSON(csvCustomKeySeparator, '|')).toEqual(expectedJSON);
       expect(convertCSVToJSON(csvCustomLineSeparator, undefined, '|')).toEqual(expectedJSON);
       expect(convertCSVToJSON(csv)).toEqual(expectedJSON);
       expect(convertCSVToJSON(csvCustomKeySeparator, '|')).toEqual(expectedJSON);

--- a/src/platform/core/common/functions/convert.ts
+++ b/src/platform/core/common/functions/convert.ts
@@ -21,7 +21,7 @@ export function convertObjectsToCSV(
   // Iterate through array, creating one output line per object
   objects.forEach((value: object, key: number) => {
     let line: string = '';
-    for (const index in objects[key]) {
+    for (const index of Object.keys(objects[key])) {
       if (line !== '') {
         line += keySeparator;
       }

--- a/src/platform/core/common/pipes/bytes/bytes.pipe.spec.ts
+++ b/src/platform/core/common/pipes/bytes/bytes.pipe.spec.ts
@@ -8,25 +8,25 @@ describe('TdBytesPipe', () => {
   });
 
   it('should return with an empty or invalid input', () => {
-    expect(pipe.transform(NaN, undefined)).toEqual('Invalid Number');
-    expect(pipe.transform(undefined, undefined)).toEqual('Invalid Number');
-    expect(pipe.transform(0.3, undefined)).toEqual('Invalid Number');
-    expect(pipe.transform(0.76, undefined)).toEqual('Invalid Number');
+    expect(pipe.transform(NaN)).toEqual('Invalid Number');
+    expect(pipe.transform(undefined)).toEqual('Invalid Number');
+    expect(pipe.transform(0.3)).toEqual('Invalid Number');
+    expect(pipe.transform(0.76)).toEqual('Invalid Number');
   });
 
   it('should return a formatted bytes to larger units', () => {
-    expect(pipe.transform(0, undefined)).toEqual('0 B');
-    expect(pipe.transform(535, undefined)).toEqual('535 B');
-    expect(pipe.transform(1024, undefined)).toEqual('1 KiB');
-    expect(pipe.transform(138540, undefined)).toEqual('135.29 KiB');
+    expect(pipe.transform(0)).toEqual('0 B');
+    expect(pipe.transform(535)).toEqual('535 B');
+    expect(pipe.transform(1024)).toEqual('1 KiB');
+    expect(pipe.transform(138540)).toEqual('135.29 KiB');
     expect(pipe.transform(138540, 1)).toEqual('135.3 KiB');
-    expect(pipe.transform(1571800, undefined)).toEqual('1.5 MiB');
+    expect(pipe.transform(1571800)).toEqual('1.5 MiB');
     expect(pipe.transform(1571800, 4)).toEqual('1.499 MiB');
-    expect(pipe.transform(10000000, undefined)).toEqual('9.54 MiB');
-    expect(pipe.transform(10485760, undefined)).toEqual('10 MiB');
+    expect(pipe.transform(10000000)).toEqual('9.54 MiB');
+    expect(pipe.transform(10485760)).toEqual('10 MiB');
     expect(pipe.transform(10201000, 3)).toEqual('9.728 MiB');
-    expect(pipe.transform(3.81861e10, undefined)).toEqual('35.56 GiB');
-    expect(pipe.transform(1.890381861e14, undefined)).toEqual('171.93 TiB');
-    expect(pipe.transform(5.35765e16, undefined)).toEqual('47.59 PiB');
+    expect(pipe.transform(3.81861e10)).toEqual('35.56 GiB');
+    expect(pipe.transform(1.890381861e14)).toEqual('171.93 TiB');
+    expect(pipe.transform(5.35765e16)).toEqual('47.59 PiB');
   });
 });

--- a/src/platform/core/common/pipes/decimal-bytes/decimal-bytes.pipe.spec.ts
+++ b/src/platform/core/common/pipes/decimal-bytes/decimal-bytes.pipe.spec.ts
@@ -8,27 +8,27 @@ describe('TdDecimalBytesPipe', () => {
   });
 
   it('should return with an empty or invalid input', () => {
-    expect(pipe.transform(NaN, undefined)).toEqual('Invalid Number');
-    expect(pipe.transform(undefined, undefined)).toEqual('Invalid Number');
-    expect(pipe.transform(0.3, undefined)).toEqual('Invalid Number');
-    expect(pipe.transform(0.76, undefined)).toEqual('Invalid Number');
+    expect(pipe.transform(NaN)).toEqual('Invalid Number');
+    expect(pipe.transform(undefined)).toEqual('Invalid Number');
+    expect(pipe.transform(0.3)).toEqual('Invalid Number');
+    expect(pipe.transform(0.76)).toEqual('Invalid Number');
   });
 
   it('should return a formatted bytes to larger units', () => {
-    expect(pipe.transform(0, undefined)).toEqual('0 B');
-    expect(pipe.transform(535, undefined)).toEqual('535 B');
-    expect(pipe.transform(1000, undefined)).toEqual('1 KB');
-    expect(pipe.transform(1024, undefined)).toEqual('1.02 KB');
+    expect(pipe.transform(0)).toEqual('0 B');
+    expect(pipe.transform(535)).toEqual('535 B');
+    expect(pipe.transform(1000)).toEqual('1 KB');
+    expect(pipe.transform(1024)).toEqual('1.02 KB');
     expect(pipe.transform(1024, 1)).toEqual('1 KB');
-    expect(pipe.transform(138540, undefined)).toEqual('138.54 KB');
+    expect(pipe.transform(138540)).toEqual('138.54 KB');
     expect(pipe.transform(138540, 1)).toEqual('138.5 KB');
-    expect(pipe.transform(1571800, undefined)).toEqual('1.57 MB');
+    expect(pipe.transform(1571800)).toEqual('1.57 MB');
     expect(pipe.transform(1571800, 4)).toEqual('1.5718 MB');
-    expect(pipe.transform(10000000, undefined)).toEqual('10 MB');
-    expect(pipe.transform(10485760, undefined)).toEqual('10.49 MB');
+    expect(pipe.transform(10000000)).toEqual('10 MB');
+    expect(pipe.transform(10485760)).toEqual('10.49 MB');
     expect(pipe.transform(10201000, 3)).toEqual('10.201 MB');
-    expect(pipe.transform(3.81861e10, undefined)).toEqual('38.19 GB');
-    expect(pipe.transform(1.890381861e14, undefined)).toEqual('189.04 TB');
-    expect(pipe.transform(5.35765e16, undefined)).toEqual('53.58 PB');
+    expect(pipe.transform(3.81861e10)).toEqual('38.19 GB');
+    expect(pipe.transform(1.890381861e14)).toEqual('189.04 TB');
+    expect(pipe.transform(5.35765e16)).toEqual('53.58 PB');
   });
 });

--- a/src/platform/core/common/pipes/digits/digits.pipe.spec.ts
+++ b/src/platform/core/common/pipes/digits/digits.pipe.spec.ts
@@ -17,47 +17,47 @@ describe('TdDigitsPipe', () => {
   });
 
   it('should return with an empty or invalid input', () => {
-    expect(pipe.transform('notanumber', undefined)).toEqual('notanumber');
-    expect(<any>pipe.transform(NaN, undefined)).toEqual(NaN);
-    expect(pipe.transform(undefined, undefined)).toEqual(undefined);
+    expect(pipe.transform('notanumber')).toEqual('notanumber');
+    expect(<any>pipe.transform(NaN)).toEqual(NaN);
+    expect(pipe.transform(undefined)).toEqual(undefined);
   });
 
   it('should return formatted digits', () => {
     /* transformations in 'en'*/
-    expect(pipe.transform('34', undefined)).toEqual('34');
+    expect(pipe.transform('34')).toEqual('34');
     expect(pipe.transform(0.45, 1)).toEqual('0.5');
     expect(pipe.transform(0.724, 2)).toEqual('0.72');
-    expect(pipe.transform(535, undefined)).toEqual('535');
-    expect(pipe.transform(138540, undefined)).toEqual('138.5 K');
+    expect(pipe.transform(535)).toEqual('535');
+    expect(pipe.transform(138540)).toEqual('138.5 K');
     expect(pipe.transform(138540, 2)).toEqual('138.54 K');
-    expect(pipe.transform(1571800, undefined)).toEqual('1.6 M');
+    expect(pipe.transform(1571800)).toEqual('1.6 M');
     expect(pipe.transform(1571800, 3)).toEqual('1.572 M');
-    expect(pipe.transform(10000000, undefined)).toEqual('10 M');
-    expect(pipe.transform(10200000, undefined)).toEqual('10.2 M');
-    expect(pipe.transform(3.81861e10, undefined)).toEqual('38.2 B');
-    expect(pipe.transform(1.890381861e14, undefined)).toEqual('189 T');
-    expect(pipe.transform(5.35765e16, undefined)).toEqual('53.6 Q');
+    expect(pipe.transform(10000000)).toEqual('10 M');
+    expect(pipe.transform(10200000)).toEqual('10.2 M');
+    expect(pipe.transform(3.81861e10)).toEqual('38.2 B');
+    expect(pipe.transform(1.890381861e14)).toEqual('189 T');
+    expect(pipe.transform(5.35765e16)).toEqual('53.6 Q');
 
     /* transformations in 'es'*/
-    expect(l10nEsPipe.transform('34', undefined)).toEqual('34');
+    expect(l10nEsPipe.transform('34')).toEqual('34');
     expect(l10nEsPipe.transform(0.45, 1)).toEqual('0,5');
     expect(l10nEsPipe.transform(0.724, 2)).toEqual('0,72');
-    expect(l10nEsPipe.transform(535, undefined)).toEqual('535');
-    expect(l10nEsPipe.transform(138540, undefined)).toEqual('138,5 K');
+    expect(l10nEsPipe.transform(535)).toEqual('535');
+    expect(l10nEsPipe.transform(138540)).toEqual('138,5 K');
     expect(l10nEsPipe.transform(138540, 2)).toEqual('138,54 K');
-    expect(l10nEsPipe.transform(1571800, undefined)).toEqual('1,6 M');
+    expect(l10nEsPipe.transform(1571800)).toEqual('1,6 M');
     expect(l10nEsPipe.transform(1571800, 3)).toEqual('1,572 M');
-    expect(l10nEsPipe.transform(10000000, undefined)).toEqual('10 M');
-    expect(l10nEsPipe.transform(10200000, undefined)).toEqual('10,2 M');
-    expect(l10nEsPipe.transform(3.81861e10, undefined)).toEqual('38,2 B');
-    expect(l10nEsPipe.transform(1.890381861e14, undefined)).toEqual('189 T');
-    expect(l10nEsPipe.transform(5.35765e16, undefined)).toEqual('53,6 Q');
+    expect(l10nEsPipe.transform(10000000)).toEqual('10 M');
+    expect(l10nEsPipe.transform(10200000)).toEqual('10,2 M');
+    expect(l10nEsPipe.transform(3.81861e10)).toEqual('38,2 B');
+    expect(l10nEsPipe.transform(1.890381861e14)).toEqual('189 T');
+    expect(l10nEsPipe.transform(5.35765e16)).toEqual('53,6 Q');
   });
 
   it('should fail since locale is not registered', () => {
     /* not registered transformations */
     expect(() => {
-      l10nFrPipe.transform(1000, undefined);
+      l10nFrPipe.transform(1000);
     }).toThrowError();
   });
 });

--- a/src/platform/core/common/pipes/time-ago/time-ago.pipe.spec.ts
+++ b/src/platform/core/common/pipes/time-ago/time-ago.pipe.spec.ts
@@ -9,9 +9,9 @@ describe('TdTimeAgoPipe', () => {
   });
 
   it('should return "Invalid Date" with an invalid date', () => {
-    expect(pipe.transform(undefined, undefined)).toEqual('Invalid Date');
+    expect(pipe.transform(undefined)).toEqual('Invalid Date');
     expect(pipe.transform(undefined, time)).toEqual('Invalid Date');
-    expect(pipe.transform('', undefined)).toEqual('Invalid Date');
+    expect(pipe.transform('')).toEqual('Invalid Date');
     expect(pipe.transform('', '')).toEqual('Invalid Date');
     expect(pipe.transform({}, {})).toEqual('Invalid Date');
     expect(pipe.transform('this is not a valid date', 'not a valid date either')).toEqual('Invalid Date');

--- a/src/platform/core/common/pipes/time-difference/time-difference.pipe.spec.ts
+++ b/src/platform/core/common/pipes/time-difference/time-difference.pipe.spec.ts
@@ -10,9 +10,9 @@ describe('TdTimeDifferencePipe', () => {
   });
 
   it('should return blank with an invalid date', () => {
-    expect(pipe.transform(undefined, undefined)).toEqual('Invalid Date');
+    expect(pipe.transform(undefined)).toEqual('Invalid Date');
     expect(pipe.transform(undefined, end)).toEqual('Invalid Date');
-    expect(pipe.transform('', undefined)).toEqual('Invalid Date');
+    expect(pipe.transform('')).toEqual('Invalid Date');
     expect(pipe.transform('', '')).toEqual('Invalid Date');
     expect(pipe.transform({}, {})).toEqual('Invalid Date');
     expect(pipe.transform('this is not a valid date', 'not a valid date either')).toEqual('Invalid Date');

--- a/src/platform/core/common/pipes/time-until/time-until.pipe.spec.ts
+++ b/src/platform/core/common/pipes/time-until/time-until.pipe.spec.ts
@@ -9,9 +9,9 @@ describe('TdTimeUntilPipe', () => {
   });
 
   it('should return "Invalid Date" with an invalid date', () => {
-    expect(pipe.transform(undefined, undefined)).toEqual('Invalid Date');
+    expect(pipe.transform(undefined)).toEqual('Invalid Date');
     expect(pipe.transform(undefined, time)).toEqual('Invalid Date');
-    expect(pipe.transform('', undefined)).toEqual('Invalid Date');
+    expect(pipe.transform('')).toEqual('Invalid Date');
     expect(pipe.transform('', '')).toEqual('Invalid Date');
     expect(pipe.transform({}, {})).toEqual('Invalid Date');
     expect(pipe.transform('this is not a valid date', 'not a valid date either')).toEqual('Invalid Date');

--- a/src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
+++ b/src/platform/core/data-table/data-table-cell/data-table-cell.component.ts
@@ -16,7 +16,7 @@ export class TdDataTableCellComponent {
    * Makes cell follow the numeric data-table specs.
    * Defaults to 'false'
    */
-  @Input('numeric') numeric: boolean = false;
+  @Input() numeric: boolean = false;
 
   /**
    * align?: 'start' | 'center' | 'end'

--- a/src/platform/core/data-table/data-table-column/data-table-column.component.ts
+++ b/src/platform/core/data-table/data-table-column/data-table-column.component.ts
@@ -39,28 +39,28 @@ export class TdDataTableColumnComponent {
    * name?: string
    * Sets unique column [name] for [sortable] events.
    */
-  @Input('name') name: string = '';
+  @Input() name: string = '';
 
   /**
    * sortable?: boolean
    * Enables sorting events, sort icons and active column states.
    * Defaults to 'false'
    */
-  @Input('sortable') sortable: boolean = false;
+  @Input() sortable: boolean = false;
 
   /**
    * active?: boolean
    * Sets column to active state when 'true'.
    * Defaults to 'false'
    */
-  @Input('active') active: boolean = false;
+  @Input() active: boolean = false;
 
   /**
    * numeric?: boolean
    * Makes column follow the numeric data-table specs and sort icon.
    * Defaults to 'false'
    */
-  @Input('numeric') numeric: boolean = false;
+  @Input() numeric: boolean = false;
 
   /**
    * sortOrder?: ['ASC' | 'DESC'] or TdDataTableSortingOrder
@@ -82,9 +82,7 @@ export class TdDataTableColumnComponent {
    * Event emitted when the column headers are clicked. [sortable] needs to be enabled.
    * Emits an [ITdDataTableSortChangeEvent] implemented object.
    */
-  @Output('sortChange') onSortChange: EventEmitter<ITdDataTableSortChangeEvent> = new EventEmitter<
-    ITdDataTableSortChangeEvent
-  >();
+  @Output() sortChange: EventEmitter<ITdDataTableSortChangeEvent> = new EventEmitter<ITdDataTableSortChangeEvent>();
 
   @HostBinding('class.mat-clickable')
   get bindClickable(): boolean {
@@ -116,7 +114,7 @@ export class TdDataTableColumnComponent {
   @HostListener('click')
   handleClick(): void {
     if (this.sortable) {
-      this.onSortChange.emit({ name: this.name, order: this._sortOrder });
+      this.sortChange.emit({ name: this.name, order: this._sortOrder });
     }
   }
 

--- a/src/platform/core/data-table/data-table.component.html
+++ b/src/platform/core/data-table/data-table.component.html
@@ -8,9 +8,9 @@
           [disabled]="!hasData"
           [indeterminate]="indeterminate && !allSelected && hasData"
           [checked]="allSelected && hasData"
-          (click)="blockEvent($event); selectAll(!checkBoxAll.checked)"
-          (keyup.enter)="selectAll(!checkBoxAll.checked)"
-          (keyup.space)="selectAll(!checkBoxAll.checked)"
+          (click)="blockEvent($event); _selectAll(!checkBoxAll.checked)"
+          (keyup.enter)="_selectAll(!checkBoxAll.checked)"
+          (keyup.space)="_selectAll(!checkBoxAll.checked)"
           (keydown.space)="blockEvent($event)"
         ></mat-checkbox>
       </th>

--- a/src/platform/core/data-table/data-table.component.spec.ts
+++ b/src/platform/core/data-table/data-table.component.spec.ts
@@ -155,7 +155,6 @@ describe('Component: DataTable', () => {
     it('should not set the data input and not fail', (done: DoneFn) => {
       inject([], () => {
         const fixture: ComponentFixture<any> = TestBed.createComponent(TdDataTableSelectableTestComponent);
-        const element: DebugElement = fixture.debugElement;
         const component: TdDataTableSelectableTestComponent = fixture.debugElement.componentInstance;
 
         component.selectable = true;
@@ -172,7 +171,6 @@ describe('Component: DataTable', () => {
     it('should select one and be in indeterminate state, select all and then unselect all', (done: DoneFn) => {
       inject([], () => {
         const fixture: ComponentFixture<any> = TestBed.createComponent(TdDataTableSelectableTestComponent);
-        const element: DebugElement = fixture.debugElement;
         const component: TdDataTableSelectableTestComponent = fixture.debugElement.componentInstance;
 
         component.selectable = true;
@@ -237,7 +235,6 @@ describe('Component: DataTable', () => {
     it('should be interminate when atleast one row is selected and allSelected when all rows are selected', (done: DoneFn) => {
       inject([], () => {
         const fixture: ComponentFixture<any> = TestBed.createComponent(TdDataTableSelectableTestComponent);
-        const element: DebugElement = fixture.debugElement;
         const component: TdDataTableSelectableTestComponent = fixture.debugElement.componentInstance;
 
         component.selectable = true;
@@ -311,7 +308,6 @@ describe('Component: DataTable', () => {
     it('should shift click and select a range of rows', (done: DoneFn) => {
       inject([], () => {
         const fixture: ComponentFixture<any> = TestBed.createComponent(TdDataTableSelectableTestComponent);
-        const element: DebugElement = fixture.debugElement;
         const component: TdDataTableSelectableTestComponent = fixture.debugElement.componentInstance;
 
         component.selectable = true;

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -417,34 +417,28 @@ export class TdDataTableComponent extends _TdDataTableMixinBase
    * Event emitted when the column headers are clicked. [sortable] needs to be enabled.
    * Emits an [ITdDataTableSortChangeEvent] implemented object.
    */
-  @Output('sortChange') onSortChange: EventEmitter<ITdDataTableSortChangeEvent> = new EventEmitter<
-    ITdDataTableSortChangeEvent
-  >();
+  @Output() sortChange: EventEmitter<ITdDataTableSortChangeEvent> = new EventEmitter<ITdDataTableSortChangeEvent>();
 
   /**
    * rowSelect?: function
    * Event emitted when a row is selected/deselected. [selectable] needs to be enabled.
    * Emits an [ITdDataTableSelectEvent] implemented object.
    */
-  @Output('rowSelect') onRowSelect: EventEmitter<ITdDataTableSelectEvent> = new EventEmitter<ITdDataTableSelectEvent>();
+  @Output() rowSelect: EventEmitter<ITdDataTableSelectEvent> = new EventEmitter<ITdDataTableSelectEvent>();
 
   /**
    * rowClick?: function
    * Event emitted when a row is clicked.
    * Emits an [ITdDataTableRowClickEvent] implemented object.
    */
-  @Output('rowClick') onRowClick: EventEmitter<ITdDataTableRowClickEvent> = new EventEmitter<
-    ITdDataTableRowClickEvent
-  >();
+  @Output() rowClick: EventEmitter<ITdDataTableRowClickEvent> = new EventEmitter<ITdDataTableRowClickEvent>();
 
   /**
    * selectAll?: function
    * Event emitted when all rows are selected/deselected by the all checkbox. [selectable] needs to be enabled.
    * Emits an [ITdDataTableSelectAllEvent] implemented object.
    */
-  @Output('selectAll') onSelectAll: EventEmitter<ITdDataTableSelectAllEvent> = new EventEmitter<
-    ITdDataTableSelectAllEvent
-  >();
+  @Output() selectAll: EventEmitter<ITdDataTableSelectAllEvent> = new EventEmitter<ITdDataTableSelectAllEvent>();
 
   constructor(
     @Optional() @Inject(DOCUMENT) private _document: any,
@@ -460,7 +454,7 @@ export class TdDataTableComponent extends _TdDataTableMixinBase
    * Allows custom comparison between row and model to see if row is selected or not
    * Default comparation is by reference
    */
-  @Input('compareWith') compareWith: (row: any, model: any) => boolean = (row: any, model: any) => {
+  @Input() compareWith: (row: any, model: any) => boolean = (row: any, model: any) => {
     return row === model;
   };
 
@@ -508,8 +502,8 @@ export class TdDataTableComponent extends _TdDataTableMixinBase
    * Loads templates and sets them in a map for faster access.
    */
   ngAfterContentInit(): void {
-    for (let i: number = 0; i < this._templates.toArray().length; i++) {
-      this._templateMap.set(this._templates.toArray()[i].tdDataTableTemplate, this._templates.toArray()[i].templateRef);
+    for (const template of this._templates.toArray()) {
+      this._templateMap.set(template.tdDataTableTemplate, template.templateRef);
     }
   }
 
@@ -640,7 +634,7 @@ export class TdDataTableComponent extends _TdDataTableMixinBase
   /**
    * Selects or clears all rows depending on 'checked' value.
    */
-  selectAll(checked: boolean): void {
+  _selectAll(checked: boolean): void {
     const toggledRows: any[] = [];
     if (checked) {
       this._data.forEach((row: any) => {
@@ -670,7 +664,7 @@ export class TdDataTableComponent extends _TdDataTableMixinBase
       this._allSelected = false;
       this._indeterminate = false;
     }
-    this.onSelectAll.emit({ rows: toggledRows, selected: checked });
+    this.selectAll.emit({ rows: toggledRows, selected: checked });
     this.onChange(this.value);
   }
 
@@ -727,15 +721,14 @@ export class TdDataTableComponent extends _TdDataTableMixinBase
             // we ignore the toggle
             if ((this._firstCheckboxValue && !rowSelected) || (!this._firstCheckboxValue && rowSelected)) {
               this._doSelection(this._data[i], i);
-            } else if (this._shiftPreviouslyPressed) {
+            } else if (
+              this._shiftPreviouslyPressed &&
+              ((currentSelected >= this._firstSelectedIndex && currentSelected <= this._lastSelectedIndex) ||
+                (currentSelected <= this._firstSelectedIndex && currentSelected >= this._lastSelectedIndex))
+            ) {
               // else if the checkbox selected was in the middle of the last selection and the first selection
               // then we undo the selections
-              if (
-                (currentSelected >= this._firstSelectedIndex && currentSelected <= this._lastSelectedIndex) ||
-                (currentSelected <= this._firstSelectedIndex && currentSelected >= this._lastSelectedIndex)
-              ) {
-                this._doSelection(this._data[i], i);
-              }
+              this._doSelection(this._data[i], i);
             }
           }
         }
@@ -784,7 +777,7 @@ export class TdDataTableComponent extends _TdDataTableMixinBase
       const element: HTMLElement = event.target as HTMLElement;
       /* tslint:disable-next-line */
       if (srcElement.getAttribute('stopRowClick') === null && element.tagName.toLowerCase() !== 'mat-pseudo-checkbox') {
-        this.onRowClick.emit({
+        this.rowClick.emit({
           row,
           index,
         });
@@ -805,7 +798,7 @@ export class TdDataTableComponent extends _TdDataTableMixinBase
       this._sortBy = column;
       this._sortOrder = TdDataTableSortingOrder.Ascending;
     }
-    this.onSortChange.next({ name: this._sortBy.name, order: this._sortOrder });
+    this.sortChange.next({ name: this._sortBy.name, order: this._sortOrder });
   }
 
   /**
@@ -929,7 +922,7 @@ export class TdDataTableComponent extends _TdDataTableMixinBase
       }
     }
     this._calculateCheckboxState();
-    this.onRowSelect.emit({ row, index: rowIndex, selected: !wasSelected });
+    this.rowSelect.emit({ row, index: rowIndex, selected: !wasSelected });
     this.onChange(this.value);
     return !wasSelected;
   }

--- a/src/platform/core/data-table/services/data-table.service.ts
+++ b/src/platform/core/data-table/services/data-table.service.ts
@@ -26,7 +26,7 @@ export class TdDataTableService {
             return itemValue.indexOf(filter) > -1;
           }
         });
-        return !(typeof res === 'undefined');
+        return typeof res !== 'undefined';
       });
     }
     return data;

--- a/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.ts
+++ b/src/platform/core/dialogs/prompt-dialog/prompt-dialog.component.ts
@@ -33,7 +33,7 @@ export class TdPromptDialogComponent implements AfterViewInit {
   }
 
   cancel(): void {
-    this._dialogRef.close(undefined);
+    this._dialogRef.close();
   }
 
   accept(): void {

--- a/src/platform/echarts/toolbox/toolbox.component.ts
+++ b/src/platform/echarts/toolbox/toolbox.component.ts
@@ -232,7 +232,7 @@ export class TdChartToolboxComponent implements OnChanges, OnDestroy {
     }
   }
 
-  private _optionToContentFormatter(): Function {
+  private _optionToContentFormatter(): () => string {
     return () => {
       this._changeDetectorRef.markForCheck();
       return (<HTMLElement>this._elementRef.nativeElement).innerHTML;

--- a/src/platform/echarts/tooltip/series-tooltip.component.ts
+++ b/src/platform/echarts/tooltip/series-tooltip.component.ts
@@ -81,7 +81,7 @@ export class TdSeriesTooltipComponent implements OnChanges, OnDestroy {
    * Formatter for tooltip
    *
    */
-  private _formatter(): Function {
+  private _formatter(): (params: any, ticket: any, callback: (ticket: string, html: string) => void) => string {
     return (params: any, ticket: any, callback: (ticket: string, html: string) => void) => {
       this._context = {
         $implicit: params,

--- a/src/platform/echarts/tooltip/tooltip.component.ts
+++ b/src/platform/echarts/tooltip/tooltip.component.ts
@@ -119,7 +119,7 @@ export class TdChartTooltipComponent implements OnChanges, OnDestroy {
     this._optionsService.clearOption('tooltip');
   }
 
-  private _formatter(): Function {
+  private _formatter(): (params: any, ticket: any, callback: (ticket: string, html: string) => void) => string {
     return (params: any, ticket: any, callback: (ticket: string, html: string) => void) => {
       this._context = {
         $implicit: params,

--- a/src/platform/flavored-markdown/flavored-markdown.component.ts
+++ b/src/platform/flavored-markdown/flavored-markdown.component.ts
@@ -330,7 +330,7 @@ export class TdFlavoredMarkdownComponent implements AfterViewInit, OnChanges {
         }
         componentRef.instance.data = data;
         componentRef.instance.sortable = true;
-        componentRef.instance.onSortChange.subscribe((event: ITdDataTableSortChangeEvent) => {
+        componentRef.instance.sortChange.subscribe((event: ITdDataTableSortChangeEvent) => {
           componentRef.instance.data.sort((a: any, b: any) => {
             const compA: any = a[event.name];
             const compB: any = b[event.name];

--- a/src/platform/http/actions/class/http.decorator.ts
+++ b/src/platform/http/actions/class/http.decorator.ts
@@ -7,7 +7,7 @@ import { TdHttpService } from '../../interceptors/http.service';
 /**
  * Decorator used to give a service http capabilities using TdHttpService
  */
-export function TdHttp(config: ITdHttpRESTConfig): Function {
+export function TdHttp(config: ITdHttpRESTConfig): <T extends new (...args: any[]) => {}>(constructor: any) => any {
   return function<T extends new (...args: any[]) => {}>(constructor: any): any {
     return class extends mixinHttp(constructor, config, TdHttpService) {};
   };
@@ -16,7 +16,9 @@ export function TdHttp(config: ITdHttpRESTConfig): Function {
 /**
  * Decorator used to give a service http capabilities using HttpClient
  */
-export function TdHttpClient(config: ITdHttpRESTConfig): Function {
+export function TdHttpClient(
+  config: ITdHttpRESTConfig,
+): <T extends new (...args: any[]) => {}>(constructor: any) => any {
   return function<T extends new (...args: any[]) => {}>(constructor: any): any {
     return class extends mixinHttp(constructor, config, HttpClient) {};
   };

--- a/src/platform/http/actions/methods/abstract-method.decorator.ts
+++ b/src/platform/http/actions/methods/abstract-method.decorator.ts
@@ -58,7 +58,7 @@ export function TdAbstractMethod(config: {
   method: TdHttpMethod;
   path: string;
   options?: ITdHttpRESTOptions;
-}): Function {
+}): (target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function>) => any {
   return function(target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function>): any {
     const wrappedFunction: Function = descriptor.value;
     // replace method call with our own and proxy it

--- a/src/platform/http/actions/methods/delete.decorator.ts
+++ b/src/platform/http/actions/methods/delete.decorator.ts
@@ -4,7 +4,10 @@ import { TdAbstractMethod } from './abstract-method.decorator';
 /**
  * Decorator that adds DELETE request capabilities to a method
  */
-export function TdDELETE(config: { path: string; options?: ITdHttpRESTOptions }): Function {
+export function TdDELETE(config: {
+  path: string;
+  options?: ITdHttpRESTOptions;
+}): (target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function>) => any {
   return TdAbstractMethod(<any>Object.assign(
     {
       method: 'DELETE',

--- a/src/platform/http/actions/methods/get.decorator.ts
+++ b/src/platform/http/actions/methods/get.decorator.ts
@@ -4,7 +4,10 @@ import { TdAbstractMethod } from './abstract-method.decorator';
 /**
  * Decorator that adds GET request capabilities to a method
  */
-export function TdGET(config: { path: string; options?: ITdHttpRESTOptions }): Function {
+export function TdGET(config: {
+  path: string;
+  options?: ITdHttpRESTOptions;
+}): (target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function>) => any {
   return TdAbstractMethod(<any>Object.assign(
     {
       method: 'GET',

--- a/src/platform/http/actions/methods/patch.decorator.ts
+++ b/src/platform/http/actions/methods/patch.decorator.ts
@@ -4,7 +4,10 @@ import { TdAbstractMethod } from './abstract-method.decorator';
 /**
  * Decorator that adds PATCH request capabilities to a method
  */
-export function TdPATCH(config: { path: string; options?: ITdHttpRESTOptions }): Function {
+export function TdPATCH(config: {
+  path: string;
+  options?: ITdHttpRESTOptions;
+}): (target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function>) => any {
   return TdAbstractMethod(<any>Object.assign(
     {
       method: 'PATCH',

--- a/src/platform/http/actions/methods/post.decorator.ts
+++ b/src/platform/http/actions/methods/post.decorator.ts
@@ -4,7 +4,10 @@ import { TdAbstractMethod } from './abstract-method.decorator';
 /**
  * Decorator that adds POST request capabilities to a method
  */
-export function TdPOST(config: { path: string; options?: ITdHttpRESTOptions }): Function {
+export function TdPOST(config: {
+  path: string;
+  options?: ITdHttpRESTOptions;
+}): (target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function>) => any {
   return TdAbstractMethod(<any>Object.assign(
     {
       method: 'POST',

--- a/src/platform/http/actions/methods/put.decorator.ts
+++ b/src/platform/http/actions/methods/put.decorator.ts
@@ -4,7 +4,10 @@ import { TdAbstractMethod } from './abstract-method.decorator';
 /**
  * Decorator that adds PUT request capabilities to a method
  */
-export function TdPUT(config: { path: string; options?: ITdHttpRESTOptions }): Function {
+export function TdPUT(config: {
+  path: string;
+  options?: ITdHttpRESTOptions;
+}): (target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function>) => any {
   return TdAbstractMethod(<any>Object.assign(
     {
       method: 'PUT',

--- a/src/platform/http/actions/params/abstract-param.decorator.ts
+++ b/src/platform/http/actions/params/abstract-param.decorator.ts
@@ -7,7 +7,10 @@ export const tdHttpRESTParam: symbol = Symbol('TdHttpRESTParam');
  * Abstract implementation of the http param decorator
  * @internal
  */
-export function TdAbstractParam(type: TdParamType, param?: string): Function {
+export function TdAbstractParam(
+  type: TdParamType,
+  param?: string,
+): (target: object, propertyKey: string | symbol, parameterIndex: number) => void {
   return function(target: object, propertyKey: string | symbol, parameterIndex: number): void {
     const parameters: { index: number; param: string; type: TdParamType }[] =
       Reflect.getOwnMetadata(tdHttpRESTParam, target, propertyKey) || [];

--- a/src/platform/http/actions/params/body.decorator.ts
+++ b/src/platform/http/actions/params/body.decorator.ts
@@ -3,6 +3,6 @@ import { TdAbstractParam } from './abstract-param.decorator';
 /**
  * Decorator that is used to define which parameter is the http body in a method
  */
-export function TdBody(): Function {
+export function TdBody(): (target: object, propertyKey: string | symbol, parameterIndex: number) => void {
   return TdAbstractParam('body');
 }

--- a/src/platform/http/actions/params/param.decorator.ts
+++ b/src/platform/http/actions/params/param.decorator.ts
@@ -3,6 +3,6 @@ import { TdAbstractParam } from './abstract-param.decorator';
 /**
  * Decorator that is used to define which parameter is an http parameter in a method
  */
-export function TdParam(param: string): Function {
+export function TdParam(param: string): (target: object, propertyKey: string | symbol, parameterIndex: number) => void {
   return TdAbstractParam('param', param);
 }

--- a/src/platform/http/actions/params/query-params.decorator.ts
+++ b/src/platform/http/actions/params/query-params.decorator.ts
@@ -3,6 +3,6 @@ import { TdAbstractParam } from './abstract-param.decorator';
 /**
  * Decorator that is used to define which parameter is the http query parameters in a method
  */
-export function TdQueryParams(): Function {
+export function TdQueryParams(): (target: object, propertyKey: string | symbol, parameterIndex: number) => void {
   return TdAbstractParam('queryParams');
 }

--- a/src/platform/http/actions/params/response.decorator.ts
+++ b/src/platform/http/actions/params/response.decorator.ts
@@ -3,6 +3,6 @@ import { TdAbstractParam } from './abstract-param.decorator';
 /**
  * Decorator that is used to define which parameter is the http response in a method
  */
-export function TdResponse(): Function {
+export function TdResponse(): (target: object, propertyKey: string | symbol, parameterIndex: number) => void {
   return TdAbstractParam('response');
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,3 @@
 {
-  "rulesDirectory": ["./node_modules/codelyzer"],
   "extends": ["./src/platform/core/common/configs/tslint/tslint.json", "tslint-config-prettier"]
 }


### PR DESCRIPTION
## Description

- run on core breadcrumbs - data-table
- Targeting #1539


### Breaking changes

data-table: `selectAll()` -> `_selectAll()`

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] sanity test of changes
- [ ] `npm run serve`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
