### PR TITLE
fix(menu): Use default utility class for no padding

### DIFF
--- a/src/platform/core/dynamic-menu/dynamic-menu-item/dynamic-menu-item.component.html
+++ b/src/platform/core/dynamic-menu/dynamic-menu-item/dynamic-menu-item.component.html
@@ -16,7 +16,7 @@
         <div class="group-label text-sm">{{ item.text }}</div>
       </ng-container>
       <ng-container *ngIf="item.link || item.action">
-        <div mat-menu-item class="paddin-none">
+        <div mat-menu-item class="pad-none">
           <td-dynamic-menu-link [item]="item" (itemClicked)="emitClicked($event)"></td-dynamic-menu-link>
         </div>
       </ng-container>

--- a/src/platform/core/dynamic-menu/dynamic-menu-item/dynamic-menu-item.component.scss
+++ b/src/platform/core/dynamic-menu/dynamic-menu-item/dynamic-menu-item.component.scss
@@ -4,7 +4,3 @@
 .group-label {
   padding: 16px;
 }
-
-.paddin-none {
-  padding: 0;
-}


### PR DESCRIPTION
## Description

Use the already existing utility styles class `pad-none` for no padding instead of creating a custom class.

### What's included?

- Using utility class for no padding

#### Test Steps

- [x] `npm run serve`
- [x] Go to http://localhost:4200/#/components/dynamic-menu/examples
- [x] The menu should work like before

#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

None.