### PR TITLE
fix: hardcoded sidenav color

### DIFF
--- a/src/platform/core/common/styles/core/_sidenav.scss
+++ b/src/platform/core/common/styles/core/_sidenav.scss
@@ -7,9 +7,6 @@
       mat-icon {
         @include rtl(margin-left, 0, $margin);
         @include rtl(margin-right, $margin, 0);
-
-        color: #737373;
-        fill: #737373;
       }
     }
     [mat-list-item] {


### PR DESCRIPTION
## Description
-hard coded colors are causing side effects

### What's included?
- removal of hard coded colors inside sidenav scss

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`


#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
