### PR TITLE
feat(dialogs): add isDestructive parameter to confirm dialog

### DIFF
--- a/src/platform/core/dialogs/README.md
+++ b/src/platform/core/dialogs/README.md
@@ -57,7 +57,7 @@ export class Demo {
       title: 'Confirm', //OPTIONAL, hides if not provided
       cancelButton: 'Disagree', //OPTIONAL, defaults to 'CANCEL'
       acceptButton: 'Agree', //OPTIONAL, defaults to 'ACCEPT'
-      acceptButtonColor: 'warn', //OPTIONAL, defaults to 'accent'
+      isDestructive: false, //OPTIONAL, defaults to false
       width: '500px', //OPTIONAL, defaults to 400px
     }).afterClosed().subscribe((accept: boolean) => {
       if (accept) {

--- a/src/platform/core/dialogs/README.md
+++ b/src/platform/core/dialogs/README.md
@@ -57,6 +57,7 @@ export class Demo {
       title: 'Confirm', //OPTIONAL, hides if not provided
       cancelButton: 'Disagree', //OPTIONAL, defaults to 'CANCEL'
       acceptButton: 'Agree', //OPTIONAL, defaults to 'ACCEPT'
+      acceptButtonColor: 'warn', //OPTIONAL, defaults to 'accent'
       width: '500px', //OPTIONAL, defaults to 400px
     }).afterClosed().subscribe((accept: boolean) => {
       if (accept) {

--- a/src/platform/core/dialogs/confirm-dialog/confirm-dialog.component.html
+++ b/src/platform/core/dialogs/confirm-dialog/confirm-dialog.component.html
@@ -7,7 +7,7 @@
   </td-dialog-content>
   <td-dialog-actions>
     <button mat-button #closeBtn (keydown.arrowright)="acceptBtn.focus()" (click)="cancel()">{{ cancelButton }}</button>
-    <button mat-button color="accent" #acceptBtn (keydown.arrowleft)="closeBtn.focus()" (click)="accept()">
+    <button mat-button [color]="acceptButtonColor" #acceptBtn (keydown.arrowleft)="closeBtn.focus()" (click)="accept()">
       {{ acceptButton }}
     </button>
   </td-dialog-actions>

--- a/src/platform/core/dialogs/confirm-dialog/confirm-dialog.component.html
+++ b/src/platform/core/dialogs/confirm-dialog/confirm-dialog.component.html
@@ -7,7 +7,13 @@
   </td-dialog-content>
   <td-dialog-actions>
     <button mat-button #closeBtn (keydown.arrowright)="acceptBtn.focus()" (click)="cancel()">{{ cancelButton }}</button>
-    <button mat-button [color]="acceptButtonColor" #acceptBtn (keydown.arrowleft)="closeBtn.focus()" (click)="accept()">
+    <button
+      mat-button
+      [color]="isDestructive ? 'warn' : 'accent'"
+      #acceptBtn
+      (keydown.arrowleft)="closeBtn.focus()"
+      (click)="accept()"
+    >
       {{ acceptButton }}
     </button>
   </td-dialog-actions>

--- a/src/platform/core/dialogs/confirm-dialog/confirm-dialog.component.ts
+++ b/src/platform/core/dialogs/confirm-dialog/confirm-dialog.component.ts
@@ -11,7 +11,7 @@ export class TdConfirmDialogComponent {
   message: string;
   cancelButton: string = 'CANCEL';
   acceptButton: string = 'ACCEPT';
-  acceptButtonColor: string = 'accent';
+  isDestructive: boolean = false;
 
   constructor(private _dialogRef: MatDialogRef<TdConfirmDialogComponent>) {}
 

--- a/src/platform/core/dialogs/confirm-dialog/confirm-dialog.component.ts
+++ b/src/platform/core/dialogs/confirm-dialog/confirm-dialog.component.ts
@@ -11,6 +11,7 @@ export class TdConfirmDialogComponent {
   message: string;
   cancelButton: string = 'CANCEL';
   acceptButton: string = 'ACCEPT';
+  acceptButtonColor: string = 'accent';
 
   constructor(private _dialogRef: MatDialogRef<TdConfirmDialogComponent>) {}
 

--- a/src/platform/core/dialogs/services/dialog.service.ts
+++ b/src/platform/core/dialogs/services/dialog.service.ts
@@ -20,6 +20,7 @@ export interface IAlertConfig extends IDialogConfig {
 
 export interface IConfirmConfig extends IDialogConfig {
   acceptButton?: string;
+  acceptButtonColor?: string;
   cancelButton?: string;
 }
 
@@ -107,6 +108,7 @@ export class TdDialogService {
    *     title?: string;
    *     viewContainerRef?: ViewContainerRef;
    *     acceptButton?: string;
+   *     acceptButtonColor?: string;
    *     cancelButton?: string;
    * }
    *
@@ -124,6 +126,9 @@ export class TdDialogService {
     confirmDialogComponent.message = config.message;
     if (config.acceptButton) {
       confirmDialogComponent.acceptButton = config.acceptButton;
+    }
+    if (config.acceptButtonColor) {
+      confirmDialogComponent.acceptButtonColor = config.acceptButtonColor;
     }
     if (config.cancelButton) {
       confirmDialogComponent.cancelButton = config.cancelButton;

--- a/src/platform/core/dialogs/services/dialog.service.ts
+++ b/src/platform/core/dialogs/services/dialog.service.ts
@@ -20,8 +20,8 @@ export interface IAlertConfig extends IDialogConfig {
 
 export interface IConfirmConfig extends IDialogConfig {
   acceptButton?: string;
-  acceptButtonColor?: string;
   cancelButton?: string;
+  isDestructive?: boolean;
 }
 
 export interface IPromptConfig extends IConfirmConfig {
@@ -108,8 +108,8 @@ export class TdDialogService {
    *     title?: string;
    *     viewContainerRef?: ViewContainerRef;
    *     acceptButton?: string;
-   *     acceptButtonColor?: string;
    *     cancelButton?: string;
+   *     isDestructive?: boolean;
    * }
    *
    * Opens a confirm dialog with the provided config.
@@ -127,8 +127,8 @@ export class TdDialogService {
     if (config.acceptButton) {
       confirmDialogComponent.acceptButton = config.acceptButton;
     }
-    if (config.acceptButtonColor) {
-      confirmDialogComponent.acceptButtonColor = config.acceptButtonColor;
+    if (config.isDestructive) {
+      confirmDialogComponent.isDestructive = config.isDestructive;
     }
     if (config.cancelButton) {
       confirmDialogComponent.cancelButton = config.cancelButton;


### PR DESCRIPTION
## Description
Enable usage of the confirm dialog with a `color="warn"` button

Resolves #1778 

### What's included?
<!-- List features included in this PR -->
- Add `isDestructive` parameter to `TdConfirmDialogComponent` and `IConfirmConfig` interface. Defaults to `false`.

#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

![Screen Shot 2020-07-21 at 12 36 01 PM](https://user-images.githubusercontent.com/5451986/88086168-e9e4d180-cb54-11ea-9d5d-5ae0b34c5273.png)

