### PR TITLE
fix: quick fix on mat-divider margin

### DIFF
--- a/src/platform/core/user-profile/user-profile-menu/user-profile-menu.component.scss
+++ b/src/platform/core/user-profile/user-profile-menu/user-profile-menu.component.scss
@@ -16,13 +16,13 @@
   padding-top: 0;
 }
 
-::ng-deep .mat-action-list .mat-divider,
-::ng-deep .mat-divider {
-  margin: 8px 0;
-}
-
-// TODO remove styles when bug gets addressed in td-menu in Covalent
 :host ::ng-deep {
+  .mat-action-list .mat-divider,
+  .mat-divider {
+    margin: 8px 0;
+  }
+
+  // TODO remove all styles below when bug gets addressed in td-menu in Covalent
   mat-divider:last-child {
     display: none;
   }


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Scoping margin on mat-divider to component so it doesn't propagate

### What's included?
<!-- List features included in this PR -->
- Scoping margin on mat-divider to component and updating comment

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] go to: http://localhost:4200/#/components/user-profile/overview
- [ ] open user profile menu
- [ ] verify it spacing looks exactly like screenshot below

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="418" alt="Screen Shot 2020-07-06 at 4 30 37 PM" src="https://user-images.githubusercontent.com/8982240/86666986-07873800-bfa6-11ea-9ead-cefd565eaa7d.png">
