### PR TITLE
fix(loading): added missing entry components

### DIFF
--- a/src/platform/core/dialogs/dialogs.module.ts
+++ b/src/platform/core/dialogs/dialogs.module.ts
@@ -53,6 +53,7 @@ const TD_DIALOGS_ENTRY_COMPONENTS: Type<any>[] = [
   ],
   declarations: [TD_DIALOGS],
   exports: [TD_DIALOGS],
+  entryComponents: [TD_DIALOGS_ENTRY_COMPONENTS],
   providers: [TdDialogService],
 })
 export class CovalentDialogsModule {}

--- a/src/platform/core/loading/loading.module.ts
+++ b/src/platform/core/loading/loading.module.ts
@@ -20,6 +20,7 @@ const TD_LOADING_ENTRY_COMPONENTS: Type<any>[] = [TdLoadingComponent];
   imports: [CommonModule, MatProgressBarModule, MatProgressSpinnerModule, OverlayModule, PortalModule],
   declarations: [TD_LOADING],
   exports: [TD_LOADING],
+  entryComponents: [TD_LOADING_ENTRY_COMPONENTS],
   providers: [LOADING_FACTORY_PROVIDER, LOADING_PROVIDER],
 })
 export class CovalentLoadingModule {}

--- a/src/platform/dynamic-forms/dynamic-forms.module.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.module.ts
@@ -68,6 +68,7 @@ const TD_DYNAMIC_FORMS_ENTRY_COMPONENTS: Type<any>[] = [
     CovalentFileModule,
   ],
   exports: [TD_DYNAMIC_FORMS, TD_DYNAMIC_FORMS_ENTRY_COMPONENTS],
+  entryComponents: [TD_DYNAMIC_FORMS_ENTRY_COMPONENTS],
   providers: [DYNAMIC_FORMS_PROVIDER],
 })
 export class CovalentDynamicFormsModule {}


### PR DESCRIPTION
## Description
I have added the missing entry components within the `CovalentLoadingModule`.

### What's included?
- Fix for #1759

#### Test Steps
- [ ] `npm run build:lib`
- [ ] `add a tdLoading directive to a template`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
