### PR TITLE
feat(markdown-nav): expose button click events

### DIFF
--- a/src/app/content/components/component-demos/flavored-markdown/demos/flavored-markdown-demo-buttons/flavored-markdown-demo-buttons.component.ts
+++ b/src/app/content/components/component-demos/flavored-markdown/demos/flavored-markdown-demo-buttons/flavored-markdown-demo-buttons.component.ts
@@ -19,6 +19,6 @@ export class FlavoredMarkdownDemoButtonsComponent {
   constructor(private _snackBar: MatSnackBar) {}
 
   handleButtonClicked(data: ITdFlavoredMarkdownButtonClickEvent): void {
-    this._snackBar.open(`Button clicked: ${JSON.stringify(data)}`);
+    this._snackBar.open(`Button clicked: ${JSON.stringify(data)}`, undefined, { duration: 2000 });
   }
 }

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-events/markdown-navigator-demo-events.component.html
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-events/markdown-navigator-demo-events.component.html
@@ -1,0 +1,3 @@
+<button mat-raised-button color="primary" (click)="openDialog()">
+  Open
+</button>

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-events/markdown-navigator-demo-events.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-events/markdown-navigator-demo-events.component.ts
@@ -28,7 +28,7 @@ export class MarkdownNavigatorDemoEventsComponent {
       ],
     });
     dialogRef.componentInstance.buttonClicked.subscribe((data: ITdFlavoredMarkdownButtonClickEvent) =>
-      this._snackBar.open(`Button clicked: ${JSON.stringify(data)}`),
+      this._snackBar.open(`Button clicked: ${JSON.stringify(data)}`, undefined, { duration: 2000 }),
     );
   }
 }

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-events/markdown-navigator-demo-events.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-events/markdown-navigator-demo-events.component.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { TdMarkdownNavigatorWindowService, TdMarkdownNavigatorWindowComponent } from '@covalent/markdown-navigator';
+import { MatDialogRef } from '@angular/material/dialog';
+import { ITdFlavoredMarkdownButtonClickEvent } from '@covalent/flavored-markdown';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'markdown-navigator-demo-events',
+  styleUrls: ['./markdown-navigator-demo-events.component.scss'],
+  templateUrl: './markdown-navigator-demo-events.component.html',
+})
+export class MarkdownNavigatorDemoEventsComponent {
+  constructor(
+    private _markdownNavigatorWindowService: TdMarkdownNavigatorWindowService,
+    private _snackBar: MatSnackBar,
+  ) {}
+  openDialog(): void {
+    const dialogRef: MatDialogRef<TdMarkdownNavigatorWindowComponent> = this._markdownNavigatorWindowService.open({
+      items: [
+        {
+          title: 'Mars',
+          markdownString: `[Go to Mars](#data={"planet": "mars"})`,
+        },
+        {
+          title: 'Jupiter',
+          markdownString: `[Go to Jupiter](#data={"planet": "Jupiter"})`,
+        },
+      ],
+    });
+    dialogRef.componentInstance.buttonClicked.subscribe((data: ITdFlavoredMarkdownButtonClickEvent) =>
+      this._snackBar.open(`Button clicked: ${JSON.stringify(data)}`),
+    );
+  }
+}

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
@@ -5,3 +5,7 @@
 <demo-component [demoId]="'markdown-navigator-demo-footer'">
     <markdown-navigator-demo-footer></markdown-navigator-demo-footer>
 </demo-component>
+
+<demo-component [demoId]="'markdown-navigator-demo-events'">
+    <markdown-navigator-demo-events></markdown-navigator-demo-events>
+</demo-component>

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.module.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.module.ts
@@ -12,6 +12,7 @@ import {
   MarkdownNavigatorDemoFooterExampleBComponent,
 } from './markdown-navigator-demo-footer/markdown-navigator-demo-footer.component';
 import { MatListModule } from '@angular/material/list';
+import { MarkdownNavigatorDemoEventsComponent } from './markdown-navigator-demo-events/markdown-navigator-demo-events.component';
 
 @NgModule({
   declarations: [
@@ -20,6 +21,7 @@ import { MatListModule } from '@angular/material/list';
     MarkdownNavigatorDemoFooterComponent,
     MarkdownNavigatorDemoFooterExampleAComponent,
     MarkdownNavigatorDemoFooterExampleBComponent,
+    MarkdownNavigatorDemoEventsComponent,
   ],
   imports: [
     DemoModule,

--- a/src/platform/flavored-markdown/README.md
+++ b/src/platform/flavored-markdown/README.md
@@ -21,6 +21,11 @@ This component uses `<td-markdown>` to render the markdown. See `<td-markdown>`'
 + anchor?: string
   + Anchor to jump to.
 
+#### Outputs
+
++ buttonClicked: ITdFlavoredMarkdownButtonClickEvent
+  + Emitted when a button is clicked
+
 #### Events
 
 + contentReady: undefined
@@ -112,6 +117,11 @@ A component that fetches markdown from a GitHub url and renders it using `<td-fl
 
 + anchor?: string
   + Anchor to jump to.
+
+#### Outputs
+
++ buttonClicked: ITdFlavoredMarkdownButtonClickEvent
+  + Emitted when a button is clicked
 
 #### Events
 

--- a/src/platform/flavored-markdown/flavored-markdown-loader/flavored-markdown-loader.component.html
+++ b/src/platform/flavored-markdown/flavored-markdown-loader/flavored-markdown-loader.component.html
@@ -11,4 +11,5 @@
   [hostedUrl]="url"
   [anchor]="anchor"
   (contentReady)="contentReady.emit()"
+  (buttonClicked)="buttonClicked.emit($event)"
 ></td-flavored-markdown>

--- a/src/platform/flavored-markdown/flavored-markdown-loader/flavored-markdown-loader.component.ts
+++ b/src/platform/flavored-markdown/flavored-markdown-loader/flavored-markdown-loader.component.ts
@@ -9,6 +9,7 @@ import {
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { TdMarkdownLoaderService } from '@covalent/markdown';
+import { ITdFlavoredMarkdownButtonClickEvent } from '../flavored-markdown.component';
 
 // TODO: make a td-markdown-loader component
 
@@ -48,6 +49,8 @@ export class TdFlavoredMarkdownLoaderComponent implements OnChanges {
    * Emitted when loading of markdown file fails.
    */
   @Output() loadFailed: EventEmitter<Error> = new EventEmitter();
+
+  @Output() buttonClicked: EventEmitter<ITdFlavoredMarkdownButtonClickEvent> = new EventEmitter();
 
   content: string;
   loading: boolean = true;

--- a/src/platform/markdown-navigator/README.md
+++ b/src/platform/markdown-navigator/README.md
@@ -18,6 +18,11 @@ A component for rendering and navigating through markdown, such as documentation
 + footer:? Type<any>
   + Custom component to be used as global footer
 
+#### Outputs
+
++ buttonClicked: ITdFlavoredMarkdownButtonClickEvent
+  + Emitted when a button is clicked
+
 For reference:
 
 ```typescript
@@ -97,6 +102,8 @@ A component that contains a MarkdownNavigator component and a toolbar
 
 + closed: void
   + Event emitted when the close button is clicked.
++ buttonClicked: ITdFlavoredMarkdownButtonClickEvent
+  + Emitted when a button is clicked
 
 ## Setup
 

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.spec.ts
@@ -11,6 +11,7 @@ import {
   IMarkdownNavigatorWindowLabels,
 } from '../markdown-navigator-window/markdown-navigator-window.component';
 import { DEEPLY_NESTED_TREE, compareByTitle } from '../markdown-navigator.component.spec';
+import { ITdFlavoredMarkdownButtonClickEvent } from '@covalent/flavored-markdown';
 
 const RAW_MARKDOWN_HEADING: string = 'Heading';
 const RAW_MARKDOWN: string = `# ${RAW_MARKDOWN_HEADING}`;
@@ -326,6 +327,42 @@ describe('MarkdownNavigatorWindowService', () => {
         await wait(fixture);
         expect(overlayContainerElement.querySelectorAll(`td-markdown-navigator`).length).toBe(1);
         expect(_markdownNavigatorWindowService.isOpen).toBeTruthy();
+        _markdownNavigatorWindowService.close();
+      },
+    ),
+  ));
+  it('should be able to listen to markdown button events', async(
+    inject(
+      [TdMarkdownNavigatorWindowService],
+      async (_markdownNavigatorWindowService: TdMarkdownNavigatorWindowService) => {
+        const fixture: ComponentFixture<TestComponent> = TestBed.createComponent(TestComponent);
+
+        const marsButtonEvent: ITdFlavoredMarkdownButtonClickEvent = {
+          text: 'Got to Mars',
+          data: '{"oribital_speed": "24.007 km/s"}',
+        };
+        const dialogRef: MatDialogRef<TdMarkdownNavigatorWindowComponent> = _markdownNavigatorWindowService.open({
+          items: [
+            {
+              title: 'Mars',
+              markdownString: ` [${marsButtonEvent.text}](#data=${marsButtonEvent.data})`,
+            },
+          ],
+        });
+
+        let event: ITdFlavoredMarkdownButtonClickEvent;
+        dialogRef.componentInstance.buttonClicked.subscribe((data: ITdFlavoredMarkdownButtonClickEvent) => {
+          event = data;
+        });
+
+        await wait(fixture);
+
+        const button: HTMLElement = document.querySelector('td-markdown-navigator button');
+        button.click();
+
+        await wait(fixture);
+
+        expect(event).toEqual(marsButtonEvent);
         _markdownNavigatorWindowService.close();
       },
     ),

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.html
@@ -14,5 +14,6 @@
     [startAt]="startAt"
     [compareWith]="compareWith"
     [footer]="footer"
+    (buttonClicked)="buttonClicked.emit($event)"
   ></td-markdown-navigator>
 </td-window-dialog>

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
@@ -5,6 +5,7 @@ import {
   IMarkdownNavigatorLabels,
   IMarkdownNavigatorCompareWith,
 } from '../markdown-navigator.component';
+import { ITdFlavoredMarkdownButtonClickEvent } from '@covalent/flavored-markdown';
 
 export interface IMarkdownNavigatorWindowLabels extends IMarkdownNavigatorLabels {
   title?: string;
@@ -36,6 +37,7 @@ export class TdMarkdownNavigatorWindowComponent {
 
   @Output() closed: EventEmitter<void> = new EventEmitter();
   @Output() dockToggled: EventEmitter<boolean> = new EventEmitter();
+  @Output() buttonClicked: EventEmitter<ITdFlavoredMarkdownButtonClickEvent> = new EventEmitter();
 
   get markdownNavigatorLabels(): IMarkdownNavigatorLabels {
     if (this.labels) {

--- a/src/platform/markdown-navigator/markdown-navigator.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator.component.html
@@ -70,6 +70,7 @@
         [content]="markdownString"
         [hostedUrl]="url"
         [anchor]="anchor"
+        (buttonClicked)="buttonClicked.emit($event)"
       ></td-flavored-markdown>
     </div>
     <ng-container *ngComponentOutlet="footerComponent"></ng-container>

--- a/src/platform/markdown-navigator/markdown-navigator.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.ts
@@ -9,8 +9,11 @@ import {
   ChangeDetectorRef,
   ChangeDetectionStrategy,
   Type,
+  Output,
+  EventEmitter,
 } from '@angular/core';
 import { removeLeadingHash, isAnchorLink, TdMarkdownLoaderService } from '@covalent/markdown';
+import { ITdFlavoredMarkdownButtonClickEvent } from '@covalent/flavored-markdown';
 
 export interface IMarkdownNavigatorItem {
   title?: string;
@@ -128,6 +131,8 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
    * Defaults to comparison by strict equality (===)
    */
   @Input() compareWith: IMarkdownNavigatorCompareWith;
+
+  @Output() buttonClicked: EventEmitter<ITdFlavoredMarkdownButtonClickEvent> = new EventEmitter();
 
   @ViewChild('markdownWrapper') markdownWrapper: ElementRef;
 


### PR DESCRIPTION
## Description

- Exposes button click events
- Adds a test


#### Test Steps
<!-- Add instructions on how to test your changes -->
- View events demo on http://localhost:4200/#/components/markdown-navigator/examples

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
