### PR TITLE
feat(markdown-nav): support descriptions and icons

### DIFF
--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-basic/markdown-navigator-demo-basic.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-basic/markdown-navigator-demo-basic.component.ts
@@ -1,50 +1,29 @@
 import { Component } from '@angular/core';
-import {
-  TdMarkdownNavigatorWindowService,
-  TdMarkdownNavigatorWindowComponent,
-  IMarkdownNavigatorItem,
-} from '@covalent/markdown-navigator';
-import { MatDialogRef } from '@angular/material/dialog';
+import { TdMarkdownNavigatorWindowService, IMarkdownNavigatorItem } from '@covalent/markdown-navigator';
 
 @Component({
   selector: 'markdown-navigator-demo-basic',
   styleUrls: ['./markdown-navigator-demo-basic.component.scss'],
   templateUrl: './markdown-navigator-demo-basic.component.html',
-  preserveWhitespaces: true,
 })
 export class MarkdownNavigatorDemoBasicComponent {
-  windowOpen: boolean = false;
-  ref: MatDialogRef<TdMarkdownNavigatorWindowComponent>;
-  oneItem: IMarkdownNavigatorItem[] = [
-    {
-      url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
-    },
-  ];
-  options: { name: string; value: IMarkdownNavigatorItem[] }[] = [
-    {
-      name: 'One item',
-      value: this.oneItem,
-    },
-  ];
-  selected: { name: string; value: IMarkdownNavigatorItem[] } = this.options[0];
-  currentItems: IMarkdownNavigatorItem[] = this.selected.value;
-
   constructor(private _markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) {}
-
   openDialog(): void {
-    if (this.windowOpen) {
-      this.closeDialog();
-    }
-    this.ref = this._markdownNavigatorWindowService.open({ items: this.currentItems });
-    this.ref.afterOpened().subscribe(() => {
-      this.windowOpen = true;
+    this._markdownNavigatorWindowService.open({
+      items: [
+        {
+          title: 'Covalent',
+          description: 'Terdata UI Platform',
+          icon: 'whatshot',
+          url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
+        },
+        {
+          title: 'RxJS',
+          description: 'Reactive programming',
+          icon: 'speed',
+          url: 'https://github.com/ReactiveX/rxjs/blob/master/README.md',
+        },
+      ],
     });
-
-    this.ref.afterClosed().subscribe(() => {
-      this.windowOpen = false;
-    });
-  }
-  closeDialog(): void {
-    this.ref.close();
   }
 }

--- a/src/platform/markdown-navigator/README.md
+++ b/src/platform/markdown-navigator/README.md
@@ -26,6 +26,8 @@ interface IMarkdownNavigatorItem {
   markdownString?: string; // raw markdown
   anchor?: string;
   children?: IMarkdownNavigatorItem[];
+  description?: string;
+  icon?: string;
 }
 ```
 

--- a/src/platform/markdown-navigator/markdown-navigator.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator.component.html
@@ -45,11 +45,12 @@
         matTooltipShowDelay="500"
       >
         <mat-icon matListIcon>
-          subject
+          {{ getIcon(item) }}
         </mat-icon>
         <span matLine class="truncate">
           {{ getTitle(item) }}
         </span>
+        <span matLine class="truncate">{{ item.description }}</span>
         <mat-divider></mat-divider>
       </button>
     </mat-action-list>

--- a/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
@@ -27,6 +27,19 @@ const RAW_MARKDOWN_ITEM: IMarkdownNavigatorItem[] = [
 
 const FLAT_MIXED_ITEMS: IMarkdownNavigatorItem[] = [...URL_ITEM, ...RAW_MARKDOWN_ITEM];
 
+const ITEMS_WITH_CUSTOM_ICONS: IMarkdownNavigatorItem[] = [
+  { ...URL_ITEM[0], icon: 'whatshot' },
+  { ...RAW_MARKDOWN_ITEM[0], icon: 'touch_app' },
+];
+
+const ITEMS_WITH_DESCRIPTIONS: IMarkdownNavigatorItem[] = [
+  {
+    ...URL_ITEM[0],
+    description: 'An introduction into what Covalent is all about',
+  },
+  { ...RAW_MARKDOWN_ITEM[0], description: 'An example of using raw markdown' },
+];
+
 const NESTED_MIXED_ITEMS: IMarkdownNavigatorItem[] = [
   {
     title: 'First item',
@@ -344,6 +357,40 @@ describe('MarkdownNavigatorComponent', () => {
       expect(markdownNavigator.showTdMarkdown).toBeFalsy();
       expect(markdownNavigator.showTdMarkdownLoader).toBeFalsy();
       expect(listItems.length).toBe(FLAT_MIXED_ITEMS.length);
+    }),
+  ));
+
+  it('should use custom icons if passed in', async(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> = TestBed.createComponent(
+        TdMarkdownNavigatorTestComponent,
+      );
+
+      fixture.componentInstance.items = ITEMS_WITH_CUSTOM_ICONS;
+      await wait(fixture);
+
+      const listItems: DebugElement[] = fixture.debugElement.queryAll(By.css('mat-action-list button'));
+
+      expect(listItems.length).toBe(ITEMS_WITH_CUSTOM_ICONS.length);
+      expect(listItems[0].nativeElement.textContent).toContain(ITEMS_WITH_CUSTOM_ICONS[0].icon);
+      expect(listItems[1].nativeElement.textContent).toContain(ITEMS_WITH_CUSTOM_ICONS[1].icon);
+    }),
+  ));
+
+  it('should use descriptions if passed in', async(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> = TestBed.createComponent(
+        TdMarkdownNavigatorTestComponent,
+      );
+
+      fixture.componentInstance.items = ITEMS_WITH_DESCRIPTIONS;
+      await wait(fixture);
+
+      const listItems: DebugElement[] = fixture.debugElement.queryAll(By.css('mat-action-list button'));
+
+      expect(listItems.length).toBe(ITEMS_WITH_DESCRIPTIONS.length);
+      expect(listItems[0].nativeElement.textContent).toContain(ITEMS_WITH_DESCRIPTIONS[0].description);
+      expect(listItems[1].nativeElement.textContent).toContain(ITEMS_WITH_DESCRIPTIONS[1].description);
     }),
   ));
 

--- a/src/platform/markdown-navigator/markdown-navigator.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.ts
@@ -18,6 +18,8 @@ export interface IMarkdownNavigatorItem {
   markdownString?: string; // raw markdown
   anchor?: string;
   children?: IMarkdownNavigatorItem[];
+  description?: string;
+  icon?: string;
 }
 
 export interface IMarkdownNavigatorLabels {
@@ -288,6 +290,12 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
         getTitleFromMarkdownString(item.markdownString) ||
         ''
       ).trim();
+    }
+  }
+
+  getIcon(item: IMarkdownNavigatorItem): string {
+    if (item) {
+      return item.icon || 'subject';
     }
   }
 


### PR DESCRIPTION
## Description

Adds ability to add icons and descriptions to markdown nav items

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run test`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![localhost_9876__id=18958887(Pixel 2)](https://user-images.githubusercontent.com/7193975/77110242-7d10cd80-69e2-11ea-9711-d2d7808f6ceb.png)

![localhost_9876__id=18958887(Pixel 2) (1)](https://user-images.githubusercontent.com/7193975/77110235-7a15dd00-69e2-11ea-9421-a23aca6d50fd.png)
