### PR TITLE
feat(deprecate-code-editor-autolayout): removed autoLayout input

### DIFF
--- a/src/platform/code-editor/README.md
+++ b/src/platform/code-editor/README.md
@@ -16,8 +16,6 @@
   + Additional Styling applied to Editor Container
 + theme?: string
   + Theme used to style the Editor
-+ automaticLayout?: boolean
-  + Implemented via setInterval that constantly probes for the container's size. Defaults to false.
 + editorOptions?: object
   + Editor Options Object of valid Configurations listed here: <a href="https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditoroptions.html">https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditoroptions.html</a>
 + layout?: function()

--- a/src/platform/code-editor/code-editor.component.spec.ts
+++ b/src/platform/code-editor/code-editor.component.spec.ts
@@ -378,20 +378,13 @@ describe('Component: App', () => {
 @Component({
   template: `
     <div>
-      <td-code-editor
-        #editor1
-        automaticLayout
-        style="height: 200px"
-        theme="vs"
-        flex
-        language="javascript"
-      ></td-code-editor>
+      <td-code-editor #editor1 style="height: 200px" theme="vs" flex language="javascript"></td-code-editor>
     </div>
     <div>
-      <td-code-editor #editor2 automaticLayout style="height: 200px" theme="vs" flex language="HTML"></td-code-editor>
+      <td-code-editor #editor2 style="height: 200px" theme="vs" flex language="HTML"></td-code-editor>
     </div>
     <div>
-      <td-code-editor #editor3 automaticLayout style="height: 200px" theme="vs" flex language="css"></td-code-editor>
+      <td-code-editor #editor3 style="height: 200px" theme="vs" flex language="css"></td-code-editor>
     </div>
   `,
 })

--- a/src/platform/code-editor/code-editor.component.ts
+++ b/src/platform/code-editor/code-editor.component.ts
@@ -69,18 +69,6 @@ export class TdCodeEditorComponent implements OnInit, AfterViewInit, ControlValu
   @ViewChild('editorContainer', { static: true }) _editorContainer: ElementRef;
 
   /**
-   * automaticLayout?: boolean
-   * @deprecated in favor of our own resize implementation.
-   */
-  @Input('automaticLayout')
-  set automaticLayout(automaticLayout: boolean) {
-    // tslint:disable-next-line
-    console.warn(
-      '[automaticLayout] has been deprecated in favor of our own resize implementation and will be removed on 3.0.0',
-    );
-  }
-
-  /**
    * editorInitialized: function($event)
    * Event emitted when editor is first initialized
    */


### PR DESCRIPTION
## Description
Removed autoLayout input from code editor. Addresses issue https://github.com/Teradata/covalent/issues/1516

### What's included?
- Global find/remove of autoLayout

#### Test Steps
- [ ] `npm run serve`
- [ ] bring up browser, confirm autoLayout no long appears in docs

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
