### PR TITLE
feat(layout): add dense mode

### DIFF
--- a/src/platform/core/layout/_layout-theme.scss
+++ b/src/platform/core/layout/_layout-theme.scss
@@ -62,6 +62,28 @@
       z-index: 1;
     }
   }
+
+  body[dense] td-layout-nav,
+  body[dense] td-layout-nav-list,
+  body[dense] td-layout-card-over,
+  td-layout-nav[dense],
+  td-layout-nav-list[dense],
+  td-layout-card-over[dense] {
+    mat-toolbar.td-layout-toolbar {
+      &.mat-toolbar-row,
+      &.mat-toolbar-single-row {
+        height: 48px;
+      }
+    }
+  }
+  body[dense] td-layout-card-over,
+  td-layout-card-over[dense] {
+    .td-layout-card-over-wrapper {
+      margin: -48px;
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
   .mat-drawer-side.td-layout-sidenav {
     @include mat-elevation(2);
   }

--- a/src/platform/core/layout/layout-card-over/layout-card-over.component.html
+++ b/src/platform/core/layout/layout-card-over/layout-card-over.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar [color]="color"></mat-toolbar>
+<mat-toolbar class="td-layout-toolbar" [color]="color"></mat-toolbar>
 <div class="td-layout-card-over-wrapper">
   <div
     class="td-layout-card-over"

--- a/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
+++ b/src/platform/core/layout/layout-nav-list/layout-nav-list.component.html
@@ -9,7 +9,7 @@
       [style.max-width]="sidenavWidth"
       [style.min-width]="sidenavWidth"
     >
-      <mat-toolbar [color]="color">
+      <mat-toolbar class="td-layout-toolbar" [color]="color">
         <ng-content select="[td-menu-button]"></ng-content>
         <span
           *ngIf="icon || logo || toolbarTitle"
@@ -28,7 +28,7 @@
       </div>
     </mat-sidenav>
     <div class="td-layout-nav-list-main">
-      <mat-toolbar [color]="color">
+      <mat-toolbar class="td-layout-toolbar" [color]="color">
         <ng-content select="[td-toolbar-content]"></ng-content>
       </mat-toolbar>
       <div class="td-layout-nav-list-content" cdkScrollable>

--- a/src/platform/core/layout/layout-nav/layout-nav.component.html
+++ b/src/platform/core/layout/layout-nav/layout-nav.component.html
@@ -1,5 +1,5 @@
 <div class="td-layout-nav-wrapper">
-  <mat-toolbar [color]="color">
+  <mat-toolbar class="td-layout-toolbar" [color]="color">
     <ng-content select="[td-menu-button]"></ng-content>
     <span
       *ngIf="icon || logo || toolbarTitle"


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Add dense as an attribute selector so layouts can make their toolbars 48px instead of 64px.

If material ever decides to add a dense option for toolbars, we will just leverage it under the covers.

### What's included?
<!-- List features included in this PR -->
- `dense` attribute for layouts or added to body

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] add `dense` to either `td-layout-nav`, `td-layout-card-over`, `td-layout-nav-list` or the `body` tag and see toolbars inside the component become 48px height. (this will not affect components outside the component)

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
