### PR TITLE
fix(resizable-dialog): remove internal rxjs import

### DIFF
--- a/src/platform/core/dialogs/resizable-draggable-dialog/resizable-draggable-dialog.ts
+++ b/src/platform/core/dialogs/resizable-draggable-dialog/resizable-draggable-dialog.ts
@@ -1,9 +1,7 @@
 import { Renderer2 } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
 import { DragRef } from '@angular/cdk/drag-drop';
-import { fromEvent } from 'rxjs/internal/observable/fromEvent';
-import { Subscription } from 'rxjs';
-import { merge } from 'rxjs';
+import { merge, Subscription, fromEvent } from 'rxjs';
 import { Point } from '@angular/cdk/drag-drop/drag-ref';
 
 enum corners {


### PR DESCRIPTION
## Description

Remove internal rxjs import.

Addresses rxjs import issue in https://github.com/Teradata/covalent/issues/1402#issuecomment-573593269

#### Test Steps
- Run `npm run serve`
- Navigate to http://localhost:4200/#/components/markdown-navigator/overview
- View markdown navigator window demo and ensure it is still resizable.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
