### PR TITLE
feat(flavored-markdown): render links  with special syntax as buttons

### DIFF
--- a/src/app/content/components/component-demos/flavored-markdown/demos/flavored-markdown-demo-buttons/flavored-markdown-demo-buttons.component.html
+++ b/src/app/content/components/component-demos/flavored-markdown/demos/flavored-markdown-demo-buttons/flavored-markdown-demo-buttons.component.html
@@ -1,0 +1,1 @@
+<td-flavored-markdown (buttonClicked)="handleButtonClicked($event)">{{ buttonsFlavoredMarkdown }}</td-flavored-markdown>

--- a/src/app/content/components/component-demos/flavored-markdown/demos/flavored-markdown-demo-buttons/flavored-markdown-demo-buttons.component.ts
+++ b/src/app/content/components/component-demos/flavored-markdown/demos/flavored-markdown-demo-buttons/flavored-markdown-demo-buttons.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { ITdFlavoredMarkdownButtonClickEvent } from '@covalent/flavored-markdown';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'flavored-markdown-demo-buttons',
+  styleUrls: ['./flavored-markdown-demo-buttons.component.scss'],
+  templateUrl: './flavored-markdown-demo-buttons.component.html',
+})
+export class FlavoredMarkdownDemoButtonsComponent {
+  buttonsFlavoredMarkdown: string = `
+    ## Buttons
+
+    [Go to Mars](#data={"planet": "mars"})
+    ---
+    [Go to Jupiter](#data={"planet": "Jupiter"})
+  `;
+
+  constructor(private _snackBar: MatSnackBar) {}
+
+  handleButtonClicked(data: ITdFlavoredMarkdownButtonClickEvent): void {
+    this._snackBar.open(`Button clicked: ${JSON.stringify(data)}`);
+  }
+}

--- a/src/app/content/components/component-demos/flavored-markdown/demos/flavored-markdown-demo.component.html
+++ b/src/app/content/components/component-demos/flavored-markdown/demos/flavored-markdown-demo.component.html
@@ -10,6 +10,10 @@
   <flavored-markdown-demo-tables></flavored-markdown-demo-tables>
 </demo-component>
 
+<demo-component [demoId]="'flavored-markdown-demo-buttons'" [demoTitle]="'Buttons'">
+  <flavored-markdown-demo-buttons></flavored-markdown-demo-buttons>
+</demo-component>
+
 <demo-component [demoId]="'flavored-markdown-demo-loader'" [demoTitle]="'Flavored Markdown Loader'">
   <flavored-markdown-demo-loader></flavored-markdown-demo-loader>
 </demo-component>

--- a/src/app/content/components/component-demos/flavored-markdown/demos/flavored-markdown-demo.module.ts
+++ b/src/app/content/components/component-demos/flavored-markdown/demos/flavored-markdown-demo.module.ts
@@ -8,6 +8,8 @@ import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { FlavoredMarkdownDemoComponent } from './flavored-markdown-demo.component';
 import { FlavoredMarkdownDemoRoutingModule } from './flavored-markdown-demo-routing.module';
 import { DemoModule } from '../../../../../components/shared/demo-tools/demo.module';
+import { FlavoredMarkdownDemoButtonsComponent } from './flavored-markdown-demo-buttons/flavored-markdown-demo-buttons.component';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 @NgModule({
   declarations: [
@@ -16,12 +18,14 @@ import { DemoModule } from '../../../../../components/shared/demo-tools/demo.mod
     FlavoredMarkdownDemoInlineComponent,
     FlavoredMarkdownDemoTablesComponent,
     FlavoredMarkdownDemoLoaderComponent,
+    FlavoredMarkdownDemoButtonsComponent,
   ],
   imports: [
     DemoModule,
     FlavoredMarkdownDemoRoutingModule,
     /** Covalent Modules */
     CovalentFlavoredMarkdownModule,
+    MatSnackBarModule,
     /** Angular Modules */
     CommonModule,
   ],

--- a/src/platform/flavored-markdown/flavored-markdown.module.ts
+++ b/src/platform/flavored-markdown/flavored-markdown.module.ts
@@ -9,9 +9,14 @@ import { CovalentHighlightModule, TdHighlightComponent } from '@covalent/highlig
 import { CovalentMarkdownModule, TdMarkdownComponent } from '@covalent/markdown';
 
 import { TdFlavoredListComponent } from './cfm-list/cfm-list.component';
-import { TdFlavoredMarkdownComponent, TdFlavoredMarkdownContainerDirective } from './flavored-markdown.component';
+import {
+  TdFlavoredMarkdownComponent,
+  TdFlavoredMarkdownContainerDirective,
+  TdFlavoredMarkdownButtonComponent,
+} from './flavored-markdown.component';
 import { TdFlavoredMarkdownLoaderComponent } from './flavored-markdown-loader/flavored-markdown-loader.component';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
   imports: [
@@ -22,12 +27,14 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
     CovalentDataTableModule,
     CovalentHighlightModule,
     CovalentMarkdownModule,
+    MatButtonModule,
   ],
   declarations: [
     TdFlavoredListComponent,
     TdFlavoredMarkdownComponent,
     TdFlavoredMarkdownContainerDirective,
     TdFlavoredMarkdownLoaderComponent,
+    TdFlavoredMarkdownButtonComponent,
   ],
   exports: [TdFlavoredMarkdownComponent, TdFlavoredMarkdownLoaderComponent],
 })

--- a/src/platform/flavored-markdown/flavored-markdown.spec.ts
+++ b/src/platform/flavored-markdown/flavored-markdown.spec.ts
@@ -1,7 +1,89 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed, async, ComponentFixture } from '@angular/core/testing';
+import { Component, Output, EventEmitter } from '@angular/core';
+import { CovalentFlavoredMarkdownModule } from './flavored-markdown.module';
+import { ITdFlavoredMarkdownButtonClickEvent } from './flavored-markdown.component';
 
-describe('Component: TdDynamicForms', () => {
-  it('', () => {
-    expect(true).toBeTruthy();
+@Component({
+  template: `
+    <td-flavored-markdown (buttonClicked)="buttonClicked.emit($event)">{{ markdown }}</td-flavored-markdown>
+  `,
+})
+class TdFlavoredMarkdownTestComponent {
+  markdown: string = '';
+  @Output() buttonClicked: EventEmitter<ITdFlavoredMarkdownButtonClickEvent> = new EventEmitter<
+    ITdFlavoredMarkdownButtonClickEvent
+  >();
+}
+
+describe('Component: TdFlavoredMarkdown should: ', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [CovalentFlavoredMarkdownModule],
+      declarations: [TdFlavoredMarkdownTestComponent],
+    });
+    TestBed.compileComponents();
+  }));
+
+  it('should render a special link as a button', async () => {
+    const fixture: ComponentFixture<TdFlavoredMarkdownTestComponent> = TestBed.createComponent(
+      TdFlavoredMarkdownTestComponent,
+    );
+    const element: HTMLElement = fixture.nativeElement;
+    fixture.componentInstance.markdown = `
+      [Open tour step 1](#data=step1)
+      [Open tour step 2](#data=step2)
+      `;
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(element.querySelector('.mat-button-base')).toBeTruthy();
+  });
+
+  it('should be able to listen to click events and grab data', async () => {
+    const fixture: ComponentFixture<TdFlavoredMarkdownTestComponent> = TestBed.createComponent(
+      TdFlavoredMarkdownTestComponent,
+    );
+    const element: HTMLElement = fixture.nativeElement;
+    const step1: ITdFlavoredMarkdownButtonClickEvent = {
+      text: 'Open tour step 1',
+      data: 'step1Data',
+    };
+    const step2: ITdFlavoredMarkdownButtonClickEvent = {
+      text: 'Open tour step 2',
+      data: 'step2Data',
+    };
+    fixture.componentInstance.markdown = `
+      [${step1.text}](#data=${step1.data})
+      [${step2.text}](#data=${step2.data})
+      `;
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const buttons: HTMLButtonElement[] = Array.from(element.querySelectorAll('button'));
+    let receivedData: ITdFlavoredMarkdownButtonClickEvent;
+
+    fixture.componentInstance.buttonClicked.subscribe((clickEvent: ITdFlavoredMarkdownButtonClickEvent) => {
+      receivedData = clickEvent;
+    });
+
+    buttons[0].click();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(receivedData).toEqual(step1);
+
+    buttons[1].click();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(receivedData).toEqual(step2);
   });
 });


### PR DESCRIPTION
## Description

- Converts links with special syntax into mat-raised-buttons
```
[This is a button](#data=whateverdatayouwant
[This is a button](#data=step_1)
[This is a button](#data={"planet": "Jupiter"})
```
- Added a demo
- Added some tests

### TODO

- Add documentation


#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] View example on http://localhost:4200/#/components/flavored-markdown/examples

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![Screen Shot 2020-03-26 at 15 11 56](https://user-images.githubusercontent.com/7193975/77702161-1efd6080-6f75-11ea-8463-931b83c2a608.png)
