### PR TITLE
fix(dynamic-forms): show label as mat-label instead of placeholder

### DIFF
--- a/src/app/content/components/component-demos/dynamic-forms/demos/dynamic-forms-demo-text/dynamic-forms-demo-text.component.ts
+++ b/src/app/content/components/component-demos/dynamic-forms/demos/dynamic-forms-demo-text/dynamic-forms-demo-text.component.ts
@@ -18,6 +18,7 @@ export class DynamicFormsDemoTextComponent {
     {
       name: 'requiredInput',
       label: 'Input Label',
+      placeholder: 'Input Placeholder',
       type: TdDynamicElement.Input,
       required: true,
       flex: 50,

--- a/src/app/content/components/component-demos/dynamic-forms/dynamic-forms.component.ts
+++ b/src/app/content/components/component-demos/dynamic-forms/dynamic-forms.component.ts
@@ -19,6 +19,7 @@ export class DynamicFormsDemoComponent {
     {
       name: 'required-input',
       label: 'Input Label',
+      placeholder: 'Input Placeholder',
       type: TdDynamicElement.Input,
       required: true,
       flex: 50,

--- a/src/platform/dynamic-forms/dynamic-element.component.ts
+++ b/src/platform/dynamic-forms/dynamic-element.component.ts
@@ -135,6 +135,11 @@ export class TdDynamicElementComponent
    */
   @Input() errorMessageTemplate: TemplateRef<any> = undefined;
 
+  /**
+   * Sets the placeholder message
+   */
+  @Input() placeholder: string = '';
+
   @ViewChild(TdDynamicElementDirective, { static: true }) childElement: TdDynamicElementDirective;
 
   @HostBinding('attr.max')
@@ -177,6 +182,7 @@ export class TdDynamicElementComponent
     this._instance.selections = this.selections;
     this._instance.multiple = this.multiple;
     this._instance.errorMessageTemplate = this.errorMessageTemplate;
+    this._instance.placeholder = this.placeholder;
     if (this.customConfig) {
       Object.getOwnPropertyNames(this.customConfig).forEach((name: string) => {
         this._instance[name] = this.customConfig[name];

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.html
@@ -1,11 +1,12 @@
 <div class="td-dynamic-datepicker-wrapper">
   <mat-form-field class="td-dynamic-datepicker-field">
+    <mat-label>{{ label }}</mat-label>
     <input
       #elementInput
       matInput
       [matDatepicker]="dynamicDatePicker"
       [formControl]="control"
-      [placeholder]="label"
+      [placeholder]="placeholder"
       [required]="required"
       [name]="name"
       [min]="min"

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-datepicker/dynamic-datepicker.component.ts
@@ -24,4 +24,6 @@ export class TdDynamicDatepickerComponent {
   max: number = undefined;
 
   errorMessageTemplate: TemplateRef<any> = undefined;
+
+  placeholder: string = '';
 }

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
@@ -10,10 +10,11 @@
     (keyup.delete)="fileInput.clear()"
     (keyup.backspace)="fileInput.clear()"
   >
+    <mat-label>{{ label }}</mat-label>
     <input
       matInput
       [value]="control?.value?.name"
-      [placeholder]="label"
+      [placeholder]="placeholder"
       [attr.name]="name"
       [disabled]="control?.disabled"
       readonly

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-file-input/dynamic-file-input.component.ts
@@ -19,6 +19,8 @@ export class TdDynamicFileInputComponent {
 
   errorMessageTemplate: TemplateRef<any> = undefined;
 
+  placeholder: string = '';
+
   _handlefileDrop(value: File): void {
     this.control.setValue(value);
   }

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.html
@@ -1,10 +1,11 @@
 <div class="td-dynamic-input-wrapper">
   <mat-form-field class="td-dynamic-input-field">
+    <mat-label>{{ label }}</mat-label>
     <input
       #elementInput
       matInput
       [formControl]="control"
-      [placeholder]="label"
+      [placeholder]="placeholder"
       [type]="type"
       [required]="required"
       [attr.name]="name"

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-input/dynamic-input.component.ts
@@ -28,4 +28,6 @@ export class TdDynamicInputComponent {
   maxLength: number = undefined;
 
   errorMessageTemplate: TemplateRef<any> = undefined;
+
+  placeholder: string = '';
 }

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.html
@@ -1,8 +1,9 @@
 <div class="td-dynamic-select-wrapper">
   <mat-form-field class="td-dynamic-select-field">
+    <mat-label>{{ label }}</mat-label>
     <mat-select
       [formControl]="control"
-      [placeholder]="label"
+      [placeholder]="placeholder"
       [required]="required"
       [attr.name]="name"
       [multiple]="multiple"

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-select/dynamic-select.component.ts
@@ -22,4 +22,6 @@ export class TdDynamicSelectComponent {
   multiple: boolean = undefined;
 
   errorMessageTemplate: TemplateRef<any> = undefined;
+
+  placeholder: string = '';
 }

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-textarea/dynamic-textarea.component.html
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-textarea/dynamic-textarea.component.html
@@ -1,10 +1,11 @@
 <div class="td-dynamic-textarea-wrapper">
   <mat-form-field class="td-dynamic-textarea-field">
+    <mat-label>{{ label }}</mat-label>
     <textarea
       #elementInput
       matInput
       [formControl]="control"
-      [placeholder]="label"
+      [placeholder]="placeholder"
       [required]="required"
       [attr.name]="name"
       rows="4"

--- a/src/platform/dynamic-forms/dynamic-elements/dynamic-textarea/dynamic-textarea.component.ts
+++ b/src/platform/dynamic-forms/dynamic-elements/dynamic-textarea/dynamic-textarea.component.ts
@@ -18,4 +18,6 @@ export class TdDynamicTextareaComponent {
   required: boolean = undefined;
 
   errorMessageTemplate: TemplateRef<any> = undefined;
+
+  placeholder: string = '';
 }

--- a/src/platform/dynamic-forms/dynamic-forms.component.html
+++ b/src/platform/dynamic-forms/dynamic-forms.component.html
@@ -27,6 +27,7 @@
           [multiple]="element.multiple"
           [customConfig]="element.customConfig"
           [errorMessageTemplate]="getErrorTemplateRef(element.name)"
+          [placeholder]="element.placeholder"
         ></td-dynamic-element>
       </div>
     </ng-template>

--- a/src/platform/dynamic-forms/dynamic-forms.component.spec.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.component.spec.ts
@@ -550,6 +550,35 @@ describe('Component: TdDynamicForms', () => {
       }),
     ),
   );
+
+  it(
+    `should render the placeholder for input fields`,
+    waitForAsync(
+      inject([], async () => {
+        const fixture: ComponentFixture<any> = TestBed.createComponent(TdDynamicFormsTestComponent);
+        const component: TdDynamicFormsTestComponent = fixture.debugElement.componentInstance;
+
+        component.elements = [
+          {
+            name: 'input',
+            type: TdDynamicElement.Input,
+            label: 'LABEL',
+            placeholder: 'PLACEHOLDER',
+          },
+        ];
+        fixture.detectChanges();
+
+        await fixture.whenStable();
+        const inputElement: DebugElement = fixture.debugElement.query(By.css('[data-placeholder]'));
+        inputElement.triggerEventHandler('focus', {});
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const labelElement: DebugElement = fixture.debugElement.query(By.css('mat-label'));
+        expect(inputElement.attributes['placeholder']).toBe('PLACEHOLDER');
+        expect(labelElement.nativeElement.textContent).toEqual('LABEL');
+      }),
+    ),
+  );
 });
 
 @Component({

--- a/src/platform/dynamic-forms/services/dynamic-forms.service.ts
+++ b/src/platform/dynamic-forms/services/dynamic-forms.service.ts
@@ -56,6 +56,7 @@ export interface ITdDynamicElementConfig {
   flex?: number;
   validators?: ITdDynamicElementValidator[];
   customConfig?: ITdDynamicElementCustomConfig;
+  placeholder?: string;
 }
 
 export const DYNAMIC_ELEMENT_NAME_REGEX: RegExp = /^[^0-9][^\@]*$/;


### PR DESCRIPTION
## Description

To differentiate between the label and the placeholder for
dynamic-forms, a dedicated placeholder property was added.

This change does not change the appearance of the form fields, as
material treated the placeholder mostly the same as the mat-label
if no mat-label is provided.

Closes #1820

### What's included?

- Label is set as `mat-label`
- Placeholder can be set for form field types
-- `TdDynamicElement.Input` (including `TdDynamicType.Text`, `TdDynamicType.Number` and `TdDynamicElement.Password`)
-- `TdDynamicElement.Textarea`
-- `TdDynamicElement.Select` (including `TdDynamicType.Array`)
-- `TdDynamicElement.FileInput`
-- `TdDynamicElement.Datepicker` (including `TdDynamicType.Date`)
- Additionally when the material form field appearance is set, the label does not vanish anymore on focus.

#### Test Steps

- [ ] `npm run serve`
- [ ] navigate to the dynamic forms demo
- [ ] ensure the top right form field contains the label "Input Label"
- [ ] click on the top right form field
- [ ] ensure the label floats above the form field
- [ ] ensure the input field contains the placeholder "Input Placeholder"

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker

Without setting the form field appearance:
![image](https://user-images.githubusercontent.com/3329142/100547861-5e4d2100-3269-11eb-8791-7ed621f855a4.png)

With the form field appearance set to `fill`:
![image](https://user-images.githubusercontent.com/3329142/100548114-eaac1380-326a-11eb-8095-261e5372ac2f.png)
