### PR TITLE
fix(editor): remove grey border

### DIFF
--- a/libs/angular-code-editor/src/lib/code-editor.component.ts
+++ b/libs/angular-code-editor/src/lib/code-editor.component.ts
@@ -62,7 +62,7 @@ export class TdCodeEditorComponent
   private _widthSubject: Subject<number> = new Subject<number>();
   private _heightSubject: Subject<number> = new Subject<number>();
 
-  private _editorStyle = 'width:100%;height:100%;border:1px solid grey;';
+  private _editorStyle = 'width:100%;height:100%;';
   private _value = '';
   private _theme = 'vs';
   private _language = 'javascript';


### PR DESCRIPTION
## Description

removing gray border inserted in every monaco editor instance

#### Test Steps

- [ ] `npm run start`
- [ ] then go look at the editor docs

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
