### PR TITLE
fix(nx): side sheet behavior change

### DIFF
--- a/apps/docs-app/src/app/content/components/component-demos/side-sheet/demos/side-sheet-demo-multi/side-sheet-demo-multi.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/side-sheet/demos/side-sheet-demo-multi/side-sheet-demo-multi.component.ts
@@ -11,11 +11,7 @@ import { SubPageMode, CovalentSideSheet } from '@covalent/core/side-sheet';
     </div>
 
     <div style="display:flex; justify-content:space-between; padding-top:50px">
-      <button
-        mat-raised-button
-        color="primary"
-        (click)="openSideSheet('pushed')"
-      >
+      <button mat-raised-button color="primary" (click)="openSideSheet()">
         Open pushed
       </button>
     </div>
@@ -24,32 +20,31 @@ import { SubPageMode, CovalentSideSheet } from '@covalent/core/side-sheet';
       <button
         mat-raised-button
         color="primary"
-        (click)="openSideSheet('shifted')"
+        (click)="openSideSheet(SubPageOpenMode.shifted)"
       >
         Open shifted
       </button>
     </div>
 
     <div style="display:flex; justify-content:space-between; padding-top:50px">
-      <button mat-raised-button color="primary" (click)="openSideSheet('none')">
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="openSideSheet(SubPageOpenMode.none)"
+      >
         Open none
       </button>
     </div>
   `,
 })
 export class SideSheetDemoExampleComponent {
+  SubPageOpenMode = SubPageMode;
   constructor(private sideSheet: CovalentSideSheet) {}
 
-  openSideSheet(mode?: string): void {
-    let subPageMode: SubPageMode = SubPageMode.pushed;
-    if (mode === 'shifted') {
-      subPageMode = SubPageMode.shifted;
-    } else if (mode === 'none') {
-      subPageMode = SubPageMode.none;
-    }
+  openSideSheet(mode: SubPageMode = SubPageMode.pushed): void {
     this.sideSheet.open(SideSheetDemoExampleLayeredComponent, {
       minWidth: '400px',
-      subPageMode: subPageMode,
+      subPageMode: mode,
     });
   }
 }

--- a/apps/docs-app/src/app/content/components/component-demos/side-sheet/demos/side-sheet-demo-multi/side-sheet-demo-multi.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/side-sheet/demos/side-sheet-demo-multi/side-sheet-demo-multi.component.ts
@@ -1,31 +1,62 @@
 import { Component } from '@angular/core';
-import { CovalentSideSheet } from '@covalent/core/side-sheet';
+import { SubPageMode, CovalentSideSheet } from '@covalent/core/side-sheet';
 
 @Component({
   selector: 'example',
   template: `
     it works from a component
-    <div style="display:flex; justify-content:space-between;">
-      <button mat-raised-button color="primary" (click)="openSideSheet()">
-        Open
-      </button>
+
+    <div style="display:flex; justify-content:right; padding-top:50px">
       <button mat-raised-button td-side-sheet-close>Close</button>
+    </div>
+
+    <div style="display:flex; justify-content:space-between; padding-top:50px">
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="openSideSheet('pushed')"
+      >
+        Open pushed
+      </button>
+    </div>
+
+    <div style="display:flex; justify-content:space-between; padding-top:50px">
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="openSideSheet('shifted')"
+      >
+        Open shifted
+      </button>
+    </div>
+
+    <div style="display:flex; justify-content:space-between; padding-top:50px">
+      <button mat-raised-button color="primary" (click)="openSideSheet('none')">
+        Open none
+      </button>
     </div>
   `,
 })
 export class SideSheetDemoExampleComponent {
   constructor(private sideSheet: CovalentSideSheet) {}
 
-  openSideSheet(): void {
+  openSideSheet(mode?: string): void {
+    let subPageMode: SubPageMode = SubPageMode.pushed;
+    if (mode === 'shifted') {
+      subPageMode = SubPageMode.shifted;
+    } else if (mode === 'none') {
+      subPageMode = SubPageMode.none;
+    }
     this.sideSheet.open(SideSheetDemoExampleLayeredComponent, {
-      minWidth: '800px',
+      minWidth: '400px',
+      subPageMode: subPageMode,
     });
   }
 }
 
 @Component({
   selector: 'example-layered',
-  template: 'Im Mulit layered!',
+  template: 'Im Multi layered!',
 })
 class SideSheetDemoExampleLayeredComponent {}
 

--- a/libs/angular/side-sheet/src/side-sheet.config.ts
+++ b/libs/angular/side-sheet/src/side-sheet.config.ts
@@ -1,3 +1,11 @@
 import { MatDialogConfig } from '@angular/material/dialog';
 
-export class CovalentSideSheetConfig<D = any> extends MatDialogConfig<D> {}
+export enum SubPageMode {
+  pushed = 'pushed',
+  shifted = 'shifted',
+  none = 'none',
+}
+
+export class CovalentSideSheetConfig<D = any> extends MatDialogConfig<D> {
+  subPageMode?: string = SubPageMode.pushed;
+}

--- a/libs/angular/side-sheet/src/side-sheet.ts
+++ b/libs/angular/side-sheet/src/side-sheet.ts
@@ -38,7 +38,7 @@ import { filter, take } from 'rxjs/operators';
 import { Directionality } from '@angular/cdk/bidi';
 
 import { CovalentSideSheetRef } from './side-sheet-ref';
-import { CovalentSideSheetConfig } from './side-sheet.config';
+import { SubPageMode, CovalentSideSheetConfig } from './side-sheet.config';
 
 @Directive()
 export class _CovalentSideSheetBase<C extends _CovalentSideSheetContainerBase>
@@ -98,12 +98,22 @@ export class _CovalentSideSheetBase<C extends _CovalentSideSheetContainerBase>
       this.openSideSheets.slice(-1)[0];
     const prevOverlayRef = prevSideSheetRef?.overlayRef;
 
-    // Animate previous side sheet to full width
-    if (prevOverlayRef?.overlayElement) {
+    if (
+      prevOverlayRef?.overlayElement &&
+      config.subPageMode !== SubPageMode.none
+    ) {
       prevOverlayRef.overlayElement.style.transition = `${AnimationDurations.COMPLEX} ${AnimationCurves.DECELERATION_CURVE}`;
-      prevOverlayRef.overlayElement.style.minWidth = `${
-        (window as any).innerWidth
-      }px`;
+      if (config.subPageMode === SubPageMode.pushed) {
+        // Animate previous side sheet to full width
+        prevOverlayRef.overlayElement.style.minWidth = `${
+          (window as any).innerWidth
+        }px`;
+      } else if (config.subPageMode === SubPageMode.shifted) {
+        // Animate previous side sheet to current sidesheet width + 200px
+        prevOverlayRef.overlayElement.style.minWidth = `${
+          sideSheetRef.overlayRef.overlayElement.offsetWidth + 200
+        }px`;
+      }
     }
 
     // Revert the previous side sheet config & size


### PR DESCRIPTION
## Description

When secondary side sheet is opened, provide 3 options to user:

1. 'pushed'. --  push the parent side sheet to entire width of the window
2. 'shifted' -- shift the parent side sheet to left 
3. 'none' --  secondary sheet simply cover the parent

### What's included?

Secondary side sheet change

#### Test Steps


- [ ] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![Secondary sidesheet](https://user-images.githubusercontent.com/114519302/192831409-317c8eb4-44c4-41d9-900b-daac8ce8c333.gif)

