### PR TITLE
fix(dialogs): disable user selection for draggable dialogs

### DIFF
--- a/src/platform/core/dialogs/resizable-draggable-dialog/resizable-draggable-dialog.ts
+++ b/src/platform/core/dialogs/resizable-draggable-dialog/resizable-draggable-dialog.ts
@@ -157,6 +157,7 @@ export class ResizableDraggableDialog {
   }
 
   private _handleMouseDown(event: PointerEvent, corner: corners): void {
+    this._renderer2.setStyle(<HTMLElement>this._document.body, 'user-select', 'none');
     const { width: originalWidth, height: originalHeight } = this._getDialogWrapperDimensions();
     const originalMouseX: number = event.pageX;
     const originalMouseY: number = event.pageY;
@@ -217,6 +218,7 @@ export class ResizableDraggableDialog {
       fromEvent(window, 'pointerup'),
       fromEvent(window, 'pointercancel'),
     ).subscribe(() => {
+      this._renderer2.removeStyle(<HTMLElement>this._document.body, 'user-select');
       mouseMoveSub.unsubscribe();
       mouseUpSub.unsubscribe();
     });


### PR DESCRIPTION
## Description
User should not be able select the dialog content while resizing or for draggable dialogs.

### What's included?
<!-- List features included in this PR -->
- user selection is disabled while dialog resizing.
- user selection is disabled for draggable dialogs.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then go to components
- [ ] finally go to dialogs.
- [ ] try any draggable dialog examples.
- [ ] dialog content should not be selected.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
