### PR TITLE
fix(guided-tour): allowing custom buttons

### DIFF
--- a/src/platform/guided-tour/guided.tour.ts
+++ b/src/platform/guided-tour/guided.tour.ts
@@ -263,7 +263,7 @@ export class CovalentGuidedTour extends TourButtonsActions {
       // check if highlight was provided for the step, else fallback into shepherds usage
       step.highlightClass =
         step.attachToOptions && step.attachToOptions.highlight ? 'shepherd-highlight' : step.highlightClass;
-      
+
       // Adding buttons in the steps if no buttons are defined
       if (step.buttons.length === 0) {
         if (index === 0) {


### PR DESCRIPTION
Allowing custom buttons to be passed in and replace the normal back next finish buttons. We need this to allow for cross app tour navigation

## Description
<!-- Talk about the great work you've done! -->

### What's included?
<!-- List features included in this PR -->
- One
- Two
- Three

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
