### PR TITLE
fix: fixed moving child list to bottom on markdown-navigator(VAC-649)

### DIFF
--- a/src/platform/markdown-navigator/markdown-navigator.component.html
+++ b/src/platform/markdown-navigator/markdown-navigator.component.html
@@ -33,6 +33,34 @@
   </ng-container>
 
   <div class="scroll-area" id="td-markdown-navigator-content">
+    <div *ngIf="showTdMarkdownLoader || showTdMarkdown" class="markdown-wrapper" #markdownWrapper>
+      <td-message
+        *ngIf="markdownLoaderError"
+        [sublabel]="markdownLoaderError"
+        color="warn"
+        icon="error"
+        [attr.data-test]="'markdown-loader-error'"
+      ></td-message>
+      <td-flavored-markdown-loader
+        *ngIf="showTdMarkdownLoader"
+        [url]="url"
+        [httpOptions]="httpOptions"
+        [anchor]="anchor"
+        [copyCodeToClipboard]="copyCodeToClipboard"
+        [copyCodeTooltips]="copyCodeTooltips"
+        (loadFailed)="handleMarkdownLoaderError($event)"
+      ></td-flavored-markdown-loader>
+      <td-flavored-markdown
+        *ngIf="showTdMarkdown"
+        [content]="markdownString"
+        [hostedUrl]="url"
+        [anchor]="anchor"
+        [copyCodeToClipboard]="copyCodeToClipboard"
+        [copyCodeTooltips]="copyCodeTooltips"
+        (buttonClicked)="buttonClicked.emit($event)"
+      ></td-flavored-markdown>
+    </div>
+
     <td-message
       *ngIf="childrenUrlError"
       [sublabel]="childrenUrlError"
@@ -63,33 +91,6 @@
       </mat-action-list>
     </div>
 
-    <div *ngIf="showTdMarkdownLoader || showTdMarkdown" class="markdown-wrapper" #markdownWrapper>
-      <td-message
-        *ngIf="markdownLoaderError"
-        [sublabel]="markdownLoaderError"
-        color="warn"
-        icon="error"
-        [attr.data-test]="'markdown-loader-error'"
-      ></td-message>
-      <td-flavored-markdown-loader
-        *ngIf="showTdMarkdownLoader"
-        [url]="url"
-        [httpOptions]="httpOptions"
-        [anchor]="anchor"
-        [copyCodeToClipboard]="copyCodeToClipboard"
-        [copyCodeTooltips]="copyCodeTooltips"
-        (loadFailed)="handleMarkdownLoaderError($event)"
-      ></td-flavored-markdown-loader>
-      <td-flavored-markdown
-        *ngIf="showTdMarkdown"
-        [content]="markdownString"
-        [hostedUrl]="url"
-        [anchor]="anchor"
-        [copyCodeToClipboard]="copyCodeToClipboard"
-        [copyCodeTooltips]="copyCodeTooltips"
-        (buttonClicked)="buttonClicked.emit($event)"
-      ></td-flavored-markdown>
-    </div>
     <ng-container *ngComponentOutlet="footerComponent"></ng-container>
   </div>
 </ng-container>


### PR DESCRIPTION
## Description

Moved the url rendering to top and children to bottom in markdown window navigator

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots

Before

<img width="853" alt="Screen Shot 2021-04-05 at 10 26 01 PM" src="https://user-images.githubusercontent.com/70976603/113651162-1b57eb80-9657-11eb-951b-de13162ff1a1.png">

After

<img width="840" alt="Screen Shot 2021-04-05 at 10 35 26 PM" src="https://user-images.githubusercontent.com/70976603/113651176-23b02680-9657-11eb-8d74-d336db7b6fa4.png">

