### PR TITLE
test(markdown-nav): add ability to jump to a point in tree

### DIFF
--- a/src/app/components/components/markdown-navigator/markdown-navigator.component.html
+++ b/src/app/components/components/markdown-navigator/markdown-navigator.component.html
@@ -8,126 +8,107 @@
     <mat-tab-group mat-stretch-tabs>
       <mat-tab>
         <ng-template matTabLabel>Demo</ng-template>
-        <div layout="row">
-          <div flex="50">
-            <mat-radio-group [(ngModel)]="selected" (change)="select()">
-              <mat-radio-button *ngFor="let option of options" [value]="option">
-                {{ option.name }}
-                <br />
-              </mat-radio-button>
-            </mat-radio-group>
-            <td-code-editor flex [language]="'json'" [(ngModel)]="userInput" [style.height.px]="200"></td-code-editor>
-            <button mat-button class="text-upper" color="primary" (click)="tryUserInput()">Try</button>
-          </div>
-          <div flex="50">
-            <td-markdown-navigator [items]="currentItems" [style.height.px]="450"></td-markdown-navigator>
-          </div>
+        <div>
+          <mat-radio-group [(ngModel)]="selected" (change)="selectOption()">
+            <mat-radio-button *ngFor="let option of options" [value]="option">
+              {{ option.name }}
+            </mat-radio-button>
+          </mat-radio-group>
+          <td-code-editor
+            flex
+            [language]="'json'"
+            [editorOptions]="{ minimap: { enabled: false } }"
+            [(ngModel)]="input"
+            [style.height.px]="200"
+          ></td-code-editor>
+          <button mat-button class="text-upper" color="primary" (click)="applyInput()">Apply</button>
+          <button mat-button class="text-upper" color="primary" (click)="demoStartAt()">Jump to a place</button>
+        </div>
+        <div>
+          <td-markdown-navigator
+            [items]="currentTree"
+            [startAt]="startAt"
+            [compareWith]="compareByTitle"
+            [style.height.px]="250"
+          ></td-markdown-navigator>
         </div>
       </mat-tab>
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <td-highlight lang="html">
           <![CDATA[
-            <mat-radio-group [(ngModel)]="selected" (change)="select()">
-              <mat-radio-button *ngFor="let option of options" [value]="option">
-                option.name
-                <br />
-              </mat-radio-button>
-            </mat-radio-group>
-            <td-code-editor flex [language]="'json'" [(ngModel)]="userInput" [style.height.px]="200"></td-code-editor>
-            <button mat-button class="text-upper" color="primary" (click)="tryUserInput()">Try</button>
+            <td-markdown-navigator
+              [items]="currentTree"
+              [startAt]="startAt"
+              [compareWith]="compareByTitle"
+              [style.height.px]="250"
+            ></td-markdown-navigator>
           ]]>
         </td-highlight>
         <td-highlight lang="typescript">
-            <![CDATA[
+          <![CDATA[
           import {
             IMarkdownNavigatorItem,
           } from '@covalent/markdown-navigator';
 
-          oneItem: IMarkdownNavigatorItem[] = [
-            {
-              url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
-            },
-          ];
+          public currentTree: IMarkdownNavigatorItem[] = [];
+          public startAt: IMarkdownNavigatorItem;
+          public compareByTitle: (o1: IMarkdownNavigatorItem, o2: IMarkdownNavigatorItem) => boolean = (
+            o1: IMarkdownNavigatorItem,
+            o2: IMarkdownNavigatorItem,
+          ): boolean => o1.title === o2.title;
+          ]]>
+        </td-highlight>
+      </mat-tab>
+    </mat-tab-group>
+  </mat-card-content>
+</mat-card>
 
-          itemWithRawMarkdown: IMarkdownNavigatorItem[] = [
-            {
-              markdownString: '\n\n# Raw markdown example\n \n> Amazing\n\n1. List\n2. of\n3. items\n\n',
-            },
-          ];
-
-          multipleItems: IMarkdownNavigatorItem[] = [
-            {
-              url: 'https://raw.githubusercontent.com/Teradata/nodejs-driver/develop/README.md',
-              title: 'Node.js Driver for Teradata',
-            },
-            {
-              url: 'https://raw.githubusercontent.com/angular/angular/master/README.md',
-              title: 'Angular',
-            },
-          ];
-
-          oneItemWithAnchor: IMarkdownNavigatorItem[] = [
-            {
-              url: 'https://raw.githubusercontent.com/Teradata/covalent/develop/docs/DEVELOPER_GUIDE.md',
-              anchor: 'Developer Guide for the Platform',
-            },
-          ];
-
-          nestedItems: IMarkdownNavigatorItem[] = [
-            {
-              title: 'Covalent',
-              children: [
-                {
-                  title: 'Components',
-                  children: [
-                    {
-                      url: 'https://raw.githubusercontent.com/Teradata/covalent/develop/src/platform/core/loading/README.md',
-                      title: 'tdLoading',
-                    },
-                  ],
-                },
-              ],
-            },
-          ];
-
-          options: { name: string; value: IMarkdownNavigatorItem[] }[] = [
-            {
-              name: 'One item',
-              value: this.oneItem,
-            },
-            {
-              name: 'Raw markdown',
-              value: this.itemWithRawMarkdown,
-            },
-            { name: 'Multiple items', value: this.multipleItems },
-            { name: 'One item with anchor', value: this.oneItemWithAnchor },
-            { name: 'Nested items', value: this.nestedItems },
-          ];
-
-          selected: { name: string; value: IMarkdownNavigatorItem[] } = this.options[0];
-          currentItems: IMarkdownNavigatorItem[] = this.selected.value;
-          userInput: string = this.prettyJson(this.currentItems);
-
-          select(): void {
-            this.use(this.selected.value);
-          }
-
-          use(items: IMarkdownNavigatorItem[]): void {
-            this.currentItems = items;
-            this.userInput = this.prettyJson(this.currentItems);
-          }
-
-          tryUserInput(): void {
-            this.use(JSON.parse(this.userInput));
-          }
-
-          prettyJson(items: IMarkdownNavigatorItem[]): string {
-            return JSON.stringify(items, undefined, 4);
-          }
+<mat-card>
+  <mat-card-title>Markdown Navigator Window component</mat-card-title>
+  <mat-card-subtitle>
+    A component that contains a MarkdownNavigator component and a toolbar
+  </mat-card-subtitle>
+  <mat-divider></mat-divider>
+  <mat-card-content>
+    <mat-tab-group mat-stretch-tabs>
+      <mat-tab>
+        <ng-template matTabLabel>Demo</ng-template>
+        <td-markdown-navigator-window
+          [items]="currentTree"
+          [startAt]="startAt"
+          [compareWith]="compareByTitle"
+          [style.height.px]="250"
+        ></td-markdown-navigator-window>
+      </mat-tab>
+      <mat-tab>
+        <ng-template matTabLabel>Code</ng-template>
+        <mat-card-content>
+          <td-highlight lang="html">
+            <![CDATA[
+            <td-markdown-navigator-window
+              [items]="currentTree"
+              [startAt]="startAt"
+              [compareWith]="compareByTitle"
+              [style.height.px]="250"
+            ></td-markdown-navigator-window>
             ]]>
-
           </td-highlight>
+          <td-highlight lang="typescript">
+            <![CDATA[
+            import {
+              IMarkdownNavigatorItem,
+            } from '@covalent/markdown-navigator';
+
+            public currentTree: IMarkdownNavigatorItem[] = [];
+            public startAt: IMarkdownNavigatorItem;
+            public compareByTitle: (o1: IMarkdownNavigatorItem, o2: IMarkdownNavigatorItem) => boolean = (
+              o1: IMarkdownNavigatorItem,
+              o2: IMarkdownNavigatorItem,
+            ): boolean => o1.title === o2.title;
+            ]]>
+          </td-highlight>
+        </mat-card-content>
       </mat-tab>
     </mat-tab-group>
   </mat-card-content>
@@ -136,14 +117,15 @@
 <mat-card>
   <mat-card-title>Markdown Navigator Window Service</mat-card-title>
   <mat-card-subtitle>
-    A service that opens a MarkdownNavigatorWindowComponent inside a draggable dialog. Uses the openDraggable method of the TdDialogService.
+    A service that opens a MarkdownNavigatorWindowComponent inside a draggable dialog. Uses the openDraggable method of
+    the TdDialogService.
   </mat-card-subtitle>
   <mat-divider></mat-divider>
   <mat-tab-group mat-stretch-tabs>
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <mat-card-actions>
-        <button mat-button class="text-upper" color="primary" (click)="openDialog()">
+        <button mat-button class="text-upper" color="primary" (click)="openWindow()">
           Open
         </button>
       </mat-card-actions>
@@ -153,7 +135,7 @@
       <mat-card-content>
         <td-highlight lang="html">
           <![CDATA[
-          <button mat-button class="text-upper" color="primary" (click)="openDialog()">
+          <button mat-button class="text-upper" color="primary" (click)="openWindow()">
             Open
           </button>
           ]]>
@@ -161,20 +143,13 @@
         <td-highlight lang="typescript">
           <![CDATA[
           import {
-            IMarkdownNavigatorItem,
             MarkdownNavigatorWindowService,
           } from '@covalent/markdown-navigator';
 
-          currentItems: IMarkdownNavigatorItem[] = [
-          {
-            url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
-          },
-          ];
-
           constructor(private _markdownNavigatorWindowService: MarkdownNavigatorWindowService) {}
 
-          openDialog(): void {
-            this._markdownNavigatorWindowService.open({ items: this.currentItems });
+          public openWindow(): void {
+            this._markdownNavigatorWindowService.open(this.windowConfig);
           }
           ]]>
         </td-highlight>
@@ -193,7 +168,15 @@
     <mat-tab>
       <ng-template matTabLabel>Demo</ng-template>
       <mat-card-actions>
-        <button mat-button class="text-upper" color="primary" [tdMarkdownNavigatorWindow]="{ items: currentItems }" [disabled]="false">Open</button>
+        <button
+          mat-button
+          class="text-upper"
+          color="primary"
+          [tdMarkdownNavigatorWindow]="windowConfig"
+          [disabled]="false"
+        >
+          Open
+        </button>
       </mat-card-actions>
     </mat-tab>
     <mat-tab>
@@ -201,16 +184,15 @@
       <mat-card-content>
         <td-highlight lang="html">
           <![CDATA[
-          <button mat-button class="text-upper" color="primary" [tdMarkdownNavigatorWindow]="{ items: currentItems }" [disabled]="false">Open</button>
-          ]]>
-        </td-highlight>
-        <td-highlight lang="typescript">
-          <![CDATA[
-          currentItems: IMarkdownNavigatorItem[] = [
-          {
-            url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
-          },
-          ];
+          <button
+            mat-button
+            class="text-upper"
+            color="primary"
+            [tdMarkdownNavigatorWindow]="windowConfig"
+            [disabled]="false"
+          >
+            Open
+          </button>
           ]]>
         </td-highlight>
       </mat-card-content>

--- a/src/app/components/components/markdown-navigator/markdown-navigator.component.scss
+++ b/src/app/components/components/markdown-navigator/markdown-navigator.component.scss
@@ -1,9 +1,3 @@
-mat-radio-group {
-  display: flex;
-  flex-direction: column;
-  margin: 16px 0;
-}
-
 mat-radio-button {
   margin: 8px;
 }

--- a/src/app/components/components/markdown-navigator/markdown-navigator.component.ts
+++ b/src/app/components/components/markdown-navigator/markdown-navigator.component.ts
@@ -1,7 +1,52 @@
 import { Component, HostBinding } from '@angular/core';
-
 import { slideInDownAnimation } from '../../../app.animations';
-import { IMarkdownNavigatorItem, MarkdownNavigatorWindowService } from '@covalent/markdown-navigator';
+import {
+  IMarkdownNavigatorItem,
+  MarkdownNavigatorWindowService,
+  IMarkdownNavigatorWindowConfig,
+} from '@covalent/markdown-navigator';
+
+function prettyJson(items: IMarkdownNavigatorItem[]): string {
+  return JSON.stringify(items, undefined, 4);
+}
+
+const singleLevelTree: IMarkdownNavigatorItem[] = [
+  {
+    url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
+  },
+];
+const biLevelTree: IMarkdownNavigatorItem[] = [
+  {
+    url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
+    title: 'Covalent',
+  },
+  {
+    url: 'https://raw.githubusercontent.com/angular/angular/master/README.md',
+    title: 'Angular',
+  },
+  {
+    markdownString: '\n\n# Raw markdown example\n \n> Amazing\n\n1. List\n2. of\n3. items\n\n',
+    title: 'Raw markdown',
+  },
+];
+const multiLevelTree: IMarkdownNavigatorItem[] = [
+  {
+    title: 'Covalent',
+    children: [
+      {
+        title: 'Components',
+        children: [
+          {
+            url: 'https://raw.githubusercontent.com/Teradata/covalent/develop/src/platform/core/loading/README.md',
+            title: 'tdLoading',
+          },
+        ],
+      },
+    ],
+  },
+  biLevelTree[1],
+  biLevelTree[2],
+];
 
 @Component({
   selector: 'markdown-navigator-demo',
@@ -14,92 +59,54 @@ export class MarkdownNavigatorDemoComponent {
   @HostBinding('@routeAnimation') routeAnimation: boolean = true;
   @HostBinding('class.td-route-animation') classAnimation: boolean = true;
 
-  oneItem: IMarkdownNavigatorItem[] = [
+  public options: { name: string; value: IMarkdownNavigatorItem[] }[] = [
+    { name: 'Multi-level', value: multiLevelTree },
+    { name: 'Bi-level', value: biLevelTree },
     {
-      url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
+      name: 'Single-level',
+      value: singleLevelTree,
     },
   ];
+  public selected: { name: string; value: IMarkdownNavigatorItem[] } = this.options[0];
+  public currentTree: IMarkdownNavigatorItem[] = this.selected.value;
+  public startAt: IMarkdownNavigatorItem;
+  public input: string = prettyJson(this.currentTree);
 
-  itemWithRawMarkdown: IMarkdownNavigatorItem[] = [
-    {
-      markdownString: '\n\n# Raw markdown example\n \n> Amazing\n\n1. List\n2. of\n3. items\n\n',
-    },
-  ];
-
-  multipleItems: IMarkdownNavigatorItem[] = [
-    {
-      url: 'https://raw.githubusercontent.com/Teradata/nodejs-driver/develop/README.md',
-      title: 'Node.js Driver for Teradata',
-    },
-    {
-      url: 'https://raw.githubusercontent.com/angular/angular/master/README.md',
-      title: 'Angular',
-    },
-  ];
-
-  oneItemWithAnchor: IMarkdownNavigatorItem[] = [
-    {
-      url: 'https://raw.githubusercontent.com/Teradata/covalent/develop/docs/DEVELOPER_GUIDE.md',
-      anchor: 'Adding a new documentation component',
-    },
-  ];
-
-  nestedItems: IMarkdownNavigatorItem[] = [
-    {
-      title: 'Covalent',
-      children: [
-        {
-          title: 'Components',
-          children: [
-            {
-              url: 'https://raw.githubusercontent.com/Teradata/covalent/develop/src/platform/core/loading/README.md',
-              title: 'tdLoading',
-            },
-          ],
-        },
-      ],
-    },
-  ];
-
-  options: { name: string; value: IMarkdownNavigatorItem[] }[] = [
-    {
-      name: 'One item',
-      value: this.oneItem,
-    },
-    {
-      name: 'Raw markdown',
-      value: this.itemWithRawMarkdown,
-    },
-    { name: 'Multiple items', value: this.multipleItems },
-    { name: 'One item with anchor', value: this.oneItemWithAnchor },
-    { name: 'Nested items', value: this.nestedItems },
-  ];
-  selected: { name: string; value: IMarkdownNavigatorItem[] } = this.options[0];
-  currentItems: IMarkdownNavigatorItem[] = this.selected.value;
-  userInput: string = this.prettyJson(this.currentItems);
   constructor(private _markdownNavigatorWindowService: MarkdownNavigatorWindowService) {}
 
-  select(): void {
+  public compareByTitle: (o1: IMarkdownNavigatorItem, o2: IMarkdownNavigatorItem) => boolean = (
+    o1: IMarkdownNavigatorItem,
+    o2: IMarkdownNavigatorItem,
+  ): boolean => o1.title === o2.title;
+
+  public get windowConfig(): IMarkdownNavigatorWindowConfig {
+    return { items: this.currentTree, startAt: this.startAt, compareWith: this.compareByTitle };
+  }
+
+  public selectOption(): void {
+    this.startAt = undefined;
     this.use(this.selected.value);
   }
 
-  use(items: IMarkdownNavigatorItem[]): void {
-    this.currentItems = items;
-    this.userInput = this.prettyJson(this.currentItems);
+  public use(items: IMarkdownNavigatorItem[]): void {
+    this.currentTree = items;
+    this.input = prettyJson(this.currentTree);
     if (this._markdownNavigatorWindowService.isOpen) {
-      this.openDialog();
+      this.openWindow();
     }
   }
 
-  tryUserInput(): void {
-    this.use(JSON.parse(this.userInput));
+  public applyInput(): void {
+    this.use(JSON.parse(this.input));
   }
 
-  prettyJson(items: IMarkdownNavigatorItem[]): string {
-    return JSON.stringify(items, undefined, 4);
+  public demoStartAt(): void {
+    this.selected = this.options[0];
+    this.startAt = { title: 'tdLoading' };
+    this.use(JSON.parse(JSON.stringify(this.selected.value)));
   }
 
-  openDialog(): void {
-    this._markdownNavigatorWindowService.open({ items: this.currentItems });
+  public openWindow(): void {
+    this._markdownNavigatorWindowService.open(this.windowConfig);
   }
 }

--- a/src/platform/flavored-markdown/flavored-markdown-loader/flavored-markdown-loader.component.ts
+++ b/src/platform/flavored-markdown/flavored-markdown-loader/flavored-markdown-loader.component.ts
@@ -55,13 +55,14 @@ export class TdFlavoredMarkdownLoaderComponent implements OnChanges {
 
   async loadMarkdown(): Promise<void> {
     this.loading = true;
+    this._changeDetectorRef.detectChanges();
     try {
       this.content = await this._markdownUrlLoaderService.load(this.url, this.httpOptions);
     } catch (error) {
       this.loadFailed.emit(error);
     } finally {
       this.loading = false;
-      this._changeDetectorRef.markForCheck();
+      this._changeDetectorRef.detectChanges();
     }
   }
 }

--- a/src/platform/flavored-markdown/flavored-markdown-loader/flavored-markdown-loader.component.ts
+++ b/src/platform/flavored-markdown/flavored-markdown-loader/flavored-markdown-loader.component.ts
@@ -65,14 +65,14 @@ export class TdFlavoredMarkdownLoaderComponent implements OnChanges {
 
   async loadMarkdown(): Promise<void> {
     this.loading = true;
-    this._changeDetectorRef.detectChanges();
+    this._changeDetectorRef.markForCheck();
     try {
       this.content = await this._markdownUrlLoaderService.load(this.url, this.httpOptions);
     } catch (error) {
       this.loadFailed.emit(error);
     } finally {
       this.loading = false;
-      this._changeDetectorRef.detectChanges();
+      this._changeDetectorRef.markForCheck();
     }
   }
 }

--- a/src/platform/flavored-markdown/flavored-markdown-loader/flavored-markdown-loader.component.ts
+++ b/src/platform/flavored-markdown/flavored-markdown-loader/flavored-markdown-loader.component.ts
@@ -1,4 +1,13 @@
-import { Component, Input, ChangeDetectorRef, SimpleChanges, OnChanges, Output, EventEmitter } from '@angular/core';
+import {
+  Component,
+  Input,
+  ChangeDetectorRef,
+  SimpleChanges,
+  OnChanges,
+  Output,
+  EventEmitter,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { MarkdownLoaderService } from '@covalent/markdown';
 
 // TODO: make a td-markdown-loader component
@@ -7,6 +16,7 @@ import { MarkdownLoaderService } from '@covalent/markdown';
   selector: 'td-flavored-markdown-loader',
   styleUrls: ['./flavored-markdown-loader.component.scss'],
   templateUrl: './flavored-markdown-loader.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TdFlavoredMarkdownLoaderComponent implements OnChanges {
   /**

--- a/src/platform/markdown-navigator/README.md
+++ b/src/platform/markdown-navigator/README.md
@@ -9,9 +9,11 @@ A component for rendering and navigating through markdown, such as documentation
   + List of IMarkdownNavigatorItems to be rendered
 + labels?: IMarkdownNavigatorLabels
   + Translated labels
-+ toolbarColor?: ThemePalette
-  + Color palette for toolbar
-  + Defaults to 'primary'
++ jumpTo?: IMarkdownNavigatorItem
+  + Item to jump to
++ compareWith?: IMarkdownNavigatorCompareWith
+  + Function used to find jumpTo item
+  + Defaults to comparison by strict equality (===)
 
 ## Setup
 
@@ -116,6 +118,8 @@ interface IMarkdownNavigatorWindowConfig {
   dialogConfig?: MatDialogConfig;
   labels?: IMarkdownNavigatorWindowLabels;
   toolbarColor?: ThemePalette;
+  jumpTo?: IMarkdownNavigatorItem;
+  compareWith?: IMarkdownNavigatorCompareWith;
 }
 ```
 
@@ -185,6 +189,8 @@ interface IMarkdownNavigatorWindowConfig {
   dialogConfig?: MatDialogConfig;
   labels?: IMarkdownNavigatorWindowLabels;
   toolbarColor?: ThemePalette;
+  jumpTo?: IMarkdownNavigatorItem;
+  compareWith?: IMarkdownNavigatorCompareWith;
 }
 ```
 

--- a/src/platform/markdown-navigator/README.md
+++ b/src/platform/markdown-navigator/README.md
@@ -5,90 +5,19 @@ A component for rendering and navigating through markdown, such as documentation
 ## API Summary
 
 #### Inputs
+
 + items: IMarkdownNavigatorItem[]
   + List of IMarkdownNavigatorItems to be rendered
 + labels?: IMarkdownNavigatorLabels
   + Translated labels
-+ jumpTo?: IMarkdownNavigatorItem
++ startAt?: IMarkdownNavigatorItem
   + Item to jump to
 + compareWith?: IMarkdownNavigatorCompareWith
-  + Function used to find jumpTo item
+  + Function used to find startAt item
   + Defaults to comparison by strict equality (===)
 
-## Setup
-
-```typescript
-import { CovalentMarkdownNavigatorModule } from '@covalent/markdown-navigator';
-@NgModule({
-  imports: [
-    CovalentMarkdownNavigatorModule,
-    ...
-  ],
-  ...
-})
-export class MyModule {}
-```
-
-## Usage
-
-```html
-  <td-markdown-navigator [items]="items"></td-markdown-navigator>
-
-```
-
-#### Sample items
-
-```typescript
-oneItem: IMarkdownNavigatorItem[] = [
-  {
-    url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
-  },
-];
-
-itemWithRawMarkdown: IMarkdownNavigatorItem[] = [
-  {
-    markdownString: '\n\n# Raw markdown example\n \n> Amazing\n\n1. List\n2. of\n3. items\n\n',
-  },
-];
-
-multipleItems: IMarkdownNavigatorItem[] = [
-  {
-    url: 'https://raw.githubusercontent.com/Teradata/nodejs-driver/develop/README.md',
-    title: 'Node.js Driver for Teradata',
-  },
-  {
-    url: 'https://raw.githubusercontent.com/angular/angular/master/README.md',
-    title: 'Angular',
-  },
-];
-
-oneItemWithAnchor: IMarkdownNavigatorItem[] = [
-  {
-    url: 'https://raw.githubusercontent.com/Teradata/covalent/develop/docs/DEVELOPER_GUIDE.md',
-    anchor: 'Adding a new documentation component',
-  },
-];
-
-nestedItems: IMarkdownNavigatorItem[] = [
-  {
-    title: 'Covalent',
-    children: [
-      {
-        title: 'Components',
-        children: [
-          {
-            url: 'https://raw.githubusercontent.com/Teradata/covalent/develop/src/platform/core/loading/README.md',
-            title: 'tdLoading',
-          },
-        ],
-      },
-    ],
-  },
-];
-
-```
-
 For reference:
+
 ```typescript
 interface IMarkdownNavigatorItem {
   title?: string;
@@ -98,6 +27,78 @@ interface IMarkdownNavigatorItem {
   anchor?: string;
   children?: IMarkdownNavigatorItem[];
 }
+```
+
+## Setup
+
+```typescript
+import { CovalentMarkdownNavigatorModule } from '@covalent/markdown-navigator';
+@NgModule({
+  imports: [CovalentMarkdownNavigatorModule]
+})
+export class MyModule {}
+```
+
+## Usage
+
+```html
+<td-markdown-navigator [items]="items"></td-markdown-navigator>
+```
+
+```typescript
+const items = [
+  {
+    title: 'Covalent',
+    children: [
+      {
+        title: 'Components',
+        children: [
+          {
+            url: 'https://raw.githubusercontent.com/Teradata/covalent/develop/src/platform/core/loading/README.md',
+            title: 'tdLoading'
+          }
+        ]
+      }
+    ]
+  }
+];
+```
+
+# MarkdownNavigatorWindowComponent
+
+A component that contains a MarkdownNavigator component and a toolbar
+
+## API Summary
+
+#### Inputs
+
++ items: IMarkdownNavigatorItem[]
+  + List of IMarkdownNavigatorItems to be rendered
++ labels?: IMarkdownNavigatorLabels
+  + Translated labels
++ startAt?: IMarkdownNavigatorItem
+  + Item to jump to
++ compareWith?: IMarkdownNavigatorCompareWith
+  + Function used to find startAt item
+  + Defaults to comparison by strict equality (===)
++ toolbarColor?: ThemePalette
+  + Toolbar color
+  + Defaults to 'primary'
+
+## Setup
+
+```typescript
+import { CovalentMarkdownNavigatorModule } from '@covalent/markdown-navigator';
+@NgModule({
+  imports: [CovalentMarkdownNavigatorModule]
+})
+export class MyModule {}
+```
+
+## Usage
+
+```html
+<td-markdown-navigator-window [items]="items"></td-markdown-navigator-window>
 ```
 
 # MarkdownNavigatorWindowService
@@ -112,13 +113,14 @@ A service that opens a MarkdownNavigatorWindowComponent inside a draggable dialo
   + Opens a MarkdownNavigatorWindowComponent inside a draggable dialog.
 
 For reference:
+
 ```typescript
 interface IMarkdownNavigatorWindowConfig {
   items: IMarkdownNavigatorItem[];
   dialogConfig?: MatDialogConfig;
   labels?: IMarkdownNavigatorWindowLabels;
   toolbarColor?: ThemePalette;
-  jumpTo?: IMarkdownNavigatorItem;
+  startAt?: IMarkdownNavigatorItem;
   compareWith?: IMarkdownNavigatorCompareWith;
 }
 ```
@@ -128,46 +130,33 @@ interface IMarkdownNavigatorWindowConfig {
 ```typescript
 import { CovalentMarkdownNavigatorModule } from '@covalent/markdown-navigator';
 @NgModule({
-  imports: [
-    CovalentMarkdownNavigatorModule,
-    ...
-  ],
-  ...
+  imports: [CovalentMarkdownNavigatorModule]
 })
 export class MyModule {}
 ```
 
-
 ## Usage
-
-Example:
 
 ```typescript
 import {
   MarkdownNavigatorWindowComponent,
   MarkdownNavigatorWindowService,
-  IMarkdownNavigatorItem,
+  IMarkdownNavigatorItem
 } from '@covalent/markdown-navigator';
 import { MatDialogRef } from '@angular/material/dialog';
 
-export class SampleComponent{
-
+export class SampleComponent {
   constructor(private _markdownNavigatorWindowService: MarkdownNavigatorWindowService) {}
 
   ngOnInit(): void {
     const ref: MatDialogRef<MarkdownNavigatorWindowComponent> = this._markdownNavigatorWindowService.open({
       items: [{ url: 'https://github.com/Teradata/covalent/blob/develop/README.md' }]
     });
-    ref.afterOpened().subscribe(() => {
-
-    });
-    ref.afterClosed().subscribe(() => {
-
-    });
+    ref.afterOpened().subscribe(() => {});
+    ref.afterClosed().subscribe(() => {});
   }
 }
 ```
-
 
 # MarkdownNavigatorWindowDirective
 
@@ -182,32 +171,15 @@ A directive that calls the MarkdownNavigatorWindowService open method on click e
 + disabled: boolean
   + Whether disabled or not
 
-For reference:
-```typescript
-interface IMarkdownNavigatorWindowConfig {
-  items: IMarkdownNavigatorItem[];
-  dialogConfig?: MatDialogConfig;
-  labels?: IMarkdownNavigatorWindowLabels;
-  toolbarColor?: ThemePalette;
-  jumpTo?: IMarkdownNavigatorItem;
-  compareWith?: IMarkdownNavigatorCompareWith;
-}
-```
-
 ## Setup
 
 ```typescript
 import { CovalentMarkdownNavigatorModule } from '@covalent/markdown-navigator';
 @NgModule({
-  imports: [
-    CovalentMarkdownNavigatorModule,
-    ...
-  ],
-  ...
+  imports: [CovalentMarkdownNavigatorModule]
 })
 export class MyModule {}
 ```
-
 
 ## Usage
 

--- a/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.spec.ts
@@ -23,7 +23,7 @@ class TestComponent {
 describe('MarkdownNavigatorWindowDirective', () => {
   let overlayContainerElement: HTMLElement;
 
-  async function wait(fixture: ComponentFixture<any>): Promise<void> {
+  async function wait(fixture: ComponentFixture<TestComponent>): Promise<void> {
     fixture.detectChanges();
     await fixture.whenStable();
   }
@@ -55,6 +55,10 @@ describe('MarkdownNavigatorWindowDirective', () => {
         fixture.debugElement.query(By.css('button')).nativeElement.click();
         await wait(fixture);
         expect(overlayContainerElement.querySelector(`td-markdown-navigator`)).toBeTruthy();
+        // tslint:disable-next-line:no-useless-cast
+        (<HTMLElement>overlayContainerElement.querySelector(`[data-test="close-button"]`)).click();
+        await wait(fixture);
+        expect(overlayContainerElement.querySelector(`td-markdown-navigator`)).toBeFalsy();
       },
     ),
   ));

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.spec.ts
@@ -10,6 +10,7 @@ import {
   MarkdownNavigatorWindowComponent,
   IMarkdownNavigatorWindowLabels,
 } from '../markdown-navigator-window/markdown-navigator-window.component';
+import { DEEPLY_NESTED_TREE, compareByTitle } from '../markdown-navigator.component.spec';
 
 const RAW_MARKDOWN_HEADING: string = 'Heading';
 const RAW_MARKDOWN: string = `# ${RAW_MARKDOWN_HEADING}`;
@@ -22,7 +23,7 @@ const RAW_MARKDOWN_ITEMS: IMarkdownNavigatorItem[] = [
   },
 ];
 
-async function wait(fixture: ComponentFixture<any>): Promise<void> {
+async function wait(fixture: ComponentFixture<TestComponent>): Promise<void> {
   fixture.detectChanges();
   await fixture.whenStable();
 }
@@ -117,6 +118,55 @@ describe('MarkdownNavigatorWindowService', () => {
 
         expect(dialogRef.componentInstance.items).toEqual(RAW_MARKDOWN_ITEMS);
         expect(getMarkdownNavigator().querySelectorAll('mat-action-list button').length).toBe(2);
+
+        dialogRef.close();
+        await wait(fixture);
+      },
+    ),
+  ));
+
+  it('should open to a certain item', async(
+    inject(
+      [MarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+        const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
+        const dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
+          items: DEEPLY_NESTED_TREE,
+          jumpTo: DEEPLY_NESTED_TREE[0],
+        });
+
+        await wait(fixture);
+        await dialogRef.afterOpened().toPromise();
+
+        expect(dialogRef.componentInstance.jumpTo).toEqual(DEEPLY_NESTED_TREE[0]);
+        expect(getMarkdownNavigator().querySelector('[data-test="title"]').textContent).toContain(
+          DEEPLY_NESTED_TREE[0].title,
+        );
+
+        dialogRef.close();
+        await wait(fixture);
+      },
+    ),
+  ));
+
+  it('should open to a certain item using compareWith function', async(
+    inject(
+      [MarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+        const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
+        const dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
+          items: DEEPLY_NESTED_TREE,
+          jumpTo: DEEPLY_NESTED_TREE[1],
+          compareWith: compareByTitle,
+        });
+
+        await wait(fixture);
+        await dialogRef.afterOpened().toPromise();
+
+        expect(dialogRef.componentInstance.compareWith).toEqual(compareByTitle);
+        expect(getMarkdownNavigator().querySelector('[data-test="title"]').textContent).toContain(
+          DEEPLY_NESTED_TREE[1].title,
+        );
 
         dialogRef.close();
         await wait(fixture);

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.spec.ts
@@ -132,13 +132,13 @@ describe('MarkdownNavigatorWindowService', () => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
         const dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
           items: DEEPLY_NESTED_TREE,
-          jumpTo: DEEPLY_NESTED_TREE[0],
+          startAt: DEEPLY_NESTED_TREE[0],
         });
 
         await wait(fixture);
         await dialogRef.afterOpened().toPromise();
 
-        expect(dialogRef.componentInstance.jumpTo).toEqual(DEEPLY_NESTED_TREE[0]);
+        expect(dialogRef.componentInstance.startAt).toEqual(DEEPLY_NESTED_TREE[0]);
         expect(getMarkdownNavigator().querySelector('[data-test="title"]').textContent).toContain(
           DEEPLY_NESTED_TREE[0].title,
         );
@@ -156,7 +156,7 @@ describe('MarkdownNavigatorWindowService', () => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
         const dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
           items: DEEPLY_NESTED_TREE,
-          jumpTo: DEEPLY_NESTED_TREE[1],
+          startAt: DEEPLY_NESTED_TREE[1],
           compareWith: compareByTitle,
         });
 

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
@@ -6,13 +6,15 @@ import {
   IMarkdownNavigatorWindowLabels,
 } from '../markdown-navigator-window/markdown-navigator-window.component';
 import { TdDialogService } from '@covalent/core/dialogs';
-import { IMarkdownNavigatorItem } from '../markdown-navigator.component';
+import { IMarkdownNavigatorItem, IMarkdownNavigatorCompareWith } from '../markdown-navigator.component';
 
 export interface IMarkdownNavigatorWindowConfig {
   items: IMarkdownNavigatorItem[];
   dialogConfig?: MatDialogConfig;
   labels?: IMarkdownNavigatorWindowLabels;
   toolbarColor?: ThemePalette;
+  jumpTo?: IMarkdownNavigatorItem;
+  compareWith?: IMarkdownNavigatorCompareWith;
 }
 
 const CDK_OVERLAY_CUSTOM_CLASS: string = 'td-draggable-markdown-navigator-window-wrapper';
@@ -27,8 +29,8 @@ const DEFAULT_DRAGGABLE_DIALOG_CONFIG: MatDialogConfig = {
 };
 @Injectable()
 export class MarkdownNavigatorWindowService {
-  markdownNavigatorWindowDialog: MatDialogRef<MarkdownNavigatorWindowComponent> = undefined;
-  markdownNavigatorWindowDialogsOpen: number = 0;
+  private markdownNavigatorWindowDialog: MatDialogRef<MarkdownNavigatorWindowComponent> = undefined;
+  private markdownNavigatorWindowDialogsOpen: number = 0;
 
   constructor(private _tdDialogService: TdDialogService) {}
 
@@ -48,6 +50,8 @@ export class MarkdownNavigatorWindowService {
 
     this.markdownNavigatorWindowDialog.componentInstance.items = config.items;
     this.markdownNavigatorWindowDialog.componentInstance.labels = config.labels;
+    this.markdownNavigatorWindowDialog.componentInstance.jumpTo = config.jumpTo;
+    this.markdownNavigatorWindowDialog.componentInstance.compareWith = config.compareWith;
     this.markdownNavigatorWindowDialog.componentInstance.toolbarColor =
       'toolbarColor' in config ? config.toolbarColor : 'primary';
     this.markdownNavigatorWindowDialog.componentInstance.closed.subscribe(() => this.close());

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
@@ -13,7 +13,7 @@ export interface IMarkdownNavigatorWindowConfig {
   dialogConfig?: MatDialogConfig;
   labels?: IMarkdownNavigatorWindowLabels;
   toolbarColor?: ThemePalette;
-  jumpTo?: IMarkdownNavigatorItem;
+  startAt?: IMarkdownNavigatorItem;
   compareWith?: IMarkdownNavigatorCompareWith;
 }
 
@@ -50,7 +50,7 @@ export class MarkdownNavigatorWindowService {
 
     this.markdownNavigatorWindowDialog.componentInstance.items = config.items;
     this.markdownNavigatorWindowDialog.componentInstance.labels = config.labels;
-    this.markdownNavigatorWindowDialog.componentInstance.jumpTo = config.jumpTo;
+    this.markdownNavigatorWindowDialog.componentInstance.startAt = config.startAt;
     this.markdownNavigatorWindowDialog.componentInstance.compareWith = config.compareWith;
     this.markdownNavigatorWindowDialog.componentInstance.toolbarColor =
       'toolbarColor' in config ? config.toolbarColor : 'primary';

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.html
@@ -23,6 +23,6 @@
 <td-markdown-navigator
   [items]="items"
   [labels]="markdownNavigatorLabels"
-  [jumpTo]="jumpTo"
+  [startAt]="startAt"
   [compareWith]="compareWith"
 ></td-markdown-navigator>

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.html
@@ -10,6 +10,7 @@
         [matTooltip]="closeLabel"
         (click)="closed.emit()"
         class="td-markdown-navigator-window-close"
+        [attr.data-test]="'close-button'"
       >
         <mat-icon [attr.aria-label]="closeLabel">
           close
@@ -19,4 +20,9 @@
   </mat-toolbar-row>
 </mat-toolbar>
 
-<td-markdown-navigator [items]="items" [labels]="markdownNavigatorLabels"></td-markdown-navigator>
+<td-markdown-navigator
+  [items]="items"
+  [labels]="markdownNavigatorLabels"
+  [jumpTo]="jumpTo"
+  [compareWith]="compareWith"
+></td-markdown-navigator>

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.spec.ts
@@ -47,7 +47,7 @@ async function wait(
       [style.height.px]="450"
       [labels]="labels"
       [toolbarColor]="toolbarColor"
-      [jumpTo]="jumpTo"
+      [startAt]="startAt"
       [compareWith]="compareWith"
     ></td-markdown-navigator-window>
   `,
@@ -56,7 +56,7 @@ class TdMarkdownNavigatorWindowTestComponent {
   items: IMarkdownNavigatorItem[] = [];
   labels: IMarkdownNavigatorWindowLabels;
   toolbarColor: ThemePalette;
-  jumpTo: IMarkdownNavigatorItem;
+  startAt: IMarkdownNavigatorItem;
   compareWith: IMarkdownNavigatorCompareWith;
 }
 
@@ -249,24 +249,24 @@ describe('MarkdownNavigatorWindowComponent', () => {
     }),
   ));
 
-  it('pass jumpTo item to markdownNavigator component', async(
+  it('pass startAt item to markdownNavigator component', async(
     inject([], async () => {
       const fixture: ComponentFixture<TdMarkdownNavigatorWindowTestComponent> = TestBed.createComponent(
         TdMarkdownNavigatorWindowTestComponent,
       );
 
-      fixture.componentInstance.jumpTo = DEEPLY_NESTED_TREE[0];
+      fixture.componentInstance.startAt = DEEPLY_NESTED_TREE[0];
       await wait(fixture);
 
       const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
         By.directive(MarkdownNavigatorComponent),
       ).componentInstance;
 
-      expect(markdownNavigator.jumpTo).toEqual(DEEPLY_NESTED_TREE[0]);
+      expect(markdownNavigator.startAt).toEqual(DEEPLY_NESTED_TREE[0]);
 
-      fixture.componentInstance.jumpTo = DEEPLY_NESTED_TREE[1];
+      fixture.componentInstance.startAt = DEEPLY_NESTED_TREE[1];
       await wait(fixture);
-      expect(markdownNavigator.jumpTo).toEqual(DEEPLY_NESTED_TREE[1]);
+      expect(markdownNavigator.startAt).toEqual(DEEPLY_NESTED_TREE[1]);
     }),
   ));
 

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.spec.ts
@@ -14,7 +14,9 @@ import {
   IMarkdownNavigatorItem,
   MarkdownNavigatorComponent,
   DEFAULT_MARKDOWN_NAVIGATOR_LABELS,
+  IMarkdownNavigatorCompareWith,
 } from '../markdown-navigator.component';
+import { DEEPLY_NESTED_TREE, compareByTitle } from '../markdown-navigator.component.spec';
 
 const RAW_MARKDOWN_HEADING: string = 'Heading';
 const RAW_MARKDOWN: string = `# ${RAW_MARKDOWN_HEADING}`;
@@ -30,7 +32,9 @@ const RAW_MARKDOWN_ITEM: IMarkdownNavigatorItem[] = [
   },
 ];
 
-async function wait(fixture: ComponentFixture<any>): Promise<void> {
+async function wait(
+  fixture: ComponentFixture<TdMarkdownNavigatorWindowTestComponent | TdMarkdownNavigatorWindowWOColorTestComponent>,
+): Promise<void> {
   fixture.detectChanges();
   await fixture.whenStable();
 }
@@ -43,6 +47,8 @@ async function wait(fixture: ComponentFixture<any>): Promise<void> {
       [style.height.px]="450"
       [labels]="labels"
       [toolbarColor]="toolbarColor"
+      [jumpTo]="jumpTo"
+      [compareWith]="compareWith"
     ></td-markdown-navigator-window>
   `,
 })
@@ -50,6 +56,8 @@ class TdMarkdownNavigatorWindowTestComponent {
   items: IMarkdownNavigatorItem[] = [];
   labels: IMarkdownNavigatorWindowLabels;
   toolbarColor: ThemePalette;
+  jumpTo: IMarkdownNavigatorItem;
+  compareWith: IMarkdownNavigatorCompareWith;
 }
 
 @Component({
@@ -238,6 +246,50 @@ describe('MarkdownNavigatorWindowComponent', () => {
       await wait(fixture);
 
       expect(markdownNavigatorWindow.closed.emit).toHaveBeenCalled();
+    }),
+  ));
+
+  it('pass jumpTo item to markdownNavigator component', async(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorWindowTestComponent> = TestBed.createComponent(
+        TdMarkdownNavigatorWindowTestComponent,
+      );
+
+      fixture.componentInstance.jumpTo = DEEPLY_NESTED_TREE[0];
+      await wait(fixture);
+
+      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(MarkdownNavigatorComponent),
+      ).componentInstance;
+
+      expect(markdownNavigator.jumpTo).toEqual(DEEPLY_NESTED_TREE[0]);
+
+      fixture.componentInstance.jumpTo = DEEPLY_NESTED_TREE[1];
+      await wait(fixture);
+      expect(markdownNavigator.jumpTo).toEqual(DEEPLY_NESTED_TREE[1]);
+    }),
+  ));
+
+  it('pass compareWith item to markdownNavigator component', async(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorWindowTestComponent> = TestBed.createComponent(
+        TdMarkdownNavigatorWindowTestComponent,
+      );
+      function compareByUrl(o1: IMarkdownNavigatorItem, o2: IMarkdownNavigatorItem): boolean {
+        return o1.url === o2.url;
+      }
+      fixture.componentInstance.compareWith = compareByUrl;
+      await wait(fixture);
+
+      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(MarkdownNavigatorComponent),
+      ).componentInstance;
+
+      expect(markdownNavigator.compareWith).toEqual(compareByUrl);
+
+      fixture.componentInstance.compareWith = compareByTitle;
+      await wait(fixture);
+      expect(markdownNavigator.compareWith).toEqual(compareByTitle);
     }),
   ));
 });

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
@@ -25,7 +25,7 @@ export class MarkdownNavigatorWindowComponent {
   @Input() items: IMarkdownNavigatorItem[];
   @Input() labels: IMarkdownNavigatorWindowLabels;
   @Input() toolbarColor: ThemePalette = 'primary';
-  @Input() jumpTo: IMarkdownNavigatorItem;
+  @Input() startAt: IMarkdownNavigatorItem;
   @Input() compareWith: IMarkdownNavigatorCompareWith;
   toolbarHeight: number = 56;
 

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
@@ -1,6 +1,10 @@
 import { Component, Output, EventEmitter, Input, ChangeDetectionStrategy } from '@angular/core';
 import { ThemePalette } from '@angular/material/core';
-import { IMarkdownNavigatorItem, IMarkdownNavigatorLabels } from '../markdown-navigator.component';
+import {
+  IMarkdownNavigatorItem,
+  IMarkdownNavigatorLabels,
+  IMarkdownNavigatorCompareWith,
+} from '../markdown-navigator.component';
 
 export interface IMarkdownNavigatorWindowLabels extends IMarkdownNavigatorLabels {
   title?: string;
@@ -21,6 +25,8 @@ export class MarkdownNavigatorWindowComponent {
   @Input() items: IMarkdownNavigatorItem[];
   @Input() labels: IMarkdownNavigatorWindowLabels;
   @Input() toolbarColor: ThemePalette = 'primary';
+  @Input() jumpTo: IMarkdownNavigatorItem;
+  @Input() compareWith: IMarkdownNavigatorCompareWith;
   toolbarHeight: number = 56;
 
   @Output() closed: EventEmitter<void> = new EventEmitter();

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
@@ -1,4 +1,4 @@
-import { Component, Output, EventEmitter, Input } from '@angular/core';
+import { Component, Output, EventEmitter, Input, ChangeDetectionStrategy } from '@angular/core';
 import { ThemePalette } from '@angular/material/core';
 import { IMarkdownNavigatorItem, IMarkdownNavigatorLabels } from '../markdown-navigator.component';
 
@@ -15,6 +15,7 @@ export const DEFAULT_MARKDOWN_NAVIGATOR_WINDOW_LABELS: IMarkdownNavigatorWindowL
   selector: 'td-markdown-navigator-window',
   templateUrl: './markdown-navigator-window.component.html',
   styleUrls: ['./markdown-navigator-window.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MarkdownNavigatorWindowComponent {
   @Input() items: IMarkdownNavigatorItem[];

--- a/src/platform/markdown-navigator/markdown-navigator.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator.component.html
@@ -3,13 +3,25 @@
 
   <ng-container *ngIf="showHeader">
     <div [style.display]="'flex'">
-      <button *ngIf="showHomeButton" mat-icon-button [matTooltip]="goHomeLabel" (click)="reset()">
+      <button
+        *ngIf="showHomeButton"
+        mat-icon-button
+        [matTooltip]="goHomeLabel"
+        (click)="reset()"
+        [attr.data-test]="'home-button'"
+      >
         <mat-icon [attr.aria-label]="goHomeLabel">
           home
         </mat-icon>
       </button>
 
-      <button *ngIf="showGoBackButton" mat-icon-button [matTooltip]="goBackLabel" (click)="goBack()">
+      <button
+        *ngIf="showGoBackButton"
+        mat-icon-button
+        [matTooltip]="goBackLabel"
+        (click)="goBack()"
+        [attr.data-test]="'back-button'"
+      >
         <mat-icon [attr.aria-label]="goBackLabel">
           arrow_back
         </mat-icon>

--- a/src/platform/markdown-navigator/markdown-navigator.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator.component.html
@@ -26,7 +26,9 @@
           arrow_back
         </mat-icon>
       </button>
-      <span flex *ngIf="currentItemTitle" class="mat-body-2 title truncate">{{ currentItemTitle }}</span>
+      <span flex *ngIf="currentItemTitle" class="mat-body-2 title truncate" [attr.data-test]="'title'">
+        {{ currentItemTitle }}
+      </span>
     </div>
 
     <mat-divider [style.position]="'relative'"></mat-divider>

--- a/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
@@ -110,12 +110,14 @@ async function wait(fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>)
 function getItem(fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>, index: number): HTMLElement {
   return fixture.debugElement.queryAll(By.css('mat-action-list button'))[index].nativeElement;
 }
-function goBack(fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>): void {
+async function goBack(fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>): Promise<void> {
   fixture.debugElement.query(By.css('.mat-icon-button[data-test="back-button"]')).nativeElement.click();
+  await wait(fixture);
 }
 
-function goHome(fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>): void {
+async function goHome(fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>): Promise<void> {
   fixture.debugElement.query(By.css('.mat-icon-button[data-test="home-button"]')).nativeElement.click();
+  await wait(fixture);
 }
 function getMarkdown(fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>): string {
   return fixture.debugElement.query(By.css('td-flavored-markdown ')).nativeElement.textContent;
@@ -129,66 +131,80 @@ export function compareByTitle(o1: IMarkdownNavigatorItem, o2: IMarkdownNavigato
   return o1.title === o2.title;
 }
 
-function validateTree(fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>): void {
+async function validateTree(fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>): Promise<void> {
   expect(getItem(fixture, 0).textContent).toContain('A');
   getItem(fixture, 0).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('A');
   expect(getItem(fixture, 0).textContent).toContain('A1');
   getItem(fixture, 0).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('A1');
   expect(getItem(fixture, 0).textContent).toContain('A1I');
   getItem(fixture, 0).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('A1I');
   expect(getMarkdown(fixture)).toContain('A1I');
-  goBack(fixture);
+  await goBack(fixture);
   expect(getItem(fixture, 1).textContent).toContain('A1II');
   getItem(fixture, 1).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('A1II');
   expect(getMarkdown(fixture)).toContain('A1II');
-  goBack(fixture);
-  goBack(fixture);
+  await goBack(fixture);
+  await goBack(fixture);
   expect(getItem(fixture, 1).textContent).toContain('A2');
   getItem(fixture, 1).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('A2');
   expect(getItem(fixture, 0).textContent).toContain('A2I');
   getItem(fixture, 0).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('A2I');
   expect(getMarkdown(fixture)).toContain('A2I');
-  goBack(fixture);
+  await goBack(fixture);
   expect(getItem(fixture, 1).textContent).toContain('A2II');
   getItem(fixture, 1).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('A2II');
   expect(getMarkdown(fixture)).toContain('A2II');
-  goBack(fixture);
-  goBack(fixture);
-  goBack(fixture);
+  await goBack(fixture);
+  await goBack(fixture);
+  await goBack(fixture);
   expect(getItem(fixture, 1).textContent).toContain('B');
   getItem(fixture, 1).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('B');
   expect(getItem(fixture, 0).textContent).toContain('B1');
   getItem(fixture, 0).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('B1');
   expect(getItem(fixture, 0).textContent).toContain('B1I');
   getItem(fixture, 0).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('B1I');
   expect(getMarkdown(fixture)).toContain('B1I');
-  goBack(fixture);
+  await goBack(fixture);
   expect(getItem(fixture, 1).textContent).toContain('B1II');
   getItem(fixture, 1).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('B1II');
   expect(getMarkdown(fixture)).toContain('B1II');
-  goBack(fixture);
-  goBack(fixture);
+  await goBack(fixture);
+  await goBack(fixture);
   expect(getItem(fixture, 1).textContent).toContain('B2');
   getItem(fixture, 1).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('B2');
   expect(getItem(fixture, 0).textContent).toContain('B2I');
   getItem(fixture, 0).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('B2I');
   expect(getMarkdown(fixture)).toContain('B2I');
-  goBack(fixture);
+  await goBack(fixture);
   expect(getItem(fixture, 1).textContent).toContain('B2II');
   getItem(fixture, 1).click();
+  await wait(fixture);
   expect(getTitle(fixture)).toContain('B2II');
   expect(getMarkdown(fixture)).toContain('B2II');
 }
@@ -448,10 +464,13 @@ describe('MarkdownNavigatorComponent', () => {
       await wait(fixture);
 
       getItem(fixture, 0).click();
+      await wait(fixture);
       getItem(fixture, 0).click();
+      await wait(fixture);
       getItem(fixture, 0).click();
+      await wait(fixture);
       expect(getMarkdown(fixture)).toContain('A1I');
-      goHome(fixture);
+      await goHome(fixture);
       expect(getItem(fixture, 0).textContent).toContain('A');
       expect(getItem(fixture, 1).textContent).toContain('B');
 
@@ -484,7 +503,7 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.startAt = DEEPLY_NESTED_TREE[1];
       await wait(fixture);
       expect(getTitle(fixture)).toContain('B');
-      goBack(fixture);
+      await goBack(fixture);
       validateTree(fixture);
     }),
   ));

--- a/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
@@ -37,9 +37,87 @@ const NESTED_MIXED_ITEMS: IMarkdownNavigatorItem[] = [
   },
 ];
 
+const DEEPLY_NESTED_TREE: IMarkdownNavigatorItem[] = [
+  {
+    title: 'A',
+    children: [
+      {
+        title: 'A1',
+        children: [
+          {
+            markdownString: 'A1I',
+            title: 'A1I',
+          },
+          {
+            markdownString: 'A1II',
+            title: 'A1II',
+          },
+        ],
+      },
+      {
+        title: 'A2',
+        children: [
+          {
+            markdownString: 'A2I',
+            title: 'A2I',
+          },
+          {
+            markdownString: 'A2II',
+            title: 'A2II',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'B',
+    children: [
+      {
+        title: 'B1',
+        children: [
+          {
+            markdownString: 'B1I',
+            title: 'B1I',
+          },
+          {
+            markdownString: 'B1II',
+            title: 'B1II',
+          },
+        ],
+      },
+      {
+        title: 'B2',
+        children: [
+          {
+            markdownString: 'B2I',
+            title: 'B2I',
+          },
+          {
+            markdownString: 'B2II',
+            title: 'B2II',
+          },
+        ],
+      },
+    ],
+  },
+];
+
 async function wait(fixture: ComponentFixture<any>): Promise<void> {
   fixture.detectChanges();
   await fixture.whenStable();
+}
+function getItem(fixture: ComponentFixture<any>, index: number) {
+  return fixture.debugElement.queryAll(By.css('mat-action-list button'))[index].nativeElement;
+}
+function goBack(fixture: ComponentFixture<any>) {
+  fixture.debugElement.query(By.css('.mat-icon-button[data-test="back-button"]')).nativeElement.click();
+}
+
+function goHome(fixture: ComponentFixture<any>) {
+  fixture.debugElement.query(By.css('.mat-icon-button[data-test="home-button"]')).nativeElement.click();
+}
+function getMarkdown(fixture: ComponentFixture<any>): string {
+  return fixture.debugElement.query(By.css('td-flavored-markdown ')).nativeElement.textContent;
 }
 
 @Component({
@@ -264,6 +342,84 @@ describe('MarkdownNavigatorComponent', () => {
       expect(markdownNavigator.goHomeLabel).toContain(SAMPLE_LABELS.goHome);
       expect(markdownNavigator.emptyStateLabel).toContain(SAMPLE_LABELS.emptyState);
       expect(elem.nativeElement.textContent).toContain(SAMPLE_LABELS.emptyState);
+    }),
+  ));
+
+  it('should be able to navigate up and down tree using the back button', async(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> = TestBed.createComponent(
+        TdMarkdownNavigatorTestComponent,
+      );
+
+      fixture.componentInstance.items = DEEPLY_NESTED_TREE;
+      await wait(fixture);
+
+      expect(getItem(fixture, 0).textContent).toContain('A');
+      getItem(fixture, 0).click();
+      expect(getItem(fixture, 0).textContent).toContain('A1');
+      getItem(fixture, 0).click();
+      expect(getItem(fixture, 0).textContent).toContain('A1I');
+      getItem(fixture, 0).click();
+      expect(getMarkdown(fixture)).toContain('A1I');
+      goBack(fixture);
+      expect(getItem(fixture, 1).textContent).toContain('A1II');
+      getItem(fixture, 1).click();
+      expect(getMarkdown(fixture)).toContain('A1II');
+      goBack(fixture);
+      goBack(fixture);
+      expect(getItem(fixture, 1).textContent).toContain('A2');
+      getItem(fixture, 1).click();
+      expect(getItem(fixture, 0).textContent).toContain('A2I');
+      getItem(fixture, 0).click();
+      expect(getMarkdown(fixture)).toContain('A2I');
+      goBack(fixture);
+      expect(getItem(fixture, 1).textContent).toContain('A2II');
+      getItem(fixture, 1).click();
+      expect(getMarkdown(fixture)).toContain('A2II');
+      goBack(fixture);
+      goBack(fixture);
+      goBack(fixture);
+      expect(getItem(fixture, 1).textContent).toContain('B');
+      getItem(fixture, 1).click();
+      expect(getItem(fixture, 0).textContent).toContain('B1');
+      getItem(fixture, 0).click();
+      expect(getItem(fixture, 0).textContent).toContain('B1I');
+      getItem(fixture, 0).click();
+      expect(getMarkdown(fixture)).toContain('B1I');
+      goBack(fixture);
+      expect(getItem(fixture, 1).textContent).toContain('B1II');
+      getItem(fixture, 1).click();
+      expect(getMarkdown(fixture)).toContain('B1II');
+      goBack(fixture);
+      goBack(fixture);
+      expect(getItem(fixture, 1).textContent).toContain('B2');
+      getItem(fixture, 1).click();
+      expect(getItem(fixture, 0).textContent).toContain('B2I');
+      getItem(fixture, 0).click();
+      expect(getMarkdown(fixture)).toContain('B2I');
+      goBack(fixture);
+      expect(getItem(fixture, 1).textContent).toContain('B2II');
+      getItem(fixture, 1).click();
+      expect(getMarkdown(fixture)).toContain('B2II');
+    }),
+  ));
+
+  it('should be able to go to root using home button', async(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> = TestBed.createComponent(
+        TdMarkdownNavigatorTestComponent,
+      );
+
+      fixture.componentInstance.items = DEEPLY_NESTED_TREE;
+      await wait(fixture);
+
+      getItem(fixture, 0).click();
+      getItem(fixture, 0).click();
+      getItem(fixture, 0).click();
+      expect(getMarkdown(fixture)).toContain('A1I');
+      goHome(fixture);
+      expect(getItem(fixture, 0).textContent).toContain('A');
+      expect(getItem(fixture, 1).textContent).toContain('B');
     }),
   ));
 });

--- a/src/platform/markdown-navigator/markdown-navigator.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.ts
@@ -232,7 +232,7 @@ export class MarkdownNavigatorComponent implements OnChanges {
       this.currentMarkdownItem = undefined;
     }
     this.historyStack = [];
-    this._changeDetectorRef.detectChanges();
+    this._changeDetectorRef.markForCheck();
   }
 
   goBack(): void {
@@ -252,7 +252,7 @@ export class MarkdownNavigatorComponent implements OnChanges {
       // one level down just go to root
       this.reset();
     }
-    this._changeDetectorRef.detectChanges();
+    this._changeDetectorRef.markForCheck();
   }
 
   handleItemSelected(item: IMarkdownNavigatorItem): void {
@@ -276,7 +276,7 @@ export class MarkdownNavigatorComponent implements OnChanges {
       // render markdown
       this.currentMarkdownItem = item;
     }
-    this._changeDetectorRef.detectChanges();
+    this._changeDetectorRef.markForCheck();
   }
 
   getTitle(item: IMarkdownNavigatorItem): string {
@@ -301,6 +301,7 @@ export class MarkdownNavigatorComponent implements OnChanges {
       );
       (ancestors || []).forEach((ancestor: IMarkdownNavigatorItem) => this.handleItemSelected(ancestor));
     }
+    this._changeDetectorRef.markForCheck();
   }
 
   private async handleLinkClick(event: Event): Promise<void> {
@@ -308,7 +309,7 @@ export class MarkdownNavigatorComponent implements OnChanges {
     const link: HTMLAnchorElement = <HTMLAnchorElement>event.target;
     const url: URL = new URL(link.href);
     this.loading = true;
-    this._changeDetectorRef.detectChanges();
+    this._changeDetectorRef.markForCheck();
     try {
       const markdownString: string = await this._markdownUrlLoaderService.load(url.href);
       // pass in url to be able to use currentMarkdownItem.url later on
@@ -320,6 +321,6 @@ export class MarkdownNavigatorComponent implements OnChanges {
     } finally {
       this.loading = false;
     }
-    this._changeDetectorRef.detectChanges();
+    this._changeDetectorRef.markForCheck();
   }
 }

--- a/src/platform/markdown-navigator/markdown-navigator.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.ts
@@ -1,4 +1,14 @@
-import { Component, Input, OnChanges, SimpleChanges, HostListener, ViewChild, ElementRef } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnChanges,
+  SimpleChanges,
+  HostListener,
+  ViewChild,
+  ElementRef,
+  ChangeDetectorRef,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { removeLeadingHash, isAnchorLink, MarkdownLoaderService } from '@covalent/markdown';
 
 export interface IMarkdownNavigatorItem {
@@ -52,6 +62,7 @@ function isMarkdownHref(anchor: HTMLAnchorElement): boolean {
   selector: 'td-markdown-navigator',
   templateUrl: './markdown-navigator.component.html',
   styleUrls: ['./markdown-navigator.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MarkdownNavigatorComponent implements OnChanges {
   /**
@@ -76,7 +87,10 @@ export class MarkdownNavigatorComponent implements OnChanges {
 
   loading: boolean = false;
 
-  constructor(private _markdownUrlLoaderService: MarkdownLoaderService) {}
+  constructor(
+    private _markdownUrlLoaderService: MarkdownLoaderService,
+    private _changeDetectorRef: ChangeDetectorRef,
+  ) {}
 
   @HostListener('click', ['$event'])
   clickListener(event: Event): void {
@@ -176,6 +190,7 @@ export class MarkdownNavigatorComponent implements OnChanges {
       this.currentMarkdownItem = undefined;
     }
     this.historyStack = [];
+    this._changeDetectorRef.detectChanges();
   }
 
   handleItemSelected(item: IMarkdownNavigatorItem): void {
@@ -205,6 +220,7 @@ export class MarkdownNavigatorComponent implements OnChanges {
       // render markdown
       this.currentMarkdownItem = item;
     }
+    this._changeDetectorRef.detectChanges();
   }
 
   goBack(): void {
@@ -219,6 +235,7 @@ export class MarkdownNavigatorComponent implements OnChanges {
       }
       this.historyStack = this.historyStack.slice(0, -1);
     }
+    this._changeDetectorRef.detectChanges();
   }
 
   getTitle(item: IMarkdownNavigatorItem): string {
@@ -238,6 +255,7 @@ export class MarkdownNavigatorComponent implements OnChanges {
     const link: HTMLAnchorElement = <HTMLAnchorElement>event.target;
     const url: URL = new URL(link.href);
     this.loading = true;
+    this._changeDetectorRef.detectChanges();
     try {
       const markdownString: string = await this._markdownUrlLoaderService.load(url.href);
       // pass in url to be able to use currentMarkdownItem.url later on
@@ -249,5 +267,6 @@ export class MarkdownNavigatorComponent implements OnChanges {
     } finally {
       this.loading = false;
     }
+    this._changeDetectorRef.detectChanges();
   }
 }

--- a/src/platform/markdown-navigator/markdown-navigator.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.ts
@@ -104,16 +104,16 @@ export class MarkdownNavigatorComponent implements OnChanges {
   @Input() labels: IMarkdownNavigatorLabels;
 
   /**
-   * goTo?: IMarkdownNavigatorItem
+   * startAt?: IMarkdownNavigatorItem
    *
-   * Item to jump to
+   * Item to start to
    */
-  @Input() jumpTo: IMarkdownNavigatorItem;
+  @Input() startAt: IMarkdownNavigatorItem;
 
   /**
    * compareWith?: IMarkdownNavigatorCompareWith
    *
-   * Function used to find jumpTo item
+   * Function used to find startAt item
    * Defaults to comparison by strict equality (===)
    */
   @Input() compareWith: IMarkdownNavigatorCompareWith;
@@ -216,9 +216,9 @@ export class MarkdownNavigatorComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.items) {
       this.reset();
-    }
-    if (changes.jumpTo && this.items) {
-      this._jumpTo(this.jumpTo);
+      if (this.items && this.startAt) {
+        this._jumpTo(this.startAt);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

- Make markdown-navigator related components on push 
- Add tree validation tests
- Add `startAt` input 
- Add compareWith input
- Add more tests

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [x] `npm run serve`
- [x] Go to http://localhost:4200/#/components/markdown-navigator and make sure demos still work

#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
