### PR TITLE
fix(dynamic-forms): fixed defualt value for booleans

### DIFF
--- a/libs/angular-dynamic-forms/src/lib/dynamic-elements/dynamic-select/dynamic-select.component.html
+++ b/libs/angular-dynamic-forms/src/lib/dynamic-elements/dynamic-select/dynamic-select.component.html
@@ -10,7 +10,7 @@
     >
       <mat-option
         *ngFor="let selection of selections"
-        [value]="selection.value || selection"
+        [value]="selection.value ?? selection"
       >
         {{ selection.label || selection }}
       </mat-option>


### PR DESCRIPTION
## Description

closes #1876

setting the default value with a boolean of `false` will not correctly set the default value.

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
