### PR TITLE
fix(rxjs): in package from ~ to ^

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "echarts-wordcloud": "^2.0.0",
     "highlight.js": "^11.4.0",
     "monaco-editor": "^0.32.1",
-    "rxjs": "~7.4.0",
+    "rxjs": "^7.4.0",
     "shepherd.js": "^9.0.0",
     "showdown": "^2.0.3",
     "tslib": "^2.0.0",


### PR DESCRIPTION
## Description

Changed versioning of rxjs in package.json from `~7.4.0` to `^7.4.0`

### What's included?

#### Test Steps

- [ ] `npm run start`

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
