### PR TITLE
fix(guided-tour): step button override error

### DIFF
--- a/src/platform/guided-tour/guided.tour.ts
+++ b/src/platform/guided-tour/guided.tour.ts
@@ -265,7 +265,7 @@ export class CovalentGuidedTour extends TourButtonsActions {
         step.attachToOptions && step.attachToOptions.highlight ? 'shepherd-highlight' : step.highlightClass;
 
       // Adding buttons in the steps if no buttons are defined
-      if (step.buttons.length === 0) {
+      if (!step.buttons || step.buttons.length === 0) {
         if (index === 0) {
           // first step
           step.buttons = [nextButton];


### PR DESCRIPTION
## Description
Fixes an error in our logic for setting default buttons on guided tour steps. While the existing condition worked if `step.buttons` was defined as an empty array, if it was not defined, the `length` check would blow up and the tour wouldn't start.

### What's included?
<!-- List features included in this PR -->
- Aforementioned logic fix

#### Test Steps
<!-- Add instructions on how to test your changes -->
- [ ] `npm run serve`
- [ ] try creating a tour with at least one step (without a `buttons` field defined)
- [ ] compare with develop 

#### General Tests for Every PR

- [ ] `npm run serve:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
