### PR TITLE
fix(dialogs): theming adjustment for dialog header

### DIFF
--- a/src/platform/core/dialogs/_dialog-theme.scss
+++ b/src/platform/core/dialogs/_dialog-theme.scss
@@ -25,6 +25,12 @@
   $warn: map-get($theme, warn);
   $foreground: map-get($theme, foreground);
   $background: map-get($theme, background);
+
+  .mat-toolbar.td-window-dialog-toolbar {
+    color: mat-color($foreground, text);
+    border-bottom: 1px solid mat-color($foreground, divider);
+  }
+
   .td-dialog-message {
     color: mat-color($foreground, secondary-text);
   }

--- a/src/platform/core/dialogs/window-dialog/window-dialog.component.scss
+++ b/src/platform/core/dialogs/window-dialog/window-dialog.component.scss
@@ -10,6 +10,10 @@
   text-overflow: ellipsis;
 }
 
+.td-window-dialog-toolbar {
+  background: none;
+}
+
 .td-window-dialog-title {
   margin-bottom: 0;
 }


### PR DESCRIPTION
## Description

Small fix for the Help Dialog header of the markdown navigator component 

### What's included?
- CSS adjustment to dialog headers in the Core module

#### Test Steps
- [ ] `npm run serve`
- [ ] then navigate to Components -> Markdown Navigator -> Examples
- [ ] finally go to bottom and open some examples that open the navigator window

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Before

![Screen Shot 2021-09-14 at 3 59 53 PM](https://user-images.githubusercontent.com/3837706/133325510-ceef896f-606f-4483-9d7e-61bc6cd000c0.png)


##### After
![Screen Shot 2021-09-13 at 1 47 58 PM](https://user-images.githubusercontent.com/3837706/133324935-ba7f4d39-8d32-4918-8541-d868d129a88d.png)
