### PR TITLE
chore(): upgrade angular support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Certain covalent version are meant for certain angular versions, and here is the
 | Covalent | Angular
 |:---:|:---:|
 | 2.X | 8.X |
-| 3.X | 9.X / 10.X |
-| Future / Nightly | 10.X |
+| 3.X | 9.X / 10.X / 11.x |
+| Future / Nightly | 11.X |
 
 ## Browser Support
 

--- a/build.conf.js
+++ b/build.conf.js
@@ -3,8 +3,8 @@
 module.exports = {
   deployed: 'deploy/platform/',
   echartsVersion: '^4.2.1',
-  angularVersion: '^9.0.0 || ^10.0.0-0',
-  materialVersion: '^9.0.0 || ^10.0.0-0',
+  angularVersion: '^9.0.0 || ^10.0.0-0 || ^11.0.0-0',
+  materialVersion: '^9.0.0 || ^10.0.0-0 || ^11.0.0-0',
   showdownVersion: '^1.9.1',
   highlightVersion: '^9.13.1',
   monacoVersion: '^0.20.0',


### PR DESCRIPTION
## Description
upgrading the build support matrix for angular and angular material

### What's included?
- update to build script to include support for ng11
- README update

#### Test Steps
- [ ] run `npm run build:lib`
- [ ] inspect the dependency section of the package.json for all built projects under `/deploy`

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
