### PR TITLE
fix(dynamic-forms): fix name attribute for other inputs

### DIFF
--- a/libs/angular-dynamic-forms/src/lib/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
+++ b/libs/angular-dynamic-forms/src/lib/dynamic-elements/dynamic-file-input/dynamic-file-input.component.html
@@ -15,7 +15,7 @@
       matInput
       [value]="control?.value?.name"
       [placeholder]="placeholder"
-      [attr.name]="name"
+      [name]="name"
       [disabled]="control?.disabled"
       readonly
     />

--- a/libs/angular-dynamic-forms/src/lib/dynamic-elements/dynamic-textarea/dynamic-textarea.component.html
+++ b/libs/angular-dynamic-forms/src/lib/dynamic-elements/dynamic-textarea/dynamic-textarea.component.html
@@ -7,7 +7,7 @@
       [formControl]="control"
       [placeholder]="placeholder"
       [required]="required"
-      [attr.name]="name"
+      [name]="name"
       rows="4"
     ></textarea>
     <mat-hint>{{ hint }}</mat-hint>


### PR DESCRIPTION
## Description
Changing name attribute for material inputs based on recent NG 13 updates

### What's included?
- Updates text area and file input component to use new syntax for `name` attributes for material inputs

#### Test Steps
- [ ] `npm run start`
- [ ] then go to the dynamic forms doc
- [ ] finally verify there is a ng name attribute added for the two form inputs

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![Screen Shot 2022-04-11 at 2 48 39 PM](https://user-images.githubusercontent.com/3837706/162808706-01454a66-641e-4126-adcc-146630fa9e30.png)
