### PR TITLE
Feat/tour events observable

### DIFF
--- a/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo-go-back-navigation/guided-tour-demo-go-back-navigation.component.html
+++ b/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo-go-back-navigation/guided-tour-demo-go-back-navigation.component.html
@@ -2,5 +2,5 @@
   <button mat-raised-button color="accent" (click)="startTour()">Start tour</button>
   <h3 id="step-1">Step 1</h3>
   <button mat-raised-button id="advance-button" [routerLink]="['/']">Step 2, click to navigate to step 3</button>
-  <h3 id="step-3">Step 4</h3>
+  <h3 id="step-4">Step 4</h3>
 </div>

--- a/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo-go-back-navigation/guided-tour-demo-go-back-navigation.component.html
+++ b/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo-go-back-navigation/guided-tour-demo-go-back-navigation.component.html
@@ -1,0 +1,6 @@
+<div id="go-back-navigation-demo">
+  <button mat-raised-button color="accent" (click)="startTour()">Start tour</button>
+  <h3 id="step-1">Step 1</h3>
+  <button mat-raised-button id="advance-button" [routerLink]="['/']">Step 2, click to navigate to step 3</button>
+  <h3 id="step-3">Step 4</h3>
+</div>

--- a/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo-go-back-navigation/guided-tour-demo-go-back-navigation.component.scss
+++ b/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo-go-back-navigation/guided-tour-demo-go-back-navigation.component.scss
@@ -1,0 +1,3 @@
+button {
+  margin-bottom: 1em;
+}

--- a/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo-go-back-navigation/guided-tour-demo-go-back-navigation.component.ts
+++ b/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo-go-back-navigation/guided-tour-demo-go-back-navigation.component.ts
@@ -54,7 +54,7 @@ export class GuidedTourDemoGoBackNavigationComponent implements OnInit {
             route: '/components/guided-tour/examples',
           },
           attachTo: {
-            element: '#go-back-navigation-demo #step-3',
+            element: '#go-back-navigation-demo #step-4',
             on: 'top',
           },
         },

--- a/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo-go-back-navigation/guided-tour-demo-go-back-navigation.component.ts
+++ b/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo-go-back-navigation/guided-tour-demo-go-back-navigation.component.ts
@@ -1,0 +1,69 @@
+import { Component, OnInit } from '@angular/core';
+import { CovalentGuidedTourService, IGuidedTour, ITourEvent } from '@covalent/guided-tour';
+import { Router } from '@angular/router';
+@Component({
+  selector: 'guided-tour-demo-go-back-navigation',
+  styleUrls: ['./guided-tour-demo-go-back-navigation.component.scss'],
+  templateUrl: './guided-tour-demo-go-back-navigation.component.html',
+})
+export class GuidedTourDemoGoBackNavigationComponent implements OnInit {
+  constructor(private _guidedTourService: CovalentGuidedTourService) {}
+
+  ngOnInit(): void {
+    const goBackNavigationTour: IGuidedTour = {
+      useModalOverlay: true,
+      steps: [
+        {
+          id: 'step-1',
+          title: 'Step 1',
+          text: 'Continue tour',
+          attachTo: {
+            element: '#go-back-navigation-demo #step-1',
+            on: 'top',
+          },
+        },
+        {
+          id: 'step-2',
+          title: 'Step 2',
+          text: 'Step will navigate to the root (/)',
+          attachTo: {
+            element: '#go-back-navigation-demo #advance-button',
+            on: 'top',
+          },
+          advanceOn: {
+            selector: '#go-back-navigation-demo #advance-button',
+            event: ITourEvent.click, // event of some sort
+          },
+          advanceOnOptions: {
+            allowGoBack: true,
+          },
+        },
+        {
+          id: 'step-3',
+          title: 'Step 3',
+          text: 'Step has navigated to the home page',
+          advanceOnOptions: {
+            allowGoBack: false,
+          },
+        },
+        {
+          id: 'step-4',
+          title: 'Step 4',
+          text: 'Click the back button (<) will navigate back to step 3 on the home page',
+          routing: {
+            route: '/components/guided-tour/examples',
+          },
+          attachTo: {
+            element: '#go-back-navigation-demo #step-3',
+            on: 'top',
+          },
+        },
+      ],
+    };
+    this._guidedTourService.registerTour('goBackNavigationTour', goBackNavigationTour);
+  }
+
+  startTour(): void {
+    this._guidedTourService.startTour('goBackNavigationTour');
+  }
+}

--- a/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo.component.html
+++ b/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo.component.html
@@ -25,3 +25,7 @@
 <demo-component [demoId]="'guided-tour-demo-skip-count'" [demoTitle]="'Skip and remove step(s) from count'">
   <guided-tour-demo-skip-count></guided-tour-demo-skip-count>
 </demo-component>
+
+<demo-component [demoId]="'guided-tour-demo-go-back-navigation'" [demoTitle]="'Going back with navigation'">
+  <guided-tour-demo-go-back-navigation></guided-tour-demo-go-back-navigation>
+</demo-component>

--- a/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo.module.ts
+++ b/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo.module.ts
@@ -11,7 +11,7 @@ import { GuidedTourDemoDelayComponent } from './guided-tour-demo-delay/guided-to
 import { GuidedTourDemoNotFoundComponent } from './guided-tour-demo-not-found/guided-tour-demo-not-found.component';
 import { GuidedTourDemoGoBackComponent } from './guided-tour-demo-go-back/guided-tour-demo-go-back.component';
 import { GuidedTourDemoSkipCountComponent } from './guided-tour-demo-skip-count/guided-tour-demo-skip-count.component';
-
+import { GuidedTourDemoGoBackNavigationComponent } from './guided-tour-demo-go-back-navigation/guided-tour-demo-go-back-navigation.component';
 @NgModule({
   declarations: [
     GuidedTourDemoComponent,
@@ -21,6 +21,7 @@ import { GuidedTourDemoSkipCountComponent } from './guided-tour-demo-skip-count/
     GuidedTourDemoNotFoundComponent,
     GuidedTourDemoGoBackComponent,
     GuidedTourDemoSkipCountComponent,
+    GuidedTourDemoGoBackNavigationComponent,
   ],
   imports: [CommonModule, DemoModule, GuidedTourDemoBasicSharedModule, GuidedTourDemoRoutingModule, MatButtonModule],
 })

--- a/src/platform/guided-tour/README.md
+++ b/src/platform/guided-tour/README.md
@@ -12,7 +12,9 @@ A wrapper around [Shepherd](https://shepherdjs.dev) with extra functionality. Ma
   + Start a certain tour
 + initializeOnQueryParams(queryParam: string = 'tour'): Observable<ParamMap>
   + Listen to query params to launch a tour
-
++ tourEvent$(str: TourEvents): Observable<IGuidedTourEvent>
+  + Observable of tour events
+  
 ```ts
 // for reference
 export type TourStep = Shepherd.Step.StepOptions;
@@ -78,6 +80,22 @@ export interface IGuidedTourStep extends ITourStep {
     extras?: NavigationExtras;
   };
 }
+
+export enum TourEvents {
+  complete = 'complete',
+  cancel = 'cancel',
+  hide = 'hide',
+  show = 'show',
+  start = 'start',
+  active = 'active',
+  inactive = 'inactive',
+}
+
+export interface IGuidedTourEvent {
+  step: any; // current step tour is showing
+  previous: any; // previous step of the tour
+  tour: any; // tour object
+}
 ```
 
 ## Setup
@@ -121,6 +139,8 @@ const basicDemoTour: IGuidedTour = {
 };
 this._guidedTourService.registerTour('basicDemoTour', basicDemoTour);
 this._guidedTourService.startTour('basicDemoTour');
+this._guidedTourService.tourEvent$(TourEvents.show)
+  .subscribe((event: IGuidedTourEvent) => { /* event object contains current step, previous step and tour objects */});
 ```
 
 ```html

--- a/src/platform/guided-tour/_guided-tour-theme.scss
+++ b/src/platform/guided-tour/_guided-tour-theme.scss
@@ -72,4 +72,7 @@
     line-height: $mat-icon-button-size;
     border-radius: $mat-icon-button-border-radius;
   }
+  .shepherd-void-button {
+    display: none;
+  }
 }

--- a/src/platform/guided-tour/guided-tour.service.ts
+++ b/src/platform/guided-tour/guided-tour.service.ts
@@ -65,12 +65,11 @@ export class CovalentGuidedTourService extends CovalentGuidedTour {
       const tourInstance: Shepherd.Tour = this.shepherdTour.addSteps(
         this._configureRoutesForSteps(this._prepareTour(guidedTour.steps, guidedTour.finishButtonText)),
       );
-      this.start();
       // init route transition if step URL is different then the current location.
       this.tourEvent$('show').subscribe((tourEvent: any) => {
         const currentURL: string = this._router.url.split(/[?#]/)[0];
         const {
-          step: { id },
+          step: { id, options },
         } = tourEvent;
         if (this._tourStepURLs.has(id)) {
           const stepRoute: string = this._tourStepURLs.get(id);
@@ -78,9 +77,14 @@ export class CovalentGuidedTourService extends CovalentGuidedTour {
             this._router.navigate([stepRoute]);
           }
         } else {
-          this._tourStepURLs.set(id, currentURL);
+          if (options && options.routing) {
+            this._tourStepURLs.set(id, options.routing.route);
+          } else {
+            this._tourStepURLs.set(id, currentURL);
+          }
         }
       });
+      this.start();
       return tourInstance;
     } else {
       // tslint:disable-next-line:no-console

--- a/src/platform/guided-tour/guided-tour.service.ts
+++ b/src/platform/guided-tour/guided-tour.service.ts
@@ -29,11 +29,26 @@ export interface IGuidedTourStep extends ITourStep {
 /**
  *  Router enabled Shepherd tour
  */
+export enum TourEvents {
+  complete = 'complete',
+  cancel = 'cancel',
+  hide = 'hide',
+  show = 'show',
+  start = 'start',
+  active = 'active',
+  inactive = 'inactive',
+}
+
+export interface IGuidedTourEvent {
+  step: any;
+  previous: any;
+  tour: any;
+}
 
 @Injectable()
 export class CovalentGuidedTourService extends CovalentGuidedTour {
   private _toursMap: Map<string, IGuidedTour> = new Map<string, IGuidedTour>();
-  private _tourStepURLs: Map<string, string> = new Map();
+  private _tourStepURLs: Map<string, string> = new Map<string, string>();
   constructor(private _router: Router, private _route: ActivatedRoute, private _httpClient: HttpClient) {
     super();
     _router.events
@@ -47,7 +62,7 @@ export class CovalentGuidedTourService extends CovalentGuidedTour {
       });
   }
 
-  tourEvent$(str: string): Observable<any> {
+  tourEvent$(str: TourEvents): Observable<IGuidedTourEvent> {
     return fromEvent(this.shepherdTour, str);
   }
 
@@ -66,7 +81,7 @@ export class CovalentGuidedTourService extends CovalentGuidedTour {
         this._configureRoutesForSteps(this._prepareTour(guidedTour.steps, guidedTour.finishButtonText)),
       );
       // init route transition if step URL is different then the current location.
-      this.tourEvent$('show').subscribe((tourEvent: any) => {
+      this.tourEvent$(TourEvents.show).subscribe((tourEvent: IGuidedTourEvent) => {
         const currentURL: string = this._router.url.split(/[?#]/)[0];
         const {
           step: { id, options },

--- a/src/platform/guided-tour/guided-tour.service.ts
+++ b/src/platform/guided-tour/guided-tour.service.ts
@@ -10,14 +10,13 @@ import {
 } from '@angular/router';
 import Shepherd from 'shepherd.js';
 import { tap, map, filter } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import { Observable, fromEvent } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { CovalentGuidedTour, ITourStep, ITourOptions } from './guided.tour';
 
 export interface IGuidedTour extends ITourOptions {
   steps: IGuidedTourStep[];
   finishButtonText?: string;
-  dismissButtonText?: string;
 }
 
 export interface IGuidedTourStep extends ITourStep {
@@ -34,7 +33,7 @@ export interface IGuidedTourStep extends ITourStep {
 @Injectable()
 export class CovalentGuidedTourService extends CovalentGuidedTour {
   private _toursMap: Map<string, IGuidedTour> = new Map<string, IGuidedTour>();
-
+  private _tourStepURLs: Map<string, string> = new Map();
   constructor(private _router: Router, private _route: ActivatedRoute, private _httpClient: HttpClient) {
     super();
     _router.events
@@ -46,6 +45,10 @@ export class CovalentGuidedTourService extends CovalentGuidedTour {
           this.shepherdTour.cancel();
         }
       });
+  }
+
+  tourEvent$(str: string): Observable<any> {
+    return fromEvent(this.shepherdTour, str);
   }
 
   async registerTour(tourName: string, tour: IGuidedTour | string): Promise<void> {
@@ -60,11 +63,24 @@ export class CovalentGuidedTourService extends CovalentGuidedTour {
       // remove steps from tour since we need to preprocess them first
       this.newTour(Object.assign({}, guidedTour, { steps: undefined }));
       const tourInstance: Shepherd.Tour = this.shepherdTour.addSteps(
-        this._configureRoutesForSteps(
-          this._prepareTour(guidedTour.steps, guidedTour.finishButtonText, guidedTour.dismissButtonText),
-        ),
+        this._configureRoutesForSteps(this._prepareTour(guidedTour.steps, guidedTour.finishButtonText)),
       );
       this.start();
+      // init route transition if step URL is different then the current location.
+      this.tourEvent$('show').subscribe((tourEvent: any) => {
+        const currentURL: string = this._router.url.split(/[?#]/)[0];
+        const {
+          step: { id },
+        } = tourEvent;
+        if (this._tourStepURLs.has(id)) {
+          const stepRoute: string = this._tourStepURLs.get(id);
+          if (stepRoute !== currentURL) {
+            this._router.navigate([stepRoute]);
+          }
+        } else {
+          this._tourStepURLs.set(id, currentURL);
+        }
+      });
       return tourInstance;
     } else {
       // tslint:disable-next-line:no-console

--- a/src/platform/guided-tour/guided.tour.ts
+++ b/src/platform/guided-tour/guided.tour.ts
@@ -89,6 +89,7 @@ const defaultStepOptions: TourStep = {
 
 const MAT_ICON_BUTTON: string = 'mat-icon-button material-icons mat-button-base';
 const MAT_BUTTON: string = 'mat-button-base mat-button';
+const MAT_BUTTON_INVISIBLE: string = 'shepherd-void-button';
 
 export class CovalentGuidedTour extends TourButtonsActions {
   private _destroyedEvent$: Subject<void>;
@@ -214,6 +215,14 @@ export class CovalentGuidedTour extends TourButtonsActions {
       classes: MAT_BUTTON,
     };
 
+    const voidButton: TourStepButton = {
+      text: '',
+      action(): void {
+        return;
+      },
+      classes: MAT_BUTTON_INVISIBLE,
+    };
+
     // listen to the destroyed event to clean up all the streams
     this._destroyedEvent$.pipe(first()).subscribe(() => {
       backEvent$.complete();
@@ -275,9 +284,8 @@ export class CovalentGuidedTour extends TourButtonsActions {
         advanceOn instanceof Array
       ) {
         step.advanceOn = undefined;
-        if (step.advanceOnOptions && step.advanceOnOptions.allowGoBack) {
-          step.buttons = [backButton];
-        }
+        step.buttons =
+          step.advanceOnOptions && step.advanceOnOptions.allowGoBack ? [backButton, voidButton] : [voidButton];
       }
       // adds a default beforeShowPromise function
       step.beforeShowPromise = () => {
@@ -344,7 +352,7 @@ export class CovalentGuidedTour extends TourButtonsActions {
             // we had to use `any` since the tour doesnt expose the steps in any fashion nor a way to check if we have modified them at all
             if (this.shepherdTour.getCurrentStep() === (<any>this.shepherdTour).steps[0]) {
               this.shepherdTour.getCurrentStep().updateStepOptions({
-                buttons: originalSteps[index].advanceOn ? [] : [nextButton],
+                buttons: originalSteps[index].advanceOn ? [voidButton] : [nextButton],
               });
             }
             // register to the attempts observable to notify deeveloper when number has been reached

--- a/src/platform/guided-tour/guided.tour.ts
+++ b/src/platform/guided-tour/guided.tour.ts
@@ -164,11 +164,7 @@ export class CovalentGuidedTour extends TourButtonsActions {
     this.shepherdTour.start();
   }
 
-  protected _prepareTour(
-    originalSteps: ITourStep[],
-    finishLabel: string = 'finish',
-    dismissLabel: string = 'cancel tour',
-  ): ITourStep[] {
+  protected _prepareTour(originalSteps: ITourStep[], finishLabel: string = 'finish'): ITourStep[] {
     // create Subjects for back and forward events
     const backEvent$: Subject<void> = new Subject<void>();
     const forwardEvent$: Subject<void> = new Subject<void>();
@@ -215,11 +211,6 @@ export class CovalentGuidedTour extends TourButtonsActions {
     const finishButton: TourStepButton = {
       text: finishLabel,
       action: this['finish'].bind(this),
-      classes: MAT_BUTTON,
-    };
-    const dismissButton: TourStepButton = {
-      text: dismissLabel,
-      action: this['cancel'].bind(this),
       classes: MAT_BUTTON,
     };
 
@@ -284,8 +275,9 @@ export class CovalentGuidedTour extends TourButtonsActions {
         advanceOn instanceof Array
       ) {
         step.advanceOn = undefined;
-        step.buttons =
-          step.advanceOnOptions && step.advanceOnOptions.allowGoBack ? [backButton, dismissButton] : [dismissButton];
+        if (step.advanceOnOptions && step.advanceOnOptions.allowGoBack) {
+          step.buttons = [backButton];
+        }
       }
       // adds a default beforeShowPromise function
       step.beforeShowPromise = () => {
@@ -348,11 +340,11 @@ export class CovalentGuidedTour extends TourButtonsActions {
           }
           // if we have an id as a string in either case, we use it (we ignore it if its HTMLElement)
           if (id) {
-            // if current step is the first step of the tour, we set the buttons to be only "next" or "dismiss"
+            // if current step is the first step of the tour, we set the buttons to be only "next"
             // we had to use `any` since the tour doesnt expose the steps in any fashion nor a way to check if we have modified them at all
             if (this.shepherdTour.getCurrentStep() === (<any>this.shepherdTour).steps[0]) {
               this.shepherdTour.getCurrentStep().updateStepOptions({
-                buttons: originalSteps[index].advanceOn ? [dismissButton] : [nextButton],
+                buttons: originalSteps[index].advanceOn ? [] : [nextButton],
               });
             }
             // register to the attempts observable to notify deeveloper when number has been reached


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Created tourEvent$ observable and step/url Map for router transitions
### What's included?
<!-- List features included in this PR -->
- tourEvent$ observable
- step/url Map for tour route transitions
- going back with navigation demo
- changed dismissButton to voidButton and set display: none
#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] select guided tour / examples
- [ ] run going back with navigation example



#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![tour-event](https://user-images.githubusercontent.com/4431785/91452897-fb945580-e833-11ea-93a6-d9b917eed99a.gif)