### PR TITLE
feat(markdown-navigator): add MarkdownNavigatorWindowDirective

### DIFF
--- a/src/app/components/components/markdown-navigator/markdown-navigator.component.html
+++ b/src/app/components/components/markdown-navigator/markdown-navigator.component.html
@@ -210,7 +210,7 @@
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <mat-card-actions>
-        <button mat-button class="text-upper" color="primary" [tdMarkdownNavigatorWindow]="{ items: currentItems }">Open</button>
+        <button mat-button class="text-upper" color="primary" [tdMarkdownNavigatorWindow]="{ items: currentItems }" [disabled]="false">Open</button>
       </mat-card-actions>
     </mat-tab>
     <mat-tab>
@@ -218,7 +218,7 @@
       <mat-card-content>
         <td-highlight lang="html">
           <![CDATA[
-          <button mat-button class="text-upper" color="primary" [tdMarkdownNavigatorWindow]="{ items: currentItems }">Open</button>
+          <button mat-button class="text-upper" color="primary" [tdMarkdownNavigatorWindow]="{ items: currentItems }" [disabled]="false">Open</button>
           ]]>
         </td-highlight>
         <td-highlight lang="typescript">

--- a/src/app/components/components/markdown-navigator/markdown-navigator.component.html
+++ b/src/app/components/components/markdown-navigator/markdown-navigator.component.html
@@ -145,7 +145,7 @@
       <ng-template matTabLabel>Demo</ng-template>
       <mat-card-actions>
         <button mat-button class="text-upper" color="primary" (click)="openDialog()">
-          Open Draggable Markdown Navigator Window
+          Open
         </button>
       </mat-card-actions>
     </mat-tab>
@@ -154,9 +154,9 @@
       <mat-card-content>
         <td-highlight lang="html">
           <![CDATA[
-            <button mat-button class="text-upper" color="primary" (click)="openDialog()">
-              Open Draggable Markdown Navigator Window
-            </button>
+          <button mat-button class="text-upper" color="primary" (click)="openDialog()">
+            Open
+          </button>
           ]]>
         </td-highlight>
         <td-highlight lang="typescript">
@@ -193,6 +193,41 @@
           closeDialog(): void {
             this.ref.close();
           }
+          ]]>
+        </td-highlight>
+      </mat-card-content>
+    </mat-tab>
+  </mat-tab-group>
+</mat-card>
+
+<mat-card>
+  <mat-card-title>Markdown Navigator Window Directive</mat-card-title>
+  <mat-card-subtitle>
+    A directive that calls the MarkdownNavigatorWindowService open method on click events.
+  </mat-card-subtitle>
+  <mat-divider></mat-divider>
+  <mat-tab-group mat-stretch-tabs>
+    <mat-tab>
+      <ng-template matTabLabel>Demo</ng-template>
+      <mat-card-actions>
+        <button mat-button class="text-upper" color="primary" [tdMarkdownNavigatorWindow]="{ items: currentItems }">Open</button>
+      </mat-card-actions>
+    </mat-tab>
+    <mat-tab>
+      <ng-template matTabLabel>Code</ng-template>
+      <mat-card-content>
+        <td-highlight lang="html">
+          <![CDATA[
+          <button mat-button class="text-upper" color="primary" [tdMarkdownNavigatorWindow]="{ items: currentItems }">Open</button>
+          ]]>
+        </td-highlight>
+        <td-highlight lang="typescript">
+          <![CDATA[
+          currentItems: IMarkdownNavigatorItem[] = [
+          {
+            url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
+          },
+          ];
           ]]>
         </td-highlight>
       </mat-card-content>

--- a/src/platform/markdown-navigator/README.md
+++ b/src/platform/markdown-navigator/README.md
@@ -177,6 +177,8 @@ A directive that calls the MarkdownNavigatorWindowService open method on click e
 
 + tdMarkdownNavigatorWindow: IMarkdownNavigatorWindowConfig
   + Config to open window with
++ disabled: boolean
+  + Whether disabled or not
 
 For reference:
 ```typescript
@@ -208,5 +210,5 @@ export class MyModule {}
 Example:
 
 ```html
-<button mat-button [tdMarkdownNavigatorWindow]="{ items: [] }">Open window</button>
+<button mat-button [tdMarkdownNavigatorWindow]="{ items: [] }" [disabled]="false">Open window</button>
 ```

--- a/src/platform/markdown-navigator/README.md
+++ b/src/platform/markdown-navigator/README.md
@@ -165,3 +165,48 @@ export class SampleComponent{
   }
 }
 ```
+
+
+# MarkdownNavigatorWindowDirective
+
+A directive that calls the MarkdownNavigatorWindowService open method on click events.
+
+## API Summary
+
+#### Inputs
+
++ tdMarkdownNavigatorWindow: IMarkdownNavigatorWindowConfig
+  + Config to open window with
+
+For reference:
+```typescript
+interface IMarkdownNavigatorWindowConfig {
+  items: IMarkdownNavigatorItem[];
+  dialogConfig?: MatDialogConfig;
+  labels?: IMarkdownNavigatorWindowLabels;
+  toolbarColor?: ThemePalette;
+}
+```
+
+## Setup
+
+```typescript
+import { CovalentMarkdownNavigatorModule } from '@covalent/markdown-navigator';
+@NgModule({
+  imports: [
+    CovalentMarkdownNavigatorModule,
+    ...
+  ],
+  ...
+})
+export class MyModule {}
+```
+
+
+## Usage
+
+Example:
+
+```html
+<button mat-button [tdMarkdownNavigatorWindow]="{ items: [] }">Open window</button>
+```

--- a/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.spec.ts
@@ -1,0 +1,60 @@
+import { async, TestBed, inject, ComponentFixture } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { CovalentMarkdownNavigatorModule } from '../markdown-navigator.module';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { Component } from '@angular/core';
+import {
+  MarkdownNavigatorWindowService,
+  IMarkdownNavigatorWindowConfig,
+} from '../markdown-navigator-window-service/markdown-navigator-window.service';
+import { By } from '@angular/platform-browser';
+
+@Component({
+  selector: 'test-component',
+  template: `
+    <button [tdMarkdownNavigatorWindow]="items">Open markdown navigator window</button>
+  `,
+})
+class TestComponent {
+  items: IMarkdownNavigatorWindowConfig = { items: [] };
+}
+
+fdescribe('MarkdownNavigatorWindowDirective', () => {
+  let overlayContainerElement: HTMLElement;
+
+  async function wait(fixture: ComponentFixture<any>): Promise<void> {
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, CovalentMarkdownNavigatorModule],
+      declarations: [TestComponent],
+      providers: [
+        {
+          provide: OverlayContainer,
+          useFactory: () => {
+            overlayContainerElement = document.createElement('div');
+            overlayContainerElement.classList.add('cdk-overlay-container');
+            document.body.appendChild(overlayContainerElement);
+            return { getContainerElement: () => overlayContainerElement };
+          },
+        },
+      ],
+    });
+  }));
+
+  it('should open and close markdown navigator window properly', async(
+    inject(
+      [MarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+        const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
+        await wait(fixture);
+        fixture.debugElement.query(By.css('button')).nativeElement.click();
+        await wait(fixture);
+        expect(overlayContainerElement.querySelector(`td-markdown-navigator`)).toBeTruthy();
+      },
+    ),
+  ));
+});

--- a/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.spec.ts
@@ -12,14 +12,15 @@ import { By } from '@angular/platform-browser';
 @Component({
   selector: 'test-component',
   template: `
-    <button [tdMarkdownNavigatorWindow]="items">Open markdown navigator window</button>
+    <button [tdMarkdownNavigatorWindow]="items" [disabled]="disabled">Open markdown navigator window</button>
   `,
 })
 class TestComponent {
   items: IMarkdownNavigatorWindowConfig = { items: [] };
+  disabled: boolean;
 }
 
-fdescribe('MarkdownNavigatorWindowDirective', () => {
+describe('MarkdownNavigatorWindowDirective', () => {
   let overlayContainerElement: HTMLElement;
 
   async function wait(fixture: ComponentFixture<any>): Promise<void> {
@@ -54,6 +55,19 @@ fdescribe('MarkdownNavigatorWindowDirective', () => {
         fixture.debugElement.query(By.css('button')).nativeElement.click();
         await wait(fixture);
         expect(overlayContainerElement.querySelector(`td-markdown-navigator`)).toBeTruthy();
+      },
+    ),
+  ));
+  it('should not open markdown navigator window if disabled', async(
+    inject(
+      [MarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+        const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
+        fixture.componentInstance.disabled = true;
+        await wait(fixture);
+        fixture.debugElement.query(By.css('button')).nativeElement.click();
+        await wait(fixture);
+        expect(overlayContainerElement.querySelector(`td-markdown-navigator`)).toBeFalsy();
       },
     ),
   ));

--- a/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.ts
@@ -9,10 +9,12 @@ import {
 })
 export class MarkdownNavigatorWindowDirective {
   @Input('tdMarkdownNavigatorWindow') config: IMarkdownNavigatorWindowConfig;
-
+  @Input() disabled: boolean = false;
   constructor(private _markdownNavigatorWindowService: MarkdownNavigatorWindowService) {}
 
   @HostListener('click') click(): void {
-    this._markdownNavigatorWindowService.open(this.config);
+    if (!this.disabled) {
+      this._markdownNavigatorWindowService.open(this.config);
+    }
   }
 }

--- a/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.ts
@@ -1,0 +1,18 @@
+import { Directive, HostListener, Input } from '@angular/core';
+import {
+  MarkdownNavigatorWindowService,
+  IMarkdownNavigatorWindowConfig,
+} from '../markdown-navigator-window-service/markdown-navigator-window.service';
+
+@Directive({
+  selector: '[tdMarkdownNavigatorWindow]',
+})
+export class MarkdownNavigatorWindowDirective {
+  @Input('tdMarkdownNavigatorWindow') config: IMarkdownNavigatorWindowConfig;
+
+  constructor(private _markdownNavigatorWindowService: MarkdownNavigatorWindowService) {}
+
+  @HostListener('click') click(): void {
+    this._markdownNavigatorWindowService.open(this.config);
+  }
+}

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@angular/core';
 import { MatDialogRef, MatDialogConfig } from '@angular/material/dialog';
-
 import { Overlay } from '@angular/cdk/overlay';
-import { CovalentMarkdownNavigatorModule } from '../markdown-navigator.module';
 import { ThemePalette } from '@angular/material/core';
 import {
   MarkdownNavigatorWindowComponent,
@@ -18,9 +16,7 @@ export interface IMarkdownNavigatorWindowConfig {
   toolbarColor?: ThemePalette;
 }
 
-@Injectable({
-  providedIn: CovalentMarkdownNavigatorModule,
-})
+@Injectable()
 export class MarkdownNavigatorWindowService {
   constructor(private _overlay: Overlay, private _tdDialogService: TdDialogService) {}
 

--- a/src/platform/markdown-navigator/markdown-navigator.module.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.module.ts
@@ -10,6 +10,8 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { CovalentDialogsModule } from '@covalent/core/dialogs';
+import { MarkdownNavigatorWindowDirective } from './markdown-navigator-window-directive/markdown-navigator-window.directive';
+import { MarkdownNavigatorWindowService } from './markdown-navigator-window-service/markdown-navigator-window.service';
 
 @NgModule({
   imports: [
@@ -26,8 +28,9 @@ import { CovalentDialogsModule } from '@covalent/core/dialogs';
     CovalentFlavoredMarkdownModule,
     CovalentDialogsModule,
   ],
-  declarations: [MarkdownNavigatorComponent, MarkdownNavigatorWindowComponent],
-  exports: [MarkdownNavigatorComponent, MarkdownNavigatorWindowComponent],
+  declarations: [MarkdownNavigatorComponent, MarkdownNavigatorWindowComponent, MarkdownNavigatorWindowDirective],
+  exports: [MarkdownNavigatorComponent, MarkdownNavigatorWindowComponent, MarkdownNavigatorWindowDirective],
   entryComponents: [MarkdownNavigatorWindowComponent],
+  providers: [MarkdownNavigatorWindowService],
 })
 export class CovalentMarkdownNavigatorModule {}


### PR DESCRIPTION
## Description

- Adds MarkdownNavigatorWindowDirective to simplify usage.
- Audit issue is fixed in https://github.com/Teradata/covalent/pull/1557
- Figured creating a re-usable button was an overkill and wanted to keep it usage agnostic so did not want to default to an info or help icon.

### What's included?

- Addresses #1526

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm ci`
- [ ] Go to http://localhost:4200/#/components/markdown-navigator
- [ ] Play around with directive demo.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
