### PR TITLE
fix(navigator): fix button regex

### DIFF
--- a/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
+++ b/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
@@ -391,7 +391,7 @@ export class TdFlavoredMarkdownComponent implements AfterViewInit, OnChanges {
   }
 
   private _replaceButtons(markdown: string): string {
-    const buttonRegExp = /\[([^[]+)\](\(#data=(.*)\))/i;
+    const buttonRegExp = /\[([^[]+)\](\(#data=(.*?)\))/i;
     const globalButtonRegExp = new RegExp(
       buttonRegExp.source,
       buttonRegExp.flags + 'g'


### PR DESCRIPTION
## Description

Change the navigator button regex

### What's included?

- Navigator button regex only detect first pair of parentheses

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
