### PR TITLE
fix(text-editor): commonjs dependencies

### DIFF
--- a/apps/docs-app/project.json
+++ b/apps/docs-app/project.json
@@ -48,7 +48,8 @@
         "scripts": [
           "node_modules/echarts/dist/echarts.js",
           "node_modules/echarts-wordcloud/dist/echarts-wordcloud.min.js",
-          "node_modules/shepherd.js/dist/js/shepherd.min.js"
+          "node_modules/shepherd.js/dist/js/shepherd.min.js",
+          "node_modules/easymde/dist/easymde.min.js"
         ]
       },
       "configurations": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.1.11-develop.1](https://github.com/Teradata/covalent/compare/v4.1.10...v4.1.11-develop.1) (2022-05-17)
+
+### Bug Fixes
+
+- **text-editor:** remove easymde as commonjs dep ([5c57c0e](https://github.com/Teradata/covalent/commit/5c57c0e50f9daa7c107a90cf9476cbf0e2e90d6f))
+
 ## [4.1.10](https://github.com/Teradata/covalent/compare/v4.1.9...v4.1.10) (2022-05-16)
 
 ### Bug Fixes

--- a/libs/angular-text-editor/src/lib/text-editor.component.ts
+++ b/libs/angular-text-editor/src/lib/text-editor.component.ts
@@ -9,13 +9,13 @@ import {
   OnDestroy,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
-import * as EasyMDE from 'easymde';
-// get access to the marked class under easymde
-import * as marked from 'marked';
+import { marked } from 'marked';
 
 const noop: any = () => {
   // empty method
 };
+
+const EasyMDE = (window as any).EasyMDE;
 
 @Component({
   selector: 'td-text-editor',
@@ -33,7 +33,7 @@ export class TdTextEditorComponent
   implements AfterViewInit, OnDestroy, ControlValueAccessor
 {
   private _value = '';
-  private _easyMDE!: EasyMDE;
+  private _easyMDE!: typeof EasyMDE;
   private _fromEditor = false;
 
   @ViewChild('easymde', { static: true }) textarea!: ElementRef;
@@ -66,7 +66,7 @@ export class TdTextEditorComponent
     return this._value;
   }
 
-  get easyMDE(): EasyMDE {
+  get easyMDE(): typeof EasyMDE {
     return this._easyMDE;
   }
 
@@ -87,7 +87,7 @@ export class TdTextEditorComponent
     this.options.element = this.textarea.nativeElement;
 
     // If content entered is html then don't evaluate it, prevent xss vulnerabilities
-    marked.marked.setOptions({ sanitize: true });
+    marked.setOptions({ sanitize: true });
     this._easyMDE = new EasyMDE(this.options);
     this._easyMDE.value(this.value);
     this._easyMDE.codemirror.on('change', this._onChange);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "covalent",
-  "version": "4.1.10",
+  "version": "4.1.11-develop.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "covalent",
-      "version": "4.1.10",
+      "version": "4.1.11-develop.1",
       "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "^13.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "covalent",
-  "version": "4.1.10",
+  "version": "4.1.11-develop.1",
   "description": "Teradata UI Platform built on Angular Material",
   "keywords": [
     "angular",


### PR DESCRIPTION
## Description

After using `@covalent/text-editor` it was discovered that EasyMDE library was not being correctly imported in a 12.x/13.x project.

closes #1940 

### What's included?

- Moving away from module import over to a commonjs style include

NOTE: Consumers must now import EasyMDE within their projects. this will no longer be included directly in the component.

#### Test Steps

- [ ] `npm run start`
- [ ] then open localhost and view the text-editor example
- [ ] finally verify the text-editor works exactly as beforre

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
