### PR TITLE
fix(markdown-navigator): add button click to flavored markdown loader

### DIFF
--- a/libs/markdown-navigator/src/markdown-navigator.component.html
+++ b/libs/markdown-navigator/src/markdown-navigator.component.html
@@ -57,6 +57,7 @@
         [copyCodeToClipboard]="copyCodeToClipboard"
         [copyCodeTooltips]="copyCodeTooltips"
         (loadFailed)="handleMarkdownLoaderError($event)"
+        (buttonClicked)="buttonClicked.emit($event)"
       ></td-flavored-markdown-loader>
       <td-flavored-markdown
         *ngIf="showTdMarkdown"


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->

### What's included?

<!-- List features included in this PR -->

- Add button click event to flavored markdown loader

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
