### PR TITLE
VAC-442 youtube markdown embeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "npm run tslint && npm run stylelint",
     "tslint": "./node_modules/.bin/tslint -p ./tsconfig.json --format codeFrame -c ./tslint.json './src/**/*.ts'",
     "stylelint": "./node_modules/.bin/stylelint 'src/**/*.scss' --config stylelint.config.js --syntax scss",
-    "postinstall": "npm rebuild node-sass && webdriver-manager update && ngcc && npm install ./src/platform/coding-standards --no-save",
+    "postinstall": "npm rebuild node-sass && ngcc && npm install ./src/platform/coding-standards --no-save",
     "test": "ng test covalent-docs --code-coverage --source-map=false --watch=false && npm run test:schematics",
     "test:watch": "ng test --code-coverage --source-map=false --watch=true",
     "test:schematics": "tsc -p src/platform/core/schematics/tsconfig.spec.json && jasmine src/platform/core/schematics/**/*.spec.js",

--- a/src/app/content/components/component-demos/markdown/demos/markdown-demo-youtube/markdown-demo-youtube.component.html
+++ b/src/app/content/components/component-demos/markdown/demos/markdown-demo-youtube/markdown-demo-youtube.component.html
@@ -1,0 +1,2 @@
+<h2>Embed videos directly</h2>
+<td-markdown>{{ videoMarkdown }}</td-markdown>

--- a/src/app/content/components/component-demos/markdown/demos/markdown-demo-youtube/markdown-demo-youtube.component.ts
+++ b/src/app/content/components/component-demos/markdown/demos/markdown-demo-youtube/markdown-demo-youtube.component.ts
@@ -1,0 +1,43 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'markdown-demo-youtube',
+  styleUrls: ['./markdown-demo-youtube.component.scss'],
+  templateUrl: './markdown-demo-youtube.component.html',
+})
+export class MarkdownDemoYoutubeComponent {
+  videoMarkdown: string = `
+## Embed YouTube Videos
+
+Use this custom embed syntax and you can embed YouTube videos with ease
+\`\`\`![youtube URL here]\`\`\`
+
+This works with any of these base URLs (with or without the 'https://www.' portion):
+* youtube.com
+* youtu.be
+
+## Example
+
+
+
+### Short syntax
+(youtu.be/dQw4w9WgXcQ)
+
+![youtu.be/dQw4w9WgXcQ]
+
+### Watch link syntax
+(https://www.youtube.com/watch?v=dQw4w9WgXcQ&start=10)
+
+![https://www.youtube.com/watch?v=dQw4w9WgXcQ&start=10]
+
+### Embed link syntax
+(www.youtube.com/embed/dQw4w9WgXcQ?start=20)
+
+![www.youtube.com/embed/dQw4w9WgXcQ?start=20]
+
+### Playlist embedding
+(https://youtube.com/playlist?list=PLXIU9mpT9-03zDjIdMvJRmcANfW644x3F)
+
+![https://youtube.com/playlist?list=PLXIU9mpT9-03zDjIdMvJRmcANfW644x3F&autoplay=1]
+  `;
+}

--- a/src/app/content/components/component-demos/markdown/demos/markdown-demo.component.html
+++ b/src/app/content/components/component-demos/markdown/demos/markdown-demo.component.html
@@ -9,3 +9,7 @@
 <demo-component [demoId]="'markdown-demo-hosted-url'" [demoTitle]="'Hosted URL For Generating Absolute URLs'">
   <markdown-demo-hosted-url></markdown-demo-hosted-url>
 </demo-component>
+
+<demo-component [demoId]="'markdown-demo-youtube'" [demoTitle]="'YouTube video embedding'">
+  <markdown-demo-youtube></markdown-demo-youtube>
+</demo-component>

--- a/src/app/content/components/component-demos/markdown/demos/markdown-demo.module.ts
+++ b/src/app/content/components/component-demos/markdown/demos/markdown-demo.module.ts
@@ -7,6 +7,7 @@ import { MarkdownDemoRoutingModule } from './markdown-demo-routing.module';
 import { DemoModule } from '../../../../../components/shared/demo-tools/demo.module';
 import { MarkdownDemoAnchorJumpingComponent } from './markdown-demo-anchor-jumping/markdown-demo-anchor-jumping.component';
 import { MarkdownDemoHostedUrlComponent } from './markdown-demo-hosted-url/markdown-demo-hosted-url.component';
+import { MarkdownDemoYoutubeComponent } from './markdown-demo-youtube/markdown-demo-youtube.component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 
@@ -16,6 +17,7 @@ import { MatCardModule } from '@angular/material/card';
     MarkdownDemoBasicComponent,
     MarkdownDemoAnchorJumpingComponent,
     MarkdownDemoHostedUrlComponent,
+    MarkdownDemoYoutubeComponent,
   ],
   imports: [
     DemoModule,

--- a/src/platform/core/data-table/data-table.component.ts
+++ b/src/platform/core/data-table/data-table.component.ts
@@ -226,9 +226,8 @@ export class TdDataTableComponent
 
   /** template fetching support */
   private _templateMap: Map<string, TemplateRef<any>> = new Map<string, TemplateRef<any>>();
-  @ContentChildren(TdDataTableTemplateDirective, { descendants: true }) _templates: QueryList<
-    TdDataTableTemplateDirective
-  >;
+  @ContentChildren(TdDataTableTemplateDirective, { descendants: true })
+  _templates: QueryList<TdDataTableTemplateDirective>;
 
   @ViewChild('scrollableDiv', { static: true }) _scrollableDiv: ElementRef;
 

--- a/src/platform/core/expansion-panel/expansion-panel-group.component.ts
+++ b/src/platform/core/expansion-panel/expansion-panel-group.component.ts
@@ -40,9 +40,8 @@ export class TdExpansionPanelGroupComponent implements AfterContentInit, OnDestr
     }
   }
 
-  @ContentChildren(TdExpansionPanelComponent, { descendants: true }) expansionPanels: QueryList<
-    TdExpansionPanelComponent
-  >;
+  @ContentChildren(TdExpansionPanelComponent, { descendants: true })
+  expansionPanels: QueryList<TdExpansionPanelComponent>;
 
   constructor(private _renderer: Renderer2, private _elementRef: ElementRef) {
     this._renderer.addClass(this._elementRef.nativeElement, 'td-expansion-panel-group');

--- a/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
+++ b/src/platform/core/layout/navigation-drawer/navigation-drawer.component.ts
@@ -46,13 +46,11 @@ export class TdNavigationDrawerComponent implements OnInit, OnDestroy {
     return this._menuToggled;
   }
 
-  @ContentChildren(TdNavigationDrawerMenuDirective, { descendants: true }) _drawerMenu: QueryList<
-    TdNavigationDrawerMenuDirective
-  >;
+  @ContentChildren(TdNavigationDrawerMenuDirective, { descendants: true })
+  _drawerMenu: QueryList<TdNavigationDrawerMenuDirective>;
 
-  @ContentChildren(TdNavigationDrawerToolbarDirective, { descendants: true }) _toolbar: QueryList<
-    TdNavigationDrawerToolbarDirective
-  >;
+  @ContentChildren(TdNavigationDrawerToolbarDirective, { descendants: true })
+  _toolbar: QueryList<TdNavigationDrawerToolbarDirective>;
 
   /**
    * Checks if there is a [TdNavigationDrawerMenuDirective] has content.

--- a/src/platform/dynamic-forms/dynamic-forms.component.ts
+++ b/src/platform/dynamic-forms/dynamic-forms.component.ts
@@ -30,9 +30,8 @@ export class TdDynamicFormsComponent implements AfterContentInit, OnDestroy {
   private _destroy$: Subject<any> = new Subject();
   private _destroyControl$: Subject<string> = new Subject();
 
-  @ContentChildren(TdDynamicFormsErrorTemplateDirective, { descendants: true }) _errorTemplates: QueryList<
-    TdDynamicFormsErrorTemplateDirective
-  >;
+  @ContentChildren(TdDynamicFormsErrorTemplateDirective, { descendants: true })
+  _errorTemplates: QueryList<TdDynamicFormsErrorTemplateDirective>;
   dynamicForm: FormGroup;
 
   /**

--- a/src/platform/echarts/tooltip/series-tooltip.component.ts
+++ b/src/platform/echarts/tooltip/series-tooltip.component.ts
@@ -39,9 +39,8 @@ export class TdSeriesTooltipComponent implements OnChanges, OnDestroy {
   };
   @Input() extraCssText: string;
 
-  @ContentChild(TdChartTooltipFormatterDirective, { read: TemplateRef, static: true }) formatterTemplate: TemplateRef<
-    any
-  >;
+  @ContentChild(TdChartTooltipFormatterDirective, { read: TemplateRef, static: true })
+  formatterTemplate: TemplateRef<any>;
   @ViewChild('tooltipContent', { static: true }) fullTemplate: TemplateRef<any>;
 
   constructor(

--- a/src/platform/echarts/tooltip/tooltip.component.ts
+++ b/src/platform/echarts/tooltip/tooltip.component.ts
@@ -66,9 +66,8 @@ export class TdChartTooltipComponent implements OnChanges, OnDestroy {
   };
   @Input() extraCssText: string; // series
 
-  @ContentChild(TdChartTooltipFormatterDirective, { read: TemplateRef, static: true }) formatterTemplate: TemplateRef<
-    any
-  >;
+  @ContentChild(TdChartTooltipFormatterDirective, { read: TemplateRef, static: true })
+  formatterTemplate: TemplateRef<any>;
   @ViewChild('tooltipContent', { static: true }) fullTemplate: TemplateRef<any>;
 
   constructor(

--- a/src/platform/flavored-markdown/flavored-markdown.component.ts
+++ b/src/platform/flavored-markdown/flavored-markdown.component.ts
@@ -48,9 +48,8 @@ export class TdFlavoredMarkdownButtonComponent {
   @HostBinding('style.display') display: string = 'inline-block';
   @Input() text: string = '';
   @Input() data: string = '';
-  @Output() clicked: EventEmitter<ITdFlavoredMarkdownButtonClickEvent> = new EventEmitter<
-    ITdFlavoredMarkdownButtonClickEvent
-  >();
+  @Output()
+  clicked: EventEmitter<ITdFlavoredMarkdownButtonClickEvent> = new EventEmitter<ITdFlavoredMarkdownButtonClickEvent>();
   emitClick(): void {
     this.clicked.emit({ text: this.text, data: this.data });
   }
@@ -154,9 +153,8 @@ export class TdFlavoredMarkdownComponent implements AfterViewInit, OnChanges {
    * Event emitted when a button is clicked
    * Is an object containing text and data of button
    */
-  @Output() buttonClicked: EventEmitter<ITdFlavoredMarkdownButtonClickEvent> = new EventEmitter<
-    ITdFlavoredMarkdownButtonClickEvent
-  >();
+  @Output()
+  buttonClicked: EventEmitter<ITdFlavoredMarkdownButtonClickEvent> = new EventEmitter<ITdFlavoredMarkdownButtonClickEvent>();
 
   @ViewChild(TdFlavoredMarkdownContainerDirective, { static: true }) container: TdFlavoredMarkdownContainerDirective;
 

--- a/src/platform/flavored-markdown/flavored-markdown.spec.ts
+++ b/src/platform/flavored-markdown/flavored-markdown.spec.ts
@@ -10,9 +10,8 @@ import { ITdFlavoredMarkdownButtonClickEvent } from './flavored-markdown.compone
 })
 class TdFlavoredMarkdownTestComponent {
   markdown: string = '';
-  @Output() buttonClicked: EventEmitter<ITdFlavoredMarkdownButtonClickEvent> = new EventEmitter<
-    ITdFlavoredMarkdownButtonClickEvent
-  >();
+  @Output()
+  buttonClicked: EventEmitter<ITdFlavoredMarkdownButtonClickEvent> = new EventEmitter<ITdFlavoredMarkdownButtonClickEvent>();
 }
 
 describe('Component: TdFlavoredMarkdown should: ', () => {

--- a/src/platform/markdown/markdown-utils/markdown-utils.ts
+++ b/src/platform/markdown/markdown-utils/markdown-utils.ts
@@ -94,3 +94,29 @@ export function isRawGithubHref(href: string): boolean {
     return false;
   }
 }
+
+export function renderVideoElements(html: string): string {
+  const ytLongEmbed: RegExp = /!\[(?:(?:https?:)?(?:\/\/)?)(?:(?:www)?.)?youtube.(?:.+?)\/(?:(?:embed\/)([\w-]{11})(\?[\w%;-]+(?:=[\w%;-]+)?(?:&[\w%;-]+(?:=[\w%;-]+)?)*)?)]/gi;
+  const ytLongWatch: RegExp = /!\[(?:(?:https?:)?(?:\/\/)?)(?:(?:www)?.)?youtube.(?:.+?)\/(?:(?:watch\?v=)([\w-]{11})(&[\w%;-]+(?:=[\w%;-]+)?)*)]/gi;
+  const ytShort: RegExp = /!\[(?:(?:https?:)?(?:\/\/)?)?youtu.be\/([\w-]{11})\??([\w%;-]+(?:=[\w%;-]+)?(?:&[\w%;-]+(?:=[\w%;-]+)?)*)?]/gi;
+  const ytPlaylist: RegExp = /!\[(?:(?:https?:)?(?:\/\/)?)(?:(?:www)?.)?youtube.(?:.+?)\/(?:(?:playlist\?list=)([\w-]{34})(&[\w%;-]+(?:=[\w%;-]+)?)*)]/gi;
+
+  function convert(match: string, id: string, flags: string): string {
+    if (flags) {
+      id += '?' + flags.replace(/&amp;/gi, '&');
+    }
+    return `<iframe allow="fullscreen" frameborder="0" src="https://www.youtube.com/embed/${id}"></iframe>`;
+  }
+  function convertPL(match: string, id: string, flags: string): string {
+    if (flags) {
+      id += flags.replace(/&amp;/gi, '&');
+    }
+    return `<iframe allow="fullscreen" frameborder="0" src="https://www.youtube.com/embed/videoseries?list=${id}"></iframe>`;
+  }
+
+  return html
+    .replace(ytLongWatch, convert)
+    .replace(ytLongEmbed, convert)
+    .replace(ytShort, convert)
+    .replace(ytPlaylist, convertPL);
+}

--- a/src/platform/markdown/markdown.component.ts
+++ b/src/platform/markdown/markdown.component.ts
@@ -12,7 +12,7 @@ import {
   HostBinding,
   HostListener,
 } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import {
   scrollToAnchor,
   genHeadingId,
@@ -21,6 +21,7 @@ import {
   rawGithubHref,
   isGithubHref,
   isRawGithubHref,
+  renderVideoElements,
 } from './markdown-utils/markdown-utils';
 
 declare const require: any;
@@ -264,7 +265,8 @@ export class TdMarkdownComponent implements OnChanges, AfterViewInit {
     const htmlWithAbsoluteHrefs: string = normalizeHtmlHrefs(html, this._hostedUrl);
     const htmlWithAbsoluteImgSrcs: string = normalizeImageSrcs(htmlWithAbsoluteHrefs, this._hostedUrl);
     const htmlWithHeadingIds: string = addIdsToHeadings(htmlWithAbsoluteImgSrcs);
-    div.innerHTML = htmlWithHeadingIds;
+    const htmlWithVideos: SafeHtml = renderVideoElements(htmlWithHeadingIds);
+    this._renderer.setProperty(div, 'innerHTML', htmlWithVideos);
     return div;
   }
 


### PR DESCRIPTION
## Description
Page help desperately wants for video capability, so now we can add YouTube embedded videos natively like so:
```![youtu.be/videoID]```

### What's included?
- Native iframe embeds added for youtube share links
- Ability to embed playlists as well as single videos

#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="826" alt="Screen Shot 2021-02-04 at 2 34 06 PM" src="https://user-images.githubusercontent.com/3385635/106945656-14176e80-66f6-11eb-9580-1ac7e8108d8c.png">
