### PR TITLE
feat(markdown-navigator): adding breadcrumbs

### DIFF
--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-editor/markdown-navigator-demo-editor.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-editor/markdown-navigator-demo-editor.component.html
@@ -5,13 +5,13 @@
       [language]="'json'"
       [(ngModel)]="input"
       [style.height.px]="300"
+      [style.margin-bottom.px]="16"
       [editorOptions]="{
         minimap: {
           enabled: false
         }
       }"
     ></td-code-editor>
-
     <div layout="row" layout-align="space-between center">
       <mat-slide-toggle [(ngModel)]="windowShouldOpen" (change)="openOrClose()"
         >Open window</mat-slide-toggle
@@ -21,7 +21,7 @@
       </button>
     </div>
   </div>
-  <div flex="50" flex-xs="100">
+  <div flex="50" flex-xs="100" style="margin-left: 16px">
     <td-markdown-navigator
       [items]="items"
       [style.height.px]="300"

--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-editor/markdown-navigator-demo-editor.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-editor/markdown-navigator-demo-editor.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import {
   IMarkdownNavigatorItem,
   TdMarkdownNavigatorWindowService,
-  IMarkdownNavigatorWindowConfig,
 } from '@covalent/markdown-navigator';
 
 function prettyJson(items: IMarkdownNavigatorItem[]): string {

--- a/apps/docs-app/src/styles.scss
+++ b/apps/docs-app/src/styles.scss
@@ -3,6 +3,7 @@
 @import '../../../libs/markdown/markdown-theme';
 @import '../../../libs/angular-highlight/highlight-theme';
 @import '../../../libs/markdown-flavored/flavored-markdown-theme';
+@import '../../../libs/markdown-navigator/markdon-navigator-theme';
 @import '../../../libs/angular-guided-tour/guided-tour-theme';
 @import '../../../libs/angular-guided-tour/styles/guided-tour.scss';
 
@@ -68,6 +69,8 @@ $theme: mat-light-theme($primary, $accent, $warn);
 
 ); // OR @import '~highlight.js/styles/vs.css';
 @include covalent-flavored-markdown-theme($theme);
+@include covalent-markdown-navigator-theme($theme);
+@include covalent-markdown-navigator-typography($custom-typography);
 @include teradata-brand($theme);
 
 @include covalent-guided-tour-theme($theme);
@@ -116,6 +119,7 @@ body .mat-card {
   @include covalent-theme($theme-dark);
   @include covalent-markdown-theme($theme-dark);
   @include covalent-flavored-markdown-theme($theme-dark);
+  @include covalent-markdown-navigator-theme($theme-dark);
   @include teradata-brand($theme-dark);
 
   @include covalent-guided-tour-theme($theme-dark);

--- a/apps/docs-app/tsconfig.editor.json
+++ b/apps/docs-app/tsconfig.editor.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["**/*.ts"],
-  "compilerOptions": {
-    "types": ["jest", "node"]
-  }
-}

--- a/apps/docs-app/tsconfig.json
+++ b/apps/docs-app/tsconfig.json
@@ -8,9 +8,6 @@
     },
     {
       "path": "./tsconfig.spec.json"
-    },
-    {
-      "path": "./tsconfig.editor.json"
     }
   ],
   "compilerOptions": {

--- a/libs/angular-code-editor/src/lib/code-editor.component.ts
+++ b/libs/angular-code-editor/src/lib/code-editor.component.ts
@@ -111,6 +111,7 @@ export class TdCodeEditorComponent
   @Input()
   override set value(value: string) {
     this._value = value;
+
     if (this._componentInitialized) {
       this.applyValue();
     }

--- a/libs/angular/breadcrumbs/src/breadcrumb/breadcrumb.component.html
+++ b/libs/angular/breadcrumbs/src/breadcrumb/breadcrumb.component.html
@@ -4,6 +4,5 @@
   class="td-breadcrumb-separator-icon"
   [style.cursor]="'default'"
   (click)="_handleIconClick($event)"
+  >{{ separatorIcon }}</mat-icon
 >
-  {{ separatorIcon }}
-</mat-icon>

--- a/libs/angular/breadcrumbs/src/breadcrumbs.component.scss
+++ b/libs/angular/breadcrumbs/src/breadcrumbs.component.scss
@@ -1,6 +1,6 @@
 :host {
-  display: block;
-  width: 100%;
+  display: flex;
+  align-items: center;
 
   &.td-breadcrumbs {
     white-space: nowrap;

--- a/libs/angular/breadcrumbs/src/breadcrumbs.component.ts
+++ b/libs/angular/breadcrumbs/src/breadcrumbs.component.ts
@@ -6,15 +6,14 @@ import {
   OnDestroy,
   ChangeDetectionStrategy,
   AfterContentInit,
-  DoCheck,
   ChangeDetectorRef,
   ElementRef,
   Input,
   HostBinding,
 } from '@angular/core';
 
-import { Subscription, Subject, fromEvent, merge } from 'rxjs';
-import { debounceTime, distinctUntilChanged, startWith } from 'rxjs/operators';
+import { Subscription, fromEvent } from 'rxjs';
+import { debounceTime, startWith } from 'rxjs/operators';
 
 import { TdBreadcrumbComponent } from './breadcrumb/breadcrumb.component';
 
@@ -25,10 +24,9 @@ import { TdBreadcrumbComponent } from './breadcrumb/breadcrumb.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TdBreadcrumbsComponent
-  implements OnInit, DoCheck, AfterContentInit, OnDestroy
+  implements OnInit, AfterContentInit, OnDestroy
 {
   private _resizeSubscription: Subscription = Subscription.EMPTY;
-  private _widthSubject: Subject<number> = new Subject<number>();
   private _contentChildrenSub!: Subscription;
   private _resizing = false;
   private _separatorIcon = 'chevron_right';
@@ -58,25 +56,18 @@ export class TdBreadcrumbsComponent
   ) {}
 
   ngOnInit(): void {
-    this._resizeSubscription = merge(
-      fromEvent(window, 'resize').pipe(debounceTime(10)),
-      this._widthSubject.asObservable().pipe(distinctUntilChanged())
-    ).subscribe(() => {
-      if (!this._resizing) {
-        this._resizing = true;
-        setTimeout(() => {
-          this._calculateVisibility();
-          this._resizing = false;
-          this._changeDetectorRef.markForCheck();
-        }, 100);
-      }
-    });
-  }
-
-  ngDoCheck(): void {
-    if (this._elementRef && this._elementRef.nativeElement) {
-      this._widthSubject.next(this.nativeElementWidth);
-    }
+    this._resizeSubscription = fromEvent(window, 'resize')
+      .pipe(debounceTime(10))
+      .subscribe(() => {
+        if (!this._resizing) {
+          this._resizing = true;
+          setTimeout(() => {
+            this._calculateVisibility();
+            this._resizing = false;
+            this._changeDetectorRef.markForCheck();
+          }, 100);
+        }
+      });
   }
 
   ngAfterContentInit(): void {

--- a/libs/markdown-flavored/src/lib/flavored-markdown.component.scss
+++ b/libs/markdown-flavored/src/lib/flavored-markdown.component.scss
@@ -9,13 +9,12 @@ $code-font: 'Menlo', 'Monaco', 'Andale Mono', 'lucida console', 'Courier New',
     }
   }
 
-  td-data-table,
   mat-checkbox {
     display: block;
   }
 
-  td-data-table,
   td-highlight,
+  mat-table,
   mat-checkbox:last-of-type {
     margin-bottom: 16px;
   }

--- a/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
+++ b/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
@@ -501,7 +501,7 @@ export class TdFlavoredMarkdownComponent implements AfterViewInit, OnChanges {
           (col: string, index: number) => {
             return {
               label: col,
-              name: col.toLowerCase().trim(),
+              name: col ? col.toLowerCase().trim() : 'column',
               numeric: /^--*[ \t]*:[ \t]*$/.test(alignment[index]),
             };
           }

--- a/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
+++ b/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
@@ -501,7 +501,7 @@ export class TdFlavoredMarkdownComponent implements AfterViewInit, OnChanges {
           (col: string, index: number) => {
             return {
               label: col,
-              name: col ? col.toLowerCase().trim() : 'column',
+              name: col ? col.toLowerCase().trim() : `column ${index}`,
               numeric: /^--*[ \t]*:[ \t]*$/.test(alignment[index]),
             };
           }

--- a/libs/markdown-navigator/_markdon-navigator-theme.scss
+++ b/libs/markdown-navigator/_markdon-navigator-theme.scss
@@ -13,7 +13,7 @@
 @mixin covalent-markdown-navigator-theme($theme) {
   $foreground: map-get($theme, foreground);
   $secondary: map-get($foreground, secondary-text);
-  
+
   td-markdown-navigator {
     td-breadcrumbs {
       color: $secondary;

--- a/libs/markdown-navigator/_markdon-navigator-theme.scss
+++ b/libs/markdown-navigator/_markdon-navigator-theme.scss
@@ -1,0 +1,22 @@
+@mixin covalent-markdown-navigator-typography($fontConfig) {
+  td-markdown-navigator {
+    td-breadcrumbs .mat-button {
+      @include mat-typography-level-to-styles($fontConfig, caption);
+    }
+
+    .breadcrumb-current-title {
+      @include mat-typography-level-to-styles($fontConfig, headline);
+    }
+  }
+}
+
+@mixin covalent-markdown-navigator-theme($theme) {
+  $foreground: map-get($theme, foreground);
+  $secondary: map-get($foreground, secondary-text);
+  
+  td-markdown-navigator {
+    td-breadcrumbs {
+      color: $secondary;
+    }
+  }
+}

--- a/libs/markdown-navigator/ng-package.json
+++ b/libs/markdown-navigator/ng-package.json
@@ -1,4 +1,5 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
-  "dest": "../../dist/libs/markdown-navigator"
+  "dest": "../../dist/libs/markdown-navigator",
+  "assets": ["./**/*theme.scss"]
 }

--- a/libs/markdown-navigator/src/markdown-navigator.component.html
+++ b/libs/markdown-navigator/src/markdown-navigator.component.html
@@ -4,38 +4,34 @@
     mode="indeterminate"
     color="accent"
   ></mat-progress-bar>
-
   <ng-container *ngIf="showHeader">
-    <div [style.display]="'flex'">
-      <button
-        id="td-markdown-navigator-home-button"
-        *ngIf="showHomeButton"
-        mat-icon-button
+    <td-breadcrumbs>
+      <a
+        td-breadcrumb
         [matTooltip]="goHomeLabel ?? ''"
         (click)="reset()"
         [attr.data-test]="'home-button'"
+        >Home</a
       >
-        <mat-icon [attr.aria-label]="goHomeLabel">home</mat-icon>
-      </button>
-
-      <button
-        id="td-markdown-navigator-back-button"
-        *ngIf="showGoBackButton"
-        mat-icon-button
-        [matTooltip]="goBackLabel ?? ''"
-        (click)="goBack()"
-        [attr.data-test]="'back-button'"
+      <ng-container
+        *ngFor="let stack of historyStack; last as isLast; index as index"
       >
-        <mat-icon [attr.aria-label]="goBackLabel">arrow_back</mat-icon>
-      </button>
-      <span
-        flex
-        *ngIf="currentItemTitle"
-        class="mat-body-2 title truncate"
-        [attr.data-test]="'title'"
-      >
-        {{ currentItemTitle }}
-      </span>
+        <ng-container *ngIf="!isLast; else lastBreadCrumb">
+          <a
+            td-breadcrumb
+            (click)="goBack(index)"
+            [attr.data-test]="'back-button'"
+          >
+            {{ stack.title }}
+          </a>
+        </ng-container>
+        <ng-template #lastBreadCrumb>
+          <mat-icon>chevron_right</mat-icon>
+        </ng-template>
+      </ng-container>
+    </td-breadcrumbs>
+    <div class="breadcrumb-current-title" [attr.data-test]="'title'">
+      {{ currentItemTitle }}
     </div>
 
     <mat-divider [style.position]="'relative'"></mat-divider>

--- a/libs/markdown-navigator/src/markdown-navigator.component.html
+++ b/libs/markdown-navigator/src/markdown-navigator.component.html
@@ -21,12 +21,11 @@
             td-breadcrumb
             (click)="goBack(index)"
             [attr.data-test]="'back-button'"
+            >{{ stack.title }}</a
           >
-            {{ stack.title }}
-          </a>
         </ng-container>
         <ng-template #lastBreadCrumb>
-          <mat-icon>chevron_right</mat-icon>
+          <mat-icon class="breadcrumb-end-icon">chevron_right</mat-icon>
         </ng-template>
       </ng-container>
     </td-breadcrumbs>

--- a/libs/markdown-navigator/src/markdown-navigator.component.scss
+++ b/libs/markdown-navigator/src/markdown-navigator.component.scss
@@ -7,6 +7,20 @@
   display: flex;
   flex-direction: column;
 
+  td-breadcrumbs::ng-deep {
+    margin: 16px 16px 8px;
+
+    mat-icon {
+      font-size: 16px;
+      margin-left: 4px;
+      margin-right: 4px;
+    }
+  }
+
+  .breadcrumb-current-title {
+    margin: 0 16px 16px;
+  }
+
   .scroll-area {
     min-height: 1px;
     overflow-y: auto;

--- a/libs/markdown-navigator/src/markdown-navigator.component.scss
+++ b/libs/markdown-navigator/src/markdown-navigator.component.scss
@@ -12,12 +12,14 @@
 
     mat-icon {
       font-size: 16px;
-      margin-left: 4px;
-      margin-right: 4px;
+      margin-left: 1px;
+      margin-right: 0;
+      margin-top: -1px;
     }
   }
 
   .breadcrumb-current-title {
+    font-weight: 700;
     margin: 0 16px 16px;
   }
 

--- a/libs/markdown-navigator/src/markdown-navigator.component.scss
+++ b/libs/markdown-navigator/src/markdown-navigator.component.scss
@@ -20,6 +20,7 @@
 
   .breadcrumb-end-icon {
     line-height: 16px;
+    margin-top: 1px;
   }
 
   .breadcrumb-current-title {

--- a/libs/markdown-navigator/src/markdown-navigator.component.scss
+++ b/libs/markdown-navigator/src/markdown-navigator.component.scss
@@ -18,6 +18,10 @@
     }
   }
 
+  .breadcrumb-end-icon {
+    line-height: 16px;
+  }
+
   .breadcrumb-current-title {
     font-weight: 700;
     margin: 0 16px 16px;

--- a/libs/markdown-navigator/src/markdown-navigator.component.spec.ts
+++ b/libs/markdown-navigator/src/markdown-navigator.component.spec.ts
@@ -12,7 +12,7 @@ import {
   IMarkdownNavigatorCompareWith,
 } from './markdown-navigator.component';
 import { By } from '@angular/platform-browser';
-import { Component, DebugElement, Type } from '@angular/core';
+import { Component, DebugElement, Type, ViewChild } from '@angular/core';
 import { CovalentMarkdownNavigatorModule } from './markdown-navigator.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {
@@ -194,9 +194,7 @@ function getItem(
 async function goBack(
   fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>
 ): Promise<void> {
-  fixture.debugElement
-    .query(By.css('.mat-icon-button[data-test="back-button"]'))
-    .nativeElement.click();
+  fixture.componentInstance.navigator.goBack();
   await wait(fixture);
 }
 
@@ -204,7 +202,7 @@ async function goHome(
   fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>
 ): Promise<void> {
   fixture.debugElement
-    .query(By.css('.mat-icon-button[data-test="home-button"]'))
+    .query(By.css('[data-test="home-button"]'))
     .nativeElement.click();
   await wait(fixture);
 }
@@ -327,6 +325,9 @@ class TdMarkdownNavigatorTestComponent {
   startAt!: IMarkdownNavigatorItem | IMarkdownNavigatorItem[];
   compareWith!: IMarkdownNavigatorCompareWith;
   footer!: Type<any>;
+
+  @ViewChild(TdMarkdownNavigatorComponent)
+  navigator!: TdMarkdownNavigatorComponent;
 }
 
 describe('MarkdownNavigatorComponent', () => {

--- a/libs/markdown-navigator/src/markdown-navigator.component.ts
+++ b/libs/markdown-navigator/src/markdown-navigator.component.ts
@@ -150,14 +150,8 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
     return this.historyStack.length > 0;
   }
 
-  get showHomeButton(): boolean {
-    return this.historyStack.length > 1;
-  }
-
   get showHeader(): boolean {
-    return (
-      this.showHomeButton || this.showGoBackButton || !!this.currentItemTitle
-    );
+    return this.showGoBackButton || !!this.currentItemTitle;
   }
 
   get showMenu(): boolean {
@@ -284,7 +278,7 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
     this._changeDetectorRef.markForCheck();
   }
 
-  goBack(): void {
+  goBack(goBackLength = 1): void {
     this.loading = false;
     this.clearErrors();
     if (this.historyStack.length > 1) {
@@ -295,12 +289,12 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
         parent = this.historyStack[this.historyStack.length - 3]
           ? this.historyStack[this.historyStack.length - 3]
           : undefined;
-        this.historyStack = this.historyStack.slice(0, -1);
+        this.historyStack = this.historyStack.slice(0, -goBackLength);
       }
 
       if (parent) {
         this.currentMarkdownItem = parent;
-        this.historyStack = this.historyStack.slice(0, -1);
+        this.historyStack = this.historyStack.slice(0, -goBackLength);
         this.setChildrenAsCurrentMenuItems(parent);
       } else {
         this.reset();

--- a/libs/markdown-navigator/src/markdown-navigator.module.ts
+++ b/libs/markdown-navigator/src/markdown-navigator.module.ts
@@ -12,6 +12,7 @@ import { CovalentDialogsModule } from '@covalent/core/dialogs';
 import { CovalentMessageModule } from '@covalent/core/message';
 import { TdMarkdownNavigatorWindowDirective } from './markdown-navigator-window-directive/markdown-navigator-window.directive';
 import { TdMarkdownNavigatorWindowService } from './markdown-navigator-window-service/markdown-navigator-window.service';
+import { CovalentBreadcrumbsModule } from '@covalent/core/breadcrumbs';
 
 @NgModule({
   imports: [
@@ -23,9 +24,10 @@ import { TdMarkdownNavigatorWindowService } from './markdown-navigator-window-se
     MatListModule,
     MatIconModule,
     MatProgressBarModule,
-    CovalentMessageModule,
-    CovalentFlavoredMarkdownModule,
+    CovalentBreadcrumbsModule,
     CovalentDialogsModule,
+    CovalentFlavoredMarkdownModule,
+    CovalentMessageModule,
   ],
   declarations: [
     TdMarkdownNavigatorComponent,

--- a/libs/markdown/src/lib/markdown.component.ts
+++ b/libs/markdown/src/lib/markdown.component.ts
@@ -25,8 +25,7 @@ import {
   renderVideoElements,
 } from './markdown-utils/markdown-utils';
 
-declare const require: any;
-const showdown: any = require('showdown/dist/showdown.js');
+import * as showdown from 'showdown';
 
 // TODO: assumes it is a github url
 // allow override somehow
@@ -113,7 +112,11 @@ function normalizeImageSrcs(html: string, currentHref: string): string {
       .forEach((image: HTMLImageElement) => {
         const src = image.getAttribute('src') ?? '';
         try {
+          /* tslint:disable-next-line:no-unused-expression */
           new URL(src);
+          if (isGithubHref(src)) {
+            image.src = rawGithubHref(src);
+          }
         } catch {
           image.src = generateAbsoluteHref(
             isGithubHref(currentHref)

--- a/libs/markdown/src/lib/markdown.component.ts
+++ b/libs/markdown/src/lib/markdown.component.ts
@@ -113,11 +113,7 @@ function normalizeImageSrcs(html: string, currentHref: string): string {
       .forEach((image: HTMLImageElement) => {
         const src = image.getAttribute('src') ?? '';
         try {
-          /* tslint:disable-next-line:no-unused-expression */
           new URL(src);
-          if (isGithubHref(src)) {
-            image.src = rawGithubHref(src);
-          }
         } catch {
           image.src = generateAbsoluteHref(
             isGithubHref(currentHref)


### PR DESCRIPTION
## Description
Adding TD breadcrumbs to markdown navigator window

### What's included?
- adding breadcrumbs to navigator window per UX mocks
- Fixed live editor demo for markdown navigator window

#### Test Steps
- [ ] `npm run start`
- [ ] then go to localhost:4200
- [ ] finally test the examples in the markdown navigator app

#### General Tests for Every PR

- [ ] `npm run start:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
![Screen Shot 2022-03-14 at 5 38 56 PM](https://user-images.githubusercontent.com/3837706/158283353-673c1e87-6ba4-4d7e-9b60-81d7a1e0165e.png)
![Screen Shot 2022-03-14 at 5 39 08 PM](https://user-images.githubusercontent.com/3837706/158283354-5a5bdc04-cda3-40f9-860a-f61649ae477e.png)
