### PR TITLE
perf(breadcrumbs): reduce change detection cycles

### DIFF
--- a/libs/angular/breadcrumbs/src/breadcrumb/breadcrumb.component.html
+++ b/libs/angular/breadcrumbs/src/breadcrumb/breadcrumb.component.html
@@ -1,8 +1,8 @@
 <ng-content></ng-content>
 <mat-icon
   *ngIf="displayIcon"
+  #icon
   class="td-breadcrumb-separator-icon"
   [style.cursor]="'default'"
-  (click)="_handleIconClick($event)"
   >{{ separatorIcon }}</mat-icon
 >

--- a/libs/angular/breadcrumbs/src/breadcrumb/breadcrumb.component.spec.ts
+++ b/libs/angular/breadcrumbs/src/breadcrumb/breadcrumb.component.spec.ts
@@ -1,0 +1,43 @@
+import { ApplicationRef, Component } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatIconModule } from '@angular/material/icon';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { TdBreadcrumbComponent } from './breadcrumb.component';
+
+describe('Components: Breadcrumb', () => {
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [NoopAnimationsModule, MatIconModule],
+        declarations: [TdBreadcrumbTestComponent, TdBreadcrumbComponent],
+      });
+    })
+  );
+
+  it('should prevent default and stop event propagation when the `mat-icon` is clicked but should not trigger change detection', () => {
+    const fixture: ComponentFixture<TdBreadcrumbTestComponent> =
+      TestBed.createComponent(TdBreadcrumbTestComponent);
+    fixture.detectChanges();
+    const appRef = TestBed.inject(ApplicationRef);
+    jest.spyOn(appRef, 'tick');
+    const event = new MouseEvent('click');
+    jest.spyOn(event, 'preventDefault');
+    jest.spyOn(event, 'stopPropagation');
+
+    fixture.debugElement
+      .query(By.css('mat-icon'))
+      .nativeElement.dispatchEvent(event);
+
+    expect(appRef.tick).not.toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+  });
+});
+
+@Component({
+  selector: 'td-breadcrumb-test',
+  template: '<td-breadcrumb></td-breadcrumb>',
+})
+class TdBreadcrumbTestComponent {}


### PR DESCRIPTION
On the `td-breadcrumbs` side I've wrapped the `fromEvent` with `isPlatformServer` guard because it's throwing `window is not defined` on the Node.js side. I've also wrapped the `fromEvent` with `runOutsideAngular` so the change detection is only triggered when the very last timer is fired (and not on `resize` events, `debounceTime` and `setTimeout`).

On the `td-breadcrumb` side I've remove `(click)` from the template and added it manually so it doesn't trigger CD. Also added tests for those changes.