### PR TITLE
Feat/markdown nav footer

### DIFF
--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-footer/markdown-navigator-demo-footer.component.html
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-footer/markdown-navigator-demo-footer.component.html
@@ -1,0 +1,3 @@
+<button mat-raised-button color="primary"  [tdMarkdownNavigatorWindow]="mdNavWindowConfig">
+  Open Markdown Navigator With Footer
+</button>

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-footer/markdown-navigator-demo-footer.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-footer/markdown-navigator-demo-footer.component.ts
@@ -1,0 +1,51 @@
+import { Component } from '@angular/core';
+import { IMarkdownNavigatorWindowConfig } from '@covalent/markdown-navigator';
+
+@Component({
+  selector: 'markdown-navigator-demo-footer-example-a',
+  template: `
+    <div [style.padding.em]="1">
+      <button mat-raised-button>
+        Launch space shuttle
+      </button>
+    </div>
+  `,
+})
+export class MarkdownNavigatorDemoFooterExampleAComponent {}
+
+@Component({
+  selector: 'markdown-navigator-demo-footer-example-b',
+  template: `
+    <div>
+      <h2 [style.padding-right.em]="0.5" [style.padding-left.em]="0.5">Learn more:</h2>
+      <mat-nav-list>
+        <a mat-list-item href="https://angular.io/" target="_blank">Angular</a>
+        <a mat-list-item href="https://rxjs-dev.firebaseapp.com/" target="_blank">RxJS</a>
+        <a mat-list-item href="https://material.angular.io/ " target="_blank">Angular Material</a>
+      </mat-nav-list>
+    </div>
+  `,
+})
+export class MarkdownNavigatorDemoFooterExampleBComponent {}
+
+@Component({
+  selector: 'markdown-navigator-demo-footer',
+  styleUrls: ['./markdown-navigator-demo-footer.component.scss'],
+  templateUrl: './markdown-navigator-demo-footer.component.html',
+})
+export class MarkdownNavigatorDemoFooterComponent {
+  mdNavWindowConfig: IMarkdownNavigatorWindowConfig = {
+    items: [
+      {
+        title: 'Button Footer',
+        markdownString: `With a button as a footer`,
+        footer: MarkdownNavigatorDemoFooterExampleAComponent,
+      },
+      {
+        title: 'Nav list footer',
+        markdownString: ` With a nav-list as a footer`,
+        footer: MarkdownNavigatorDemoFooterExampleBComponent,
+      },
+    ],
+  };
+}

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-footer/markdown-navigator-demo-footer.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-footer/markdown-navigator-demo-footer.component.ts
@@ -46,6 +46,12 @@ export class MarkdownNavigatorDemoFooterComponent {
         markdownString: ` With a nav-list as a footer`,
         footer: MarkdownNavigatorDemoFooterExampleBComponent,
       },
+      {
+        title: 'Global footer',
+        markdownString: `With a footer that was set at the top level`,
+        footer: MarkdownNavigatorDemoFooterExampleAComponent,
+      },
     ],
+    footer: MarkdownNavigatorDemoFooterExampleAComponent,
   };
 }

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
@@ -1,3 +1,7 @@
 <demo-component [demoId]="'markdown-navigator-demo-basic'" [demoTitle]="'Basic'">
     <markdown-navigator-demo-basic></markdown-navigator-demo-basic>
 </demo-component>
+
+<demo-component [demoId]="'markdown-navigator-demo-footer'">
+    <markdown-navigator-demo-footer></markdown-navigator-demo-footer>
+</demo-component>

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.module.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.module.ts
@@ -6,9 +6,21 @@ import { MarkdownNavigatorDemoComponent } from './markdown-navigator-demo.compon
 import { MarkdownNavigatorDemoRoutingModule } from './markdown-navigator-demo-routing.module';
 import { DemoModule } from '../../../../../components/shared/demo-tools/demo.module';
 import { MatButtonModule } from '@angular/material/button';
+import {
+  MarkdownNavigatorDemoFooterComponent,
+  MarkdownNavigatorDemoFooterExampleAComponent,
+  MarkdownNavigatorDemoFooterExampleBComponent,
+} from './markdown-navigator-demo-footer/markdown-navigator-demo-footer.component';
+import { MatListModule } from '@angular/material/list';
 
 @NgModule({
-  declarations: [MarkdownNavigatorDemoComponent, MarkdownNavigatorDemoBasicComponent],
+  declarations: [
+    MarkdownNavigatorDemoComponent,
+    MarkdownNavigatorDemoBasicComponent,
+    MarkdownNavigatorDemoFooterComponent,
+    MarkdownNavigatorDemoFooterExampleAComponent,
+    MarkdownNavigatorDemoFooterExampleBComponent,
+  ],
   imports: [
     DemoModule,
     MarkdownNavigatorDemoRoutingModule,
@@ -17,6 +29,7 @@ import { MatButtonModule } from '@angular/material/button';
     /** Angular Modules */
     CommonModule,
     MatButtonModule,
+    MatListModule,
   ],
 })
 export class MarkdownNavigatorDemoModule {}

--- a/src/platform/markdown-navigator/README.md
+++ b/src/platform/markdown-navigator/README.md
@@ -15,6 +15,8 @@ A component for rendering and navigating through markdown, such as documentation
 + compareWith?: IMarkdownNavigatorCompareWith
   + Function used to find startAt item
   + Defaults to comparison by strict equality (===)
++ footer:? Type<any>
+  + Custom component to be used as global footer
 
 For reference:
 
@@ -28,6 +30,7 @@ interface IMarkdownNavigatorItem {
   children?: IMarkdownNavigatorItem[];
   description?: string;
   icon?: string;
+  footer?: Type<any>;
 }
 ```
 
@@ -86,17 +89,14 @@ A component that contains a MarkdownNavigator component and a toolbar
 + toolbarColor?: ThemePalette
   + Toolbar color
   + Defaults to 'primary'
-+ docked?: boolean
-  + Whether docked or not.
-  + Defaults to false
++ footer:? Type<any>;
+  + Custom component to be used as global footer
+
 
 #### Outputs
 
 + closed: void
   + Event emitted when the close button is clicked.
-+ dockToggled: boolean
-  + Event emitted when the toggle dock state button is clicked.
-  + Emits current docked state.
 
 ## Setup
 
@@ -135,6 +135,7 @@ interface IMarkdownNavigatorWindowConfig {
   toolbarColor?: ThemePalette;
   startAt?: IMarkdownNavigatorItem;
   compareWith?: IMarkdownNavigatorCompareWith;
+  footer?: Type<any>;
 }
 ```
 

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, RendererFactory2, Renderer2 } from '@angular/core';
+import { Injectable, Inject, RendererFactory2, Renderer2, Type } from '@angular/core';
 import { MatDialogRef, MatDialogConfig, DialogPosition } from '@angular/material/dialog';
 import { ThemePalette } from '@angular/material/core';
 import {
@@ -17,6 +17,7 @@ export interface IMarkdownNavigatorWindowConfig {
   toolbarColor?: ThemePalette;
   startAt?: IMarkdownNavigatorItem;
   compareWith?: IMarkdownNavigatorCompareWith;
+  footer?: Type<any>;
 }
 
 const CDK_OVERLAY_CUSTOM_CLASS: string = 'td-window-dialog';
@@ -91,6 +92,7 @@ export class TdMarkdownNavigatorWindowService {
     this.markdownNavigatorWindowDialog.componentInstance.toolbarColor =
       'toolbarColor' in config ? config.toolbarColor : 'primary';
     this.markdownNavigatorWindowDialogsOpen++;
+    this.markdownNavigatorWindowDialog.componentInstance.footer = config.footer;
     dragRefSubject.subscribe((dragRf: DragRef) => {
       this.dragRef = dragRf;
       this.resizableDraggableDialog = new ResizableDraggableDialog(

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.html
@@ -13,5 +13,6 @@
     [style.display]="docked ? 'none' : 'inherit'"
     [startAt]="startAt"
     [compareWith]="compareWith"
+    [footer]="footer"
   ></td-markdown-navigator>
 </td-window-dialog>

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
@@ -1,4 +1,4 @@
-import { Component, Output, EventEmitter, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Output, EventEmitter, Input, ChangeDetectionStrategy, Type } from '@angular/core';
 import { ThemePalette } from '@angular/material/core';
 import {
   IMarkdownNavigatorItem,
@@ -32,6 +32,7 @@ export class TdMarkdownNavigatorWindowComponent {
   @Input() startAt: IMarkdownNavigatorItem;
   @Input() compareWith: IMarkdownNavigatorCompareWith;
   @Input() docked: boolean = false;
+  @Input() footer: Type<any>;
 
   @Output() closed: EventEmitter<void> = new EventEmitter();
   @Output() dockToggled: EventEmitter<boolean> = new EventEmitter();

--- a/src/platform/markdown-navigator/markdown-navigator.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator.component.html
@@ -72,6 +72,7 @@
         [anchor]="anchor"
       ></td-flavored-markdown>
     </div>
+    <ng-container *ngComponentOutlet="footer"></ng-container>
   </div>
 </ng-container>
 

--- a/src/platform/markdown-navigator/markdown-navigator.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator.component.html
@@ -72,7 +72,7 @@
         [anchor]="anchor"
       ></td-flavored-markdown>
     </div>
-    <ng-container *ngComponentOutlet="footer"></ng-container>
+    <ng-container *ngComponentOutlet="footerComponent"></ng-container>
   </div>
 </ng-container>
 

--- a/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
@@ -7,7 +7,7 @@ import {
   IMarkdownNavigatorCompareWith,
 } from './markdown-navigator.component';
 import { By } from '@angular/platform-browser';
-import { Component, DebugElement } from '@angular/core';
+import { Component, DebugElement, Type } from '@angular/core';
 import { CovalentMarkdownNavigatorModule } from './markdown-navigator.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -48,6 +48,34 @@ const NESTED_MIXED_ITEMS: IMarkdownNavigatorItem[] = [
   {
     title: 'Second item',
     children: RAW_MARKDOWN_ITEM,
+  },
+];
+
+@Component({
+  template: `
+    <div>
+      Footer A Content
+    </div>
+  `,
+})
+export class FooterAComponent {}
+
+@Component({
+  template: `
+    <div>
+      Global Footer Content
+    </div>
+  `,
+})
+export class GlobalFooterComponent {}
+
+const ITEMS_WITH_FOOTERS: IMarkdownNavigatorItem[] = [
+  {
+    markdownString: `Footer A`,
+    footer: FooterAComponent,
+  },
+  {
+    markdownString: `Global Footer`,
   },
 ];
 
@@ -250,6 +278,7 @@ async function validateTree(fixture: ComponentFixture<TdMarkdownNavigatorTestCom
       [labels]="labels"
       [startAt]="startAt"
       [compareWith]="compareWith"
+      [footer]="footer"
     ></td-markdown-navigator>
   `,
 })
@@ -258,6 +287,7 @@ class TdMarkdownNavigatorTestComponent {
   labels: IMarkdownNavigatorLabels;
   startAt: IMarkdownNavigatorItem;
   compareWith: IMarkdownNavigatorCompareWith;
+  footer: Type<any>;
 }
 
 describe('MarkdownNavigatorComponent', () => {
@@ -625,6 +655,37 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.startAt = NESTED_MIXED_ITEMS[1];
       await wait(fixture);
       expect(getTitle(fixture)).toContain(NESTED_MIXED_ITEMS[1].title);
+    }),
+  ));
+
+  it('should be able to render a custom component as a footer', async(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> = TestBed.createComponent(
+        TdMarkdownNavigatorTestComponent,
+      );
+
+      fixture.componentInstance.items = ITEMS_WITH_FOOTERS;
+      fixture.componentInstance.footer = GlobalFooterComponent;
+
+      await wait(fixture);
+
+      expect(fixture.nativeElement.textContent).toContain('Global Footer Content');
+
+      getItem(fixture, 0).click();
+
+      await wait(fixture);
+
+      expect(fixture.nativeElement.textContent).toContain('Footer A Content');
+
+      goBack(fixture);
+
+      await wait(fixture);
+
+      getItem(fixture, 1).click();
+
+      await wait(fixture);
+
+      expect(fixture.nativeElement.textContent).toContain('Global Footer Content');
     }),
   ));
 });

--- a/src/platform/markdown-navigator/markdown-navigator.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.ts
@@ -20,6 +20,7 @@ export interface IMarkdownNavigatorItem {
   children?: IMarkdownNavigatorItem[];
   description?: string;
   icon?: string;
+  footer?: any;
 }
 
 export interface IMarkdownNavigatorLabels {
@@ -170,6 +171,12 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
       return this.currentMarkdownItem.url;
     }
     return undefined;
+  }
+
+  get footer(): any {
+    if (this.currentMarkdownItem) {
+      return this.currentMarkdownItem.footer;
+    }
   }
   get httpOptions(): object {
     if (this.currentMarkdownItem) {

--- a/src/platform/markdown-navigator/markdown-navigator.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.ts
@@ -8,6 +8,7 @@ import {
   ElementRef,
   ChangeDetectorRef,
   ChangeDetectionStrategy,
+  Type,
 } from '@angular/core';
 import { removeLeadingHash, isAnchorLink, TdMarkdownLoaderService } from '@covalent/markdown';
 
@@ -20,7 +21,7 @@ export interface IMarkdownNavigatorItem {
   children?: IMarkdownNavigatorItem[];
   description?: string;
   icon?: string;
-  footer?: any;
+  footer?: Type<any>;
 }
 
 export interface IMarkdownNavigatorLabels {
@@ -114,6 +115,13 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
   @Input() startAt: IMarkdownNavigatorItem;
 
   /**
+   * footer?: Type<any>
+   *
+   * Component to be displayed in footer
+   */
+  @Input() footer: Type<any>;
+
+  /**
    * compareWith?: IMarkdownNavigatorCompareWith
    *
    * Function used to find startAt item
@@ -173,10 +181,11 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
     return undefined;
   }
 
-  get footer(): any {
-    if (this.currentMarkdownItem) {
+  get footerComponent(): any {
+    if (this.currentMarkdownItem && this.currentMarkdownItem.footer) {
       return this.currentMarkdownItem.footer;
     }
+    return this.footer;
   }
   get httpOptions(): object {
     if (this.currentMarkdownItem) {


### PR DESCRIPTION
## Description

Can inject footers into items. Works off of #1712 

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Verify http://localhost:4200/#/components/markdown-navigator/examples demo works

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![Screen Shot 2020-03-25 at 15 35 30](https://user-images.githubusercontent.com/7193975/77592004-6f5dbb00-6eae-11ea-9ca0-15b943b615a3.png)
![Screen Shot 2020-03-25 at 15 35 26](https://user-images.githubusercontent.com/7193975/77592010-71c01500-6eae-11ea-9511-83ef626a1d97.png)
