### PR TITLE
fix(material-icons-mixin): restored relative path mechanism

### DIFF
--- a/docs/UTILITY_MIXINS.md
+++ b/docs/UTILITY_MIXINS.md
@@ -21,7 +21,7 @@ We also bundle the material icons
 
 ```css
 // Include pre-bundled material-icons
-$mat-font-url: '../node_modules/@covalent/core/common/styles/font/';
+$mat-font-url: './';
 @include covalent-material-icons();
 // Alternative way to include material-icons
 // @import '../node_modules/@covalent/core/common/material-icons.css';

--- a/src/platform/core/common/styles/font/_font.scss
+++ b/src/platform/core/common/styles/font/_font.scss
@@ -5,7 +5,7 @@ $mat-font-url: 'styles/font/' !default;
     font-family: 'Material Icons';
     font-style: normal;
     font-weight: 400;
-    src: url('MaterialIcons-Regular-v48.woff2') format('woff2');
+    src: url($mat-font-url + 'MaterialIcons-Regular-v48.woff2') format('woff2');
   }
   .material-icons {
     /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */

--- a/src/platform/core/schematics/ng-add/files/theme.scss
+++ b/src/platform/core/schematics/ng-add/files/theme.scss
@@ -24,7 +24,7 @@ $custom-toolbar-typography: mat-typography-config(
 @include covalent-core();
 
 // Include material icons
-$mat-font-url: '~@covalent/core/common/styles/font/';
+$mat-font-url: './';
 @include covalent-material-icons();
 
 <% if (styleSheetUtilities) { %>

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -29,7 +29,7 @@ $custom-toolbar-typography: mat-typography-config(
 @include covalent-core();
 
 // Include material icons
-$mat-font-url: 'platform/core/common/styles/font/';
+$mat-font-url: './';
 @include covalent-material-icons();
 
 // Include covalent utility classes


### PR DESCRIPTION
## Description

Covalent includes the Material icons as a woff2 file. There are two approaches for including these icons into a project which depends on Covalent. First, import the material-icons.css that is constructed by the builder. This has a qualified relative path to the woff2 file. Second, import the covalent-material-icons mixin. The location of the woff2 file is relative to the scss file defining the mixin. To support both cases, the $mat-font-url variable must be utilized. This PR restores the use of the variable and updates the markdown indicating how to import the mixin.

### What's included?
- Restored usage of $mat-font-url and updated documentation on usage of mixin import

#### Test Steps
- [ ] `npm run serve`
- [ ] confirm that material icons appear in demos
- [ ] `npm run build:lib`
- [ ] deploy locally into dependent project
- [ ] update theme.scss to import icons via these two approaches
```css
// Include pre-bundled material-icons
$mat-font-url: './';
@include covalent-material-icons();
// Alternative way to include material-icons
// @import '../node_modules/@covalent/core/common/material-icons.css';
```
- [ ] start dependent project and confirm that material icons appear correctly
- [ ] repeat for other import approach

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
