### PR TITLE
feat(markdown-nav): add children url property

### DIFF
--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-children-url/markdown-navigator-demo-children-url.component.html
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-children-url/markdown-navigator-demo-children-url.component.html
@@ -1,0 +1,1 @@
+<td-markdown-navigator [items]="items"></td-markdown-navigator>

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-children-url/markdown-navigator-demo-children-url.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-children-url/markdown-navigator-demo-children-url.component.ts
@@ -10,7 +10,7 @@ export class MarkdownNavigatorDemoChildrenUrlComponent {
   items: IMarkdownNavigatorItem[] = [
     {
       title: '🔥',
-      childrenUrl: 'https://api.myjson.com/bins/aqnfk',
+      childrenUrl: '/assets/demos-data/children_url.json',
     },
   ];
 }

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-children-url/markdown-navigator-demo-children-url.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-children-url/markdown-navigator-demo-children-url.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { IMarkdownNavigatorItem } from '@covalent/markdown-navigator';
+
+@Component({
+  selector: 'markdown-navigator-demo-children-url',
+  styleUrls: ['./markdown-navigator-demo-children-url.component.scss'],
+  templateUrl: './markdown-navigator-demo-children-url.component.html',
+})
+export class MarkdownNavigatorDemoChildrenUrlComponent {
+  items: IMarkdownNavigatorItem[] = [
+    {
+      title: '🔥',
+      childrenUrl: 'https://api.myjson.com/bins/aqnfk',
+    },
+  ];
+}

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
@@ -9,3 +9,7 @@
 <demo-component [demoId]="'markdown-navigator-demo-events'">
     <markdown-navigator-demo-events></markdown-navigator-demo-events>
 </demo-component>
+
+<demo-component [demoId]="'markdown-navigator-demo-children-url'">
+    <markdown-navigator-demo-children-url></markdown-navigator-demo-children-url>
+</demo-component>

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.module.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.module.ts
@@ -13,6 +13,7 @@ import {
 } from './markdown-navigator-demo-footer/markdown-navigator-demo-footer.component';
 import { MatListModule } from '@angular/material/list';
 import { MarkdownNavigatorDemoEventsComponent } from './markdown-navigator-demo-events/markdown-navigator-demo-events.component';
+import { MarkdownNavigatorDemoChildrenUrlComponent } from './markdown-navigator-demo-children-url/markdown-navigator-demo-children-url.component';
 
 @NgModule({
   declarations: [
@@ -22,6 +23,7 @@ import { MarkdownNavigatorDemoEventsComponent } from './markdown-navigator-demo-
     MarkdownNavigatorDemoFooterExampleAComponent,
     MarkdownNavigatorDemoFooterExampleBComponent,
     MarkdownNavigatorDemoEventsComponent,
+    MarkdownNavigatorDemoChildrenUrlComponent,
   ],
   imports: [
     DemoModule,

--- a/src/assets/demos-data/children_url.json
+++ b/src/assets/demos-data/children_url.json
@@ -1,0 +1,10 @@
+[
+  {
+    "title": "MIB",
+    "markdownString": "> Yes siiiiirrrr"
+  },
+  {
+    "title": "Sake",
+    "markdownString": "> Yes siiiiirrrr"
+  }
+]

--- a/src/platform/markdown-navigator/README.md
+++ b/src/platform/markdown-navigator/README.md
@@ -33,6 +33,7 @@ interface IMarkdownNavigatorItem {
   markdownString?: string; // raw markdown
   anchor?: string;
   children?: IMarkdownNavigatorItem[];
+  childrenUrl?: string;
   description?: string;
   icon?: string;
   footer?: Type<any>;

--- a/src/platform/markdown-navigator/markdown-navigator.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator.component.html
@@ -35,6 +35,13 @@
   </ng-container>
 
   <div class="scroll-area">
+    <td-message
+      *ngIf="childrenUrlError"
+      [sublabel]="childrenUrlError"
+      color="warn"
+      icon="error"
+      [attr.data-test]="'children-url-error'"
+    ></td-message>
     <div *ngIf="showMenu" class="td-markdown-list">
       <mat-action-list>
         <button
@@ -58,11 +65,19 @@
     </div>
 
     <div *ngIf="showTdMarkdownLoader || showTdMarkdown" class="markdown-wrapper" #markdownWrapper>
+      <td-message
+        *ngIf="markdownLoaderError"
+        [sublabel]="markdownLoaderError"
+        color="warn"
+        icon="error"
+        [attr.data-test]="'markdown-loader-error'"
+      ></td-message>
       <td-flavored-markdown-loader
         *ngIf="showTdMarkdownLoader"
         [url]="url"
         [httpOptions]="httpOptions"
         [anchor]="anchor"
+        (loadFailed)="handleMarkdownLoaderError($event)"
       ></td-flavored-markdown-loader>
 
       <td-flavored-markdown
@@ -77,7 +92,7 @@
   </div>
 </ng-container>
 
-<div *ngIf="showEmptyState" layout="column" layout-align="center center" class=" empty-state">
+<div *ngIf="showEmptyState" layout="column" layout-align="center center" class="empty-state">
   <mat-icon matListAvatar>subject</mat-icon>
   <h2>{{ emptyStateLabel }}</h2>
 </div>

--- a/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.spec.ts
@@ -414,6 +414,98 @@ describe('MarkdownNavigatorComponent', () => {
     }),
   ));
 
+  it('should show proper error messages', async(
+    inject([], async () => {
+      const invalidMarkdownUrl: string = 'https://invalid_markdown_url.com';
+      const invalidChildrenUrl: string = 'https://invalid_children_url.com';
+      const ITEMS_WITH_ERRORS: IMarkdownNavigatorItem[] = [
+        {
+          title: 'Invalid markdown url',
+          url: invalidMarkdownUrl,
+          children: [
+            {
+              title: 'Invalid children url',
+              childrenUrl: invalidChildrenUrl,
+            },
+          ],
+        },
+        { title: 'Invalid markdown and children url', url: invalidMarkdownUrl, childrenUrl: invalidChildrenUrl },
+      ];
+      const invalidMarkdownUrlOptions: object = { status: 404, statusText: 'Not Found' };
+      const message: string = 'Failed :(';
+      function getMarkdownLoaderError(): HTMLElement {
+        return (fixture.debugElement.query(By.css('[data-test="markdown-loader-error"]')) || {}).nativeElement;
+      }
+      function getChildrenUrlError(): HTMLElement {
+        return (fixture.debugElement.query(By.css('[data-test="children-url-error"]')) || {}).nativeElement;
+      }
+
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> = TestBed.createComponent(
+        TdMarkdownNavigatorTestComponent,
+      );
+      fixture.componentInstance.items = ITEMS_WITH_ERRORS;
+
+      await wait(fixture);
+      getItem(fixture, 0).click();
+      await wait(fixture);
+
+      const invalidMarkdownUrlRequest: TestRequest = httpTestingController.expectOne(invalidMarkdownUrl);
+      invalidMarkdownUrlRequest.flush(message, invalidMarkdownUrlOptions);
+
+      await wait(fixture);
+      await wait(fixture);
+      await wait(fixture);
+
+      expect(getMarkdownLoaderError()).toBeTruthy();
+      expect(getMarkdownLoaderError().textContent).toContain('Not Found');
+
+      getItem(fixture, 0).click();
+      const invalidChildrenUrlRequest: TestRequest = httpTestingController.expectOne(invalidChildrenUrl);
+      invalidChildrenUrlRequest.flush(message, invalidMarkdownUrlOptions);
+
+      await wait(fixture);
+      await wait(fixture);
+      await wait(fixture);
+
+      expect(getMarkdownLoaderError()).toBeFalsy();
+      expect(getChildrenUrlError()).toBeTruthy();
+      goBack(fixture);
+
+      const invalidMarkdownUrlRequest2: TestRequest = httpTestingController.expectOne(invalidMarkdownUrl);
+      invalidMarkdownUrlRequest2.flush(message, invalidMarkdownUrlOptions);
+
+      await wait(fixture);
+      await wait(fixture);
+      await wait(fixture);
+
+      expect(getMarkdownLoaderError()).toBeTruthy();
+      expect(getChildrenUrlError()).toBeFalsy();
+
+      goBack(fixture);
+      getItem(fixture, 1).click();
+      await wait(fixture);
+
+      const invalidMarkdownUrlRequest3: TestRequest = httpTestingController.expectOne(invalidMarkdownUrl);
+      invalidMarkdownUrlRequest3.flush(message, invalidMarkdownUrlOptions);
+      const invalidChildrenUrlRequest2: TestRequest = httpTestingController.expectOne(invalidChildrenUrl);
+      invalidChildrenUrlRequest2.flush(message, invalidMarkdownUrlOptions);
+
+      await wait(fixture);
+      await wait(fixture);
+      await wait(fixture);
+
+      expect(getMarkdownLoaderError()).toBeTruthy();
+      expect(getChildrenUrlError()).toBeTruthy();
+
+      goBack(fixture);
+
+      expect(getMarkdownLoaderError()).toBeFalsy();
+      expect(getChildrenUrlError()).toBeFalsy();
+
+      httpTestingController.verify();
+    }),
+  ));
+
   it('should render one url item from GitHub', async(
     inject([], async () => {
       const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> = TestBed.createComponent(

--- a/src/platform/markdown-navigator/markdown-navigator.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.ts
@@ -274,8 +274,8 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
     if (this.historyStack.length > 1) {
       const parent: IMarkdownNavigatorItem = this.historyStack[this.historyStack.length - 2];
       this.currentMarkdownItem = parent;
-      this.setChildrenAsCurrentMenuItems(parent);
       this.historyStack = this.historyStack.slice(0, -1);
+      this.setChildrenAsCurrentMenuItems(parent);
     } else {
       // one level down just go to root
       this.reset();
@@ -284,9 +284,9 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
   }
 
   handleItemSelected(item: IMarkdownNavigatorItem): void {
+    this.currentMarkdownItem = item;
     this.historyStack = [...this.historyStack, item];
     this.setChildrenAsCurrentMenuItems(item);
-    this.currentMarkdownItem = item;
     this._changeDetectorRef.markForCheck();
   }
 
@@ -295,14 +295,18 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
     this.loading = true;
     this._changeDetectorRef.markForCheck();
 
-    const itemToVerifyWith: IMarkdownNavigatorItem = this.historyStack[0];
+    const stackSnapshot: IMarkdownNavigatorItem[] = this.historyStack;
     let children: IMarkdownNavigatorItem[] = [];
     if (item.children) {
       children = item.children;
     } else if (item.childrenUrl) {
       children = await this.loadChildrenUrl(item);
     }
-    if (this.historyStack[0] === itemToVerifyWith) {
+    const newStackSnapshot: IMarkdownNavigatorItem[] = this.historyStack;
+    if (
+      stackSnapshot.length === newStackSnapshot.length &&
+      stackSnapshot.every((stackItem: IMarkdownNavigatorItem, index: number) => stackItem === newStackSnapshot[index])
+    ) {
       this.currentMenuItems = children;
     }
 

--- a/src/platform/markdown-navigator/markdown-navigator.module.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.module.ts
@@ -9,6 +9,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { CovalentDialogsModule } from '@covalent/core/dialogs';
+import { CovalentMessageModule } from '@covalent/core/message';
 import { TdMarkdownNavigatorWindowDirective } from './markdown-navigator-window-directive/markdown-navigator-window.directive';
 import { TdMarkdownNavigatorWindowService } from './markdown-navigator-window-service/markdown-navigator-window.service';
 
@@ -22,7 +23,7 @@ import { TdMarkdownNavigatorWindowService } from './markdown-navigator-window-se
     MatListModule,
     MatIconModule,
     MatProgressBarModule,
-
+    CovalentMessageModule,
     CovalentFlavoredMarkdownModule,
     CovalentDialogsModule,
   ],


### PR DESCRIPTION
## Description

Adds childrenUrl property to IMarkdownNavigatorItem to enable fetching a remote list of children.
Addresses #1721 
#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] Verify children url demo on http://localhost:4200/#/components/markdown-navigator/examples works as expected

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
