### PR TITLE
build(actions): node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12
+      - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: npm
       - run: npm ci
       - run: npm run format:check
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12
+      - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: npm
       - run: npm ci
       - run: npx nx run-many --target=test --all
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12
+      - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: npm
       - run: npm ci
       - run: npx nx run-many --target=e2e --all
@@ -51,10 +51,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12
+      - name: Use Node.js 16
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: npm
       - run: npm ci
       - run: npx nx run-many --target=build --all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
+      - name: Use Node.js 16
+        uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 16
+          cache: npm
       - name: Install dependencies
         run: npx ci
       - name: SCSS Lint

--- a/.releaserc
+++ b/.releaserc
@@ -23,5 +23,11 @@
       "assets": ["*.tgz"]
     }]
   ],
-  "branches": [{ "name": "beta", "prerelease": true }, { "name": "main" }]
+  "branches": [{
+    "name": "develop",
+    "prerelease": true,
+    "channel": "next"
+  },{
+    "name": "main" 
+  }]
 }


### PR DESCRIPTION
## Description
upgrading github actions to use latest node

### What's included?
- release action upgraded to node 16
- ci action upgraded to node 16

#### Test Steps
- [ ] view the actions statues below

#### General Tests for Every PR

- [ ] `npm run start:prod` still works.
- [ ] `npm run tslint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build:lib` still works.

##### Screenshots or link to StackBlitz/Plunker
