### PR TITLE
fix(): get rid of markdown-nav-window extra scrollbar

### DIFF
--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.scss
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.scss
@@ -8,6 +8,10 @@
   margin-bottom: 0;
 }
 
+td-markdown-navigator {
+  height: calc(100% - 56px); // account for toolbar height
+}
+
 ::ng-deep {
   .td-draggable-markdown-navigator-window-wrapper {
     > .mat-dialog-container {


### PR DESCRIPTION
## Description

get rid of markdown-nav-window extra scrollbar

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] http://localhost:4200/#/components/markdown-navigator/overview
- [ ] Verify no scrollbar on Chrome and FF

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker


Before


![Screen Shot 2020-01-14 at 10 26 53](https://user-images.githubusercontent.com/7193975/72371262-db56c280-36b8-11ea-9add-00d4196c1822.png)

After

![Screen Shot 2020-01-14 at 10 24 16](https://user-images.githubusercontent.com/7193975/72371263-db56c280-36b8-11ea-83c3-88adacba5f79.png)

