### PR TITLE
fix(imports): remove require imports from highlight and markdown

### DIFF
--- a/apps/docs-app/project.json
+++ b/apps/docs-app/project.json
@@ -57,7 +57,7 @@
             {
               "type": "initial",
               "maximumWarning": "500kb",
-              "maximumError": "4mb"
+              "maximumError": "5mb"
             },
             {
               "type": "anyComponentStyle",

--- a/libs/angular-highlight/src/lib/highlight.component.ts
+++ b/libs/angular-highlight/src/lib/highlight.component.ts
@@ -15,9 +15,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ICopyCodeTooltips } from './copy-code-button/copy-code-button.component';
 
-declare const require: any;
-/* tslint:disable-next-line */
-const hljs = require('highlight.js/lib/common');
+import hljs from 'highlight.js';
 
 @Component({
   selector: 'td-highlight',

--- a/libs/markdown/src/lib/markdown.component.ts
+++ b/libs/markdown/src/lib/markdown.component.ts
@@ -25,8 +25,7 @@ import {
   renderVideoElements,
 } from './markdown-utils/markdown-utils';
 
-declare const require: any;
-const showdown: any = require('showdown/dist/showdown.js');
+import * as showdown from 'showdown';
 
 // TODO: assumes it is a github url
 // allow override somehow

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "4.0.0-beta.4",
       "hasInstallScript": true,
       "dependencies": {
-        "@angular/animations": "~13.2.0",
+        "@angular/animations": "^13.2.0",
         "@angular/cdk": "^13.2.1",
-        "@angular/common": "~13.2.0",
-        "@angular/compiler": "~13.2.0",
-        "@angular/core": "~13.2.0",
-        "@angular/forms": "~13.2.0",
+        "@angular/common": "^13.2.0",
+        "@angular/compiler": "^13.2.0",
+        "@angular/core": "^13.2.0",
+        "@angular/forms": "^13.2.0",
         "@angular/material": "^13.2.1",
-        "@angular/platform-browser": "~13.2.0",
-        "@angular/platform-browser-dynamic": "~13.2.0",
-        "@angular/router": "~13.2.0",
+        "@angular/platform-browser": "^13.2.0",
+        "@angular/platform-browser-dynamic": "^13.2.0",
+        "@angular/router": "^13.2.0",
         "@ngx-translate/core": "^14.0.0",
         "@ngx-translate/http-loader": "^7.0.0",
         "easymde": "^2.16.1",
@@ -58,6 +58,7 @@
         "@types/jest": "27.0.2",
         "@types/jsdom": "^16.2.14",
         "@types/node": "16.11.7",
+        "@types/showdown": "^1.9.4",
         "@typescript-eslint/eslint-plugin": "~5.10.0",
         "@typescript-eslint/parser": "~5.10.0",
         "autoprefixer": "^10.4.0",
@@ -5653,6 +5654,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/showdown": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-1.9.4.tgz",
+      "integrity": "sha512-50ehC3IAijfkvoNqmQ+VL73S7orOxmAK8ljQAFBv8o7G66lAZyxQj1L3BAv2dD86myLXI+sgKP1kcxAaxW356w==",
+      "dev": true
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -26048,6 +26055,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "@types/showdown": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-1.9.4.tgz",
+      "integrity": "sha512-50ehC3IAijfkvoNqmQ+VL73S7orOxmAK8ljQAFBv8o7G66lAZyxQj1L3BAv2dD86myLXI+sgKP1kcxAaxW356w==",
+      "dev": true
     },
     "@types/sinonjs__fake-timers": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@types/jest": "27.0.2",
     "@types/jsdom": "^16.2.14",
     "@types/node": "16.11.7",
+    "@types/showdown": "^1.9.4",
     "@typescript-eslint/eslint-plugin": "~5.10.0",
     "@typescript-eslint/parser": "~5.10.0",
     "autoprefixer": "^10.4.0",


### PR DESCRIPTION
## Description
using ES6 style imports for highlight.js and markdown libraries

### What's included?
- using ES6 style module imports over the node based require
- allows for better module tree shaking

#### Test Steps
- [ ] `npm run start`
- [ ] then check the highlight and markdown demos
- [ ] finally verify it builds

#### General Tests for Every PR

- [ ] `npm run start:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.
