### PR TITLE
fix(http): dont override httpParams object

### DIFF
--- a/src/platform/http/actions/methods/abstract-method.decorator.ts
+++ b/src/platform/http/actions/methods/abstract-method.decorator.ts
@@ -86,10 +86,18 @@ export function TdAbstractMethod(config: {
               newArgs[parameter.index] = arguments[parameter.index];
               const qParams: HttpParams | { [key: string]: string | string[] } = arguments[parameter.index];
               if (config.options && config.options.params) {
-                queryParams = parseParams(queryParams, config.options.params);
+                if (config.options.params instanceof HttpParams) {
+                  queryParams = parseParams(config.options.params, queryParams);
+                } else {
+                  queryParams = parseParams(queryParams, config.options.params);
+                }
               }
               if (qParams) {
-                queryParams = parseParams(queryParams, qParams);
+                if (qParams instanceof HttpParams) {
+                  queryParams = parseParams(qParams, queryParams);
+                } else {
+                  queryParams = parseParams(queryParams, qParams);
+                }
               }
             }
           }


### PR DESCRIPTION
## Description

Ran into an issue where I had to use a custom encoder, which were being ignored. So with this change, if params are already http params, use that as a base to retain encoder and other options.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] `npm run test`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
