### PR TITLE
perf(markdown): do not run change detection when the markdown is clicked

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,14 +9,14 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ develop, master, release/* ]
+    branches: [develop, master, release/*]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ develop ]
+    branches: [develop]
   schedule:
     - cron: '24 11 * * 0'
 
@@ -32,39 +32,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ['javascript']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/src/platform/markdown/markdown.component.spec.ts
+++ b/src/platform/markdown/markdown.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, waitForAsync, ComponentFixture } from '@angular/core/testing';
 import 'hammerjs';
-import { Component, DebugElement } from '@angular/core';
+import { ApplicationRef, Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { CovalentMarkdownModule } from './';
 
@@ -294,6 +294,33 @@ describe('Component: Markdown', () => {
         expect(window.scrollY).toBeLessThan(heading2ScrollPos);
       }),
     );
+
+    it('should jump to anchor if an anchor link is clicked but should not run change detection', async () => {
+      const fixture: ComponentFixture<any> = TestBed.createComponent(TdMarkdownAnchorsTestEventsComponent);
+      const component: TdMarkdownAnchorsTestEventsComponent = fixture.debugElement.componentInstance;
+      component.content = anchorTestMarkdown();
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
+      spyOn(appRef, 'tick').and.callThrough();
+
+      window.scrollTo(0, 0);
+      const originalScrollPos: number = window.scrollY;
+      const heading: HTMLElement = fixture.debugElement.nativeElement.querySelector('a');
+
+      const event: Event = new Event('click', { bubbles: true });
+      spyOn(event, 'preventDefault').and.callThrough();
+
+      heading.dispatchEvent(event);
+
+      const headingScrollPos: number = window.scrollY;
+
+      expect(appRef.tick).not.toHaveBeenCalled();
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(headingScrollPos).toBeGreaterThan(originalScrollPos);
+    });
 
     it(
       'should jump to anchor if an anchor link is clicked regardless of lang',


### PR DESCRIPTION
#### General Tests for Every PR

- [x] `npm run serve:prod` still works.
- [x] `npm run tslint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build:lib` still works.