### PR TITLE
fix(): make sure we grab tooltip templates

### DIFF
--- a/src/platform/echarts/tooltip/series-tooltip.component.ts
+++ b/src/platform/echarts/tooltip/series-tooltip.component.ts
@@ -39,7 +39,7 @@ export class TdSeriesTooltipComponent implements OnChanges, OnDestroy {
   };
   @Input() extraCssText: string;
 
-  @ContentChild(TdChartTooltipFormatterDirective, { read: TemplateRef, static: false }) formatterTemplate: TemplateRef<
+  @ContentChild(TdChartTooltipFormatterDirective, { read: TemplateRef, static: true }) formatterTemplate: TemplateRef<
     any
   >;
   @ViewChild('tooltipContent', { static: true }) fullTemplate: TemplateRef<any>;

--- a/src/platform/echarts/tooltip/tooltip.component.ts
+++ b/src/platform/echarts/tooltip/tooltip.component.ts
@@ -66,7 +66,7 @@ export class TdChartTooltipComponent implements OnChanges, OnDestroy {
   };
   @Input() extraCssText: string; // series
 
-  @ContentChild(TdChartTooltipFormatterDirective, { read: TemplateRef, static: false }) formatterTemplate: TemplateRef<
+  @ContentChild(TdChartTooltipFormatterDirective, { read: TemplateRef, static: true }) formatterTemplate: TemplateRef<
     any
   >;
   @ViewChild('tooltipContent', { static: true }) fullTemplate: TemplateRef<any>;


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Templates for tooltips werent being picked up properly.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] See tooltip formatters being picked up in demos.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
