### PR TITLE
Feat/markdown nav dialog window

### DIFF
--- a/src/app/content/components/component-demos/dialogs/demos/dialogs-demo-draggable-resizable-window/dialogs-demo-draggable-resizable-window.component.html
+++ b/src/app/content/components/component-demos/dialogs/demos/dialogs-demo-draggable-resizable-window/dialogs-demo-draggable-resizable-window.component.html
@@ -1,0 +1,1 @@
+<button mat-button color="accent" (click)="openDraggableResizableWindowDialog()" class="text-upper push-right-sm">Open Draggable Resizable Window Dialog</button>

--- a/src/app/content/components/component-demos/dialogs/demos/dialogs-demo-draggable-resizable-window/dialogs-demo-draggable-resizable-window.component.ts
+++ b/src/app/content/components/component-demos/dialogs/demos/dialogs-demo-draggable-resizable-window/dialogs-demo-draggable-resizable-window.component.ts
@@ -1,0 +1,62 @@
+import { Component, Inject, Renderer2, Output, EventEmitter } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { DragRef } from '@angular/cdk/drag-drop';
+import { TdDialogService, IDraggableRefs, ResizableDraggableDialog } from '@covalent/core/dialogs';
+
+@Component({
+  selector: 'draggable-resizable-window-dialog',
+  template: `
+    <td-window-dialog
+      [title]="'Draggable resizable window dialog'"
+      [toolbarColor]="'accent'"
+      [closeLabel]="'Close'"
+      (closed)="closed.emit()"
+    >
+      <div [style.padding.em]="1">
+        <p>Comes with a handy toolbar</p>
+        <p>Draggable via the toolbar</p>
+        <p>Resizable via the corners</p>
+      </div>
+    </td-window-dialog>
+  `,
+})
+export class DraggableResizableWindowDialogComponent {
+  @Output() closed: EventEmitter<void> = new EventEmitter();
+}
+
+@Component({
+  selector: 'dialogs-demo-draggable-resizable-window',
+  styleUrls: ['./dialogs-demo-draggable-resizable-window.component.scss'],
+  templateUrl: './dialogs-demo-draggable-resizable-window.component.html',
+})
+export class DialogsDemoDraggableResizableWindowComponent {
+  constructor(
+    private _dialogService: TdDialogService,
+    @Inject(DOCUMENT) private _document: any,
+    private _renderer2: Renderer2,
+  ) {}
+
+  openDraggableResizableWindowDialog(): void {
+    const {
+      matDialogRef,
+      dragRefSubject,
+    }: IDraggableRefs<DraggableResizableWindowDialogComponent> = this._dialogService.openDraggable({
+      component: DraggableResizableWindowDialogComponent,
+      dragHandleSelectors: ['mat-toolbar'],
+      config: {
+        panelClass: ['td-window-dialog'], // pass this class in to ensure certain css is properly added
+      },
+    });
+
+    // listen to close event
+    matDialogRef.componentInstance.closed.subscribe(() => matDialogRef.close());
+
+    let resizableDraggableDialog: ResizableDraggableDialog;
+    dragRefSubject.subscribe((dragRf: DragRef) => {
+      resizableDraggableDialog = new ResizableDraggableDialog(this._document, this._renderer2, matDialogRef, dragRf);
+    });
+
+    // Detach resize-ability event listeners after dialog closes
+    matDialogRef.afterClosed().subscribe(() => resizableDraggableDialog.detach());
+  }
+}

--- a/src/app/content/components/component-demos/dialogs/demos/dialogs-demo.component.html
+++ b/src/app/content/components/component-demos/dialogs/demos/dialogs-demo.component.html
@@ -9,3 +9,7 @@
 <demo-component [demoId]="'dialogs-demo-draggable-resizable'" [demoTitle]="'Draggable And Resizable'">
   <dialogs-demo-draggable-resizable></dialogs-demo-draggable-resizable>
 </demo-component>
+
+<demo-component [demoId]="'dialogs-demo-draggable-resizable-window'" [demoTitle]="'Draggable Resizable Window Dialog'">
+  <dialogs-demo-draggable-resizable-window></dialogs-demo-draggable-resizable-window>
+</demo-component>

--- a/src/app/content/components/component-demos/dialogs/demos/dialogs-demo.module.ts
+++ b/src/app/content/components/component-demos/dialogs/demos/dialogs-demo.module.ts
@@ -15,6 +15,10 @@ import {
 import { DialogsDemoRoutingModule } from './dialogs-demo-routing.module';
 import { DemoModule } from '../../../../../components/shared/demo-tools/demo.module';
 import { DialogsDemoBasicSharedModule } from './dialogs-demo-basic/dialogs-demo-basic-shared';
+import {
+  DraggableResizableWindowDialogComponent,
+  DialogsDemoDraggableResizableWindowComponent,
+} from './dialogs-demo-draggable-resizable-window/dialogs-demo-draggable-resizable-window.component';
 
 @NgModule({
   declarations: [
@@ -23,6 +27,8 @@ import { DialogsDemoBasicSharedModule } from './dialogs-demo-basic/dialogs-demo-
     DraggableDialogComponent,
     DraggableResizableDialogComponent,
     DialogsDemoDraggableResizableComponent,
+    DraggableResizableWindowDialogComponent,
+    DialogsDemoDraggableResizableWindowComponent,
   ],
   imports: [
     DialogsDemoBasicSharedModule,

--- a/src/platform/core/dialogs/README.md
+++ b/src/platform/core/dialogs/README.md
@@ -134,3 +134,81 @@ export class MyModule {}
 After that, just inject [TdDialogService] and use it for your dialogs.
 
 
+# ResizableDraggableDialog
+
+A utility to make a draggable dialog resizable.
+
+## Usage
+```ts
+ constructor(
+    private _dialogService: TdDialogService,
+    @Inject(DOCUMENT) private _document: any,
+    private _renderer2: Renderer2,
+  ) {}
+```
+
+```ts
+const {
+  matDialogRef,
+  dragRefSubject,
+}: IDraggableRefs<DraggableResizableDialogComponent> = this._dialogService.openDraggable({
+  component: DraggableResizableDialogComponent,
+  // CSS selectors of element(s) inside the component meant to be drag handle(s)
+  dragHandleSelectors: ['.drag-handle'],
+});
+
+let resizableDraggableDialog: ResizableDraggableDialog;
+dragRefSubject.subscribe((dragRf: DragRef) => {
+  resizableDraggableDialog = new ResizableDraggableDialog(this._document, this._renderer2, matDialogRef, dragRf);
+});
+
+// Detach resize-ability event listeners after dialog closes
+matDialogRef.afterClosed().subscribe(() => resizableDraggableDialog.detach());
+```
+
+# TdWindowDialogComponent
+
+A component that can be utilized to create a dialog with a toolbar
+
+## API Summary
+
+#### Inputs
+
++ title: string
+  + Title that appears in toolbar
++ closeLabel: string
+  + Label to be used on close button
++ toolbarColor: ThemePalette
+  + Toolbar color
+
+#### Outputs
++ closed: string
+  + Emitted when close button is clicked
+
+## Usage
+
+```ts
+@Component({
+  template: `
+    <td-window-dialog
+      [title]="'Title'"
+      [toolbarColor]="'accent'"
+      [closeLabel]="'Close'"
+      (closed)="closed.emit()"
+    >
+      <p>Comes with a handy toolbar</p>
+    </td-window-dialog>
+  `,
+})
+export class DraggableResizableWindowDialogComponent {
+  @Output() closed: EventEmitter<void> = new EventEmitter();
+}
+```
+
+```ts
+const matDialogRef: MatDialogRef<DraggableResizableWindowDialogComponent> = this._dialogService.open(
+  DraggableResizableWindowDialogComponent,
+);
+// listen to close event
+matDialogRef.componentInstance.closed.subscribe(() => matDialogRef.close());
+```

--- a/src/platform/core/dialogs/dialogs.module.ts
+++ b/src/platform/core/dialogs/dialogs.module.ts
@@ -17,6 +17,10 @@ import { TdAlertDialogComponent } from './alert-dialog/alert-dialog.component';
 import { TdConfirmDialogComponent } from './confirm-dialog/confirm-dialog.component';
 import { TdPromptDialogComponent } from './prompt-dialog/prompt-dialog.component';
 import { TdDialogService } from './services/dialog.service';
+import { TdWindowDialogComponent } from './window-dialog/window-dialog.component';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatIconModule } from '@angular/material/icon';
 
 const TD_DIALOGS: Type<any>[] = [
   TdAlertDialogComponent,
@@ -26,6 +30,7 @@ const TD_DIALOGS: Type<any>[] = [
   TdDialogTitleDirective,
   TdDialogActionsDirective,
   TdDialogContentDirective,
+  TdWindowDialogComponent,
 ];
 
 const TD_DIALOGS_ENTRY_COMPONENTS: Type<any>[] = [
@@ -35,7 +40,17 @@ const TD_DIALOGS_ENTRY_COMPONENTS: Type<any>[] = [
 ];
 
 @NgModule({
-  imports: [FormsModule, CommonModule, MatDialogModule, MatInputModule, MatButtonModule],
+  imports: [
+    FormsModule,
+    CommonModule,
+    MatDialogModule,
+    MatInputModule,
+    MatButtonModule,
+
+    MatToolbarModule,
+    MatTooltipModule,
+    MatIconModule,
+  ],
   declarations: [TD_DIALOGS],
   exports: [TD_DIALOGS],
   providers: [TdDialogService],

--- a/src/platform/core/dialogs/window-dialog/window-dialog.component.html
+++ b/src/platform/core/dialogs/window-dialog/window-dialog.component.html
@@ -1,0 +1,33 @@
+<mat-toolbar
+  [color]="toolbarColor"
+  class="td-window-dialog-toolbar"
+  [style.min-height.px]="toolbarHeight"
+  [style.cursor]="docked ? 'inherit' : 'move'"
+>
+  <mat-toolbar-row [style.height.px]="toolbarHeight">
+    <div layout="row" layout-align="start center" flex>
+      <span class="mat-title td-window-dialog-title truncate" flex>
+        {{ title }}
+      </span>
+      <!-- TODO: Resizing a drag-and-drop element was not working so removed docking/undocking for now-->
+      <!-- <button mat-icon-button [matTooltip]="toggleDockedStateLabel" (click)="toggleDockedState()">
+        <mat-icon [attr.aria-label]="toggleDockedStateLabel">
+          {{ docked ? 'unfold_more' : 'unfold_less' }}
+        </mat-icon>
+      </button> -->
+
+      <button
+        mat-icon-button
+        [matTooltip]="closeLabel"
+        (click)="closed.emit()"
+        class="td-window-dialog-close"
+        [attr.data-test]="'close-button'"
+      >
+        <mat-icon [attr.aria-label]="closeLabel">
+          close
+        </mat-icon>
+      </button>
+    </div>
+  </mat-toolbar-row>
+</mat-toolbar>
+<ng-content></ng-content>

--- a/src/platform/core/dialogs/window-dialog/window-dialog.component.scss
+++ b/src/platform/core/dialogs/window-dialog/window-dialog.component.scss
@@ -1,0 +1,27 @@
+:host {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.td-window-dialog-title {
+  margin-bottom: 0;
+}
+
+.td-window-dialog-close {
+  margin-right: -8px;
+}
+
+::ng-deep {
+  .td-window-dialog {
+    .mat-dialog-container {
+      padding: 0;
+    }
+  }
+}

--- a/src/platform/core/dialogs/window-dialog/window-dialog.component.ts
+++ b/src/platform/core/dialogs/window-dialog/window-dialog.component.ts
@@ -1,0 +1,26 @@
+import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import { ThemePalette } from '@angular/material/core';
+
+@Component({
+  selector: 'td-window-dialog',
+  templateUrl: './window-dialog.component.html',
+  styleUrls: ['./window-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TdWindowDialogComponent {
+  @Input() toolbarColor: ThemePalette;
+  @Input() docked: boolean = false;
+
+  @Input() title: string;
+  @Input() toggleDockedStateLabel: string;
+  @Input() closeLabel: string;
+
+  @Output() dockToggled: EventEmitter<boolean> = new EventEmitter();
+  @Output() closed: EventEmitter<void> = new EventEmitter();
+
+  toolbarHeight: number = 56;
+
+  toggleDockedState(): void {
+    this.dockToggled.emit(this.docked);
+  }
+}

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.spec.ts
@@ -76,7 +76,7 @@ describe('MarkdownNavigatorWindowService', () => {
         expect(getMarkdownNavigator()).toBeTruthy();
         // tslint:disable-next-line:no-useless-cast
         (<HTMLElement>(
-          overlayContainerElement.querySelector(`td-markdown-navigator-window .td-markdown-navigator-window-close`)
+          overlayContainerElement.querySelector(`td-markdown-navigator-window .td-window-dialog-close`)
         )).click();
         await wait(fixture);
 
@@ -293,14 +293,13 @@ describe('MarkdownNavigatorWindowService', () => {
         await wait(fixture);
         await dialogRef.afterOpened().toPromise();
 
-        expect(overlayContainerElement.querySelector(`.td-draggable-markdown-navigator-window-wrapper`)).toBeTruthy();
+        expect(overlayContainerElement.querySelector(`.td-window-dialog`)).toBeTruthy();
         expect(
           overlayContainerElement.querySelector(`td-markdown-navigator-window.td-draggable-markdown-navigator-window`),
         ).toBeTruthy();
-        expect(
-          window.getComputedStyle(overlayContainerElement.querySelector(`.td-markdown-navigator-window-toolbar`))
-            .cursor,
-        ).toBe('move');
+        expect(window.getComputedStyle(overlayContainerElement.querySelector(`.td-window-dialog-toolbar`)).cursor).toBe(
+          'move',
+        );
 
         _markdownNavigatorWindowService.close();
         await wait(fixture);

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
@@ -19,7 +19,7 @@ export interface IMarkdownNavigatorWindowConfig {
   compareWith?: IMarkdownNavigatorCompareWith;
 }
 
-const CDK_OVERLAY_CUSTOM_CLASS: string = 'td-draggable-markdown-navigator-window-wrapper';
+const CDK_OVERLAY_CUSTOM_CLASS: string = 'td-window-dialog';
 
 const DEFAULT_POSITION: DialogPosition = { bottom: '0px', right: '0px' };
 const DEFAULT_WIDTH: string = '360px';
@@ -30,7 +30,7 @@ const MAX_WIDTH: string = '100vw';
 const DEFAULT_DRAGGABLE_DIALOG_CONFIG: MatDialogConfig = {
   hasBackdrop: false,
   closeOnNavigation: true,
-  panelClass: CDK_OVERLAY_CUSTOM_CLASS,
+  panelClass: [CDK_OVERLAY_CUSTOM_CLASS],
   position: DEFAULT_POSITION,
   height: DEFAULT_HEIGHT,
   width: DEFAULT_WIDTH,
@@ -61,9 +61,18 @@ export class TdMarkdownNavigatorWindowService {
   public open(config: IMarkdownNavigatorWindowConfig): MatDialogRef<TdMarkdownNavigatorWindowComponent> {
     this.close();
 
+    let panelClass: string[] = [...DEFAULT_DRAGGABLE_DIALOG_CONFIG.panelClass];
+    if (config.dialogConfig && config.dialogConfig.panelClass) {
+      if (Array.isArray(config.dialogConfig.panelClass)) {
+        panelClass = [...config.dialogConfig.panelClass];
+      } else {
+        panelClass = [config.dialogConfig.panelClass];
+      }
+    }
     const draggableConfig: MatDialogConfig = {
       ...DEFAULT_DRAGGABLE_DIALOG_CONFIG,
       ...config.dialogConfig,
+      panelClass,
     };
     const {
       matDialogRef,
@@ -71,7 +80,7 @@ export class TdMarkdownNavigatorWindowService {
     }: IDraggableRefs<TdMarkdownNavigatorWindowComponent> = this._tdDialogService.openDraggable({
       component: TdMarkdownNavigatorWindowComponent,
       config: draggableConfig,
-      dragHandleSelectors: ['.td-markdown-navigator-window-toolbar'],
+      dragHandleSelectors: ['.td-window-dialog-toolbar'],
       draggableClass: 'td-draggable-markdown-navigator-window',
     });
     this.markdownNavigatorWindowDialog = matDialogRef;

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.html
@@ -1,41 +1,17 @@
-<mat-toolbar
-  [color]="toolbarColor"
-  class="td-markdown-navigator-window-toolbar"
-  [style.min-height.px]="toolbarHeight"
-  [style.cursor]="docked ? 'inherit' : 'move'"
+<td-window-dialog
+  [toolbarColor]="toolbarColor"
+  [docked]="docked"
+  [title]="titleLabel"
+  [toggleDockedStateLabel]="toggleDockedStateLabel"
+  [closeLabel]="closeLabel"
+  (dockToggled)="toggleDockedState()"
+  (closed)="closed.emit()"
 >
-  <mat-toolbar-row [style.height.px]="toolbarHeight">
-    <div layout="row" layout-align="start center" flex>
-      <span class="mat-title td-markdown-navigator-window-title truncate" flex>
-        {{ titleLabel }}
-      </span>
-      <!-- TODO: Resizing a drag-and-drop element was not working so removed docking/undocking for now-->
-      <!--
-      <button mat-icon-button [matTooltip]="toggleDockedStateLabel" (click)="toggleDockedState()">
-        <mat-icon [attr.aria-label]="toggleDockedStateLabel">
-          {{ docked ? 'unfold_more' : 'unfold_less' }}
-        </mat-icon>
-      </button>
-      -->
-      <button
-        mat-icon-button
-        [matTooltip]="closeLabel"
-        (click)="closed.emit()"
-        class="td-markdown-navigator-window-close"
-        [attr.data-test]="'close-button'"
-      >
-        <mat-icon [attr.aria-label]="closeLabel">
-          close
-        </mat-icon>
-      </button>
-    </div>
-  </mat-toolbar-row>
-</mat-toolbar>
-
-<td-markdown-navigator
-  [items]="items"
-  [labels]="markdownNavigatorLabels"
-  [style.display]="docked ? 'none' : 'inherit'"
-  [startAt]="startAt"
-  [compareWith]="compareWith"
-></td-markdown-navigator>
+  <td-markdown-navigator
+    [items]="items"
+    [labels]="markdownNavigatorLabels"
+    [style.display]="docked ? 'none' : 'inherit'"
+    [startAt]="startAt"
+    [compareWith]="compareWith"
+  ></td-markdown-navigator>
+</td-window-dialog>

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.scss
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.scss
@@ -3,29 +3,6 @@
   display: flex;
   flex-direction: column;
 }
-
-.td-markdown-navigator-window-title {
-  margin-bottom: 0;
-}
-
 td-markdown-navigator {
   height: calc(100% - 56px); // account for toolbar height
-}
-
-.td-markdown-navigator-window-close {
-  margin: 0 -8px;
-}
-
-.truncate {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-::ng-deep {
-  .td-draggable-markdown-navigator-window-wrapper {
-    > .mat-dialog-container {
-      padding: 0;
-    }
-  }
 }

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.spec.ts
@@ -243,7 +243,7 @@ describe('MarkdownNavigatorWindowComponent', () => {
 
       spyOn(markdownNavigatorWindow.closed, 'emit');
 
-      const closeButton: DebugElement = fixture.debugElement.query(By.css('.td-markdown-navigator-window-close'));
+      const closeButton: DebugElement = fixture.debugElement.query(By.css('.td-window-dialog-close'));
       closeButton.nativeElement.click();
 
       await wait(fixture);

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
@@ -31,7 +31,6 @@ export class TdMarkdownNavigatorWindowComponent {
   @Input() toolbarColor: ThemePalette = 'primary';
   @Input() startAt: IMarkdownNavigatorItem;
   @Input() compareWith: IMarkdownNavigatorCompareWith;
-  toolbarHeight: number = 56;
   @Input() docked: boolean = false;
 
   @Output() closed: EventEmitter<void> = new EventEmitter();

--- a/src/platform/markdown-navigator/markdown-navigator.module.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.module.ts
@@ -8,7 +8,6 @@ import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
-import { MatToolbarModule } from '@angular/material/toolbar';
 import { CovalentDialogsModule } from '@covalent/core/dialogs';
 import { TdMarkdownNavigatorWindowDirective } from './markdown-navigator-window-directive/markdown-navigator-window.directive';
 import { TdMarkdownNavigatorWindowService } from './markdown-navigator-window-service/markdown-navigator-window.service';
@@ -23,7 +22,6 @@ import { TdMarkdownNavigatorWindowService } from './markdown-navigator-window-se
     MatListModule,
     MatIconModule,
     MatProgressBarModule,
-    MatToolbarModule,
 
     CovalentFlavoredMarkdownModule,
     CovalentDialogsModule,


### PR DESCRIPTION
## Description

- Created a `<td-window-dialog>` that will be able to be leveraged to create window-dialogs. Consumed within the markdown nav window service.

TODO: 
- Update documentation

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Verify http://localhost:4200/#/components/markdown-navigator/examples demo works as expected.
- [ ] Verify resizable window dialog demo works as expected http://localhost:4200/#/components/dialogs/examples

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
