### PR TITLE
docs(coding-standards/husky): fix path in docs

### DIFF
--- a/src/platform/coding-standards/husky/README.md
+++ b/src/platform/coding-standards/husky/README.md
@@ -5,7 +5,7 @@ Create a `.huskyrc.js` file at the root of your project.
 ## Basic setup:
 
 ```js
-const { covalentHooks, generateHuskyConfig } = require('./src/platform/coding-standards/husky/husky.js');
+const { covalentHooks, generateHuskyConfig } = require('./node_modules/@covalent/coding-standards/husky/husky.js');
 const huskyHooks = generateHuskyConfig(covalentHooks());
 module.exports = huskyHooks;
 ```
@@ -13,7 +13,7 @@ module.exports = huskyHooks;
 ## Extend hooks setup
 
 ```js
-const { covalentHooks, generateHuskyConfig } = require('./src/platform/coding-standards/husky/husky.js');
+const { covalentHooks, generateHuskyConfig } = require('./node_modules/@covalent/coding-standards/husky/husky.js');
 const hooks = covalentHooks();
 hooks['pre-commit'] = [...hooks['pre-commit'], 'npm audit'];
 const huskyHooks = generateHuskyConfig(hooks);


### PR DESCRIPTION
## Description

Fixes path in documentation

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
