### PR TITLE
feat(markdown-navigator): only open one window at a time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_script:
   - sh -e /etc/init.d/xvfb start
 jobs:
   include:
-    - env: 'MODE=commitlint'
+    - if: type = pull_request
+      env: 'MODE=commitlint'
     - env: 'MODE=prettier'
     - env: 'MODE=lint'
     - env: 'MODE=aot'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9274,9 +9274,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -18204,9 +18204,9 @@
       "integrity": "sha1-VNjrx5SfGngQkItgAsaEFSbJnVo="
     },
     "uglify-js": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
-      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/src/app/components/components/markdown-navigator/markdown-navigator.component.html
+++ b/src/app/components/components/markdown-navigator/markdown-navigator.component.html
@@ -42,7 +42,6 @@
             <![CDATA[
           import {
             IMarkdownNavigatorItem,
-            MarkdownNavigatorWindowService
           } from '@covalent/markdown-navigator';
 
           oneItem: IMarkdownNavigatorItem[] = [
@@ -164,11 +163,8 @@
           import {
             IMarkdownNavigatorItem,
             MarkdownNavigatorWindowService,
-            MarkdownNavigatorWindowComponent,
           } from '@covalent/markdown-navigator';
 
-          windowOpen: boolean = false;
-          ref: MatDialogRef<MarkdownNavigatorWindowComponent>;
           currentItems: IMarkdownNavigatorItem[] = [
           {
             url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
@@ -178,20 +174,7 @@
           constructor(private _markdownNavigatorWindowService: MarkdownNavigatorWindowService) {}
 
           openDialog(): void {
-            if (this.windowOpen) {
-              this.closeDialog();
-            }
-            this.ref = this._markdownNavigatorWindowService.open({items: this.currentItems});
-            this.ref.afterOpened().subscribe(() => {
-              this.windowOpen = true;
-            });
-
-            this.ref.afterClosed().subscribe(() => {
-              this.windowOpen = false;
-            });
-          }
-          closeDialog(): void {
-            this.ref.close();
+            this._markdownNavigatorWindowService.open({ items: this.currentItems });
           }
           ]]>
         </td-highlight>

--- a/src/app/components/components/markdown-navigator/markdown-navigator.component.ts
+++ b/src/app/components/components/markdown-navigator/markdown-navigator.component.ts
@@ -1,12 +1,7 @@
 import { Component, HostBinding } from '@angular/core';
 
 import { slideInDownAnimation } from '../../../app.animations';
-import {
-  IMarkdownNavigatorItem,
-  MarkdownNavigatorWindowService,
-  MarkdownNavigatorWindowComponent,
-} from '@covalent/markdown-navigator';
-import { MatDialogRef } from '@angular/material/dialog';
+import { IMarkdownNavigatorItem, MarkdownNavigatorWindowService } from '@covalent/markdown-navigator';
 
 @Component({
   selector: 'markdown-navigator-demo',
@@ -82,10 +77,6 @@ export class MarkdownNavigatorDemoComponent {
   selected: { name: string; value: IMarkdownNavigatorItem[] } = this.options[0];
   currentItems: IMarkdownNavigatorItem[] = this.selected.value;
   userInput: string = this.prettyJson(this.currentItems);
-
-  windowOpen: boolean = false;
-  ref: MatDialogRef<MarkdownNavigatorWindowComponent>;
-
   constructor(private _markdownNavigatorWindowService: MarkdownNavigatorWindowService) {}
 
   select(): void {
@@ -95,7 +86,7 @@ export class MarkdownNavigatorDemoComponent {
   use(items: IMarkdownNavigatorItem[]): void {
     this.currentItems = items;
     this.userInput = this.prettyJson(this.currentItems);
-    if (this.windowOpen) {
+    if (this._markdownNavigatorWindowService.isOpen) {
       this.openDialog();
     }
   }
@@ -109,19 +100,6 @@ export class MarkdownNavigatorDemoComponent {
   }
 
   openDialog(): void {
-    if (this.windowOpen) {
-      this.closeDialog();
-    }
-    this.ref = this._markdownNavigatorWindowService.open({ items: this.currentItems });
-    this.ref.afterOpened().subscribe(() => {
-      this.windowOpen = true;
-    });
-
-    this.ref.afterClosed().subscribe(() => {
-      this.windowOpen = false;
-    });
-  }
-  closeDialog(): void {
-    this.ref.close();
+    this._markdownNavigatorWindowService.open({ items: this.currentItems });
   }
 }

--- a/src/platform/markdown-navigator/README.md
+++ b/src/platform/markdown-navigator/README.md
@@ -148,18 +148,16 @@ import { MatDialogRef } from '@angular/material/dialog';
 
 export class SampleComponent{
 
-  ref: MatDialogRef<MarkdownNavigatorWindowComponent>;
-
   constructor(private _markdownNavigatorWindowService: MarkdownNavigatorWindowService) {}
 
   ngOnInit(): void {
-    this.ref = this._markdownNavigatorWindowService.open({
+    const ref: MatDialogRef<MarkdownNavigatorWindowComponent> = this._markdownNavigatorWindowService.open({
       items: [{ url: 'https://github.com/Teradata/covalent/blob/develop/README.md' }]
     });
-    this.ref.afterOpened().subscribe(() => {
+    ref.afterOpened().subscribe(() => {
 
     });
-    this.ref.afterClosed().subscribe(() => {
+    ref.afterClosed().subscribe(() => {
 
     });
   }

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.spec.ts
@@ -258,4 +258,27 @@ describe('MarkdownNavigatorWindowService', () => {
       },
     ),
   ));
+
+  it('should only have one markdown navigator open at a time', async(
+    inject(
+      [MarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+        const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
+        expect(overlayContainerElement.querySelectorAll(`td-markdown-navigator`).length).toBe(0);
+        expect(_markdownNavigatorWindowService.isOpen).toBeFalsy();
+        _markdownNavigatorWindowService.open({
+          items: [],
+        });
+        _markdownNavigatorWindowService.open({
+          items: [],
+        });
+        _markdownNavigatorWindowService.open({
+          items: [],
+        });
+        await wait(fixture);
+        expect(overlayContainerElement.querySelectorAll(`td-markdown-navigator`).length).toBe(1);
+        expect(_markdownNavigatorWindowService.isOpen).toBeTruthy();
+      },
+    ),
+  ));
 });

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
@@ -1,7 +1,5 @@
 import { Injectable } from '@angular/core';
 import { MatDialogRef, MatDialogConfig } from '@angular/material/dialog';
-
-import { Overlay } from '@angular/cdk/overlay';
 import { CovalentMarkdownNavigatorModule } from '../markdown-navigator.module';
 import { ThemePalette } from '@angular/material/core';
 import {
@@ -18,25 +16,30 @@ export interface IMarkdownNavigatorWindowConfig {
   toolbarColor?: ThemePalette;
 }
 
+const CDK_OVERLAY_CUSTOM_CLASS: string = 'td-draggable-markdown-navigator-window-wrapper';
+
+const DEFAULT_DRAGGABLE_DIALOG_CONFIG: MatDialogConfig = {
+  hasBackdrop: false,
+  closeOnNavigation: true,
+  panelClass: CDK_OVERLAY_CUSTOM_CLASS,
+  position: { bottom: '0px', right: '0px' },
+  height: '475px',
+  width: '360px',
+};
+
 @Injectable({
   providedIn: CovalentMarkdownNavigatorModule,
 })
 export class MarkdownNavigatorWindowService {
-  constructor(private _overlay: Overlay, private _tdDialogService: TdDialogService) {}
+  markdownNavigatorWindowDialog: MatDialogRef<MarkdownNavigatorWindowComponent> = undefined;
+  markdownNavigatorWindowDialogsOpen: number = 0;
 
-  open(config: IMarkdownNavigatorWindowConfig): MatDialogRef<MarkdownNavigatorWindowComponent> {
-    const CDK_OVERLAY_CUSTOM_CLASS: string = 'td-draggable-markdown-navigator-window-wrapper';
-    const DEFAULT_DRAGGABLE_DIALOG_CONFIG: MatDialogConfig = {
-      hasBackdrop: false,
-      closeOnNavigation: true,
-      panelClass: CDK_OVERLAY_CUSTOM_CLASS,
-      position: { bottom: '0', right: '0' },
-      height: '475px',
-      width: '360px',
-      scrollStrategy: this._overlay.scrollStrategies.noop(),
-    };
+  constructor(private _tdDialogService: TdDialogService) {}
 
-    const draggableDialog: MatDialogRef<MarkdownNavigatorWindowComponent> = this._tdDialogService.openDraggable({
+  public open(config: IMarkdownNavigatorWindowConfig): MatDialogRef<MarkdownNavigatorWindowComponent> {
+    this.close();
+
+    this.markdownNavigatorWindowDialog = this._tdDialogService.openDraggable({
       component: MarkdownNavigatorWindowComponent,
       config: {
         ...DEFAULT_DRAGGABLE_DIALOG_CONFIG,
@@ -45,12 +48,27 @@ export class MarkdownNavigatorWindowService {
       dragHandleSelectors: ['.td-markdown-navigator-window-toolbar'],
       draggableClass: 'td-draggable-markdown-navigator-window',
     });
+    this.markdownNavigatorWindowDialogsOpen++;
 
-    draggableDialog.componentInstance.items = config.items;
-    draggableDialog.componentInstance.labels = config.labels;
-    draggableDialog.componentInstance.toolbarColor = 'toolbarColor' in config ? config.toolbarColor : 'primary';
-    draggableDialog.componentInstance.closed.subscribe(() => draggableDialog.close());
+    this.markdownNavigatorWindowDialog.componentInstance.items = config.items;
+    this.markdownNavigatorWindowDialog.componentInstance.labels = config.labels;
+    this.markdownNavigatorWindowDialog.componentInstance.toolbarColor =
+      'toolbarColor' in config ? config.toolbarColor : 'primary';
+    this.markdownNavigatorWindowDialog.componentInstance.closed.subscribe(() => this.close());
+    this.markdownNavigatorWindowDialog.afterClosed().subscribe(() => {
+      this.markdownNavigatorWindowDialogsOpen--;
+    });
 
-    return draggableDialog;
+    return this.markdownNavigatorWindowDialog;
+  }
+
+  public close(): void {
+    if (this.markdownNavigatorWindowDialog) {
+      this.markdownNavigatorWindowDialog.close();
+    }
+  }
+
+  public get isOpen(): boolean {
+    return this.markdownNavigatorWindowDialogsOpen > 0;
   }
 }

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
@@ -55,9 +55,12 @@ export class MarkdownNavigatorWindowService {
     this.markdownNavigatorWindowDialog.componentInstance.toolbarColor =
       'toolbarColor' in config ? config.toolbarColor : 'primary';
     this.markdownNavigatorWindowDialog.componentInstance.closed.subscribe(() => this.close());
-    this.markdownNavigatorWindowDialog.afterClosed().subscribe(() => {
-      this.markdownNavigatorWindowDialogsOpen--;
-    });
+    this.markdownNavigatorWindowDialog
+      .afterClosed()
+      .toPromise()
+      .then(() => {
+        this.markdownNavigatorWindowDialogsOpen--;
+      });
 
     return this.markdownNavigatorWindowDialog;
   }


### PR DESCRIPTION
## Description

- Allows only one window open at a time
- exposes a `close()` method
- exposes a `isOpen` getter
- Updates material and cdk to get latest drag drop fixes.
- Updates doc
- Adds a test
- do not run commitlint on travis on develop, only on PRs
- Closes #1533

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm ci`
- [ ] `npm run serve`
- Navigate to http://localhost:4200/#/components/markdown-navigator
 - Click on the `Open Draggable Markdown Navigator Window` button multiple times and make sure only one is open

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
