### PR TITLE
feat(toolbar): add dense mode

### DIFF
--- a/src/platform/core/common/styles/core/_toolbar.scss
+++ b/src/platform/core/common/styles/core/_toolbar.scss
@@ -1,4 +1,20 @@
 @mixin td-toolbar-utilities() {
+  body[dense] mat-toolbar,
+  body[dense] mat-toolbar-row,
+  mat-toolbar[dense],
+  mat-toolbar-row[dense] {
+    &.mat-toolbar-multiple-rows {
+      .mat-toolbar-row,
+      .mat-toolbar-single-row {
+        height: 48px;
+      }
+    }
+
+    &.mat-toolbar-single-row,
+    &.mat-toolbar-row {
+      height: 48px;
+    }
+  }
   mat-toolbar {
     [mat-button] {
       &:first-of-type:not(:last-child) {


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Add dense as an attribute selector so toolbars are 48px instead of 64px.

### What's included?
<!-- List features included in this PR -->
- `dense` attribute for toolbars or added to body

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] add `dense` to either `mat-toolbar` or the `body` tag and see toolbars become 48px height.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
