### PR TITLE
fix(flavored-markdown): allow for all list characters

### DIFF
--- a/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
+++ b/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
@@ -512,22 +512,25 @@ export class TdFlavoredMarkdownComponent implements AfterViewInit, OnChanges {
   }
 
   private _replaceLists(markdown: string): string {
-    const listRegExp = /(?:^|\n)(( *(\+|-))[ |\t](.*)\n)+/g;
-    const listCharRegExp = new RegExp(/\+|-/);
+    const listRegExp = /(?:^|\n)(( *(\+|\*))[ |\t](.*)\n)+/g;
+    const listCharRegExp = new RegExp(/^(\+|\*)/);
     return this._replaceComponent(
       markdown,
       TdFlavoredListComponent,
       listRegExp,
       (componentRef: ComponentRef<TdFlavoredListComponent>, match: string) => {
         const matchIndex =
-          match.indexOf('+') !== -1 ? match.indexOf('+') : match.indexOf('-');
+          match.indexOf('+') !== -1 ? match.indexOf('+') : match.indexOf('*');
+
         const lineTexts: string[] = match.split(
-          new RegExp('\\n {' + (matchIndex - 1).toString() + '}(\\+|-)[ |\\t]')
+          new RegExp(
+            '\\n {' + (matchIndex - 1).toString() + '}(\\+|\\*)[ |\\t]'
+          )
         );
         lineTexts.shift();
         const lines: IFlavoredListItem[] = [];
         lineTexts.forEach((text: string) => {
-          const sublineTexts: string[] = text.split(/\n *(\+|-) /);
+          const sublineTexts: string[] = text.split(/\n *(\+|\*) /);
           const lineText = sublineTexts.shift() ?? '';
 
           if (listCharRegExp.test(lineText)) {

--- a/libs/markdown/src/lib/markdown.component.ts
+++ b/libs/markdown/src/lib/markdown.component.ts
@@ -376,6 +376,7 @@ export class TdMarkdownComponent
     converter.setOption('tables', true);
     converter.setOption('literalMidWordUnderscores', true);
     converter.setOption('simpleLineBreaks', this._simpleLineBreaks);
+    converter.setOption('emoji', true);
     return converter.makeHtml(markdownToParse);
   }
 }


### PR DESCRIPTION
## Description

Adjusted the regex for parsing lists in the flavored markdown component

### What's included?
- flavored markdown parsing for lists now include `+,*` where before it was just `+`

#### Test Steps
- [ ] `npm run start`
- [ ] then go to the flavored markdown examples
- [ ] finally in code change the example lists for flavored markdown to use the three different supported list characters

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
