### PR TITLE
text editor - fix(sidedraw): change z-index on mat-sidedraw to 1

### DIFF
--- a/src/app/components/content-container/content-container.component.html
+++ b/src/app/components/content-container/content-container.component.html
@@ -1,5 +1,5 @@
 <mat-sidenav-container fullscreen>
-  <mat-sidenav mode="side" [opened]="media.registerQuery('gt-sm') | async" [style.width.px]="280">
+  <mat-sidenav mode="side" [opened]="media.registerQuery('gt-sm') | async" [style.width.px]="280" [style.z-index]="1">
     <app-sidenav-content></app-sidenav-content>
   </mat-sidenav>
   <mat-sidenav-content class="bgc-white-4">


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Fix fullscreen mode for Text editor demo
### What's included?
<!-- List features included in this PR -->
- changed z-index of sidedraw to 1.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] select components
- [ ] click on text-editor
- [ ] use icons in editor to show side-by-side

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![text-editor-demo](https://user-images.githubusercontent.com/4431785/76128811-42f30500-5fba-11ea-867a-f4df57a0cce9.gif)
