### PR TITLE
feat(file-service): deprecate upload method

### DIFF
--- a/src/platform/core/file/file-upload/README.md
+++ b/src/platform/core/file/file-upload/README.md
@@ -18,7 +18,7 @@ Example for usage:
   </ng-template>
 </td-file-upload>
 ```
- 
+
 ```typescript
 export class Demo {
 
@@ -44,7 +44,7 @@ export class Demo {
   cancelEvent(): void {
     ...
   }
-} 
+}
 ```
 
 ## API Summary
@@ -102,48 +102,26 @@ Service provided with methods that wrap complexity for as easier file upload exp
 
 #### Methods
 
-+ upload: function(IUploadState)
-  + Uses underlying [XMLHttpRequest] to upload a file to a url. 
-  + Will be depricated when Angular fixes [Http] to allow [FormData] as body.
++ send: function(url: string, method: string, body: File | FormData, uploadExtras: IUploadExtras)
+  + Uploads a file to a URL.
 
 ## Usage
 
-Recieves as parameter an object that implements the [IUploadOptions] interface. You have to assign a value either to `[file]` or to `[formData]`. If `[file]` is assigned then `[formData]` will be ignored; when only `[formData]` is assigned then it will be sent as form data.
-
 ```typescript
-interface IUploadOptions { 
-  url: string; 
-  method: 'post' | 'put'; 
-  file?: File;
-  headers?: {[key: string]: string};
-  formData?: FormData; 
-}
-```
+import { TdFileService } from '@covalent/core/file';
 
-Example for usage:
-
-```typescript
-import { TdFileService, IUploadOptions } from '@covalent/core/file';
-...
-  providers: [ TdFileService ]
-})
 export class Demo {
 
   file: File;
-  
-  constructor(private fileUploadService: TdFileService) { 
+
+  constructor(private fileUploadService: TdFileService) {
   };
-  
-  uploadEvent1(file: File) {    
-    let options: IUploadOptions = {
-      url: 'https://url.to/API',
-      method: 'post',
-      file: file
-    };    
-    this.fileService.upload(options).subscribe((response) => {
+
+  uploadEvent1(file: File) {
+    this.fileService.send('https://url.to/API', 'post', file).subscribe((response) => {
       ...
     });
   };
-  
+
 }
 ```

--- a/src/platform/core/file/services/file.service.spec.ts
+++ b/src/platform/core/file/services/file.service.spec.ts
@@ -1,54 +1,21 @@
-import { TestBed, inject } from '@angular/core/testing';
-import { TdFileService, IUploadOptions, CovalentFileModule } from '../';
+import { TestBed } from '@angular/core/testing';
+import { TdFileService, CovalentFileModule } from '../';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('Service: File', () => {
   let service: TdFileService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CovalentFileModule],
+      imports: [CovalentFileModule, HttpClientTestingModule],
     });
     service = TestBed.get(TdFileService);
     spyOn(XMLHttpRequest.prototype, 'open').and.callThrough();
     spyOn(XMLHttpRequest.prototype, 'setRequestHeader').and.callThrough();
   });
 
-  it('should throw error for missing file and formData', () => {
-    const options: IUploadOptions = {
-      url: 'test.url',
-      method: 'post',
-    };
-
-    spyOn(XMLHttpRequest.prototype, 'send');
-
-    service.upload(options).subscribe(
-      () => {
-        fail('Should throw error');
-      },
-      (error: any) => {
-        expect(error).toEqual('For [IUploadOptions] you have to set either the [file] or the [formData] property.');
-      },
-    );
-
-    expect(XMLHttpRequest.prototype.open).not.toHaveBeenCalled();
-    expect(XMLHttpRequest.prototype.setRequestHeader).not.toHaveBeenCalled();
-    expect(XMLHttpRequest.prototype.send).not.toHaveBeenCalled();
-  });
-
   it('should call send with no additional data and header', () => {
     const file: File = new File(['content'], 'myfile.name');
-
-    const formData: FormData = new FormData();
-    formData.append('extraData', 'data');
-    const file2: File = new File(['content'], 'myotherfile.name');
-    formData.append('myfile', file2);
-
-    const options: IUploadOptions = {
-      url: 'test.url',
-      file,
-      method: 'post',
-      formData,
-    };
 
     const mySpy: jasmine.Spy = spyOn(XMLHttpRequest.prototype, 'send').and.callFake(() => {
       XMLHttpRequest.prototype.abort();
@@ -59,7 +26,7 @@ describe('Service: File', () => {
       expect(XMLHttpRequest.prototype.setRequestHeader).toHaveBeenCalledTimes(1);
     });
 
-    service.upload(options).subscribe();
+    service.send('test.url', 'post', file).subscribe();
   });
 
   it('should call send with formData and header', () => {
@@ -67,12 +34,6 @@ describe('Service: File', () => {
     const formData: FormData = new FormData();
     formData.append('extraData', 'data');
     formData.append('myfile', file);
-    const options: IUploadOptions = {
-      url: 'test.url',
-      method: 'post',
-      headers: { 'My-Header': 'my-val' },
-      formData,
-    };
 
     const mySpy: jasmine.Spy = spyOn(XMLHttpRequest.prototype, 'send').and.callFake(() => {
       XMLHttpRequest.prototype.abort();
@@ -87,6 +48,6 @@ describe('Service: File', () => {
       expect(XMLHttpRequest.prototype.setRequestHeader).toHaveBeenCalledTimes(2);
     });
 
-    service.upload(options).subscribe();
+    service.send('test.url', 'post', formData, { headers: { 'My-Header': 'my-val' } }).subscribe();
   });
 });


### PR DESCRIPTION
## Description

- Fully deprecate upload method

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Verify documentation is accurate
- [ ] `npm run test`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
