### PR TITLE
docs(gh-pages): fix static asset path

### DIFF
--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-children-url-start-at/markdown-navigator-demo-children-url-start-at.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-children-url-start-at/markdown-navigator-demo-children-url-start-at.component.ts
@@ -16,7 +16,7 @@ export class MarkdownNavigatorDemoChildrenUrlStartAtComponent {
     {
       id: 'url-children-demo',
       title: 'Url children demo',
-      childrenUrl: '/assets/demos-data/children_url_1.json',
+      childrenUrl: 'assets/demos-data/children_url_1.json',
       /*
       For ref:
 

--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-children-url/markdown-navigator-demo-children-url.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-children-url/markdown-navigator-demo-children-url.component.ts
@@ -10,7 +10,7 @@ export class MarkdownNavigatorDemoChildrenUrlComponent {
   items: IMarkdownNavigatorItem[] = [
     {
       title: 'Url children demo',
-      childrenUrl: '/assets/demos-data/children_url_1.json',
+      childrenUrl: 'assets/demos-data/children_url_1.json',
     },
   ];
 }

--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-service/markdown-navigator-demo-service.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-service/markdown-navigator-demo-service.component.ts
@@ -29,7 +29,7 @@ export class MarkdownNavigatorDemoServiceComponent {
         {
           id: 'child_id',
           title: 'Children',
-          childrenUrl: '/assets/demos-data/children_url_1.json',
+          childrenUrl: 'assets/demos-data/children_url_1.json',
         },
       ],
       dialogConfig: {


### PR DESCRIPTION
## Description

fix  markdown docs asset path for demo

#### Test Steps

- [ ] `npm run start`
- [ ] then go to markdown navigator demo
- [ ] finally see test the demos to ensure they are not erroring with 404

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![Screen Shot 2022-03-29 at 10 13 44 PM](https://user-images.githubusercontent.com/3837706/160737235-d93cad19-3e85-482b-ab70-e8750c3a0fed.png)
