### PR TITLE
fix(markdown): add startAt option for children url

### DIFF
--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-anchor/markdown-navigator-demo-anchor.component.html
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-anchor/markdown-navigator-demo-anchor.component.html
@@ -1,1 +1,1 @@
-<td-markdown-navigator [items]="items" [style.height.px]="300" [compareWith]="compareWith"></td-markdown-navigator>
+<td-markdown-navigator [items]="items" [style.height.px]="300"></td-markdown-navigator>

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-anchor/markdown-navigator-demo-anchor.component.html
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-anchor/markdown-navigator-demo-anchor.component.html
@@ -1,1 +1,1 @@
-<td-markdown-navigator [items]="items" [style.height.px]="300"></td-markdown-navigator>
+<td-markdown-navigator [items]="items" [style.height.px]="300" [compareWith]="compareWith"></td-markdown-navigator>

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-anchor/markdown-navigator-demo-anchor.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-anchor/markdown-navigator-demo-anchor.component.ts
@@ -1,9 +1,6 @@
 import { Component } from '@angular/core';
 import { IMarkdownNavigatorItem } from '@covalent/markdown-navigator';
 
-function compareByTitle(o1: IMarkdownNavigatorItem, o2: IMarkdownNavigatorItem): boolean {
-  return o1.title === o2.title;
-}
 @Component({
   selector: 'markdown-navigator-demo-anchor',
   styleUrls: ['./markdown-navigator-demo-anchor.component.scss'],
@@ -17,16 +14,9 @@ export class MarkdownNavigatorDemoAnchorComponent {
       anchor: 'browser-support',
     },
     {
-      title: 'External Object Store',
-      childrenUrl: 'https://www.teradata.com/product-help/UseCases/use_cases.json',
-      startAtLink: { title: 'External Object Store' },
-    },
-    {
       title: 'Angular Commit Message Format',
       url: 'https://github.com/angular/angular/blob/master/CONTRIBUTING.md',
       anchor: 'commit-message-format',
     },
   ];
-
-  compareWith: (o1: IMarkdownNavigatorItem, o2: IMarkdownNavigatorItem) => boolean = compareByTitle;
 }

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-anchor/markdown-navigator-demo-anchor.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-anchor/markdown-navigator-demo-anchor.component.ts
@@ -1,6 +1,9 @@
 import { Component } from '@angular/core';
 import { IMarkdownNavigatorItem } from '@covalent/markdown-navigator';
 
+function compareByTitle(o1: IMarkdownNavigatorItem, o2: IMarkdownNavigatorItem): boolean {
+  return o1.title === o2.title;
+}
 @Component({
   selector: 'markdown-navigator-demo-anchor',
   styleUrls: ['./markdown-navigator-demo-anchor.component.scss'],
@@ -14,9 +17,16 @@ export class MarkdownNavigatorDemoAnchorComponent {
       anchor: 'browser-support',
     },
     {
+      title: 'External Object Store',
+      childrenUrl: 'https://www.teradata.com/product-help/UseCases/use_cases.json',
+      startAtLink: { title: 'External Object Store' },
+    },
+    {
       title: 'Angular Commit Message Format',
       url: 'https://github.com/angular/angular/blob/master/CONTRIBUTING.md',
       anchor: 'commit-message-format',
     },
   ];
+
+  compareWith: (o1: IMarkdownNavigatorItem, o2: IMarkdownNavigatorItem) => boolean = compareByTitle;
 }

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-start-at-onclick-children-url/markdown-navigator-demo-start-at-onclick-children-url.component.html
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-start-at-onclick-children-url/markdown-navigator-demo-start-at-onclick-children-url.component.html
@@ -1,0 +1,1 @@
+<td-markdown-navigator [items]="items" [compareWith]="compareWith"></td-markdown-navigator>

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-start-at-onclick-children-url/markdown-navigator-demo-start-at-onclick-children-url.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-start-at-onclick-children-url/markdown-navigator-demo-start-at-onclick-children-url.component.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+import { IMarkdownNavigatorItem } from '@covalent/markdown-navigator';
+
+function compareByTitle(o1: IMarkdownNavigatorItem, o2: IMarkdownNavigatorItem): boolean {
+  return o1.title === o2.title;
+}
+@Component({
+  selector: 'markdown-navigator-demo-start-at-onclick-children-url',
+  templateUrl: './markdown-navigator-demo-start-at-onclick-children-url.component.html',
+  styleUrls: ['./markdown-navigator-demo-start-at-onclick-children-url.component.scss'],
+})
+export class MarkdownNavigatorDemoStartAtOnclickChildrenUrlComponent {
+  items: IMarkdownNavigatorItem[] = [
+    {
+      id: 'external_obj_store',
+      title: 'External Object Store',
+      childrenUrl: 'https://www.teradata.com/product-help/UseCases/use_cases.json',
+      startAtLink: { title: 'External Object Store' },
+    },
+    {
+      id: 'url-children-demo',
+      title: 'Url children demo',
+      childrenUrl: '/assets/demos-data/children_url_3.json',
+      /*
+      For ref:
+
+      children_url_3.json:
+      [
+        {
+          "title": "Child 1",
+          "id": "child-1",
+          "markdownString": "> This is child 1"
+        },
+        {
+          "title": "Child 2",
+          "id": "child-2",
+          "markdownString": "> This is child 2",
+          "childrenUrl": "/assets/demos-data/children_url_2.json",
+          "startAtLink": {"id" : "grandchild-2"}
+        }
+      ]
+
+      children_url_2.json:
+      [
+        {
+          "title": "Grandchild 1",
+          "id": "grandchild-1",
+          "markdownString": "> This is grandchild 1"
+        },
+        {
+          "title": "Grandchild 2",
+          "id": "grandchild-2",
+          "markdownString": "> This is grandchild 2"
+        }
+      ]
+      */
+    },
+  ];
+  compareWith: (o1: IMarkdownNavigatorItem, o2: IMarkdownNavigatorItem) => boolean = compareByTitle;
+}

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-start-at-onclick-children-url/markdown-navigator-demo-start-at-onclick-children-url.component.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-start-at-onclick-children-url/markdown-navigator-demo-start-at-onclick-children-url.component.ts
@@ -17,12 +17,54 @@ export class MarkdownNavigatorDemoStartAtOnclickChildrenUrlComponent {
       childrenUrl: 'https://www.teradata.com/product-help/UseCases/use_cases.json',
       startAtLink: { title: 'External Object Store' },
     },
+    /*
+    For ref : On click of 'External Object Store', 
+              it opens item with title - 'External Object Store' from use-cases.json
+    
+    use_cases.json
+
+  [
+    {
+      "title": "Path Analysis",
+      "url": "https://raw.githubusercontent.com/Teradata/product-help/master/UseCases/nPath/README.md"
+    },
+    {
+      "title": "Vantage Path",
+      "url": "https://raw.githubusercontent.com/Teradata/product-help/master/UseCases/VantagePath/README.md"
+    },
+    {
+      "title": "Time Series - Consumer Complaints",
+      "url": "https://raw.githubusercontent.com/Teradata/product-help/master/UseCases/TimeSeriesAnalysis/README.md"
+    },
+    {
+      "title": "Financial Services Customer Journey",
+      "url": "https://raw.githubusercontent.com/Teradata/product-help/master/UseCases/FSCustomerJourney/README.md"
+    },
+    {
+      "title": "Knee Replacement",
+      "url": "https://raw.githubusercontent.com/Teradata/product-help/master/UseCases/KneeReplacement/README.md"
+    },
+    {
+      "title": "Manufacturing Defect Analysis",
+      "url": "https://raw.githubusercontent.com/Teradata/product-help/master/UseCases/ManufacturingDefects/README.md"
+    },
+    {
+      "title": "Deep History",
+      "url": "https://raw.githubusercontent.com/Teradata/product-help/master/UseCases/SalesOffload/README.md"
+    },
+    {
+      "title": "External Object Store",
+      "url": "https://raw.githubusercontent.com/Teradata/product-help/master/UseCases/ExternalObjectStore/README.md"
+    }
+  ]
+
+    */
     {
       id: 'url-children-demo',
       title: 'Url children demo',
       childrenUrl: '/assets/demos-data/children_url_3.json',
       /*
-      For ref:
+      For ref: click 'Url children demo' --> 'Child 2' --> goes to 'GrandChild-2'
 
       children_url_3.json:
       [

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
@@ -20,7 +20,7 @@
 
 <demo-component
   [demoId]="'markdown-navigator-demo-start-at-onclick-children-url'"
-  [demoTitle]="'Jump on title on click of child url'"
+  [demoTitle]="'StartAt on nested url'"
 >
   <markdown-navigator-demo-start-at-onclick-children-url></markdown-navigator-demo-start-at-onclick-children-url>
 </demo-component>

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
@@ -18,6 +18,13 @@
   <markdown-navigator-demo-children-url-start-at></markdown-navigator-demo-children-url-start-at>
 </demo-component>
 
+<demo-component
+  [demoId]="'markdown-navigator-demo-start-at-onclick-children-url'"
+  [demoTitle]="'Jump on title on click of child url'"
+>
+  <markdown-navigator-demo-start-at-onclick-children-url></markdown-navigator-demo-start-at-onclick-children-url>
+</demo-component>
+
 <demo-component [demoId]="'markdown-navigator-demo-footer'" [demoTitle]="'Footer'">
   <markdown-navigator-demo-footer></markdown-navigator-demo-footer>
 </demo-component>

--- a/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.module.ts
+++ b/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.module.ts
@@ -25,6 +25,7 @@ import { MarkdownNavigatorDemoEditorComponent } from './markdown-navigator-demo-
 import { CovalentCodeEditorModule } from '@covalent/code-editor';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MarkdownNavigatorDemoChildrenUrlStartAtComponent } from './markdown-navigator-demo-children-url-start-at/markdown-navigator-demo-children-url-start-at.component';
+import { MarkdownNavigatorDemoStartAtOnclickChildrenUrlComponent } from './markdown-navigator-demo-start-at-onclick-children-url/markdown-navigator-demo-start-at-onclick-children-url.component';
 
 @NgModule({
   declarations: [
@@ -41,6 +42,7 @@ import { MarkdownNavigatorDemoChildrenUrlStartAtComponent } from './markdown-nav
     MarkdownNavigatorDemoAnchorComponent,
     MarkdownNavigatorDemoEditorComponent,
     MarkdownNavigatorDemoChildrenUrlStartAtComponent,
+    MarkdownNavigatorDemoStartAtOnclickChildrenUrlComponent,
   ],
   imports: [
     DemoModule,

--- a/src/assets/demos-data/children_url_3.json
+++ b/src/assets/demos-data/children_url_3.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Child 1",
+    "id": "child-1",
+    "markdownString": "> This is child 1"
+  },
+  {
+    "title": "Child 2",
+    "id": "child-2",
+    "markdownString": "> This is child 2",
+    "childrenUrl": "/assets/demos-data/children_url_2.json",
+    "startAtLink": { "title": "Grandchild 2" }
+  }
+]

--- a/src/platform/markdown-navigator/markdown-navigator.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.ts
@@ -31,6 +31,7 @@ export interface IMarkdownNavigatorItem {
   description?: string;
   icon?: string;
   footer?: Type<any>;
+  startAtLink?: IMarkdownNavigatorItem;
 }
 
 export interface IMarkdownNavigatorLabels {
@@ -251,7 +252,7 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
       this.reset();
     }
     if (changes.startAt && this.items && this.startAt) {
-      this._jumpTo(this.startAt);
+      this._jumpTo(this.startAt, undefined);
     }
   }
 
@@ -313,6 +314,9 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
     } else if (item.childrenUrl) {
       children = await this.loadChildrenUrl(item);
     }
+    if (children && children.length && item.startAtLink) {
+      this._jumpTo(item.startAtLink, children);
+    }
     const newStackSnapshot: IMarkdownNavigatorItem[] = this.historyStack;
     if (
       stackSnapshot.length === newStackSnapshot.length &&
@@ -364,13 +368,18 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
     this._changeDetectorRef.markForCheck();
   }
 
-  private async _jumpTo(itemOrPath: IMarkdownNavigatorItem | IMarkdownNavigatorItem[]): Promise<void> {
+  private async _jumpTo(
+    itemOrPath: IMarkdownNavigatorItem | IMarkdownNavigatorItem[],
+    children: IMarkdownNavigatorItem[],
+  ): Promise<void> {
     this.reset();
     if (this.items && this.items.length > 0) {
       let path: IMarkdownNavigatorItem[] = [];
 
       if (Array.isArray(itemOrPath)) {
         path = await this.followPath(this.items, itemOrPath);
+      } else if (children && children.length > 0) {
+        path = this.findPath(children, itemOrPath);
       } else {
         path = this.findPath(this.items, itemOrPath);
       }

--- a/src/platform/markdown-navigator/markdown-navigator.component.ts
+++ b/src/platform/markdown-navigator/markdown-navigator.component.ts
@@ -396,9 +396,7 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
       } else {
         path = this.findPath(this.items, itemOrPath);
       }
-      (path || []).forEach((pathItem: IMarkdownNavigatorItem) => {
-        return this.handleItemSelected(pathItem);
-      });
+      (path || []).forEach((pathItem: IMarkdownNavigatorItem) => this.handleItemSelected(pathItem));
     }
     this._changeDetectorRef.markForCheck();
   }


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Add a startAt option for children url, so that we can jumpTo any link if childrenUrl contains multiple urls

### What's included?
<!-- List features included in this PR -->
- Add a startAt option for children url

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then go to components -> Markdown Navigator
- [ ] go to examples -> Jump on title on click of child url
- [ ] click on External Object Store and try clicking back
- [ ] click on url children demo -> child-2, it should jump directly to grandChild-2. Try going back also.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
