### PR TITLE
fix(message): fixed displaying file in demo for messages

### DIFF
--- a/src/app/content/components/component-demos/message/demos/message-demo.component.html
+++ b/src/app/content/components/component-demos/message/demos/message-demo.component.html
@@ -2,10 +2,10 @@
 Basic'">
   <message-demo-basic></message-demo-basic>
 </demo-component>
-<demo-component [demoId]="'message-demo-card'" [demoTitle]="'Message Action'">
+<demo-component [demoId]="'message-demo-action'" [demoTitle]="'Message Action'">
   <message-demo-action></message-demo-action>
 </demo-component>
-<demo-component [demoId]="'message-demo-css'" [demoTitle]="'Color Styling'">
+<demo-component [demoId]="'message-demo-color'" [demoTitle]="'Color Styling'">
   <message-demo-color></message-demo-color>
 </demo-component>
 <demo-component [demoId]="'message-demo-toggle-visibility'" [demoTitle]="'Manage Visibility'">


### PR DESCRIPTION
## Description
Fixed displaying .ts and .html file in demo examples of messages component.

### What's included?
- Closes https://github.com/Teradata/covalent/issues/1783

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] Go to http://localhost:4200/#/components/message/examples
- [ ] Click on `<>` on the toolbar of message action and color styling demo.

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
Before
<img width="1450" alt="Screen Shot 2020-09-27 at 7 48 50 PM" src="https://user-images.githubusercontent.com/70976603/94378859-82ba3f00-00fa-11eb-903a-88eb13a18765.png">

After
![Screen-Recording-2020-09-27-at-7](https://user-images.githubusercontent.com/70976603/94378971-5eab2d80-00fb-11eb-9855-56eee6ff0866.gif)

