### PR TITLE
fix:minimize-help-code(vac-1333)

### DIFF
--- a/libs/angular/dialogs/src/window-dialog/window-dialog.component.html
+++ b/libs/angular/dialogs/src/window-dialog/window-dialog.component.html
@@ -10,12 +10,15 @@
         {{ title }}
       </span>
       <!-- TODO: Resizing a drag-and-drop element was not working so removed docking/undocking for now-->
-      <button mat-icon-button (click)="toggleDockedState()">
+      <button
+        mat-icon-button
+        (click)="toggleDockedState()"
+        class="td-window-dialog-close"
+      >
         <mat-icon [attr.aria-label]="toggleDockedStateLabel">
           {{ docked ? 'expand_less' : 'expand_more' }}
         </mat-icon>
       </button>
-
       <button
         mat-icon-button
         [matTooltip]="closeLabel ?? ''"

--- a/libs/angular/dialogs/src/window-dialog/window-dialog.component.html
+++ b/libs/angular/dialogs/src/window-dialog/window-dialog.component.html
@@ -10,11 +10,11 @@
         {{ title }}
       </span>
       <!-- TODO: Resizing a drag-and-drop element was not working so removed docking/undocking for now-->
-      <!-- <button mat-icon-button [matTooltip]="toggleDockedStateLabel" (click)="toggleDockedState()">
+      <button mat-icon-button (click)="toggleDockedState()">
         <mat-icon [attr.aria-label]="toggleDockedStateLabel">
-          {{ docked ? 'unfold_more' : 'unfold_less' }}
+          {{ docked ? 'expand_less' : 'expand_more' }}
         </mat-icon>
-      </button> -->
+      </button>
 
       <button
         mat-icon-button

--- a/libs/angular/dialogs/src/window-dialog/window-dialog.component.scss
+++ b/libs/angular/dialogs/src/window-dialog/window-dialog.component.scss
@@ -26,6 +26,7 @@
   .td-window-dialog {
     .mat-dialog-container {
       padding: 0;
+      border-radius:0px !important;
     }
   }
 }

--- a/libs/angular/dialogs/src/window-dialog/window-dialog.component.scss
+++ b/libs/angular/dialogs/src/window-dialog/window-dialog.component.scss
@@ -26,7 +26,9 @@
   .td-window-dialog {
     .mat-dialog-container {
       padding: 0;
-      border-radius:0px !important;
+      border-bottom-right-radius
+      :0px !important;
+      border-bottom-left-radius:0px !important ;
     }
   }
 }

--- a/libs/markdown-navigator/src/markdown-navigator-window-service/markdown-navigator-window.service.ts
+++ b/libs/markdown-navigator/src/markdown-navigator-window-service/markdown-navigator-window.service.ts
@@ -42,7 +42,7 @@ export interface IMarkdownNavigatorWindowConfig {
 
 const CDK_OVERLAY_CUSTOM_CLASS = 'td-window-dialog';
 
-const DEFAULT_POSITION: DialogPosition = { bottom: '0px', right: '10px' };
+const DEFAULT_POSITION: DialogPosition = { bottom: '0px', right: '16px' };
 const DEFAULT_WIDTH = '350px';
 const DEFAULT_HEIGHT = '75vh';
 const MIN_HEIGHT = '56px';

--- a/libs/markdown-navigator/src/markdown-navigator-window-service/markdown-navigator-window.service.ts
+++ b/libs/markdown-navigator/src/markdown-navigator-window-service/markdown-navigator-window.service.ts
@@ -42,8 +42,8 @@ export interface IMarkdownNavigatorWindowConfig {
 
 const CDK_OVERLAY_CUSTOM_CLASS = 'td-window-dialog';
 
-const DEFAULT_POSITION: DialogPosition = { bottom: '0px', right: '0px' };
-const DEFAULT_WIDTH = '360px';
+const DEFAULT_POSITION: DialogPosition = { bottom: '0px', right: '10px' };
+const DEFAULT_WIDTH = '350px';
 const DEFAULT_HEIGHT = '75vh';
 const MIN_HEIGHT = '56px';
 const MAX_WIDTH = '100vw';


### PR DESCRIPTION
**Description** : Implemented minimized mode for the help component.
Test Steps: 1. Log in into the console app.
                     2. From left menu click on help icon, (i.e) last Icon  from bottom.
                     3. Help window will be open.
                     4. Inside window there will be maximized icon.
                     5. After we clicking on the maximized icon windo
<img width="762" alt="Minimized 2022-05-16 at 1 50 20 PM" src="https://user-images.githubusercontent.com/99816895/168680459-6d771524-6d82-43dc-a772-52c735c4086e.png">
w will be minimized and the icon will be changed to maximized. (vice versa will happen)

<img width="658" alt="Maximized 2022-05-16 at 1 50 34 PM" src="https://user-images.githubusercontent.com/99816895/168680609-4fdc290b-0bd4-47d0-830a-15d3676054b6.png">

                     

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [x] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
