### PR TITLE
feat:(markdown-nav): render md and list side by side

### DIFF
--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-basic/markdown-navigator-demo-basic.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-basic/markdown-navigator-demo-basic.component.ts
@@ -22,6 +22,16 @@ export class MarkdownNavigatorDemoBasicComponent {
           description: 'Reactive programming',
           icon: 'speed',
           url: 'https://github.com/ReactiveX/rxjs/blob/master/README.md',
+          children: [
+            {
+              title: 'Intro pt 1',
+              markdownString: '🔥',
+            },
+            {
+              title: 'Intro pt 2',
+              markdownString: '⚡',
+            },
+          ],
         },
       ],
     });

--- a/src/platform/markdown-navigator/markdown-navigator.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator.component.html
@@ -34,42 +34,44 @@
     <mat-divider [style.position]="'relative'"></mat-divider>
   </ng-container>
 
-  <div *ngIf="showMenu" class="td-markdown-list">
-    <mat-action-list>
-      <button
-        *ngFor="let item of currentMenuItems"
-        (click)="handleItemSelected(item)"
-        mat-list-item
-        [matTooltip]="getTitle(item)"
-        matTooltipPosition="before"
-        matTooltipShowDelay="500"
-      >
-        <mat-icon matListIcon>
-          {{ getIcon(item) }}
-        </mat-icon>
-        <span matLine class="truncate">
-          {{ getTitle(item) }}
-        </span>
-        <span matLine class="truncate">{{ item.description }}</span>
-        <mat-divider></mat-divider>
-      </button>
-    </mat-action-list>
-  </div>
+  <div class="scroll-area">
+    <div *ngIf="showMenu" class="td-markdown-list">
+      <mat-action-list>
+        <button
+          *ngFor="let item of currentMenuItems"
+          (click)="handleItemSelected(item)"
+          mat-list-item
+          [matTooltip]="getTitle(item)"
+          matTooltipPosition="before"
+          matTooltipShowDelay="500"
+        >
+          <mat-icon matListIcon>
+            {{ getIcon(item) }}
+          </mat-icon>
+          <span matLine class="truncate">
+            {{ getTitle(item) }}
+          </span>
+          <span matLine class="truncate">{{ item.description }}</span>
+          <mat-divider></mat-divider>
+        </button>
+      </mat-action-list>
+    </div>
 
-  <div *ngIf="showTdMarkdownLoader || showTdMarkdown" class="markdown-wrapper" #markdownWrapper>
-    <td-flavored-markdown-loader
-      *ngIf="showTdMarkdownLoader"
-      [url]="url"
-      [httpOptions]="httpOptions"
-      [anchor]="anchor"
-    ></td-flavored-markdown-loader>
+    <div *ngIf="showTdMarkdownLoader || showTdMarkdown" class="markdown-wrapper" #markdownWrapper>
+      <td-flavored-markdown-loader
+        *ngIf="showTdMarkdownLoader"
+        [url]="url"
+        [httpOptions]="httpOptions"
+        [anchor]="anchor"
+      ></td-flavored-markdown-loader>
 
-    <td-flavored-markdown
-      *ngIf="showTdMarkdown"
-      [content]="markdownString"
-      [hostedUrl]="url"
-      [anchor]="anchor"
-    ></td-flavored-markdown>
+      <td-flavored-markdown
+        *ngIf="showTdMarkdown"
+        [content]="markdownString"
+        [hostedUrl]="url"
+        [anchor]="anchor"
+      ></td-flavored-markdown>
+    </div>
   </div>
 </ng-container>
 

--- a/src/platform/markdown-navigator/markdown-navigator.component.scss
+++ b/src/platform/markdown-navigator/markdown-navigator.component.scss
@@ -6,8 +6,7 @@
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  .td-markdown-list,
-  .markdown-wrapper {
+  .scroll-area {
     min-height: 1px;
     overflow-y: auto;
     // flex

--- a/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
@@ -116,6 +116,26 @@ export const DEEPLY_NESTED_TREE: IMarkdownNavigatorItem[] = [
   },
 ];
 
+export const ITEMS_AT_SAME_LEVEL_AS_MARKDOWN: IMarkdownNavigatorItem[] = [
+  {
+    title: 'A',
+    markdownString: `
+    # Markdown
+
+    Litty
+    `,
+    children: [
+      {
+        title: 'A1',
+      },
+    ],
+  },
+  {
+    title: 'B',
+    markdownString: 'B',
+  },
+];
+
 async function wait(fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>): Promise<void> {
   fixture.detectChanges();
   await fixture.whenStable();
@@ -420,6 +440,34 @@ describe('MarkdownNavigatorComponent', () => {
     }),
   ));
 
+  it('should render list and markdown side by side', async(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> = TestBed.createComponent(
+        TdMarkdownNavigatorTestComponent,
+      );
+
+      fixture.componentInstance.items = ITEMS_AT_SAME_LEVEL_AS_MARKDOWN;
+      await wait(fixture);
+
+      const markdownNavigator: TdMarkdownNavigatorComponent = fixture.debugElement.query(
+        By.directive(TdMarkdownNavigatorComponent),
+      ).componentInstance;
+      const listItems: DebugElement[] = fixture.debugElement.queryAll(By.css('mat-action-list button'));
+
+      expect(markdownNavigator.showTdMarkdown).toBeFalsy();
+      expect(markdownNavigator.showTdMarkdownLoader).toBeFalsy();
+      expect(listItems.length).toBe(ITEMS_AT_SAME_LEVEL_AS_MARKDOWN.length);
+      expect(listItems[0].nativeElement.textContent).toContain(ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].title);
+      expect(listItems[1].nativeElement.textContent).toContain(ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[1].title);
+      getItem(fixture, 0).click();
+      await wait(fixture);
+      expect(markdownNavigator.showMenu).toBeTruthy();
+      expect(markdownNavigator.showTdMarkdown).toBeTruthy();
+      expect(getTitle(fixture)).toContain(ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].title);
+      expect(getMarkdown(fixture)).toContain('Markdown');
+    }),
+  ));
+
   it('should use default labels if labels is undefined', async(
     inject([], async () => {
       const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> = TestBed.createComponent(
@@ -576,7 +624,7 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.items = NESTED_MIXED_ITEMS;
       fixture.componentInstance.startAt = NESTED_MIXED_ITEMS[1];
       await wait(fixture);
-      expect(getMarkdown(fixture)).toContain('Heading');
+      expect(getTitle(fixture)).toContain(NESTED_MIXED_ITEMS[1].title);
     }),
   ));
 });

--- a/src/platform/markdown-navigator/markdown-navigator.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.ts
@@ -259,25 +259,8 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
 
   handleItemSelected(item: IMarkdownNavigatorItem): void {
     this.historyStack = [...this.historyStack, item];
-    if (
-      item.children &&
-      item.children.length === 1 &&
-      (!item.children[0].children || item.children[0].children.length === 0)
-    ) {
-      // clicked on item with one child that has no children
-      // don't show menu
-      this.currentMenuItems = [];
-      // render markdown
-      this.currentMarkdownItem = item.children[0];
-    } else if (item.children && item.children.length > 0) {
-      // has children, go inside
-      this.currentMenuItems = item.children;
-    } else {
-      // don't show menu
-      this.currentMenuItems = [];
-      // render markdown
-      this.currentMarkdownItem = item;
-    }
+    this.currentMenuItems = item.children;
+    this.currentMarkdownItem = item;
     this._changeDetectorRef.markForCheck();
   }
 


### PR DESCRIPTION
## Description

Render md and list at same level.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] View demo in http://localhost:4200/#/components/markdown-navigator/examples 

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="366" alt="Screen Shot 2020-03-27 at 11 58 12 AM" src="https://user-images.githubusercontent.com/7193975/77790537-41998300-7022-11ea-96f6-ecf2f2ebb85a.png">
