### PR TITLE
feat(markdown): add youtube video embeds (VAC-442)

### DIFF
--- a/src/app/content/components/component-demos/markdown/demos/markdown-demo-youtube/markdown-demo-youtube.component.html
+++ b/src/app/content/components/component-demos/markdown/demos/markdown-demo-youtube/markdown-demo-youtube.component.html
@@ -1,0 +1,2 @@
+<h2>Embed videos directly</h2>
+<td-markdown>{{ videoMarkdown }}</td-markdown>

--- a/src/app/content/components/component-demos/markdown/demos/markdown-demo-youtube/markdown-demo-youtube.component.ts
+++ b/src/app/content/components/component-demos/markdown/demos/markdown-demo-youtube/markdown-demo-youtube.component.ts
@@ -33,5 +33,9 @@ This works with any of these base URLs (with or without the 'https://www.' porti
 
 ![www.youtube.com/embed/dQw4w9WgXcQ?autoplay=true]
 
+### Playlist embedding
+(https://youtube.com/playlist?list=PLXIU9mpT9-03zDjIdMvJRmcANfW644x3F)
+
+![https://youtube.com/playlist?list=PLXIU9mpT9-03zDjIdMvJRmcANfW644x3F]
   `;
 }

--- a/src/app/content/components/component-demos/markdown/demos/markdown-demo-youtube/markdown-demo-youtube.component.ts
+++ b/src/app/content/components/component-demos/markdown/demos/markdown-demo-youtube/markdown-demo-youtube.component.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'markdown-demo-youtube',
+  styleUrls: ['./markdown-demo-youtube.component.scss'],
+  templateUrl: './markdown-demo-youtube.component.html',
+})
+export class MarkdownDemoYoutubeComponent {
+  videoMarkdown: string = `
+## Embed YouTube Videos
+
+Use this custom embed syntax and you can embed YouTube videos with ease
+\`\`\`![youtube URL here]\`\`\`
+
+This works with any of these base URLs (with or without the 'https://www.' portion):
+* youtube.com
+* youtu.be
+
+## Example
+
+### Short syntax
+(youtu.be/dQw4w9WgXcQ?autoplay=true)
+
+![youtu.be/dQw4w9WgXcQ?autoplay=true]
+
+### Watch link syntax
+(https://www.youtube.com/watch?v=dQw4w9WgXcQ&autoplay=true)
+
+![https://www.youtube.com/watch?v=dQw4w9WgXcQ&autoplay=true]
+
+### Embed link syntax
+(www.youtube.com/embed/dQw4w9WgXcQ?autoplay=true)
+
+![www.youtube.com/embed/dQw4w9WgXcQ?autoplay=true]
+
+  `;
+}

--- a/src/app/content/components/component-demos/markdown/demos/markdown-demo.component.html
+++ b/src/app/content/components/component-demos/markdown/demos/markdown-demo.component.html
@@ -9,3 +9,7 @@
 <demo-component [demoId]="'markdown-demo-hosted-url'" [demoTitle]="'Hosted URL For Generating Absolute URLs'">
   <markdown-demo-hosted-url></markdown-demo-hosted-url>
 </demo-component>
+
+<demo-component [demoId]="'markdown-demo-youtube'" [demoTitle]="'YouTube video embedding'">
+  <markdown-demo-youtube></markdown-demo-youtube>
+</demo-component>

--- a/src/app/content/components/component-demos/markdown/demos/markdown-demo.module.ts
+++ b/src/app/content/components/component-demos/markdown/demos/markdown-demo.module.ts
@@ -7,6 +7,7 @@ import { MarkdownDemoRoutingModule } from './markdown-demo-routing.module';
 import { DemoModule } from '../../../../../components/shared/demo-tools/demo.module';
 import { MarkdownDemoAnchorJumpingComponent } from './markdown-demo-anchor-jumping/markdown-demo-anchor-jumping.component';
 import { MarkdownDemoHostedUrlComponent } from './markdown-demo-hosted-url/markdown-demo-hosted-url.component';
+import { MarkdownDemoYoutubeComponent } from './markdown-demo-youtube/markdown-demo-youtube.component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 
@@ -16,6 +17,7 @@ import { MatCardModule } from '@angular/material/card';
     MarkdownDemoBasicComponent,
     MarkdownDemoAnchorJumpingComponent,
     MarkdownDemoHostedUrlComponent,
+    MarkdownDemoYoutubeComponent,
   ],
   imports: [
     DemoModule,

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -264,7 +264,6 @@ export class TdMarkdownComponent implements OnChanges, AfterViewInit {
     const htmlWithAbsoluteHrefs: string = normalizeHtmlHrefs(html, this._hostedUrl);
     const htmlWithAbsoluteImgSrcs: string = normalizeImageSrcs(htmlWithAbsoluteHrefs, this._hostedUrl);
     const htmlWithHeadingIds: string = addIdsToHeadings(htmlWithAbsoluteImgSrcs);
-    console.info(htmlWithHeadingIds);
     const htmlWithVideos: SafeHtml = this._renderVideoElements(htmlWithHeadingIds);
     this._renderer.setProperty(div, 'innerHTML', htmlWithVideos);
     return div;
@@ -302,12 +301,25 @@ export class TdMarkdownComponent implements OnChanges, AfterViewInit {
     const ytLongEmbed: RegExp = /!\[(?:(?:https?:)?(?:\/\/)?)(?:(?:www)?.)?youtube.(?:.+?)\/(?:(?:embed\/)([\w-]{11})(\?[\w%;-]+(?:=[\w%;-]+)?(?:&[\w%;-]+(?:=[\w%;-]+)?)*)?)]/gi;
     const ytLongWatch: RegExp = /!\[(?:(?:https?:)?(?:\/\/)?)(?:(?:www)?.)?youtube.(?:.+?)\/(?:(?:watch\?v=)([\w-]{11})(&[\w%;-]+(?:=[\w%;-]+)?)*)]/gi;
     const ytShort: RegExp = /!\[(?:(?:https?:)?(?:\/\/)?)?youtu.be\/([\w-]{11})\??([\w%;-]+(?:=[\w%;-]+)?(?:&[\w%;-]+(?:=[\w%;-]+)?)*)?]/gi;
+    const ytPlaylist: RegExp = /!\[(?:(?:https?:)?(?:\/\/)?)(?:(?:www)?.)?youtube.(?:.+?)\/(?:(?:playlist\?list=)([\w-]{34})(&[\w%;-]+(?:=[\w%;-]+)?)*)]/gi;
 
     function convert(match: string, id: string, flags: string): string {
-      flags = flags.replace(/&amp;/gi, '&');
-      return `<iframe allowfullscreen frameborder="0" src="https://www.youtube.com/embed/${id}?${flags}"></iframe>`;
+      if (flags) {
+        id += '?' + flags.replace(/&amp;/gi, '&');
+      }
+      return `<iframe allowfullscreen frameborder="0" src="https://www.youtube.com/embed/${id}"></iframe>`;
+    }
+    function convertPL(match: string, id: string, flags: string): string {
+      if (flags) {
+        id += flags.replace(/&amp;/gi, '&');
+      }
+      return `<iframe allowfullscreen frameborder="0" src="https://www.youtube.com/embed/videoseries?list=${id}"></iframe>`;
     }
 
-    return html.replace(ytLongWatch, convert).replace(ytLongEmbed, convert).replace(ytShort, convert);
+    return html
+      .replace(ytLongWatch, convert)
+      .replace(ytLongEmbed, convert)
+      .replace(ytShort, convert)
+      .replace(ytPlaylist, convertPL);
   }
 }


### PR DESCRIPTION
## Description
Page help desperately wants for video capability, so now we can add YouTube embedded videos natively like so:
```![youtu.be/videoID]```

### What's included?
- Native iframe embeds added for youtube share links
- Ability to embed playlists as well as single videos

#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="826" alt="Screen Shot 2021-02-04 at 2 34 06 PM" src="https://user-images.githubusercontent.com/3385635/106945656-14176e80-66f6-11eb-9580-1ac7e8108d8c.png">
