### PR TITLE
fix(highlight): move highlight display rule out of theme file

### DIFF
--- a/src/platform/highlight/_highlight-theme.scss
+++ b/src/platform/highlight/_highlight-theme.scss
@@ -6,7 +6,6 @@
 @mixin covalent-highlight-theme() {
   td-highlight {
     background: #1e1e21;
-    display: flex;
     .highlight {
       color: $light-primary-text;
     }

--- a/src/platform/highlight/highlight.component.scss
+++ b/src/platform/highlight/highlight.component.scss
@@ -4,6 +4,7 @@ $padding: 16px;
 :host ::ng-deep {
   overflow-x: auto;
   padding: $padding;
+  display: flex;
   pre,
   code,
   .highlight {


### PR DESCRIPTION
## Description
Moved display rule from `_highlight-theme.scss` to `highlight.component.scss`

Fixes #1803 
