### PR TITLE
feat(guided-tour): allow localized strings for buttons #1780

### DIFF
--- a/src/platform/guided-tour/README.md
+++ b/src/platform/guided-tour/README.md
@@ -68,6 +68,8 @@ export interface ITourStep extends TourStep {
 
 export interface IGuidedTour extends ITourOptions {
   steps: IGuidedTourStep[];
+  finishButtonText?: string; // optionally pass in a localized string; default value is 'finish'
+  dismissButtonText?: string; // optionally pass in a localized string; default value is 'cancel tour'
 }
 
 export interface IGuidedTourStep extends ITourStep {

--- a/src/platform/guided-tour/guided-tour.service.ts
+++ b/src/platform/guided-tour/guided-tour.service.ts
@@ -16,6 +16,8 @@ import { CovalentGuidedTour, ITourStep, ITourOptions } from './guided.tour';
 
 export interface IGuidedTour extends ITourOptions {
   steps: IGuidedTourStep[];
+  finishButtonText?: string;
+  dismissButtonText?: string;
 }
 
 export interface IGuidedTourStep extends ITourStep {
@@ -58,7 +60,9 @@ export class CovalentGuidedTourService extends CovalentGuidedTour {
       // remove steps from tour since we need to preprocess them first
       this.newTour(Object.assign({}, guidedTour, { steps: undefined }));
       const tourInstance: Shepherd.Tour = this.shepherdTour.addSteps(
-        this._configureRoutesForSteps(this._prepareTour(guidedTour.steps)),
+        this._configureRoutesForSteps(
+          this._prepareTour(guidedTour.steps, guidedTour.finishButtonText, guidedTour.dismissButtonText),
+        ),
       );
       this.start();
       return tourInstance;

--- a/src/platform/guided-tour/guided.tour.ts
+++ b/src/platform/guided-tour/guided.tour.ts
@@ -164,7 +164,11 @@ export class CovalentGuidedTour extends TourButtonsActions {
     this.shepherdTour.start();
   }
 
-  protected _prepareTour(originalSteps: ITourStep[]): ITourStep[] {
+  protected _prepareTour(
+    originalSteps: ITourStep[],
+    finishLabel: string = 'finish',
+    dismissLabel: string = 'cancel tour',
+  ): ITourStep[] {
     // create Subjects for back and forward events
     const backEvent$: Subject<void> = new Subject<void>();
     const forwardEvent$: Subject<void> = new Subject<void>();
@@ -209,12 +213,12 @@ export class CovalentGuidedTour extends TourButtonsActions {
     });
 
     const finishButton: TourStepButton = {
-      text: 'finish',
+      text: finishLabel,
       action: this['finish'].bind(this),
       classes: MAT_BUTTON,
     };
     const dismissButton: TourStepButton = {
-      text: 'cancel tour',
+      text: dismissLabel,
       action: this['cancel'].bind(this),
       classes: MAT_BUTTON,
     };


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Added two fields to `IGuidedTour` interface to allow passing in localized strings for the "Finish" and "Cancel Tour" buttons.

### What's included?
<!-- List features included in this PR -->
- Add optional fields `finishButtonText` and `dismissButtonText` to the `IGuidedTour`
- Modified the `_prepareTour` protected method to accept those two strings as params and use the value as the button text
- Ensured that the params are optional and will default to the same strings that were hardcoded previously
- updated readme with new interface definition

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] create a guided tour config that in addition to the steps includes fields for `finishButtonText` and `dismissButtonText` with translated values
- [ ] execute the tour
- [ ] button text will show the passed-in localized value

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

![translated_button](https://user-images.githubusercontent.com/3999743/88846139-2e0a4e80-d1b3-11ea-8c93-0170804ec06b.png)

