### PR TITLE
fix(demo): added loading icon demo

### DIFF
--- a/src/app/content/components/component-demos/loading/demos/loading-demo-icon/loading-demo-icon.component.html
+++ b/src/app/content/components/component-demos/loading/demos/loading-demo-icon/loading-demo-icon.component.html
@@ -1,0 +1,15 @@
+<mat-list>
+  <ng-template let-item let-last="last" ngFor [ngForOf]="itemList">
+    <mat-list-item>
+      <div matListAvatar>
+        <ng-template tdLoading [tdLoadingUntil]="!item.value" tdLoadingStrategy="overlay">
+          <mat-icon matListAvatar>
+            settings_backup_restore
+          </mat-icon>
+        </ng-template>
+      </div>
+      <h3 matLine>{{item.label}}</h3>
+    </mat-list-item>
+    <mat-divider *ngIf="!last"></mat-divider>
+  </ng-template>
+</mat-list>

--- a/src/app/content/components/component-demos/loading/demos/loading-demo-icon/loading-demo-icon.component.ts
+++ b/src/app/content/components/component-demos/loading/demos/loading-demo-icon/loading-demo-icon.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'loading-demo-icon',
+  templateUrl: './loading-demo-icon.component.html',
+  styleUrls: ['./loading-demo-icon.component.scss'],
+})
+export class LoadingDemoIconComponent {
+  itemList: any[] = [
+    { label: 'Light', value: true },
+    { label: 'Console', value: false },
+    { label: 'T.V.', value: true },
+  ];
+}

--- a/src/app/content/components/component-demos/loading/demos/loading-demo.component.html
+++ b/src/app/content/components/component-demos/loading/demos/loading-demo.component.html
@@ -13,3 +13,7 @@
 <demo-component [demoId]="'loading-demo-fullscreen'">
     <loading-demo-fullscreen></loading-demo-fullscreen>
 </demo-component>
+
+<demo-component [demoId]="'loading-demo-icon'">
+    <loading-demo-icon></loading-demo-icon>
+</demo-component>

--- a/src/app/content/components/component-demos/loading/demos/loading-demo.module.ts
+++ b/src/app/content/components/component-demos/loading/demos/loading-demo.module.ts
@@ -9,6 +9,9 @@ import { LoadingDemoRoutingModule } from './loading-demo-routing.module';
 import { DemoModule } from '../../../../../components/shared/demo-tools/demo.module';
 import { MatButtonModule } from '@angular/material/button';
 import { LoadingDemoFullscreenComponent } from './loading-demo-fullscreen/loading-demo-fullscreen.component';
+import { LoadingDemoIconComponent } from './loading-demo-icon/loading-demo-icon.component';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
 
 @NgModule({
   declarations: [
@@ -17,6 +20,7 @@ import { LoadingDemoFullscreenComponent } from './loading-demo-fullscreen/loadin
     LoadingDemoReplaceComponent,
     LoadingDemoObservableComponent,
     LoadingDemoFullscreenComponent,
+    LoadingDemoIconComponent,
   ],
   imports: [
     DemoModule,
@@ -26,6 +30,8 @@ import { LoadingDemoFullscreenComponent } from './loading-demo-fullscreen/loadin
     /** Angular Modules */
     CommonModule,
     MatButtonModule,
+    MatIconModule,
+    MatListModule,
   ],
 })
 export class LoadingDemoModule {}


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Added loading icon demo - covalent#1627
### What's included?
<!-- List features included in this PR -->
- loading-demo-icon component
- updates to loading demo layout html

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] click components > loading
- [ ] scroll to loading-demo-icon card

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![loading-icon-demo](https://user-images.githubusercontent.com/4431785/76028977-7d8c6d00-5ee8-11ea-95cc-2bc191aec5c8.gif)