### PR TITLE
feat(dynamic-menu3): support for grouping labels

### DIFF
--- a/src/app/content/components/component-demos/dynamic-menu/demos/dynamic-menu-demo-basic/dynamic-menu-demo-basic.component.ts
+++ b/src/app/content/components/component-demos/dynamic-menu/demos/dynamic-menu-demo-basic/dynamic-menu-demo-basic.component.ts
@@ -16,11 +16,18 @@ export class DynamicMenuDemoBasicComponent {
 
   items1: IMenuItem[] = [
     {
+      // Grouping label
+      id: 'platform',
+      text: 'Platform',
+    },
+    {
+      // Submenu trigger
       id: 'covalentlinkstrigger',
       text: 'Covalent Links',
       svgIcon: 'assets:covalent',
       children: [
         {
+          // URL link
           id: 'quickstartlink',
           text: 'Quickstart',
           icon: 'flash_on',
@@ -28,6 +35,7 @@ export class DynamicMenuDemoBasicComponent {
           newTab: true,
         },
         {
+          // URL link
           id: 'electronlink',
           text: 'Electron App',
           icon: 'laptop_mac',
@@ -35,6 +43,7 @@ export class DynamicMenuDemoBasicComponent {
           newTab: true,
         },
         {
+          // URL link
           id: 'datalink',
           text: 'Covalent Data',
           icon: 'aspect_ratio',
@@ -44,19 +53,31 @@ export class DynamicMenuDemoBasicComponent {
       ],
     },
     {
+      // Grouping label
+      id: 'framework',
+      text: 'Framework',
+    },
+    {
+      // Submenu trigger
       id: 'angularlink',
       text: 'Angular Link',
       svgIcon: 'assets:angular',
       children: [
         {
+          // URL link
           text: 'Angular Homepage',
-          icon: 'star_rate',
           link: 'https://angular.io/',
           newTab: true,
         },
       ],
     },
     {
+      // Grouping label
+      id: 'actions',
+      text: 'Actions',
+    },
+    {
+      // Action link
       id: 'actionlink',
       text: 'Do Action',
       icon: 'directions_run',

--- a/src/platform/core/dynamic-menu/README.md
+++ b/src/platform/core/dynamic-menu/README.md
@@ -1,12 +1,14 @@
 # td-dynamic-menu
 
-`td-dynamic-menu` element supports the creation of n-level deep cascading menus with links using a JSON object.
+`td-dynamic-menu` element supports the creation of n-level deep cascading menus with
+group labels and URL/action links and actions using a JSON object.
 
 ## API Summary
 
 #### Model
 
 ```typescript
+// Trigger button launches top level menu. Must specify text and/or icon.
 export interface IMenuTrigger {
   id?: string; // Optional identifier
   text?: string; // Text to display on button
@@ -15,23 +17,30 @@ export interface IMenuTrigger {
   iconClasses?: string[]; // Optional styling classes
 }
 
+// Menu items can serve one of four roles:
+// - Submenu trigger (has children property)
+// - URL link (has link property)
+// - Action link (has action property)
+// - Grouping label (has neither children, link or action properties)
 export interface IMenuItem {
   id?: string; // Optional identifier
   text: string; // Display text
   icon?: string; // Optional icon
   svgIcon?: string; // Optional svgIcon
   iconClasses?: string[]; // Optional styling classes
-  // For submenu trigger items
-  children?: IMenuItem[]; // List of items to be displayed in submenu
-  // For link items
+  // If provided, item is a submenu trigger
+  // Represents the contents of the submenu
+  children?: IMenuItem[];
+  // If provided, item is a URL link item
   link?: string; // Link ref (relative or fully qualified). Optional if
-  // defining an "action" link
-  newTab?: boolean; // Indicates where link should be opened
-  // For action items (simply emits click event)
-  action?: string; // Value returned on click event
+  // Indicates where URL should be displayed, current or new browser tab
+  newTab?: boolean;
+  // If provided, item is an action link
+  // A click on this item will emit itemClicked event
+  action?: string;
 }
 
-// Click action payload derived from IMenuItem
+// Click action event payload derived from IMenuItem
 export interface ITdDynamicMenuLinkClickEvent {
   text: string;
   action: string;
@@ -78,54 +87,65 @@ trigger: IMenuTrigger = {
 };
 
 items: IMenuItem[] = [
-  {
-    id: 'covalentlinkstrigger',
-    text: 'Covalent Links',
-    svgIcon: 'assets:covalent',
-    children: [
-      {
-        id: 'quickstartlink',
-        text: 'Quickstart',
-        icon: 'flash_on',
-        link: 'https://github.com/Teradata/covalent-quickstart',
-        newTab: true,
-      },
-      {
-        id: 'electronlink',
-        text: 'Electron App',
-        icon: 'laptop_mac',
-        link: 'https://github.com/Teradata/covalent-electron',
-        newTab: true,
-      },
-      {
-        id: 'datalink',
-        text: 'Covalent Data',
-        icon: 'aspect_ratio',
-        link: 'https://github.com/Teradata/covalent-data',
-        newTab: true,
-      },
-    ],
-  },
-  {
-    id: 'angularlink',
-    text: 'Angular Link',
-    svgIcon: 'assets:angular',
-    children: [
-      {
-        text: 'Angular Homepage',
-        icon: 'star_rate',
-        link: 'https://angular.io/',
-        newTab: true,
-      },
-    ],
-  },
-  {
-    id: 'actionlink',
-    text: 'Do Action',
-    icon: 'directions_run',
-    action: 'Go Run',
-  },
-];
+    {  // Grouping label
+      id: 'platform',
+      text: 'Platform',
+    },
+    {  // Submenu trigger
+      id: 'covalentlinkstrigger',
+      text: 'Covalent Links',
+      svgIcon: 'assets:covalent',
+      children: [
+        {  // URL link
+          id: 'quickstartlink',
+          text: 'Quickstart',
+          icon: 'flash_on',
+          link: 'https://github.com/Teradata/covalent-quickstart',
+          newTab: true,
+        },
+        {  // URL link
+          id: 'electronlink',
+          text: 'Electron App',
+          icon: 'laptop_mac',
+          link: 'https://github.com/Teradata/covalent-electron',
+          newTab: true,
+        },
+        {  // URL link
+          id: 'datalink',
+          text: 'Covalent Data',
+          icon: 'aspect_ratio',
+          link: 'https://github.com/Teradata/covalent-data',
+          newTab: true,
+        },
+      ],
+    },
+    {  // Grouping label
+      id: 'framework',
+      text: 'Framework',
+    },
+    {  // Submenu trigger
+      id: 'angularlink',
+      text: 'Angular Link',
+      svgIcon: 'assets:angular',
+      children: [
+        {  // URL link
+          text: 'Angular Homepage',
+          link: 'https://angular.io/',
+          newTab: true,
+        },
+      ],
+    },
+    {  // Grouping label
+      id: 'actions',
+      text: 'Actions',
+    },
+    {  // Action link
+      id: 'actionlink',
+      text: 'Do Action',
+      icon: 'directions_run',
+      action: 'Go Run',
+    },
+  ];
 ```
 
 ```html

--- a/src/platform/core/dynamic-menu/dynamic-menu-item/dynamic-menu-item.component.html
+++ b/src/platform/core/dynamic-menu/dynamic-menu-item/dynamic-menu-item.component.html
@@ -1,5 +1,5 @@
 <mat-menu #childMenu="matMenu" [overlapTrigger]="false">
-  <ng-template let-item ngFor [ngForOf]="items">
+  <ng-template let-item let-index="index" ngFor [ngForOf]="items">
     <ng-container *ngIf="item.children && item.children.length > 0">
       <button mat-menu-item [id]="item.id" [matMenuTriggerFor]="menu.childMenu">
         <mat-icon *ngIf="item.svgIcon" [class]="item.iconClasses" [svgIcon]="item.svgIcon"></mat-icon>
@@ -11,7 +11,13 @@
       <td-dynamic-menu-item #menu [items]="item.children"></td-dynamic-menu-item>
     </ng-container>
     <ng-container *ngIf="!item.children || item.children.length === 0">
-      <td-dynamic-menu-link [item]="item" (itemClicked)="emitClicked($event)"></td-dynamic-menu-link>
+      <ng-container *ngIf="!item.link && !item.action">
+        <mat-divider class="group-divider" *ngIf="index > 0"></mat-divider>
+        <span class="group-label text-sm">{{ item.text }}</span>
+      </ng-container>
+      <ng-container *ngIf="item.link || item.action">
+        <td-dynamic-menu-link [item]="item" (itemClicked)="emitClicked($event)"></td-dynamic-menu-link>
+      </ng-container>
     </ng-container>
   </ng-template>
 </mat-menu>

--- a/src/platform/core/dynamic-menu/dynamic-menu-item/dynamic-menu-item.component.scss
+++ b/src/platform/core/dynamic-menu/dynamic-menu-item/dynamic-menu-item.component.scss
@@ -1,0 +1,6 @@
+.group-divider {
+  margin-bottom: 8px;
+}
+.group-label {
+  padding: 16px 8px 0;
+}

--- a/src/platform/core/dynamic-menu/dynamic-menu.component.ts
+++ b/src/platform/core/dynamic-menu/dynamic-menu.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 
+// Trigger button launches top level menu. Must specify text and/or icon.
 export interface IMenuTrigger {
   id?: string; // Optional identifier
   text?: string; // Text to display on button
@@ -8,23 +9,30 @@ export interface IMenuTrigger {
   iconClasses?: string[]; // Optional styling classes
 }
 
+// Menu items can serve one of four roles:
+// - Submenu trigger (has children property)
+// - URL link (has link property)
+// - Action link (has action property)
+// - Grouping label (has neither children, link or action properties)
 export interface IMenuItem {
   id?: string; // Optional identifier
   text: string; // Display text
   icon?: string; // Optional icon
   svgIcon?: string; // Optional svgIcon
   iconClasses?: string[]; // Optional styling classes
-  // For submenu trigger items
-  children?: IMenuItem[]; // List of items to be displayed in submenu
-  // For link items
+  // If provided, item is a submenu trigger
+  // Represents the contents of the submenu
+  children?: IMenuItem[];
+  // If provided, item is a URL link item
   link?: string; // Link ref (relative or fully qualified). Optional if
-  // defining an "action" link
-  newTab?: boolean; // Indicates where link should be opened
-  // For action items (simply emits click event)
-  action?: string; // Value returned on click event
+  // Indicates where URL should be displayed, current or new browser tab
+  newTab?: boolean;
+  // If provided, item is an action link
+  // A click on this item will emit itemClicked event
+  action?: string;
 }
 
-// Click action payload derived from IMenuItem
+// Click action event payload derived from IMenuItem
 export interface ITdDynamicMenuLinkClickEvent {
   text: string;
   action: string;


### PR DESCRIPTION
## Description
Support for grouping labels and enhanced documentation.

### What's included?
- Items can now take on one of four roles, submenu trigger, URL link, action link or grouping label
- Added for comments in code and readme.

#### Test Steps
- [ ] `npm run serve`
- [ ] Navigate to dynamic-menu demo
- [ ] Confirm demo behavior, API documentation

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

![Screen Shot 2020-08-20 at 12 12 52 PM](https://user-images.githubusercontent.com/546264/90814808-83cba580-e2de-11ea-810e-8283f3828d12.png)
