### PR TITLE
fix(highlight): fix all references of lang to codeLang

### DIFF
--- a/src/app/components/shared/demo-tools/demo.component.html
+++ b/src/app/components/shared/demo-tools/demo.component.html
@@ -6,17 +6,17 @@
   </mat-toolbar-row>
   <mat-tab-group *ngIf="viewCode">
     <mat-tab label="HTML">
-      <td-highlight lang="html">
+      <td-highlight codeLang="html">
         {{ htmlFile }}
       </td-highlight>
     </mat-tab>
     <mat-tab label="TS">
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         {{ typescriptFile }}
       </td-highlight>
     </mat-tab>
     <mat-tab label="SCSS" *ngIf="stylesFile">
-      <td-highlight lang="scss">
+      <td-highlight codeLang="scss">
         {{ stylesFile }}
       </td-highlight>
     </mat-tab>

--- a/src/app/content/components/component-demos/code-editor/demos/code-editor-demo-basic/code-editor-demo-basic.component.html
+++ b/src/app/content/components/component-demos/code-editor/demos/code-editor-demo-basic/code-editor-demo-basic.component.html
@@ -11,7 +11,7 @@
 </div>
 <p>Editor Output:</p>
 <div layout="row" layout-align="start center">
-  <td-highlight class="editor" flex [content]="editorVal" [lang]="editorLanguage"></td-highlight>
+  <td-highlight class="editor" flex [content]="editorVal" [codeLang]="editorLanguage"></td-highlight>
 </div>
 
 <div layout="row" layout-align="start center" class="pad-xs pad-bottom-none">

--- a/src/app/content/docs/build-tasks/build-tasks.component.html
+++ b/src/app/content/docs/build-tasks/build-tasks.component.html
@@ -6,10 +6,10 @@
     <h3>Command Line Build Tasks</h3>
     <h4>Important: Make sure you have Node 6.11.1 or greater!</h4>
     <p>First install the CLI</p>
-    <td-highlight lang="bash">npm install -g @angular/cli@latest</td-highlight>
+    <td-highlight codeLang="bash">npm install -g @angular/cli@latest</td-highlight>
     <h4>Local server</h4>
     <p>Serve your app locally by navingating to the directory and running:</p>
-    <td-highlight lang="bash">ng serve</td-highlight>
+    <td-highlight codeLang="bash">ng serve</td-highlight>
     <p>
       Which will serve to
       <code>http://localhost:4200/</code>
@@ -23,7 +23,7 @@
       <code>ng g</code>
       )
     </p>
-    <td-highlight lang="bash">ng g component my-new-component</td-highlight>
+    <td-highlight codeLang="bash">ng g component my-new-component</td-highlight>
     <p>You can find all possible blueprints in the table below:</p>
     <table cellpadding="10">
       <thead>

--- a/src/app/content/docs/creating/creating.component.html
+++ b/src/app/content/docs/creating/creating.component.html
@@ -5,7 +5,7 @@
   <mat-card-content>
     <h3>Generate Component</h3>
     <p>Using the CLI, nagivate into the directory you want the new component, then simply:</p>
-    <td-highlight lang="html">ng generate component new-view</td-highlight>
+    <td-highlight codeLang="html">ng generate component new-view</td-highlight>
     <p>The CLI will do the heavy lifting and create the following with corresponding names:</p>
     <ul>
       <li>directory (/new-view)</li>
@@ -19,19 +19,19 @@
       into app.module.ts:
     </p>
     <p>for example in app.module.ts:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       {{ newViewRootTypescript }}
     </td-highlight>
     <p>And define those declarations/imports in @NgModule:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       {{ newViewFeatureTypescript }}
     </td-highlight>
     <p>next we'll need to create a route for this component, edit app.routes.ts:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       {{ newViewRouteTypescript }}
     </td-highlight>
     <p>and add a new path with the url you desire for this route:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       {{ newViewPathTypescript }}
     </td-highlight>
     <p>Now you can use this new route in your main nav or wherever you like!</p>

--- a/src/app/content/docs/deployment/deployment.component.html
+++ b/src/app/content/docs/deployment/deployment.component.html
@@ -5,7 +5,7 @@
   <mat-card-content>
     <h3>Creating a build</h3>
     <p>The build artifacts will be stored in the dist/ directory.</p>
-    <td-highlight lang="html">ng build</td-highlight>
+    <td-highlight codeLang="html">ng build</td-highlight>
 
     <h3>Building for production</h3>
     <p>
@@ -15,7 +15,7 @@
       <code>ng build</code>
       will set the build target and environment to production, which will optimize the build.
     </p>
-    <td-highlight lang="html">ng build --prod</td-highlight>
+    <td-highlight codeLang="html">ng build --prod</td-highlight>
 
     <h3>Ahead-of-time Compilation</h3>
     <p>
@@ -26,6 +26,6 @@
       everything in the browser. This will result in faster rendering, fewer asynchronous requests, smaller Angular
       framework size, and better security for your application.
     </p>
-    <td-highlight lang="html">ng build --prod --aot</td-highlight>
+    <td-highlight codeLang="html">ng build --prod --aot</td-highlight>
   </mat-card-content>
 </mat-card>

--- a/src/app/content/docs/icons/icons.component.html
+++ b/src/app/content/docs/icons/icons.component.html
@@ -8,7 +8,7 @@
   <h3 class="push-bottom-sm mat-title">Font Icons</h3>
   <mat-divider></mat-divider>
   <p>Font icons using ligatures are the default option and simple to use:</p>
-  <td-highlight lang="html">
+  <td-highlight codeLang="html">
     {{ iconsHtml }}
   </td-highlight>
   <p class="push-bottom-lg">
@@ -23,11 +23,11 @@
     [MatIconRegistry] so it can be referred later on:
   </p>
   <p>Typescript:</p>
-  <td-highlight lang="typescript">
+  <td-highlight codeLang="typescript">
     {{ svgIconsTypescript }}
   </td-highlight>
   <p>HTML:</p>
-  <td-highlight class="push-bottom-lg" lang="html">
+  <td-highlight class="push-bottom-lg" codeLang="html">
     {{ svgIconsHtml }}
   </td-highlight>
   <a mat-button color="accent" target="_blank" href="https://material.io/icons/" class="text-upper">Search Icons</a>

--- a/src/app/content/docs/mock-data/mock-data.component.html
+++ b/src/app/content/docs/mock-data/mock-data.component.html
@@ -24,7 +24,7 @@
     </p>
     <td-highlight>npm run start-api</td-highlight>
     <p>You should see the server running starting with:</p>
-    <td-highlight lang="bash">
+    <td-highlight codeLang="bash">
       INFO[0000] ################################################################## INFO[0000] ######## ########
       INFO[0000] ######## Teradata Covalent Atomic Data mock API server ######## INFO[0000] ######## Copyright 2016 by
       Teradata. All rights reserved. ######## INFO[0000] ######## This software is covered under the MIT license.
@@ -47,7 +47,7 @@
       For example to modify the mock users , edit
       <code>mock-api/schemas/users.yaml</code>
     </p>
-    <td-highlight lang="bash">
+    <td-highlight codeLang="bash">
       # this is a sample schema file for a user object. --- initial_entries: 10 randomize: false displayname:
       _firstname_ _lastname_ id: _firstname_._lastname_ email: _firstname_._lastname_@_company_.com created:
       _createdtimestamp_ last_access: _itemtimestamp_ site_admin: _admin_ ...
@@ -65,10 +65,10 @@
       <code>/mock-api/datum/firstname.txt</code>
       , and each value is on a single line:
     </p>
-    <td-highlight lang="bash">Aaron Benjamin Carl Olive ...</td-highlight>
+    <td-highlight codeLang="bash">Aaron Benjamin Carl Olive ...</td-highlight>
     <h3>Consuming Mock Data Endpoints</h3>
     <p>The Mock API Server generates real endpoints that can be consumed in Angular services.</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       {{ mockApiDataTypescript }}
     </td-highlight>
     <p>

--- a/src/app/content/docs/testing/testing.component.html
+++ b/src/app/content/docs/testing/testing.component.html
@@ -5,7 +5,7 @@
   <mat-card-content>
     <h3>Install TSLint for TypeScript</h3>
     <p>First ensure you have Protractor and TSLint installed, setup for TypeScript and updated Webdriver</p>
-    <td-highlight lang="bash">
+    <td-highlight codeLang="bash">
       npm install -g tslint typescript npm install -g protractor webdriver-manager update
       ./node_modules/.bin/webdriver-manager update
     </td-highlight>
@@ -17,18 +17,18 @@
       You can run tests a single time via --watch=false, and turn off building of the app via --build=false (useful for
       running it at the same time as ng serve).
     </p>
-    <td-highlight lang="bash">ng test</td-highlight>
+    <td-highlight codeLang="bash">ng test</td-highlight>
     <h3>Running end-to-end tests</h3>
     <p>Before running the tests make sure you are serving the app via ng serve.</p>
     <p>End-to-end tests are ran via Protractor.</p>
 
-    <td-highlight lang="bash">ng e2e</td-highlight>
+    <td-highlight codeLang="bash">ng e2e</td-highlight>
     <h3>Linting and formatting code</h3>
     <p>
       You can lint your app code by running ng lint. This will use the lint npm script that in generated projects uses
       tslint.
     </p>
-    <td-highlight lang="bash">ng lint</td-highlight>
+    <td-highlight codeLang="bash">ng lint</td-highlight>
   </mat-card-content>
   <mat-divider></mat-divider>
   <mat-card-actions>

--- a/src/app/content/docs/theme/theme.component.html
+++ b/src/app/content/docs/theme/theme.component.html
@@ -9,7 +9,7 @@
   <mat-divider></mat-divider>
 
   <p>Simply edit the /theme.scss file and update these SCSS variables:</p>
-  <td-highlight lang="scss">
+  <td-highlight codeLang="scss">
     {{ themeScss }}
   </td-highlight>
   <p>

--- a/src/app/content/layouts/card-over/card-over.component.html
+++ b/src/app/content/layouts/card-over/card-over.component.html
@@ -9,7 +9,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ tdLayoutMinHtml }}
     </td-highlight>
   </mat-card-content>
@@ -54,7 +54,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ tdLayoutDrawerHtml }}
     </td-highlight>
   </mat-card-content>
@@ -139,11 +139,11 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ tdLayoutLinksHtml }}
     </td-highlight>
     <h3 class="mat-title">TypeScript:</h3>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       {{ tdLayoutTypescript }}
     </td-highlight>
   </mat-card-content>

--- a/src/app/content/layouts/manage-list/manage-list.component.html
+++ b/src/app/content/layouts/manage-list/manage-list.component.html
@@ -12,7 +12,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ managedListMinHtml }}
     </td-highlight>
   </mat-card-content>
@@ -63,7 +63,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ managedListBasicHtml }}
     </td-highlight>
   </mat-card-content>
@@ -204,11 +204,11 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ managedListFullHtml }}
     </td-highlight>
     <h3 class="mat-title">TypeScript:</h3>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       {{ managedListFullTypescript }}
     </td-highlight>
   </mat-card-content>

--- a/src/app/content/layouts/nav-list/nav-list.component.html
+++ b/src/app/content/layouts/nav-list/nav-list.component.html
@@ -10,7 +10,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ navListMinHtml }}
     </td-highlight>
   </mat-card-content>
@@ -57,7 +57,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ navListBasicHtml }}
     </td-highlight>
   </mat-card-content>
@@ -151,11 +151,11 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ navListFullHtml }}
     </td-highlight>
     <h3 class="mat-title">TypeScript:</h3>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       {{ navListFullTypescript }}
     </td-highlight>
   </mat-card-content>

--- a/src/app/content/layouts/nav-view/nav-view.component.html
+++ b/src/app/content/layouts/nav-view/nav-view.component.html
@@ -11,7 +11,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ navViewMinHtml }}
     </td-highlight>
   </mat-card-content>
@@ -54,7 +54,7 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ navViewBasicHtml }}
     </td-highlight>
   </mat-card-content>
@@ -166,11 +166,11 @@
   </div>
   <mat-divider></mat-divider>
   <mat-card-content>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ navViewFullHtml }}
     </td-highlight>
     <h3 class="mat-title">TypeScript:</h3>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       {{ navViewFullTypescript }}
     </td-highlight>
   </mat-card-content>

--- a/src/app/content/layouts/overview/overview.component.html
+++ b/src/app/content/layouts/overview/overview.component.html
@@ -61,7 +61,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           {{ rwdHorizontalRowHtml }}
         </td-highlight>
         <div class="pad-top pad-bottom">
@@ -76,7 +76,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           {{ rwdVerticalColumnHtml }}
         </td-highlight>
       </div>
@@ -92,7 +92,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           {{ rwdMarginHtml }}
         </td-highlight>
         <div class="pad-top pad-bottom">
@@ -107,7 +107,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           {{ rwdPaddingHtml }}
         </td-highlight>
       </div>
@@ -127,7 +127,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           {{ rwd4030Html }}
         </td-highlight>
         <div class="pad-top pad-bottom">
@@ -142,7 +142,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           {{ rwdWidthHtml }}
         </td-highlight>
         <div class="pad-top pad-bottom">
@@ -156,7 +156,7 @@
         <div class="pad-top pad-bottom">
           <mat-divider></mat-divider>
         </div>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           {{ rwdXsHtml }}
         </td-highlight>
       </div>

--- a/src/app/content/utilities/utilities-demos/animations/animations.component.html
+++ b/src/app/content/utilities/utilities-demos/animations/animations.component.html
@@ -14,7 +14,7 @@
     Import individual animation utilities as needed into the component that will contain the elements you want to
     animate.
   </p>
-  <td-highlight lang="typescript">
+  <td-highlight codeLang="typescript">
     {{ animationTypescript }}
   </td-highlight>
 
@@ -49,11 +49,11 @@
       </button>
 
       <p>Typescript:</p>
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         {{ rotate180Typescript }}
       </td-highlight>
       <p>HTML:</p>
-      <td-highlight lang="html">
+      <td-highlight codeLang="html">
         {{ rotate180Html }}
       </td-highlight>
     </div>
@@ -73,11 +73,11 @@
       </button>
 
       <p>Typescript:</p>
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         {{ rotate45Typescript }}
       </td-highlight>
       <p>HTML:</p>
-      <td-highlight lang="html">
+      <td-highlight codeLang="html">
         {{ rotate45Html }}
       </td-highlight>
     </div>
@@ -138,11 +138,11 @@
       </div>
 
       <p>Typescript:</p>
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         {{ collapseTypescript }}
       </td-highlight>
       <p>HTML:</p>
-      <td-highlight lang="html">
+      <td-highlight codeLang="html">
         {{ collapseHtml }}
       </td-highlight>
     </div>
@@ -198,11 +198,11 @@
       </div>
 
       <p>Typescript:</p>
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         {{ fadeTypescript }}
       </td-highlight>
       <p>HTML:</p>
-      <td-highlight lang="html">
+      <td-highlight codeLang="html">
         {{ fadeHtml }}
       </td-highlight>
     </div>
@@ -306,11 +306,11 @@
       </button>
 
       <p>Typescript:</p>
-      <td-highlight lang="typescript">
+      <td-highlight codeLang="typescript">
         {{ attentionSeekersAnimationTypescript }}
       </td-highlight>
       <p>HTML:</p>
-      <td-highlight lang="html">
+      <td-highlight codeLang="html">
         {{ attentionSeekersAnimationHtml }}
       </td-highlight>
     </div>

--- a/src/app/content/utilities/utilities-demos/directives/directives.component.html
+++ b/src/app/content/utilities/utilities-demos/directives/directives.component.html
@@ -8,7 +8,7 @@
   <h3 class="push-bottom-sm mat-title">Setup</h3>
   <mat-divider></mat-divider>
   <p>Import the [CovalentCommonModule] in your NgModule:</p>
-  <td-highlight lang="typescript">
+  <td-highlight codeLang="typescript">
     {{ directiveTypescript }}
   </td-highlight>
   <a
@@ -64,7 +64,7 @@
       </li>
     </ul>
     <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ fullscreenHtml }}
     </td-highlight>
     <div layout="column">
@@ -113,7 +113,7 @@
       </mat-form-field>
     </div>
     <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ autotrimHtml }}
     </td-highlight>
   </mat-card-content>

--- a/src/app/content/utilities/utilities-demos/functions/functions.component.html
+++ b/src/app/content/utilities/utilities-demos/functions/functions.component.html
@@ -36,11 +36,11 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           {{ clipboardCodeHtml }}
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           {{ clipboardCodeTypescript }}
         </td-highlight>
       </mat-tab>
@@ -83,11 +83,11 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           {{ convertCodeHtml }}
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           {{ convertCodeTypescript }}
         </td-highlight>
       </mat-tab>
@@ -161,11 +161,11 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML:</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           {{ downloadCodeHtml }}
         </td-highlight>
         <p>Typescript:</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           {{ downloadCodeTypescript }}
         </td-highlight>
       </mat-tab>
@@ -191,11 +191,11 @@
       <mat-tab>
         <ng-template matTabLabel>Code</ng-template>
         <p>HTML</p>
-        <td-highlight lang="html">
+        <td-highlight codeLang="html">
           {{ fileCodeHtml }}
         </td-highlight>
         <p>Typescript</p>
-        <td-highlight lang="typescript">
+        <td-highlight codeLang="typescript">
           {{ fileCodeTypescript }}
         </td-highlight>
       </mat-tab>

--- a/src/app/content/utilities/utilities-demos/media/directive/media.component.html
+++ b/src/app/content/utilities/utilities-demos/media/directive/media.component.html
@@ -33,7 +33,7 @@
     </mat-list>
     <h3>Example</h3>
     <p>HTML</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ mediaToggleHtml }}
     </td-highlight>
   </div>

--- a/src/app/content/utilities/utilities-demos/media/service/media.component.html
+++ b/src/app/content/utilities/utilities-demos/media/service/media.component.html
@@ -42,7 +42,7 @@
     </mat-list>
     <h3>Example</h3>
     <p>Typescript</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       {{ mediaServiceTypescript }}
     </td-highlight>
     <p>Note: Always unsubscribe from [Observable] objects when not using them anymore.</p>
@@ -53,7 +53,7 @@
     </p>
     <h3>Setup</h3>
     <p>Import the [CovalentMediaModule] in your NgModule:</p>
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       {{ covalentMediaHtml }}
     </td-highlight>
   </div>

--- a/src/app/content/utilities/utilities-demos/pipes/pipes.component.html
+++ b/src/app/content/utilities/utilities-demos/pipes/pipes.component.html
@@ -8,7 +8,7 @@
   <h3 class="push-bottom-sm mat-title">Setup</h3>
   <mat-divider></mat-divider>
   <p>Import the [CovalentCommonModule] in your NgModule:</p>
-  <td-highlight lang="typescript">
+  <td-highlight codeLang="typescript">
     {{ covalantCommonTypescript }}
   </td-highlight>
 
@@ -47,7 +47,7 @@
       </mat-list-item>
     </mat-list>
     <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ digitsHtml }}
     </td-highlight>
   </mat-card-content>
@@ -75,7 +75,7 @@
       </mat-list-item>
     </mat-list>
     <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ bytesHtml }}
     </td-highlight>
   </mat-card-content>
@@ -103,7 +103,7 @@
       </mat-list-item>
     </mat-list>
     <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ decimalByteHtml }}
     </td-highlight>
   </mat-card-content>
@@ -127,7 +127,7 @@
       </mat-list-item>
     </mat-list>
     <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ timeAgoHtml }}
     </td-highlight>
   </mat-card-content>
@@ -151,7 +151,7 @@
       </mat-list-item>
     </mat-list>
     <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ timeUntilHtml }}
     </td-highlight>
   </mat-card-content>
@@ -183,7 +183,7 @@
       Using this pipe without arguments outputs the time difference relative to the current time.
     </p>
     <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ timeDiffHtml }}
     </td-highlight>
   </mat-card-content>
@@ -216,14 +216,14 @@
       </mat-list-item>
     </mat-list>
     <p>Usage:</p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ truncateHtml1 }}
     </td-highlight>
     <p class="mat-body-1">
       <strong>Note:</strong>
       If the last character in a returned output is a space, then that space is removed.
     </p>
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ truncateHtml2 }}
     </td-highlight>
   </mat-card-content>

--- a/src/app/content/utilities/utilities-demos/utility-styles/utility-styles.component.html
+++ b/src/app/content/utilities/utilities-demos/utility-styles/utility-styles.component.html
@@ -10,19 +10,19 @@
 <section class="push-bottom-xxl">
   <section class="push-bottom-xl">
     <h4 class="push-bottom-sm mat-title">General Utilities</h4>
-    <td-highlight lang="css">
+    <td-highlight codeLang="css">
       {{ generalCss }}
     </td-highlight>
   </section>
   <section class="push-bottom-xl">
     <h4 class="push-bottom-sm mat-title">Sizing Utilities</h4>
-    <td-highlight lang="css">
+    <td-highlight codeLang="css">
       {{ sizeCss }}
     </td-highlight>
   </section>
   <section class="push-bottom-xl">
     <h4 class="push-bottom-sm mat-title">Text Utilities</h4>
-    <td-highlight lang="css">
+    <td-highlight codeLang="css">
       {{ textCss }}
     </td-highlight>
   </section>
@@ -30,20 +30,20 @@
   <div layout-gt-md="row">
     <div flex class="push-right-sm">
       <h4 class="push-bottom-sm push-top-smP">Pad (Padding)</h4>
-      <td-highlight lang="css">
+      <td-highlight codeLang="css">
         {{ padCss }}
       </td-highlight>
     </div>
     <div flex class="push-right-sm">
       <h4 class="push-bottom-sm push-top-smP">Push (Margin)</h4>
-      <td-highlight lang="css">
+      <td-highlight codeLang="css">
         {{ pushCss }}
       </td-highlight>
     </div>
     <div flex>
       <h4 class="push-bottom-sm push-top-smP">Pull (Negative Margin)</h4>
 
-      <td-highlight lang="css">
+      <td-highlight codeLang="css">
         {{ pullCss }}
       </td-highlight>
     </div>

--- a/src/platform/flavored-markdown/flavored-markdown.component.ts
+++ b/src/platform/flavored-markdown/flavored-markdown.component.ts
@@ -324,7 +324,7 @@ export class TdFlavoredMarkdownComponent implements AfterViewInit, OnChanges {
       codeBlockRegExp,
       (componentRef: ComponentRef<TdHighlightComponent>, match: string, language: string, codeblock: string) => {
         if (language) {
-          componentRef.instance.lang = language;
+          componentRef.instance.codeLang = language;
         }
         componentRef.instance.copyCodeToClipboard = this.copyCodeToClipboard;
         componentRef.instance.copyCodeTooltips = this.copyCodeTooltips;

--- a/src/platform/highlight/README.md
+++ b/src/platform/highlight/README.md
@@ -98,14 +98,14 @@ Example for **HTML** usage:
 ```typescript
 @Component({
   template: `
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ code }}
     </td-highlight>
   `,
 })
 class ExampleComponent {
   code: string = `
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <h1>hello world!</h1>
       <span>{ {property} }</span>
     </td-highlight>
@@ -116,7 +116,7 @@ Example for **CSS** usage:
 ```typescript
 @Component({
   template: `
-    <td-highlight lang="css">
+    <td-highlight codeLang="css">
       {{ code }}
     </td-highlight>
   `,
@@ -145,7 +145,7 @@ Example for **Typescript**:
 ```typescript
 @Component({
   template: `
-    <td-highlight lang="typescript">
+    <td-highlight codeLang="typescript">
       {{ code }}
     </td-highlight>
   `,

--- a/src/platform/highlight/highlight.component.spec.ts
+++ b/src/platform/highlight/highlight.component.spec.ts
@@ -172,14 +172,14 @@ class TdHighlightEmptyStaticTestRenderingComponent {}
 
 @Component({
   template: `
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       {{ dataHtml0 }}
     </td-highlight>
   `,
 })
 class TdHighlightStaticHtmlTestRenderingComponent {
   dataHtml0: string = `
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <h1>hello world!</h1>
       <span>{{property}}</span>
     </td-highlight>
@@ -188,7 +188,7 @@ class TdHighlightStaticHtmlTestRenderingComponent {
 
 @Component({
   template: `
-    <td-highlight lang="css" [content]="content"></td-highlight>
+    <td-highlight codeLang="css" [content]="content"></td-highlight>
   `,
 })
 class TdHighlightDynamicCssTestRenderingComponent {
@@ -197,7 +197,7 @@ class TdHighlightDynamicCssTestRenderingComponent {
 
 @Component({
   template: `
-    <td-highlight [lang]="lang"></td-highlight>
+    <td-highlight [codeLang]="lang"></td-highlight>
   `,
 })
 class TdHighlightUndefinedLangTestRenderingComponent {
@@ -218,14 +218,14 @@ class TdHighlightEmptyStaticTestEventsComponent {
 
 @Component({
   template: `
-    <td-highlight lang="html" (contentReady)="tdHighlightContentIsReady()">
+    <td-highlight codeLang="html" (contentReady)="tdHighlightContentIsReady()">
       {{ dataHtml }}
     </td-highlight>
   `,
 })
 class TdHighlightStaticHtmlTestEventsComponent {
   dataHtml: string = `
-    <td-highlight lang="html">
+    <td-highlight codeLang="html">
       <h1>hello world!</h1>
       <span>{ {property} }</span>
     </td-highlight>
@@ -237,7 +237,7 @@ class TdHighlightStaticHtmlTestEventsComponent {
 
 @Component({
   template: `
-    <td-highlight lang="css" [content]="content" (contentReady)="tdHighlightContentIsReady()"></td-highlight>
+    <td-highlight codeLang="css" [content]="content" (contentReady)="tdHighlightContentIsReady()"></td-highlight>
   `,
 })
 class TdHighlightDynamicCssTestEventsComponent {
@@ -249,7 +249,7 @@ class TdHighlightDynamicCssTestEventsComponent {
 
 @Component({
   template: `
-    <td-highlight [lang]="lang" (contentReady)="tdHighlightContentIsReady()"></td-highlight>
+    <td-highlight [codeLang]="lang" (contentReady)="tdHighlightContentIsReady()"></td-highlight>
   `,
 })
 class TdHighlightUndefinedLangTestEventsComponent {


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Fix all references of lang attribute in highlight component to codeLang 

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then test all components are displaying tdHighlight

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
