### PR TITLE
Fix/vui 921 open links in markdown navigator

### DIFF
--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-service/markdown-navigator-demo-service.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-service/markdown-navigator-demo-service.component.ts
@@ -34,8 +34,6 @@ export class MarkdownNavigatorDemoServiceComponent {
         width: '300px',
         height: '300px',
       },
-
-      copyToClipboard: true,
       startAt: [{ id: 'child_id' }, { id: 'child-1' }],
     });
   }

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-service/markdown-navigator-demo-service.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-service/markdown-navigator-demo-service.component.ts
@@ -19,11 +19,24 @@ export class MarkdownNavigatorDemoServiceComponent {
           title: 'Jupiter',
           markdownString: `[Go to Jupiter](#data={"planet":"Jupiter"})`,
         },
+        {
+          title: 'Covalent Browser Support',
+          url: 'https://github.com/Teradata/covalent/blob/develop/README.md',
+          anchor: 'browser-support',
+        },
+        {
+          id: 'child_id',
+          title: 'Children',
+          childrenUrl: '/assets/demos-data/children_url_1.json',
+        },
       ],
       dialogConfig: {
         width: '300px',
         height: '300px',
       },
+
+      copyToClipboard: true,
+      startAt: [{ id: 'child_id' }, { id: 'child-1' }],
     });
   }
 }

--- a/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window-service/markdown-navigator-window.service.ts
@@ -15,7 +15,7 @@ export interface IMarkdownNavigatorWindowConfig {
   dialogConfig?: MatDialogConfig;
   labels?: IMarkdownNavigatorWindowLabels;
   toolbarColor?: ThemePalette;
-  startAt?: IMarkdownNavigatorItem;
+  startAt?: IMarkdownNavigatorItem | IMarkdownNavigatorItem[];
   compareWith?: IMarkdownNavigatorCompareWith;
   footer?: Type<any>;
 }

--- a/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator-window/markdown-navigator-window.component.ts
@@ -30,7 +30,7 @@ export class TdMarkdownNavigatorWindowComponent {
   @Input() items: IMarkdownNavigatorItem[];
   @Input() labels: IMarkdownNavigatorWindowLabels;
   @Input() toolbarColor: ThemePalette = 'primary';
-  @Input() startAt: IMarkdownNavigatorItem;
+  @Input() startAt: IMarkdownNavigatorItem | IMarkdownNavigatorItem[];
   @Input() compareWith: IMarkdownNavigatorCompareWith;
   @Input() docked: boolean = false;
   @Input() footer: Type<any>;


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Update markdown navigator service to open the child links.

### What's included?
<!-- List features included in this PR -->
- Update markdown navigator service to open the child links.

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then go to markdown navigator examples
- [ ] go to the service example. 
- [ ] a dialog window will be opened with the child link.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![image](https://user-images.githubusercontent.com/12620590/89948740-7c6c1400-dbdb-11ea-868d-e74096ca4e47.png)
![image](https://user-images.githubusercontent.com/12620590/89948791-9279d480-dbdb-11ea-9ee7-6d9cedab3364.png)
