### PR TITLE
fix(): update json-formatter.component.ts

### DIFF
--- a/src/platform/core/json-formatter/json-formatter.component.ts
+++ b/src/platform/core/json-formatter/json-formatter.component.ts
@@ -212,10 +212,7 @@ export class TdJsonFormatterComponent {
 
   private parseChildren(): void {
     if (this.isObject()) {
-      this._children = [];
-      for (const key of Object.keys(this._data)) {
-        this._children.push(key);
-      }
+      this._children = Object.keys(this._data);
     }
   }
 }


### PR DESCRIPTION
## Description
Helping the child parser not do double the work.

Part of an investigation to the formatter not being able to handle large files

### What's included?
- Improved parseChildren function

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
