### PR TITLE
feat(dynamic-forms-custom-config): custom component values

### DIFF
--- a/src/app/content/components/component-demos/dynamic-forms/demos/dynamic-forms-demo-custom-elements/dynamic-forms-demo-custom-elements.component.ts
+++ b/src/app/content/components/component-demos/dynamic-forms/demos/dynamic-forms-demo-custom-elements/dynamic-forms-demo-custom-elements.component.ts
@@ -1,11 +1,11 @@
-import { Component, TemplateRef } from '@angular/core';
+import { Component, TemplateRef, Input } from '@angular/core';
 import { AbstractControl, FormControl } from '@angular/forms';
 import { ITdDynamicElementConfig } from '@covalent/dynamic-forms';
 
 @Component({
   selector: 'td-dynamic-input-test',
   template: `
-    <td-chips [items]="selections" [formControl]="control"></td-chips>
+    <td-chips [items]="selections" [formControl]="control" [placeholder]="placeholder"></td-chips>
     <div *ngIf="errorMessageTemplate && control?.errors" class="tc-red-600" [style.font-size.%]="'70'">
       <ng-template
         [ngTemplateOutlet]="errorMessageTemplate"
@@ -18,6 +18,8 @@ export class TdTestDynamicComponent {
   control: FormControl;
   selections: string[] = [];
   errorMessageTemplate: TemplateRef<any>;
+  // This value will be set via the customConfig property
+  placeholder: string;
 }
 
 @Component({
@@ -41,6 +43,11 @@ export class DynamicFormsDemoCustomElementsComponent {
           },
         },
       ],
+      customConfig: {
+        // This is a property unique to the custom component
+        // and will be applied on instantiation of the component
+        placeholder: 'Lists',
+      },
     },
   ];
 }

--- a/src/platform/dynamic-forms/README.md
+++ b/src/platform/dynamic-forms/README.md
@@ -49,6 +49,11 @@ export class MyModule {}
 Pass an array of javascript objects that implement [ITdDynamicElementConfig] with the information to be rendered to the [elements] attribute.
 
 ```typescript
+// Property values to be set in custom component
+export interface ITdDynamicElementCustomConfig {
+  [name: string]: any;
+}
+
 export interface ITdDynamicElementConfig {
   label?: string;
   name: string;
@@ -60,11 +65,12 @@ export interface ITdDynamicElementConfig {
   max?: any;
   minLength?: any;
   maxLength?: any;
-  selections?: any[] | { value: any, label: string }[];
+  selections?: string[] | { value: any; label: string }[];
   multiple?: boolean;
   default?: any;
   flex?: number;
   validators?: ITdDynamicElementValidator[];
+  customConfig?: ITdDynamicElementCustomConfig;
 }
 ```
 

--- a/src/platform/dynamic-forms/dynamic-element.component.ts
+++ b/src/platform/dynamic-forms/dynamic-element.component.ts
@@ -17,7 +17,12 @@ import { TemplatePortalDirective } from '@angular/cdk/portal';
 
 import { mixinControlValueAccessor, IControlValueAccessor } from '@covalent/core/common';
 
-import { TdDynamicElement, TdDynamicType, TdDynamicFormsService } from './services/dynamic-forms.service';
+import {
+  TdDynamicElement,
+  TdDynamicType,
+  TdDynamicFormsService,
+  ITdDynamicElementCustomConfig,
+} from './services/dynamic-forms.service';
 
 export class TdDynamicElementBase {
   constructor(public _changeDetectorRef: ChangeDetectorRef) {}
@@ -119,6 +124,11 @@ export class TdDynamicElementComponent extends _TdDynamicElementMixinBase
   @Input() multiple: boolean = undefined;
 
   /**
+   * Sets any additional properties on custom component.
+   */
+  @Input() customConfig: ITdDynamicElementCustomConfig;
+
+  /**
    * Sets error message template so it can be injected into dynamic components.
    */
   @Input() errorMessageTemplate: TemplateRef<any> = undefined;
@@ -165,6 +175,11 @@ export class TdDynamicElementComponent extends _TdDynamicElementMixinBase
     this._instance.selections = this.selections;
     this._instance.multiple = this.multiple;
     this._instance.errorMessageTemplate = this.errorMessageTemplate;
+    if (this.customConfig) {
+      Object.getOwnPropertyNames(this.customConfig).forEach((name: string) => {
+        this._instance[name] = this.customConfig[name];
+      });
+    }
   }
 
   /**

--- a/src/platform/dynamic-forms/dynamic-forms.component.html
+++ b/src/platform/dynamic-forms/dynamic-forms.component.html
@@ -25,6 +25,7 @@
           [maxLength]="element.maxLength"
           [selections]="element.selections"
           [multiple]="element.multiple"
+          [customConfig]="element.customConfig"
           [errorMessageTemplate]="getErrorTemplateRef(element.name)"
         ></td-dynamic-element>
       </div>

--- a/src/platform/dynamic-forms/dynamic-forms.component.spec.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, inject, async, ComponentFixture } from '@angular/core/testing';
 import 'hammerjs';
-import { Component, NgModule, DebugElement } from '@angular/core';
+import { Component, NgModule, DebugElement, Input } from '@angular/core';
 import { MatNativeDateModule } from '@angular/material/core';
 import { Validators, AbstractControl, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -477,11 +477,17 @@ describe('Component: TdDynamicForms', () => {
           name: 'custom',
           type: TdDynamicTestComponent,
           default: 'value',
+          customConfig: {
+            specialValue: 'My special value',
+          },
         },
       ];
       fixture.detectChanges();
       fixture.whenStable().then(() => {
-        expect(fixture.debugElement.queryAll(By.directive(TdDynamicElementComponent)).length).toBe(1);
+        const customComponent: TdDynamicTestComponent = fixture.debugElement.query(By.directive(TdDynamicTestComponent))
+          .componentInstance;
+        expect(customComponent).toBeTruthy();
+        expect(customComponent.specialValue).toEqual('My special value');
         const dynamicFormsComponent: TdDynamicFormsComponent = fixture.debugElement.query(
           By.directive(TdDynamicFormsComponent),
         ).componentInstance;
@@ -513,6 +519,7 @@ class TdDynamicFormsTestComponent {
 })
 export class TdDynamicTestComponent {
   control: FormControl;
+  specialValue: string;
 }
 
 @NgModule({

--- a/src/platform/dynamic-forms/services/dynamic-forms.service.ts
+++ b/src/platform/dynamic-forms/services/dynamic-forms.service.ts
@@ -34,6 +34,11 @@ export interface ITdDynamicElementValidator {
   validator: ValidatorFn;
 }
 
+// Property values to be set in custom component
+export interface ITdDynamicElementCustomConfig {
+  [name: string]: any;
+}
+
 export interface ITdDynamicElementConfig {
   label?: string;
   name: string;
@@ -50,6 +55,7 @@ export interface ITdDynamicElementConfig {
   default?: any;
   flex?: number;
   validators?: ITdDynamicElementValidator[];
+  customConfig?: ITdDynamicElementCustomConfig;
 }
 
 export const DYNAMIC_ELEMENT_NAME_REGEX: RegExp = /^[^0-9][^\@]*$/;


### PR DESCRIPTION
## Description

Addresses https://github.com/Teradata/covalent/issues/1397. 

Expose a mechanism for passing through property values to custom components used within dynamic forms.

### What's included?
- Extended config object to support object of custom property/value pairs that are set in the custom component on initialization.

#### Test Steps
- [ ] `npm run serve`
- [ ] open demos
- [ ] confirm dynamic form custom component example shows placeholder of 'Labels' in autocomplete chip form.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
