### PR TITLE
feat(messages-docs): add more demos to messages, remove unused code

### DIFF
--- a/src/app/content/components/component-demos/message/demos/message-demo-basic/message-demo-basic.component.html
+++ b/src/app/content/components/component-demos/message/demos/message-demo-basic/message-demo-basic.component.html
@@ -25,10 +25,6 @@
 </button>
 <mat-divider></mat-divider>
 <p class="mat-body-1">Using <code>color</code>:</p>
-<td-message label="Purple!" sublabel="Simply add color=blah" color="purple" icon="error">
-  <button td-message-actions mat-button>VIEW MORE</button>
-</td-message>
+<td-message label="Purple!" sublabel="Simply add color=blah" color="purple" icon="error"></td-message>
 <p class="mat-body-1">Using <code>class</code>:</p>
-<td-message label="Cyan!" sublabel="Reference the Covalent style guide" class="bgc-cyan-800 tc-cyan-100" icon="error">
-  <button td-message-actions mat-button>VIEW MORE</button>
-</td-message>
+<td-message label="Cyan!" sublabel="Reference the Covalent style guide" class="bgc-cyan-800 tc-cyan-100" icon="error"></td-message>

--- a/src/app/content/components/component-demos/message/demos/message-demo-basic/message-demo-basic.component.html
+++ b/src/app/content/components/component-demos/message/demos/message-demo-basic/message-demo-basic.component.html
@@ -1,1 +1,34 @@
-<td-message label="Info" sublabel="Maybe you want to know this" color="accent" icon="info"></td-message>
+<p class="mat-body-1">Standalone message:</p>
+<td-message label="Error!" sublabel="You did something wrong!" color="warn" icon="error"></td-message>
+<p class="mat-body-1">Message in a card with action</p>
+<mat-card>
+  <td-message label="Warning!" sublabel="Your probably shouldn't do that!" class="bgc-td-orange-100 tc-td-orange" icon="warning">
+    <button td-message-actions mat-button>VIEW MORE</button>
+  </td-message>
+</mat-card>
+<p class="mat-body-1">Message in a card content:</p>
+<mat-card>
+  <mat-card-title>Card title</mat-card-title>
+  <mat-divider></mat-divider>
+  <td-message label="Info" sublabel="Maybe you want to know this" color="accent" icon="info"></td-message>
+  <mat-card-content>
+    content
+  </mat-card-content>
+</mat-card>
+<p class="mat-body-1">Toggle visibility:</p>
+<td-message #messageDemo class="pad-sm push-bottom bgc-td-orange-100 tc-td-orange" label="Hide me!" sublabel="You can toggle my visibility & add a class!">
+  <button td-message-actions mat-icon-button (click)="messageDemo.close()"><mat-icon>cancel</mat-icon></button>
+</td-message>
+<mat-divider></mat-divider>
+<button mat-button color="accent" class="text-upper pad-sm" (click)="messageDemo.toggle()">
+  Toggle Visibility
+</button>
+<mat-divider></mat-divider>
+<p class="mat-body-1">Using <code>color</code>:</p>
+<td-message label="Purple!" sublabel="Simply add color=blah" color="purple" icon="error">
+  <button td-message-actions mat-button>VIEW MORE</button>
+</td-message>
+<p class="mat-body-1">Using <code>class</code>:</p>
+<td-message label="Cyan!" sublabel="Reference the Covalent style guide" class="bgc-cyan-800 tc-cyan-100" icon="error">
+  <button td-message-actions mat-button>VIEW MORE</button>
+</td-message>

--- a/src/app/content/components/component-demos/message/demos/message-demo-basic/message-demo-basic.component.html
+++ b/src/app/content/components/component-demos/message/demos/message-demo-basic/message-demo-basic.component.html
@@ -16,7 +16,7 @@
   </mat-card-content>
 </mat-card>
 <p class="mat-body-1">Toggle visibility:</p>
-<td-message #messageDemo class="pad-sm push-bottom bgc-td-orange-100 tc-td-orange" label="Hide me!" sublabel="You can toggle my visibility & add a class!">
+<td-message #messageDemo class="pad-sm push-bottom" color="primary" label="Hide me!" sublabel="You can toggle my visibility & add a class!">
   <button td-message-actions mat-icon-button (click)="messageDemo.close()"><mat-icon>cancel</mat-icon></button>
 </td-message>
 <mat-divider></mat-divider>

--- a/src/app/content/components/component-demos/message/demos/message-demo-basic/message-demo-basic.component.html
+++ b/src/app/content/components/component-demos/message/demos/message-demo-basic/message-demo-basic.component.html
@@ -3,7 +3,7 @@
 <p class="mat-body-1">Message in a card with action</p>
 <mat-card>
   <td-message label="Warning!" sublabel="Your probably shouldn't do that!" class="bgc-td-orange-100 tc-td-orange" icon="warning">
-    <button td-message-actions mat-button>VIEW MORE</button>
+    <button td-message-actions mat-button (click)="showAlert()">VIEW MORE</button>
   </td-message>
 </mat-card>
 <p class="mat-body-1">Message in a card content:</p>

--- a/src/app/content/components/component-demos/message/demos/message-demo-basic/message-demo-basic.component.ts
+++ b/src/app/content/components/component-demos/message/demos/message-demo-basic/message-demo-basic.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { TdDialogService } from '../../../../../../../platform/core';
 
 @Component({
   selector: 'message-demo-basic',
@@ -6,4 +7,13 @@ import { Component } from '@angular/core';
   templateUrl: './message-demo-basic.component.html',
   preserveWhitespaces: true,
 })
-export class MessageDemoBasicComponent {}
+export class MessageDemoBasicComponent {
+  constructor(private _dialogService: TdDialogService) {}
+
+  showAlert(): void {
+    this._dialogService.openAlert({
+      title: 'VIEW MORE clicked!',
+      message: 'Same action can be used for navigation or showing messages like this!',
+    });
+  }
+}

--- a/src/app/content/components/component-demos/message/demos/message-demo.module.ts
+++ b/src/app/content/components/component-demos/message/demos/message-demo.module.ts
@@ -5,6 +5,10 @@ import { CovalentMessageModule } from '@covalent/core/message';
 import { MessageDemoComponent } from './message-demo.component';
 import { MessageDemoRoutingModule } from './message-demo-routing.module';
 import { DemoModule } from '../../../../../components/shared/demo-tools/demo.module';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
 
 @NgModule({
   declarations: [MessageDemoComponent, MessageDemoBasicComponent],
@@ -15,6 +19,10 @@ import { DemoModule } from '../../../../../components/shared/demo-tools/demo.mod
     CovalentMessageModule,
     /** Angular Modules */
     CommonModule,
+    MatButtonModule,
+    MatCardModule,
+    MatDividerModule,
+    MatIconModule,
   ],
 })
 export class MessageDemoModule {}

--- a/src/app/content/components/component-demos/message/message.module.ts
+++ b/src/app/content/components/component-demos/message/message.module.ts
@@ -1,17 +1,18 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
-
+import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
+
+import { CovalentMessageModule } from '@covalent/core/message';
+import { CovalentHighlightModule } from '@covalent/highlight';
 import { ComponentDetailsModule } from 'app/components/shared/component-details/component-details.module';
 import { setComponentRoutes } from 'app/content/components/components';
 import { MessageDemoComponent } from './message.component';
-import { CovalentMessageModule } from '@covalent/core/message';
-import { MatCardModule } from '@angular/material/card';
-import { MatDividerModule } from '@angular/material/divider';
+import { CovalentDialogsModule } from '../../../../../platform/core';
 import { DocumentationToolsModule } from 'app/documentation-tools';
-import { CovalentHighlightModule } from '@covalent/highlight';
-import { MatButtonModule } from '@angular/material/button';
 
 const routes: Routes = setComponentRoutes({
   overviewDemoComponent: MessageDemoComponent,
@@ -30,6 +31,7 @@ const routes: Routes = setComponentRoutes({
     MatDividerModule,
     ComponentDetailsModule,
     // Covalent
+    CovalentDialogsModule,
     CovalentMessageModule,
     CovalentHighlightModule,
     // Docs

--- a/src/app/content/components/component-demos/message/message.module.ts
+++ b/src/app/content/components/component-demos/message/message.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule, Routes, Route } from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 
 import { MatIconModule } from '@angular/material/icon';
 import { ComponentDetailsModule } from 'app/components/shared/component-details/component-details.module';
@@ -9,7 +9,6 @@ import { MessageDemoComponent } from './message.component';
 import { CovalentMessageModule } from '@covalent/core/message';
 import { MatCardModule } from '@angular/material/card';
 import { MatDividerModule } from '@angular/material/divider';
-import { MatTabsModule } from '@angular/material/tabs';
 import { DocumentationToolsModule } from 'app/documentation-tools';
 import { CovalentHighlightModule } from '@covalent/highlight';
 import { MatButtonModule } from '@angular/material/button';
@@ -27,6 +26,8 @@ const routes: Routes = setComponentRoutes({
     // Material
     MatIconModule,
     MatButtonModule,
+    MatCardModule,
+    MatDividerModule,
     ComponentDetailsModule,
     // Covalent
     CovalentMessageModule,


### PR DESCRIPTION
## Description
Bring all the demos for `messages & alerts` from old docs

### What's included?
- demos showing all sorts of messages & alerts

#### Test Steps
- [ ] `npm run serve`
- [ ] click on components
- [ ] click on `Message` from sidenav and see new docs in examples section

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
