### PR TITLE
fix(guided-tour): allowGoBack not working

### DIFF
--- a/src/platform/guided-tour/guided.tour.ts
+++ b/src/platform/guided-tour/guided.tour.ts
@@ -257,7 +257,7 @@ export class CovalentGuidedTour extends TourButtonsActions {
             this.shepherdTour.back();
           }
         },
-        classes: MAT_ICON_BUTTON,
+        classes: step.advanceOnOptions?.allowGoBack === false ? MAT_BUTTON_INVISIBLE : MAT_ICON_BUTTON,
       };
 
       // check if highlight was provided for the step, else fallback into shepherds usage


### PR DESCRIPTION
## Description

This fixes the `allowGoBack` option not working as expected for a guided tour step. Setting it false now disables / hides the button.

**ALTERNATE APPROACH:** https://github.com/9inpachi/covalent/commit/5ebdaebf668ba1b6a2a1925f900a006737e82504 (removing the back button)

### What's included?

- `allowGoBack` option working as expected
- Closes #1800 

#### Test Steps

- [x] `npm run serve`
- [x] Go to `http://localhost:4200/#/components/guided-tour/examples` OR
  - [x] Open the app, and go to "Components"
  - [x] Go to the "Guided Tour" demo and open "Examples"
- [x] Go to the last example "Going back with navigation" and start the tour
- [x] Step 3 where the tour takes to the home page should not have a back button (it did before even though `allowGoBack` is false for the step)

#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

For [STEP 3](https://github.com/Teradata/covalent/blob/develop/src/app/content/components/component-demos/guided-tour/demos/guided-tour-demo-go-back-navigation/guided-tour-demo-go-back-navigation.component.ts#L41-L48) in demo where the `allowGoBack` is set to false.

**Before**

![guided-tour-allowGoBack-b](https://user-images.githubusercontent.com/36920441/92592643-59f01800-f2b9-11ea-8ab4-95ce84a9982b.gif)

**After**

![guided-tour-allowGoBack-a](https://user-images.githubusercontent.com/36920441/92592637-58beeb00-f2b9-11ea-8778-943de8a9b36b.gif)
