### PR TITLE
fix(): revert service providers to support ng 8

### DIFF
--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-basic/markdown-navigator-demo-basic.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-basic/markdown-navigator-demo-basic.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import {
-  MarkdownNavigatorWindowService,
-  MarkdownNavigatorWindowComponent,
+  TdMarkdownNavigatorWindowService,
+  TdMarkdownNavigatorWindowComponent,
   IMarkdownNavigatorItem,
 } from '@covalent/markdown-navigator';
 import { MatDialogRef } from '@angular/material/dialog';
@@ -14,7 +14,7 @@ import { MatDialogRef } from '@angular/material/dialog';
 })
 export class MarkdownNavigatorDemoBasicComponent {
   windowOpen: boolean = false;
-  ref: MatDialogRef<MarkdownNavigatorWindowComponent>;
+  ref: MatDialogRef<TdMarkdownNavigatorWindowComponent>;
   oneItem: IMarkdownNavigatorItem[] = [
     {
       url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
@@ -29,7 +29,7 @@ export class MarkdownNavigatorDemoBasicComponent {
   selected: { name: string; value: IMarkdownNavigatorItem[] } = this.options[0];
   currentItems: IMarkdownNavigatorItem[] = this.selected.value;
 
-  constructor(private _markdownNavigatorWindowService: MarkdownNavigatorWindowService) {}
+  constructor(private _markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) {}
 
   openDialog(): void {
     if (this.windowOpen) {

--- a/src/app/content/components/component-demos/markdown-navigator/markdown-navigator.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/markdown-navigator.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import {
   IMarkdownNavigatorItem,
-  MarkdownNavigatorWindowService,
+  TdMarkdownNavigatorWindowService,
   IMarkdownNavigatorWindowConfig,
 } from '@covalent/markdown-navigator';
 
@@ -67,7 +67,7 @@ export class MarkdownNavigatorDemoComponent {
   public startAt: IMarkdownNavigatorItem;
   public input: string = prettyJson(this.currentTree);
 
-  constructor(private _markdownNavigatorWindowService: MarkdownNavigatorWindowService) {}
+  constructor(private _markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) {}
 
   public compareByTitle: (o1: IMarkdownNavigatorItem, o2: IMarkdownNavigatorItem) => boolean = (
     o1: IMarkdownNavigatorItem,

--- a/src/platform/core/common/common.module.ts
+++ b/src/platform/core/common/common.module.ts
@@ -40,9 +40,13 @@ const TD_PIPES: Type<any>[] = [
  * Services
  */
 
+import { RouterPathService } from './services/router-path.service';
+import { IconService } from './services/icon.service';
+
 @NgModule({
   imports: [FormsModule, CommonModule],
   declarations: [TD_DIRECTIVES, TD_PIPES, TD_VALIDATORS],
   exports: [FormsModule, CommonModule, TD_DIRECTIVES, TD_PIPES, TD_VALIDATORS],
+  providers: [RouterPathService, IconService],
 })
 export class CovalentCommonModule {}

--- a/src/platform/core/common/services/icon.service.ts
+++ b/src/platform/core/common/services/icon.service.ts
@@ -4,9 +4,7 @@
  */
 
 import { Injectable } from '@angular/core';
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class IconService {
   // To update, run this little script on https://material.io/resources/icons/?style=baseline
   // JSON.stringify(

--- a/src/platform/core/common/services/router-path.service.ts
+++ b/src/platform/core/common/services/router-path.service.ts
@@ -2,9 +2,8 @@ import { Injectable } from '@angular/core';
 import { Router, RoutesRecognized } from '@angular/router';
 
 import { filter, pairwise } from 'rxjs/operators';
-@Injectable({
-  providedIn: 'root',
-})
+
+@Injectable()
 export class RouterPathService {
   private static _previousRoute: string = '/';
   constructor(private _router: Router) {

--- a/src/platform/core/data-table/data-table.module.ts
+++ b/src/platform/core/data-table/data-table.module.ts
@@ -11,6 +11,7 @@ import { TdDataTableCellComponent } from './data-table-cell/data-table-cell.comp
 import { TdDataTableRowComponent, TdDataTableColumnRowComponent } from './data-table-row/data-table-row.component';
 import { TdDataTableTableComponent } from './data-table-table/data-table-table.component';
 import { TdDataTableTemplateDirective } from './directives/data-table-template.directive';
+import { TdDataTableService } from './services/data-table.service';
 
 const TD_DATA_TABLE: Type<any>[] = [
   TdDataTableComponent,
@@ -27,5 +28,6 @@ const TD_DATA_TABLE: Type<any>[] = [
   imports: [CommonModule, MatCheckboxModule, MatTooltipModule, MatIconModule, MatPseudoCheckboxModule],
   declarations: [TD_DATA_TABLE],
   exports: [TD_DATA_TABLE],
+  providers: [TdDataTableService],
 })
 export class CovalentDataTableModule {}

--- a/src/platform/core/data-table/services/data-table.service.ts
+++ b/src/platform/core/data-table/services/data-table.service.ts
@@ -2,9 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { TdDataTableSortingOrder } from '../data-table.component';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class TdDataTableService {
   /**
    * params:

--- a/src/platform/core/dialogs/dialogs.module.ts
+++ b/src/platform/core/dialogs/dialogs.module.ts
@@ -16,6 +16,7 @@ import {
 import { TdAlertDialogComponent } from './alert-dialog/alert-dialog.component';
 import { TdConfirmDialogComponent } from './confirm-dialog/confirm-dialog.component';
 import { TdPromptDialogComponent } from './prompt-dialog/prompt-dialog.component';
+import { TdDialogService } from './services/dialog.service';
 
 const TD_DIALOGS: Type<any>[] = [
   TdAlertDialogComponent,
@@ -38,5 +39,6 @@ const TD_DIALOGS_ENTRY_COMPONENTS: Type<any>[] = [
   declarations: [TD_DIALOGS],
   exports: [TD_DIALOGS],
   entryComponents: [TD_DIALOGS_ENTRY_COMPONENTS],
+  providers: [TdDialogService],
 })
 export class CovalentDialogsModule {}

--- a/src/platform/core/dialogs/services/dialog.service.ts
+++ b/src/platform/core/dialogs/services/dialog.service.ts
@@ -7,7 +7,6 @@ import { TdConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.compo
 import { TdPromptDialogComponent } from '../prompt-dialog/prompt-dialog.component';
 import { DragDrop, DragRef } from '@angular/cdk/drag-drop';
 import { DOCUMENT } from '@angular/common';
-import { CovalentDialogsModule } from '../dialogs.module';
 import { Subject } from 'rxjs';
 
 export interface IDialogConfig extends MatDialogConfig {
@@ -42,9 +41,7 @@ export interface IDraggableRefs<T> {
   dragRefSubject: Subject<DragRef>;
 }
 
-@Injectable({
-  providedIn: CovalentDialogsModule,
-})
+@Injectable()
 export class TdDialogService {
   private _renderer2: Renderer2;
 

--- a/src/platform/core/file/file.module.ts
+++ b/src/platform/core/file/file.module.ts
@@ -12,6 +12,7 @@ import { TdFileSelectDirective } from './directives/file-select.directive';
 import { TdFileDropDirective } from './directives/file-drop.directive';
 import { TdFileUploadComponent } from './file-upload/file-upload.component';
 import { TdFileInputComponent, TdFileInputLabelDirective } from './file-input/file-input.component';
+import { TdFileService } from './services/file.service';
 
 const TD_FILE: Type<any>[] = [
   TdFileSelectDirective,
@@ -25,5 +26,6 @@ const TD_FILE: Type<any>[] = [
   imports: [FormsModule, CommonModule, MatIconModule, MatButtonModule, PortalModule],
   declarations: [TD_FILE],
   exports: [TD_FILE],
+  providers: [TdFileService],
 })
 export class CovalentFileModule {}

--- a/src/platform/core/file/services/file.service.ts
+++ b/src/platform/core/file/services/file.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpRequest, HttpEvent, HttpEventType, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Observable, Subject, Subscriber } from 'rxjs';
 import { tap } from 'rxjs/operators';
-import { CovalentFileModule } from '../file.module';
+
 /**
  * @deprecated should be removed in favor of IUploadInit
  * @breaking-change 3.0.0
@@ -20,9 +20,7 @@ export interface IUploadExtras {
   params?: { [param: string]: string | string[] };
 }
 
-@Injectable({
-  providedIn: CovalentFileModule,
-})
+@Injectable()
 export class TdFileService {
   private _progressSubject: Subject<number> = new Subject<number>();
   private _progressObservable: Observable<number>;

--- a/src/platform/core/media/media.module.ts
+++ b/src/platform/core/media/media.module.ts
@@ -2,11 +2,13 @@ import { Type } from '@angular/core';
 import { NgModule } from '@angular/core';
 
 import { TdMediaToggleDirective } from './directives/media-toggle.directive';
+import { TdMediaService } from './services/media.service';
 
 const TD_MEDIA: Type<any>[] = [TdMediaToggleDirective];
 
 @NgModule({
   declarations: [TD_MEDIA],
   exports: [TD_MEDIA],
+  providers: [TdMediaService],
 })
 export class CovalentMediaModule {}

--- a/src/platform/core/media/services/media.service.ts
+++ b/src/platform/core/media/services/media.service.ts
@@ -1,9 +1,7 @@
 import { Injectable, NgZone } from '@angular/core';
 import { Observable, BehaviorSubject, Subscription, fromEvent } from 'rxjs';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class TdMediaService {
   private _resizing: boolean = false;
   private _globalSubscription: Subscription;

--- a/src/platform/dynamic-forms/dynamic-forms.module.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.module.ts
@@ -21,6 +21,7 @@ import {
   TdDynamicElementDirective,
   TdDynamicFormsErrorTemplateDirective,
 } from './dynamic-element.component';
+import { DYNAMIC_FORMS_PROVIDER } from './services/dynamic-forms.service';
 
 import { TdDynamicInputComponent } from './dynamic-elements/dynamic-input/dynamic-input.component';
 import { TdDynamicFileInputComponent } from './dynamic-elements/dynamic-file-input/dynamic-file-input.component';
@@ -67,6 +68,7 @@ const TD_DYNAMIC_FORMS_ENTRY_COMPONENTS: Type<any>[] = [
     CovalentFileModule,
   ],
   exports: [TD_DYNAMIC_FORMS, TD_DYNAMIC_FORMS_ENTRY_COMPONENTS],
+  providers: [DYNAMIC_FORMS_PROVIDER],
   entryComponents: [TD_DYNAMIC_FORMS_ENTRY_COMPONENTS],
 })
 export class CovalentDynamicFormsModule {}

--- a/src/platform/dynamic-forms/services/dynamic-forms.service.ts
+++ b/src/platform/dynamic-forms/services/dynamic-forms.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, Type } from '@angular/core';
-import { Validators, ValidatorFn, FormControl } from '@angular/forms';
+import { Injectable, Provider, SkipSelf, Optional, Type } from '@angular/core';
+import { Validators, ValidatorFn, FormControl, AbstractControl } from '@angular/forms';
 
 import { TdDynamicInputComponent } from '../dynamic-elements/dynamic-input/dynamic-input.component';
 import { TdDynamicFileInputComponent } from '../dynamic-elements/dynamic-file-input/dynamic-file-input.component';
@@ -54,9 +54,7 @@ export interface ITdDynamicElementConfig {
 
 export const DYNAMIC_ELEMENT_NAME_REGEX: RegExp = /^[^0-9][^\@]*$/;
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class TdDynamicFormsService {
   /**
    * Method to validate if the [name] is a proper element name.
@@ -138,3 +136,14 @@ export class TdDynamicFormsService {
     return validator;
   }
 }
+
+export function DYNAMIC_FORMS_PROVIDER_FACTORY(parent: TdDynamicFormsService): TdDynamicFormsService {
+  return parent || new TdDynamicFormsService();
+}
+
+export const DYNAMIC_FORMS_PROVIDER: Provider = {
+  // If there is already a service available, use that. Otherwise, provide a new one.
+  provide: TdDynamicFormsService,
+  deps: [[new Optional(), new SkipSelf(), TdDynamicFormsService]],
+  useFactory: DYNAMIC_FORMS_PROVIDER_FACTORY,
+};

--- a/src/platform/flavored-markdown/flavored-markdown-loader/flavored-markdown-loader.component.ts
+++ b/src/platform/flavored-markdown/flavored-markdown-loader/flavored-markdown-loader.component.ts
@@ -8,7 +8,7 @@ import {
   EventEmitter,
   ChangeDetectionStrategy,
 } from '@angular/core';
-import { MarkdownLoaderService } from '@covalent/markdown';
+import { TdMarkdownLoaderService } from '@covalent/markdown';
 
 // TODO: make a td-markdown-loader component
 
@@ -54,7 +54,7 @@ export class TdFlavoredMarkdownLoaderComponent implements OnChanges {
 
   constructor(
     private _changeDetectorRef: ChangeDetectorRef,
-    private _markdownUrlLoaderService: MarkdownLoaderService,
+    private _markdownUrlLoaderService: TdMarkdownLoaderService,
   ) {}
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/src/platform/markdown-navigator/README.md
+++ b/src/platform/markdown-navigator/README.md
@@ -150,17 +150,17 @@ export class MyModule {}
 
 ```typescript
 import {
-  MarkdownNavigatorWindowComponent,
-  MarkdownNavigatorWindowService,
+  TdMarkdownNavigatorWindowComponent,
+  TdMarkdownNavigatorWindowService,
   IMarkdownNavigatorItem
 } from '@covalent/markdown-navigator';
 import { MatDialogRef } from '@angular/material/dialog';
 
 export class SampleComponent {
-  constructor(private _markdownNavigatorWindowService: MarkdownNavigatorWindowService) {}
+  constructor(private _markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) {}
 
   ngOnInit(): void {
-    const ref: MatDialogRef<MarkdownNavigatorWindowComponent> = this._markdownNavigatorWindowService.open({
+    const ref: MatDialogRef<TdMarkdownNavigatorWindowComponent> = this._markdownNavigatorWindowService.open({
       items: [{ url: 'https://github.com/Teradata/covalent/blob/develop/README.md' }]
     });
     ref.afterOpened().subscribe(() => {});
@@ -171,7 +171,7 @@ export class SampleComponent {
 
 # MarkdownNavigatorWindowDirective
 
-A directive that calls the MarkdownNavigatorWindowService open method on click events.
+A directive that calls the TdMarkdownNavigatorWindowService open method on click events.
 
 ## API Summary
 

--- a/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.spec.ts
@@ -4,7 +4,7 @@ import { CovalentMarkdownNavigatorModule } from '../markdown-navigator.module';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { Component } from '@angular/core';
 import {
-  MarkdownNavigatorWindowService,
+  TdMarkdownNavigatorWindowService,
   IMarkdownNavigatorWindowConfig,
 } from '../markdown-navigator-window-service/markdown-navigator-window.service';
 import { By } from '@angular/platform-browser';
@@ -48,8 +48,8 @@ describe('MarkdownNavigatorWindowDirective', () => {
 
   it('should open and close markdown navigator window properly', async(
     inject(
-      [MarkdownNavigatorWindowService],
-      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
         await wait(fixture);
         fixture.debugElement.query(By.css('button')).nativeElement.click();
@@ -64,8 +64,8 @@ describe('MarkdownNavigatorWindowDirective', () => {
   ));
   it('should not open markdown navigator window if disabled', async(
     inject(
-      [MarkdownNavigatorWindowService],
-      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
         fixture.componentInstance.disabled = true;
         await wait(fixture);

--- a/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-directive/markdown-navigator-window.directive.ts
@@ -1,16 +1,16 @@
 import { Directive, HostListener, Input } from '@angular/core';
 import {
-  MarkdownNavigatorWindowService,
+  TdMarkdownNavigatorWindowService,
   IMarkdownNavigatorWindowConfig,
 } from '../markdown-navigator-window-service/markdown-navigator-window.service';
 
 @Directive({
   selector: '[tdMarkdownNavigatorWindow]',
 })
-export class MarkdownNavigatorWindowDirective {
+export class TdMarkdownNavigatorWindowDirective {
   @Input('tdMarkdownNavigatorWindow') config: IMarkdownNavigatorWindowConfig;
   @Input() disabled: boolean = false;
-  constructor(private _markdownNavigatorWindowService: MarkdownNavigatorWindowService) {}
+  constructor(private _markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) {}
 
   @HostListener('click') click(): void {
     if (!this.disabled) {

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed, inject, async, ComponentFixture } from '@angular/core/testing';
 import { CovalentMarkdownNavigatorModule } from '../markdown-navigator.module';
-import { MarkdownNavigatorWindowService } from './markdown-navigator-window.service';
+import { TdMarkdownNavigatorWindowService } from './markdown-navigator-window.service';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialogRef } from '@angular/material/dialog';
 import { Component } from '@angular/core';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { IMarkdownNavigatorItem, DEFAULT_MARKDOWN_NAVIGATOR_LABELS } from '../markdown-navigator.component';
 import {
-  MarkdownNavigatorWindowComponent,
+  TdMarkdownNavigatorWindowComponent,
   IMarkdownNavigatorWindowLabels,
 } from '../markdown-navigator-window/markdown-navigator-window.component';
 import { DEEPLY_NESTED_TREE, compareByTitle } from '../markdown-navigator.component.spec';
@@ -63,10 +63,10 @@ describe('MarkdownNavigatorWindowService', () => {
 
   it('should open and close markdown navigator window properly', async(
     inject(
-      [MarkdownNavigatorWindowService],
-      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
-        const dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
+        const dialogRef: MatDialogRef<TdMarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
           items: [],
         });
 
@@ -86,10 +86,10 @@ describe('MarkdownNavigatorWindowService', () => {
   ));
   it('should open with no items', async(
     inject(
-      [MarkdownNavigatorWindowService],
-      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
-        const dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
+        const dialogRef: MatDialogRef<TdMarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
           items: [],
         });
 
@@ -105,10 +105,10 @@ describe('MarkdownNavigatorWindowService', () => {
   ));
   it('should open with an item', async(
     inject(
-      [MarkdownNavigatorWindowService],
-      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
-        const dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
+        const dialogRef: MatDialogRef<TdMarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
           items: RAW_MARKDOWN_ITEMS,
         });
 
@@ -126,10 +126,10 @@ describe('MarkdownNavigatorWindowService', () => {
 
   it('should open to a certain item', async(
     inject(
-      [MarkdownNavigatorWindowService],
-      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
-        const dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
+        const dialogRef: MatDialogRef<TdMarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
           items: DEEPLY_NESTED_TREE,
           startAt: DEEPLY_NESTED_TREE[0],
         });
@@ -150,10 +150,10 @@ describe('MarkdownNavigatorWindowService', () => {
 
   it('should open to a certain item using compareWith function', async(
     inject(
-      [MarkdownNavigatorWindowService],
-      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
-        const dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
+        const dialogRef: MatDialogRef<TdMarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
           items: DEEPLY_NESTED_TREE,
           startAt: DEEPLY_NESTED_TREE[1],
           compareWith: compareByTitle,
@@ -175,10 +175,10 @@ describe('MarkdownNavigatorWindowService', () => {
 
   it('should use passed in labels', async(
     inject(
-      [MarkdownNavigatorWindowService],
-      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
-        let dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
+        let dialogRef: MatDialogRef<TdMarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
           items: [],
           labels: {},
         });
@@ -213,10 +213,10 @@ describe('MarkdownNavigatorWindowService', () => {
 
   it('should use default to primary toolbar color', async(
     inject(
-      [MarkdownNavigatorWindowService],
-      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
-        const dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
+        const dialogRef: MatDialogRef<TdMarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
           items: RAW_MARKDOWN_ITEMS,
         });
 
@@ -232,10 +232,10 @@ describe('MarkdownNavigatorWindowService', () => {
   ));
   it('should use passed in toolbar color', async(
     inject(
-      [MarkdownNavigatorWindowService],
-      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
-        let dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
+        let dialogRef: MatDialogRef<TdMarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
           items: [],
           toolbarColor: 'accent',
         });
@@ -283,10 +283,10 @@ describe('MarkdownNavigatorWindowService', () => {
 
   it('should have proper classes', async(
     inject(
-      [MarkdownNavigatorWindowService],
-      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
-        const dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
+        const dialogRef: MatDialogRef<TdMarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
           items: [],
         });
 
@@ -310,8 +310,8 @@ describe('MarkdownNavigatorWindowService', () => {
 
   it('should only have one markdown navigator open at a time', async(
     inject(
-      [MarkdownNavigatorWindowService],
-      async (_markdownNavigatorWindowService: MarkdownNavigatorWindowService) => {
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
         const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
         expect(overlayContainerElement.querySelectorAll(`td-markdown-navigator`).length).toBe(0);
         expect(_markdownNavigatorWindowService.isOpen).toBeFalsy();

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Inject, RendererFactory2, Renderer2 } from '@angular/core';
 import { MatDialogRef, MatDialogConfig, DialogPosition } from '@angular/material/dialog';
 import { ThemePalette } from '@angular/material/core';
 import {
-  MarkdownNavigatorWindowComponent,
+  TdMarkdownNavigatorWindowComponent,
   IMarkdownNavigatorWindowLabels,
 } from '../markdown-navigator-window/markdown-navigator-window.component';
 import { TdDialogService, IDraggableRefs, ResizableDraggableDialog } from '@covalent/core/dialogs';
@@ -43,11 +43,11 @@ interface IDialogDimensions {
 }
 
 @Injectable()
-export class MarkdownNavigatorWindowService {
+export class TdMarkdownNavigatorWindowService {
   private _renderer2: Renderer2;
   private dragRef: DragRef;
   private resizableDraggableDialog: ResizableDraggableDialog;
-  private markdownNavigatorWindowDialog: MatDialogRef<MarkdownNavigatorWindowComponent> = undefined;
+  private markdownNavigatorWindowDialog: MatDialogRef<TdMarkdownNavigatorWindowComponent> = undefined;
   private markdownNavigatorWindowDialogsOpen: number = 0;
 
   constructor(
@@ -58,7 +58,7 @@ export class MarkdownNavigatorWindowService {
     this._renderer2 = rendererFactory.createRenderer(undefined, undefined);
   }
 
-  public open(config: IMarkdownNavigatorWindowConfig): MatDialogRef<MarkdownNavigatorWindowComponent> {
+  public open(config: IMarkdownNavigatorWindowConfig): MatDialogRef<TdMarkdownNavigatorWindowComponent> {
     this.close();
 
     const draggableConfig: MatDialogConfig = {
@@ -68,8 +68,8 @@ export class MarkdownNavigatorWindowService {
     const {
       matDialogRef,
       dragRefSubject,
-    }: IDraggableRefs<MarkdownNavigatorWindowComponent> = this._tdDialogService.openDraggable({
-      component: MarkdownNavigatorWindowComponent,
+    }: IDraggableRefs<TdMarkdownNavigatorWindowComponent> = this._tdDialogService.openDraggable({
+      component: TdMarkdownNavigatorWindowComponent,
       config: draggableConfig,
       dragHandleSelectors: ['.td-markdown-navigator-window-toolbar'],
       draggableClass: 'td-draggable-markdown-navigator-window',
@@ -139,7 +139,7 @@ export class MarkdownNavigatorWindowService {
       });
   }
 
-  private _getDialogSize(dialogRef: MatDialogRef<MarkdownNavigatorWindowComponent>): IDialogDimensions {
+  private _getDialogSize(dialogRef: MatDialogRef<TdMarkdownNavigatorWindowComponent>): IDialogDimensions {
     const { width, height } = getComputedStyle(
       (<HTMLElement>this._document.getElementById(dialogRef.id)).parentElement,
     );

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.spec.ts
@@ -7,12 +7,12 @@ import { CovalentMarkdownNavigatorModule } from '../markdown-navigator.module';
 import { MatToolbar } from '@angular/material/toolbar';
 import {
   IMarkdownNavigatorWindowLabels,
-  MarkdownNavigatorWindowComponent,
+  TdMarkdownNavigatorWindowComponent,
   DEFAULT_MARKDOWN_NAVIGATOR_WINDOW_LABELS,
 } from './markdown-navigator-window.component';
 import {
   IMarkdownNavigatorItem,
-  MarkdownNavigatorComponent,
+  TdMarkdownNavigatorComponent,
   DEFAULT_MARKDOWN_NAVIGATOR_LABELS,
   IMarkdownNavigatorCompareWith,
 } from '../markdown-navigator.component';
@@ -91,11 +91,11 @@ describe('MarkdownNavigatorWindowComponent', () => {
 
       await wait(fixture);
 
-      const markdownNavigatorWindow: MarkdownNavigatorWindowComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorWindowComponent),
+      const markdownNavigatorWindow: TdMarkdownNavigatorWindowComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorWindowComponent),
       ).componentInstance;
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
 
       expect(markdownNavigatorWindow.titleLabel).toBe(DEFAULT_MARKDOWN_NAVIGATOR_WINDOW_LABELS.title);
@@ -115,11 +115,11 @@ describe('MarkdownNavigatorWindowComponent', () => {
 
       await wait(fixture);
 
-      const markdownNavigatorWindow: MarkdownNavigatorWindowComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorWindowComponent),
+      const markdownNavigatorWindow: TdMarkdownNavigatorWindowComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorWindowComponent),
       ).componentInstance;
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
 
       expect(markdownNavigatorWindow.titleLabel).toBe(DEFAULT_MARKDOWN_NAVIGATOR_WINDOW_LABELS.title);
@@ -148,8 +148,8 @@ describe('MarkdownNavigatorWindowComponent', () => {
       fixture.componentInstance.labels = SAMPLE_LABELS;
       await wait(fixture);
 
-      const markdownNavigatorWindow: MarkdownNavigatorWindowComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorWindowComponent),
+      const markdownNavigatorWindow: TdMarkdownNavigatorWindowComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorWindowComponent),
       ).componentInstance;
 
       expect(markdownNavigatorWindow.titleLabel).toBe(SAMPLE_LABELS.title);
@@ -173,8 +173,8 @@ describe('MarkdownNavigatorWindowComponent', () => {
       fixture.componentInstance.items = URL_ITEM;
       await wait(fixture);
 
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
 
       expect(markdownNavigator.items).toEqual(URL_ITEM);
@@ -237,8 +237,8 @@ describe('MarkdownNavigatorWindowComponent', () => {
       );
 
       await wait(fixture);
-      const markdownNavigatorWindow: MarkdownNavigatorWindowComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorWindowComponent),
+      const markdownNavigatorWindow: TdMarkdownNavigatorWindowComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorWindowComponent),
       ).componentInstance;
 
       spyOn(markdownNavigatorWindow.closed, 'emit');
@@ -261,8 +261,8 @@ describe('MarkdownNavigatorWindowComponent', () => {
       fixture.componentInstance.startAt = DEEPLY_NESTED_TREE[0];
       await wait(fixture);
 
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
 
       expect(markdownNavigator.startAt).toEqual(DEEPLY_NESTED_TREE[0]);
@@ -284,8 +284,8 @@ describe('MarkdownNavigatorWindowComponent', () => {
       fixture.componentInstance.compareWith = compareByUrl;
       await wait(fixture);
 
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorWindowComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorWindowComponent),
       ).componentInstance;
 
       expect(markdownNavigator.compareWith).toEqual(compareByUrl);

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
@@ -25,7 +25,7 @@ export const DEFAULT_MARKDOWN_NAVIGATOR_WINDOW_LABELS: IMarkdownNavigatorWindowL
   styleUrls: ['./markdown-navigator-window.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MarkdownNavigatorWindowComponent {
+export class TdMarkdownNavigatorWindowComponent {
   @Input() items: IMarkdownNavigatorItem[];
   @Input() labels: IMarkdownNavigatorWindowLabels;
   @Input() toolbarColor: ThemePalette = 'primary';

--- a/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import {
-  MarkdownNavigatorComponent,
+  TdMarkdownNavigatorComponent,
   IMarkdownNavigatorItem,
   IMarkdownNavigatorLabels,
   DEFAULT_MARKDOWN_NAVIGATOR_LABELS,
@@ -244,8 +244,8 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.items = [];
       await wait(fixture);
 
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
 
       expect(markdownNavigator.showEmptyState).toBeTruthy();
@@ -266,8 +266,8 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.items = undefined;
       await wait(fixture);
 
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
 
       expect(markdownNavigator.showEmptyState).toBeTruthy();
@@ -288,8 +288,8 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.items = RAW_MARKDOWN_ITEM;
       await wait(fixture);
 
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
 
       expect(markdownNavigator.showEmptyState).toBeFalsy();
@@ -310,8 +310,8 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.items = URL_ITEM;
       await wait(fixture);
 
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
 
       expect(markdownNavigator.showEmptyState).toBeFalsy();
@@ -332,8 +332,8 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.items = FLAT_MIXED_ITEMS;
       await wait(fixture);
 
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
       const listItems: DebugElement[] = fixture.debugElement.queryAll(By.css('mat-action-list button'));
 
@@ -356,8 +356,8 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.items = NESTED_MIXED_ITEMS;
       await wait(fixture);
 
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
       const listItems: DebugElement[] = fixture.debugElement.queryAll(By.css('mat-action-list button'));
 
@@ -382,10 +382,10 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.items = undefined;
       await wait(fixture);
 
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
-      const elem: DebugElement = fixture.debugElement.query(By.directive(MarkdownNavigatorComponent));
+      const elem: DebugElement = fixture.debugElement.query(By.directive(TdMarkdownNavigatorComponent));
 
       expect(markdownNavigator.goBackLabel).toContain(DEFAULT_MARKDOWN_NAVIGATOR_LABELS.goBack);
       expect(markdownNavigator.goHomeLabel).toContain(DEFAULT_MARKDOWN_NAVIGATOR_LABELS.goHome);
@@ -403,10 +403,10 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.labels = {};
       await wait(fixture);
 
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
-      const elem: DebugElement = fixture.debugElement.query(By.directive(MarkdownNavigatorComponent));
+      const elem: DebugElement = fixture.debugElement.query(By.directive(TdMarkdownNavigatorComponent));
 
       expect(markdownNavigator.goBackLabel).toContain(DEFAULT_MARKDOWN_NAVIGATOR_LABELS.goBack);
       expect(markdownNavigator.goHomeLabel).toContain(DEFAULT_MARKDOWN_NAVIGATOR_LABELS.goHome);
@@ -429,10 +429,10 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.labels = SAMPLE_LABELS;
       await wait(fixture);
 
-      const markdownNavigator: MarkdownNavigatorComponent = fixture.debugElement.query(
-        By.directive(MarkdownNavigatorComponent),
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
       ).componentInstance;
-      const elem: DebugElement = fixture.debugElement.query(By.directive(MarkdownNavigatorComponent));
+      const elem: DebugElement = fixture.debugElement.query(By.directive(TdMarkdownNavigatorComponent));
 
       expect(markdownNavigator.goBackLabel).toContain(SAMPLE_LABELS.goBack);
       expect(markdownNavigator.goHomeLabel).toContain(SAMPLE_LABELS.goHome);

--- a/src/platform/markdown-navigator/markdown-navigator.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.ts
@@ -9,7 +9,7 @@ import {
   ChangeDetectorRef,
   ChangeDetectionStrategy,
 } from '@angular/core';
-import { removeLeadingHash, isAnchorLink, MarkdownLoaderService } from '@covalent/markdown';
+import { removeLeadingHash, isAnchorLink, TdMarkdownLoaderService } from '@covalent/markdown';
 
 export interface IMarkdownNavigatorItem {
   title?: string;
@@ -88,7 +88,7 @@ function getAncestors(
   styleUrls: ['./markdown-navigator.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MarkdownNavigatorComponent implements OnChanges {
+export class TdMarkdownNavigatorComponent implements OnChanges {
   /**
    * items: IMarkdownNavigatorItem[]
    *
@@ -127,7 +127,7 @@ export class MarkdownNavigatorComponent implements OnChanges {
   loading: boolean = false;
 
   constructor(
-    private _markdownUrlLoaderService: MarkdownLoaderService,
+    private _markdownUrlLoaderService: TdMarkdownLoaderService,
     private _changeDetectorRef: ChangeDetectorRef,
   ) {}
 

--- a/src/platform/markdown-navigator/markdown-navigator.module.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MarkdownNavigatorComponent } from './markdown-navigator.component';
-import { MarkdownNavigatorWindowComponent } from './markdown-navigator-window/markdown-navigator-window.component';
+import { TdMarkdownNavigatorComponent } from './markdown-navigator.component';
+import { TdMarkdownNavigatorWindowComponent } from './markdown-navigator-window/markdown-navigator-window.component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatListModule } from '@angular/material/list';
@@ -10,8 +10,8 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { CovalentDialogsModule } from '@covalent/core/dialogs';
-import { MarkdownNavigatorWindowDirective } from './markdown-navigator-window-directive/markdown-navigator-window.directive';
-import { MarkdownNavigatorWindowService } from './markdown-navigator-window-service/markdown-navigator-window.service';
+import { TdMarkdownNavigatorWindowDirective } from './markdown-navigator-window-directive/markdown-navigator-window.directive';
+import { TdMarkdownNavigatorWindowService } from './markdown-navigator-window-service/markdown-navigator-window.service';
 
 @NgModule({
   imports: [
@@ -28,9 +28,9 @@ import { MarkdownNavigatorWindowService } from './markdown-navigator-window-serv
     CovalentFlavoredMarkdownModule,
     CovalentDialogsModule,
   ],
-  declarations: [MarkdownNavigatorComponent, MarkdownNavigatorWindowComponent, MarkdownNavigatorWindowDirective],
-  exports: [MarkdownNavigatorComponent, MarkdownNavigatorWindowComponent, MarkdownNavigatorWindowDirective],
-  entryComponents: [MarkdownNavigatorWindowComponent],
-  providers: [MarkdownNavigatorWindowService],
+  declarations: [TdMarkdownNavigatorComponent, TdMarkdownNavigatorWindowComponent, TdMarkdownNavigatorWindowDirective],
+  exports: [TdMarkdownNavigatorComponent, TdMarkdownNavigatorWindowComponent, TdMarkdownNavigatorWindowDirective],
+  entryComponents: [TdMarkdownNavigatorWindowComponent],
+  providers: [TdMarkdownNavigatorWindowService],
 })
 export class CovalentMarkdownNavigatorModule {}

--- a/src/platform/markdown/markdown-loader/markdown-loader.service.spec.ts
+++ b/src/platform/markdown/markdown-loader/markdown-loader.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, inject, async } from '@angular/core/testing';
-import { MarkdownLoaderService } from './markdown-loader.service';
+import { TdMarkdownLoaderService } from './markdown-loader.service';
 import { CovalentMarkdownModule } from '../markdown.module';
 
 const SAMPLE_HEADING: string = 'Covalent: UI Platform based on Angular-Material';
@@ -11,7 +11,7 @@ const RAW_GH_BRANCH_URL: string = 'https://raw.githubusercontent.com/Teradata/co
 const NON_MARKDOWN_URL: string = 'https://teradata.github.io/covalent/#/';
 const UNREACHABLE_URL: string = 'https://github.com/';
 
-describe('MarkdownLoaderService', () => {
+describe('Service: MarkdownLoader', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [CovalentMarkdownModule],
@@ -19,35 +19,35 @@ describe('MarkdownLoaderService', () => {
   }));
 
   it('should fetch from a raw github url', async(
-    inject([MarkdownLoaderService], async (_markdownLoaderService: MarkdownLoaderService) => {
+    inject([TdMarkdownLoaderService], async (_markdownLoaderService: TdMarkdownLoaderService) => {
       const markdown: string = await _markdownLoaderService.load(RAW_GH_URL);
       expect(markdown).toContain(SAMPLE_HEADING);
     }),
   ));
 
   it('should fetch from a non-raw github url', async(
-    inject([MarkdownLoaderService], async (_markdownLoaderService: MarkdownLoaderService) => {
+    inject([TdMarkdownLoaderService], async (_markdownLoaderService: TdMarkdownLoaderService) => {
       const markdown: string = await _markdownLoaderService.load(GH_URL);
       expect(markdown).toContain(SAMPLE_HEADING);
     }),
   ));
 
   it('should fetch from a raw branch github url', async(
-    inject([MarkdownLoaderService], async (_markdownLoaderService: MarkdownLoaderService) => {
+    inject([TdMarkdownLoaderService], async (_markdownLoaderService: TdMarkdownLoaderService) => {
       const markdown: string = await _markdownLoaderService.load(RAW_GH_BRANCH_URL);
       expect(markdown).toContain(SAMPLE_HEADING);
     }),
   ));
 
   it('should fetch from a non-raw branch github url', async(
-    inject([MarkdownLoaderService], async (_markdownLoaderService: MarkdownLoaderService) => {
+    inject([TdMarkdownLoaderService], async (_markdownLoaderService: TdMarkdownLoaderService) => {
       const markdown: string = await _markdownLoaderService.load(BRANCH_GH_URL);
       expect(markdown).toContain(SAMPLE_HEADING);
     }),
   ));
 
   it('should throw error if content response type is not plain or markdown', async(
-    inject([MarkdownLoaderService], async (_markdownLoaderService: MarkdownLoaderService) => {
+    inject([TdMarkdownLoaderService], async (_markdownLoaderService: TdMarkdownLoaderService) => {
       let failed: boolean = false;
       try {
         await _markdownLoaderService.load(NON_MARKDOWN_URL);
@@ -60,7 +60,7 @@ describe('MarkdownLoaderService', () => {
   ));
 
   it('should throw error if url is not reachable', async(
-    inject([MarkdownLoaderService], async (_markdownLoaderService: MarkdownLoaderService) => {
+    inject([TdMarkdownLoaderService], async (_markdownLoaderService: TdMarkdownLoaderService) => {
       let failed: boolean = false;
       try {
         await _markdownLoaderService.load(UNREACHABLE_URL);

--- a/src/platform/markdown/markdown-loader/markdown-loader.service.ts
+++ b/src/platform/markdown/markdown-loader/markdown-loader.service.ts
@@ -3,10 +3,8 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { isGithubHref, rawGithubHref } from '../markdown-utils/markdown-utils';
 
-@Injectable({
-  providedIn: 'root',
-})
-export class MarkdownLoaderService {
+@Injectable()
+export class TdMarkdownLoaderService {
   constructor(private _http: HttpClient, private _sanitizer: DomSanitizer) {}
 
   async load(url: string, httpOptions: object = {}): Promise<string> {

--- a/src/platform/markdown/markdown.module.ts
+++ b/src/platform/markdown/markdown.module.ts
@@ -1,13 +1,15 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { TdMarkdownComponent } from './markdown.component';
 import { HttpClientModule } from '@angular/common/http';
+
+import { TdMarkdownComponent } from './markdown.component';
+import { TdMarkdownLoaderService } from './markdown-loader/markdown-loader.service';
 
 @NgModule({
   imports: [CommonModule, HttpClientModule],
   declarations: [TdMarkdownComponent],
   exports: [TdMarkdownComponent],
-  providers: [HttpClientModule],
+  providers: [TdMarkdownLoaderService],
 })
 export class CovalentMarkdownModule {}


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Backwards compatibility with angular 8.

For some reason, the compiler doesnt recognize `providedIn` syntax if the project was built using angular 9 and used in an angular 8 project.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
