### PR TITLE
fix(http): *DEPRECATE* http class decorators

### DIFF
--- a/src/platform/http/actions/README.md
+++ b/src/platform/http/actions/README.md
@@ -14,7 +14,7 @@ import { Observable } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 
 import {
-  TdHttp,
+  mixinHttp,
   TdGET,
   TdPOST,
   TdBody,
@@ -24,15 +24,14 @@ import {
 } from '@covalent/http';
 
 /**
- * TdHttp uses TdHttpService and TdHttpClient uses HttpClient
+ * mixinHttp can use TdHttpService and HttpClient
  */
 
-@TdHttp({ // or @TdHttpClient({
+@Injectable()
+export class TestHttpService extends mixinHttp(class {}, {
   baseUrl: 'www.mybaseurl.com',
   baseHeaders: new HttpHeaders({ 'Accept': 'application/json' }),
-})
-@Injectable()
-export class TestHttpService {
+}) { // or }, HttpClient) {
   /**
    * Generates http request [www.mybaseurl.com/myitems] GET and returns an HttpResponse object
    */

--- a/src/platform/http/actions/class/http.decorator.ts
+++ b/src/platform/http/actions/class/http.decorator.ts
@@ -6,6 +6,7 @@ import { TdHttpService } from '../../interceptors/http.service';
 
 /**
  * Decorator used to give a service http capabilities using TdHttpService
+ * @deprecated will be removed in angular 10
  */
 export function TdHttp(config: ITdHttpRESTConfig): <T extends new (...args: any[]) => {}>(constructor: any) => any {
   return function<T extends new (...args: any[]) => {}>(constructor: any): any {
@@ -15,6 +16,7 @@ export function TdHttp(config: ITdHttpRESTConfig): <T extends new (...args: any[
 
 /**
  * Decorator used to give a service http capabilities using HttpClient
+ * @deprecated will be removed in angular 10
  */
 export function TdHttpClient(
   config: ITdHttpRESTConfig,


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->

Deprecate `TdHttp` and `TdClientHttp` decorators in favor of mixin extends.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
