### PR TITLE
feat(markdown): fix gh svg links

### DIFF
--- a/src/platform/markdown/markdown-utils/markdown-utils.spec.ts
+++ b/src/platform/markdown/markdown-utils/markdown-utils.spec.ts
@@ -6,6 +6,7 @@ import {
   isGithubHref,
   rawGithubHref,
   scrollToAnchor,
+  isRawGithubHref,
 } from './markdown-utils';
 import { Component } from '@angular/core';
 import { async, TestBed, ComponentFixture } from '@angular/core/testing';
@@ -126,11 +127,22 @@ describe('Markdown utils', () => {
   it('isGithubHref should check whether an href is from github.com', () => {
     expect(isGithubHref('')).toBe(false);
     expect(isGithubHref(undefined)).toBe(false);
+    expect(isGithubHref('github.com')).toBe(false);
+    expect(isGithubHref('subdomain.github.com')).toBe(false);
+    expect(isGithubHref('https://raw.githubusercontent.com')).toBe(false);
     expect(isGithubHref('http://github.com')).toBe(true);
     expect(isGithubHref('https://github.com')).toBe(true);
     expect(isGithubHref('https://github.com/something')).toBe(true);
-    expect(isGithubHref('github.com')).toBe(false);
-    expect(isGithubHref('subdomain.github.com')).toBe(false);
+  });
+
+  it('isRawGithubHref should check whether an href is from raw.githubusercontent.com', () => {
+    expect(isRawGithubHref('')).toBe(false);
+    expect(isRawGithubHref(undefined)).toBe(false);
+    expect(isRawGithubHref('raw.githubusercontent.com')).toBe(false);
+    expect(isRawGithubHref('https://raw.githubusercontent.com')).toBe(true);
+    expect(isRawGithubHref('http://raw.githubusercontent.com')).toBe(true);
+    expect(isRawGithubHref('https://raw.githubusercontent.com')).toBe(true);
+    expect(isRawGithubHref('https://raw.githubusercontent.com/something')).toBe(true);
   });
 
   it('scrollToAnchor should scroll to anchor within provided element, or parent if tryParent is true', async () => {

--- a/src/platform/markdown/markdown-utils/markdown-utils.ts
+++ b/src/platform/markdown/markdown-utils/markdown-utils.ts
@@ -57,12 +57,12 @@ export function isAnchorLink(anchor: HTMLAnchorElement): boolean {
   }
   return false;
 }
+const RAW_GITHUB_HOSTNAME: string = 'raw.githubusercontent.com';
 
 export function rawGithubHref(githubHref: string): string {
   if (githubHref) {
     try {
       const url: URL = new URL(githubHref);
-      const RAW_GITHUB_HOSTNAME: string = 'raw.githubusercontent.com';
       if (url.hostname === RAW_GITHUB_HOSTNAME) {
         return url.href;
       } else if (isGithubHref(githubHref)) {
@@ -81,6 +81,15 @@ export function isGithubHref(href: string): boolean {
   try {
     const temp: URL = new URL(href);
     return temp.hostname === 'github.com';
+  } catch {
+    return false;
+  }
+}
+
+export function isRawGithubHref(href: string): boolean {
+  try {
+    const temp: URL = new URL(href);
+    return temp.hostname === RAW_GITHUB_HOSTNAME;
   } catch {
     return false;
   }

--- a/src/platform/markdown/markdown.component.spec.ts
+++ b/src/platform/markdown/markdown.component.spec.ts
@@ -379,6 +379,7 @@ describe('Component: Markdown', () => {
       const RAW_LINK: string = 'https://raw.githubusercontent.com/Teradata/covalent/develop/';
       const EXTERNAL_IMG: string = 'https://angular.io/assets/images/logos/angular/angular.svg';
       const SUB_DIRECTORY: string = 'dir/';
+      const SVG_IMG: string = 'src/assets/icons/covalent.svg';
       // these are not valid image urls
       const images: string[][] = [
         [`./${SIBLING_IMG}`, `${RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`],
@@ -388,6 +389,7 @@ describe('Component: Markdown', () => {
         [`${RAW_LINK}${ROOT_IMG}`, `${RAW_LINK}${ROOT_IMG}`],
         [`${EXTERNAL_IMG}`, `${EXTERNAL_IMG}`],
         [`${NON_RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`, `${RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`],
+        [`${NON_RAW_LINK}${SVG_IMG}`, `${RAW_LINK}${SVG_IMG}?sanitize=true`],
       ];
 
       let markdown: string = '';

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -20,6 +20,7 @@ import {
   removeTrailingHash,
   rawGithubHref,
   isGithubHref,
+  isRawGithubHref,
 } from './markdown-utils/markdown-utils';
 
 declare const require: any;
@@ -109,6 +110,14 @@ function normalizeImageSrcs(html: string, currentHref: string): string {
         }
       } catch {
         image.src = generateAbsoluteHref(isGithubHref(currentHref) ? rawGithubHref(currentHref) : currentHref, src);
+      }
+      // gh svgs need to have ?sanitize=true
+      if (isRawGithubHref(image.src)) {
+        const url: URL = new URL(image.src);
+        if (url.pathname.endsWith('.svg')) {
+          url.searchParams.set('sanitize', 'true');
+          image.src = url.href;
+        }
       }
     });
 


### PR DESCRIPTION
## Description

- gh svg links need to end with `sanitize=true` to get image vs text.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] npm ci
- [ ] npm run serve
- [ ] go to http://localhost:4200/#/components/markdown-navigator
- [ ] use https://github.com/Teradata/product-help/blob/master/Test-CaaS/fhm1558121996862.md in the demo
- [ ] ensure that the svg diagram is rendered

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
