### PR TITLE
fix(search): re-implementing mixinControlValueAccessor

### DIFF
--- a/apps/docs-app/src/app/content/components/component-demos/search/demos/search-demo-input/search-demo-input.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/search/demos/search-demo-input/search-demo-input.component.html
@@ -30,7 +30,8 @@
       [appearance]="appearance"
       [showUnderline]="true"
       placeholder="Search using debounce"
-      (searchDebounce)="searchInputTerm = $event"
+      (searchDebounce)="searchChange($event)"
+      (clear)="modeChange()"
       searchIcon="image_search"
     ></td-search-input>
     <td-search-input
@@ -38,8 +39,8 @@
       [appearance]="appearance"
       [showUnderline]="true"
       placeholder="Search using enter/clear"
-      (search)="searchInputTerm = $event"
-      (clear)="searchInputTerm = ''"
+      (search)="searchChange($event)"
+      (clear)="modeChange()"
       searchIcon="search"
     ></td-search-input>
   </div>

--- a/apps/docs-app/src/app/content/components/component-demos/search/demos/search-demo-input/search-demo-input.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/search/demos/search-demo-input/search-demo-input.component.ts
@@ -18,6 +18,10 @@ export class SearchDemoInputComponent {
   searchInputTerm = '';
   debounce = 0;
 
+  searchChange($event: string) {
+    this.searchInputTerm = $event;
+  }
+
   modeChange(): void {
     this.searchInputTerm = '';
   }

--- a/libs/angular/search/src/search-input/search-input.component.ts
+++ b/libs/angular/search/src/search-input/search-input.component.ts
@@ -20,17 +20,23 @@ import {
   transition,
   animate,
 } from '@angular/animations';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Dir } from '@angular/cdk/bidi';
 import { MatInput } from '@angular/material/input';
 import { MatFormFieldAppearance } from '@angular/material/form-field';
-
+import { fromEvent, Subject } from 'rxjs';
 import { debounceTime, skip, takeUntil } from 'rxjs/operators';
-import { fromEvent, noop, Subject } from 'rxjs';
+import {
+  IControlValueAccessor,
+  mixinControlValueAccessor,
+} from '@covalent/core/common';
 
 export class TdSearchInputBase {
   constructor(public _changeDetectorRef: ChangeDetectorRef) {}
 }
+
+export const _TdSearchInputMixinBase =
+  mixinControlValueAccessor(TdSearchInputBase);
 
 @Component({
   providers: [
@@ -73,7 +79,8 @@ export class TdSearchInputBase {
   ],
 })
 export class TdSearchInputComponent
-  implements ControlValueAccessor, OnInit, OnDestroy
+  extends _TdSearchInputMixinBase
+  implements IControlValueAccessor, OnInit, OnDestroy
 {
   @ViewChild(MatInput, { static: true }) _input?: MatInput;
 
@@ -111,7 +118,7 @@ export class TdSearchInputComponent
    */
   @Input() clearIcon = 'cancel';
 
-  @Input() value?: unknown;
+  @Input() override value!: unknown;
 
   /**
    * searchDebounce: function($event)
@@ -148,9 +155,11 @@ export class TdSearchInputComponent
 
   constructor(
     @Optional() private _dir: Dir,
-    private _changeDetectorRef: ChangeDetectorRef,
+    override _changeDetectorRef: ChangeDetectorRef,
     private _ngZone: NgZone
-  ) {}
+  ) {
+    super(_changeDetectorRef);
+  }
 
   ngOnInit(): void {
     this._input?.ngControl?.valueChanges
@@ -172,19 +181,6 @@ export class TdSearchInputComponent
 
   ngOnDestroy(): void {
     this._destroy$.next();
-  }
-
-  writeValue(value: unknown): void {
-    this.value = value;
-    this._changeDetectorRef.markForCheck();
-  }
-
-  registerOnChange(): void {
-    noop;
-  }
-
-  registerOnTouched(): void {
-    noop;
   }
 
   /**


### PR DESCRIPTION
## Description

re-implementing the search input to use mixinControlValueAccessor from our common package

closes #1932 

### What's included?

- re-implements mixinControlValueAccessor

#### Test Steps

- [ ] `npm run start`
- [ ] then this go to localhost:4200
- [ ] finally go to the search input demos and test out the examples to ensure it still works

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
