### PR TITLE
feat(loading): add a fullscreen loading demo

### DIFF
--- a/src/app/components/shared/demo-tools/demo.component.scss
+++ b/src/app/components/shared/demo-tools/demo.component.scss
@@ -5,3 +5,7 @@
     height: 56px;
   }
 }
+:host {
+  display: block;
+  margin-bottom: 2em;
+}

--- a/src/app/content/components/component-demos/loading/demos/loading-demo-fullscreen/loading-demo-fullscreen.component.html
+++ b/src/app/content/components/component-demos/loading/demos/loading-demo-fullscreen/loading-demo-fullscreen.component.html
@@ -1,0 +1,3 @@
+<button mat-raised-button color="primary" (click)="toggleDefaultFullscreenDemo()" class="text-upper">Toggle default fullscreen Loader</button>
+
+<button mat-raised-button color="primary" (click)="toggleCustomFullscreenDemo()" class="text-upper">Toggle custom Fullscreen Loader</button>

--- a/src/app/content/components/component-demos/loading/demos/loading-demo-fullscreen/loading-demo-fullscreen.component.scss
+++ b/src/app/content/components/component-demos/loading/demos/loading-demo-fullscreen/loading-demo-fullscreen.component.scss
@@ -1,0 +1,3 @@
+button {
+  margin-right: 1em;
+}

--- a/src/app/content/components/component-demos/loading/demos/loading-demo-fullscreen/loading-demo-fullscreen.component.ts
+++ b/src/app/content/components/component-demos/loading/demos/loading-demo-fullscreen/loading-demo-fullscreen.component.ts
@@ -8,6 +8,8 @@ import { TdLoadingService, LoadingMode, LoadingType } from '@covalent/core/loadi
 })
 export class LoadingDemoFullscreenComponent {
   constructor(private _loadingService: TdLoadingService) {
+    // optional, only necessary for a custom config
+    // used in toggleCustomFullscreenDemo()
     this._loadingService.create({
       name: 'customFullscreenDemo',
       mode: LoadingMode.Indeterminate,

--- a/src/app/content/components/component-demos/loading/demos/loading-demo-fullscreen/loading-demo-fullscreen.component.ts
+++ b/src/app/content/components/component-demos/loading/demos/loading-demo-fullscreen/loading-demo-fullscreen.component.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+import { TdLoadingService, LoadingMode, LoadingType } from '@covalent/core/loading';
+
+@Component({
+  selector: 'loading-demo-fullscreen',
+  styleUrls: ['./loading-demo-fullscreen.component.scss'],
+  templateUrl: './loading-demo-fullscreen.component.html',
+})
+export class LoadingDemoFullscreenComponent {
+  constructor(private _loadingService: TdLoadingService) {
+    this._loadingService.create({
+      name: 'customFullscreenDemo',
+      mode: LoadingMode.Indeterminate,
+      type: LoadingType.Linear,
+      color: 'accent',
+    });
+  }
+
+  toggleDefaultFullscreenDemo(): void {
+    this._loadingService.register();
+    setTimeout(() => this._loadingService.resolve(), 1500);
+  }
+
+  toggleCustomFullscreenDemo(): void {
+    this._loadingService.register('customFullscreenDemo');
+    setTimeout(() => this._loadingService.resolve('customFullscreenDemo'), 1500);
+  }
+}

--- a/src/app/content/components/component-demos/loading/demos/loading-demo.component.html
+++ b/src/app/content/components/component-demos/loading/demos/loading-demo.component.html
@@ -1,3 +1,7 @@
 <demo-component [demoId]="'loading-demo-basic'">
     <loading-demo-basic></loading-demo-basic>
 </demo-component>
+
+<demo-component [demoId]="'loading-demo-fullscreen'">
+    <loading-demo-fullscreen></loading-demo-fullscreen>
+</demo-component>

--- a/src/app/content/components/component-demos/loading/demos/loading-demo.module.ts
+++ b/src/app/content/components/component-demos/loading/demos/loading-demo.module.ts
@@ -6,9 +6,10 @@ import { LoadingDemoComponent } from './loading-demo.component';
 import { LoadingDemoRoutingModule } from './loading-demo-routing.module';
 import { DemoModule } from '../../../../../components/shared/demo-tools/demo.module';
 import { MatButtonModule } from '@angular/material/button';
+import { LoadingDemoFullscreenComponent } from './loading-demo-fullscreen/loading-demo-fullscreen.component';
 
 @NgModule({
-  declarations: [LoadingDemoComponent, LoadingDemoBasicComponent],
+  declarations: [LoadingDemoComponent, LoadingDemoBasicComponent, LoadingDemoFullscreenComponent],
   imports: [
     DemoModule,
     LoadingDemoRoutingModule,


### PR DESCRIPTION
## Description

Add a fullscreen loading demo
Addresses https://github.com/Teradata/covalent/issues/1583


#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] http://localhost:4200/#/components/loading/examples
- [ ] verify demos work

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![Screen Shot 2020-01-14 at 08 55 15](https://user-images.githubusercontent.com/7193975/72364621-a7c16b80-36ab-11ea-9cfd-9a8fc715853d.png)
