### PR TITLE
fix(menu): fix dynamic menu hover

### DIFF
--- a/src/platform/core/dynamic-menu/dynamic-menu-item/dynamic-menu-item.component.html
+++ b/src/platform/core/dynamic-menu/dynamic-menu-item/dynamic-menu-item.component.html
@@ -16,7 +16,9 @@
         <div class="group-label text-sm">{{ item.text }}</div>
       </ng-container>
       <ng-container *ngIf="item.link || item.action">
-        <td-dynamic-menu-link [item]="item" (itemClicked)="emitClicked($event)"></td-dynamic-menu-link>
+        <div mat-menu-item class="paddin-none">
+          <td-dynamic-menu-link [item]="item" (itemClicked)="emitClicked($event)"></td-dynamic-menu-link>
+        </div>
       </ng-container>
     </ng-container>
   </ng-template>

--- a/src/platform/core/dynamic-menu/dynamic-menu-item/dynamic-menu-item.component.scss
+++ b/src/platform/core/dynamic-menu/dynamic-menu-item/dynamic-menu-item.component.scss
@@ -4,3 +4,7 @@
 .group-label {
   padding: 16px;
 }
+
+.paddin-none {
+  padding: 0;
+}


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
    covalent#1797  - Dynamic menu sub menu stays open

### What's included?
<!-- List features included in this PR -->
- Fix the issue where dynamic menu's sub menu remains open, if we hover on to other menu option

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then go to Components -> Dynamic menu
- [ ] finally try the example

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
