### PR TITLE
feat: add color use guide to covalent

### DIFF
--- a/libs/components/src/card/card.scss
+++ b/libs/components/src/card/card.scss
@@ -5,5 +5,8 @@
 
 .mdc-card__actions {
   color: var(--mdc-theme-text-primary-on-background);
+}
+.mdc-card__actions:first-of-type {
   border-bottom: 1px solid var(--mdc-theme-border);
+  padding-left: 16px;
 }

--- a/libs/components/styles/theme/_all-theme.scss
+++ b/libs/components/styles/theme/_all-theme.scss
@@ -25,6 +25,10 @@
   --mdc-theme-negative: #{map-get($theme, error)};
   --mdc-theme-positive: #{map-get($theme, positive)};
   --mdc-theme-caution: #{map-get($theme, caution)};
+  --mdc-theme-emphasis: #{map-get($theme, emphasis)};
+
+  // Alias for primary
+  --mdc-theme-accent: #{map-get($theme, accent)};
 
   // Background colors
   --mdc-theme-background: #{map-get($theme, background)};
@@ -84,10 +88,30 @@
       $theme,
       surface-neutral-highlight-hover
     )};
+  --mdc-theme-surface-emphasis: #{map-get($theme, surface-emphasis)};
+  --mdc-theme-surface-emphasis-highlight: #{map-get(
+      $theme,
+      surface-emphasis-highlight
+    )};
+  --mdc-theme-surface-emphasis-highlight-hover: #{map-get(
+      $theme,
+      surface-emphasis-highlight-hover
+    )};
   --mdc-theme-on-primary: #{map-get($theme, on-primary)};
   --mdc-theme-on-secondary: #{map-get($theme, on-secondary)};
   --mdc-theme-on-surface: #{map-get($theme, on-surface)};
   --mdc-theme-border: #{map-get($theme, divider)};
+
+  // Alias for primary
+  --mdc-theme-surface-accent: #{map-get($theme, surface-primary)};
+  --mdc-theme-surface-accent-highlight: #{map-get(
+      $theme,
+      surface-primary-highlight
+    )};
+  --mdc-theme-surface-accent-highlight-hover: #{map-get(
+      $theme,
+      surface-primary-highlight-hover
+    )};
 
   // Surfaces
   --mdc-theme-background: #{map-get($theme, background)};
@@ -318,7 +342,7 @@
   @include button.button-theme($theme);
   @include card.card-theme($theme);
   @include checkbox.checkbox-theme($theme);
-  @include chips.chips-theme($theme);
+  // @include chips.chips-theme($theme);
   @include data-table.data-table-theme($theme);
   @include dialog.dialog-theme($theme);
   @include drawer.drawer-theme($theme);
@@ -337,10 +361,11 @@
 
   // Links
   a[href] {
-    color: var(--mdc-theme-text-primary-on-background);
+    color: var(--mdc-theme-secondary);
+    text-decoration: underline;
 
     &:hover {
-      text-decoration: underline;
+      text-decoration: none;
     }
   }
 }

--- a/libs/components/styles/theme/_all-theme.scss
+++ b/libs/components/styles/theme/_all-theme.scss
@@ -342,7 +342,7 @@
   @include button.button-theme($theme);
   @include card.card-theme($theme);
   @include checkbox.checkbox-theme($theme);
-  // @include chips.chips-theme($theme);
+  @include chips.chips-theme($theme);
   @include data-table.data-table-theme($theme);
   @include dialog.dialog-theme($theme);
   @include drawer.drawer-theme($theme);

--- a/libs/components/styles/theme/theme.scss
+++ b/libs/components/styles/theme/theme.scss
@@ -8,10 +8,15 @@
     map-get(variables.$tokens, typography)
   );
 }
-
 .dark {
   @include theme.components-theme(
     map-get(variables.$tokens, dark),
+    map-get(variables.$tokens, typography)
+  );
+}
+.light {
+  @include theme.components-theme(
+    map-get(variables.$tokens, light),
     map-get(variables.$tokens, typography)
   );
 }

--- a/libs/tokens/build/css/variables.css
+++ b/libs/tokens/build/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Aug 2022 18:24:44 GMT
+ * Generated on Wed, 28 Sep 2022 18:22:21 GMT
  */
 
 :root {
@@ -16,12 +16,17 @@
   --td-light-on-surface: rgba(0, 0, 0, 0.87);
   --td-light-on-error: white;
   --td-light-divider: rgba(0, 0, 0, 0.12);
+  --td-light-emphasis: #546e7a;
+  --td-light-accent: #007373;
   --td-light-background: #f5f5f5;
   --td-light-surface: white;
   --td-light-surface-canvas: #eee;
   --td-light-surface-primary: #85dddc;
   --td-light-surface-primary-highlight: rgba(#85dddc, 0.1);
   --td-light-surface-primary-highlight-hover: rgba(#85dddc, 0.2);
+  --td-light-surface-accent: #85dddc;
+  --td-light-surface-accent-highlight: rgba(#85dddc, 0.1);
+  --td-light-surface-accent-highlight-hover: rgba(#85dddc, 0.2);
   --td-light-surface-secondary: #85dddc;
   --td-light-surface-secondary-highlight: rgba(#85dddc, 0.1);
   --td-light-surface-secondary-highlight-hover: rgba(#85dddc, 0.2);
@@ -37,6 +42,9 @@
   --td-light-surface-neutral: #bdbdbd;
   --td-light-surface-neutral-highlight: rgba(#bdbdbd, 0.04);
   --td-light-surface-neutral-highlight-hover: rgba(#bdbdbd, 0.08);
+  --td-light-surface-emphasis: #afb6b9;
+  --td-light-surface-emphasis-highlight: rgba(#afb6b9, 0.1);
+  --td-light-surface-emphasis-highlight-hover: rgba(#afb6b9, 0.2);
   --td-light-text-primary-on-background: rgba(0, 0, 0, 0.87);
   --td-light-text-secondary-on-background: rgba(0, 0, 0, 0.54);
   --td-light-text-hint-on-background: rgba(0, 0, 0, 0.38);
@@ -65,12 +73,17 @@
   --td-dark-on-surface: white;
   --td-dark-on-error: rgba(0, 0, 0, 0.87);
   --td-dark-divider: rgba(255, 255, 255, 0.2);
+  --td-dark-emphasis: #b0bec5;
+  --td-dark-accent: #59cecd;
   --td-dark-background: #161c1f;
   --td-dark-surface: #28353b;
   --td-dark-surface-canvas: #101314;
   --td-dark-surface-primary: #045c5c;
   --td-dark-surface-primary-highlight: rgba(#045c5c, 0.4);
   --td-dark-surface-primary-highlight-hover: rgba(#045c5c, 0.6);
+  --td-dark-surface-accent: #045c5c;
+  --td-dark-surface-accent-highlight: rgba(#045c5c, 0.4);
+  --td-dark-surface-accent-highlight-hover: rgba(#045c5c, 0.6);
   --td-dark-surface-secondary: #045c5c;
   --td-dark-surface-secondary-highlight: rgba(#045c5c, 0.4);
   --td-dark-surface-secondary-highlight-hover: rgba(#045c5c, 0.6);
@@ -86,6 +99,9 @@
   --td-dark-surface-neutral: #43515a;
   --td-dark-surface-neutral-highlight: rgba(#43515a, 0.4);
   --td-dark-surface-neutral-highlight-hover: rgba(#43515a, 0.6);
+  --td-dark-surface-emphasis: #43515a;
+  --td-dark-surface-emphasis-highlight: rgba(#43515a, 0.4);
+  --td-dark-surface-emphasis-highlight-hover: rgba(#43515a, 0.6);
   --td-dark-text-primary-on-background: white;
   --td-dark-text-secondary-on-background: rgba(255, 255, 255, 0.7);
   --td-dark-text-hint-on-background: rgba(255, 255, 255, 0.5);

--- a/libs/tokens/build/js/variables.d.ts
+++ b/libs/tokens/build/js/variables.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Aug 2022 18:24:44 GMT
+ * Generated on Wed, 28 Sep 2022 18:22:21 GMT
  */
 
 export const TdLightPrimary: string;
@@ -15,12 +15,17 @@ export const TdLightOnBackground: string;
 export const TdLightOnSurface: string;
 export const TdLightOnError: string;
 export const TdLightDivider: string;
+export const TdLightEmphasis: string;
+export const TdLightAccent: string;
 export const TdLightBackground: string;
 export const TdLightSurface: string;
 export const TdLightSurfaceCanvas: string;
 export const TdLightSurfacePrimary: string;
 export const TdLightSurfacePrimaryHighlight: string;
 export const TdLightSurfacePrimaryHighlightHover: string;
+export const TdLightSurfaceAccent: string;
+export const TdLightSurfaceAccentHighlight: string;
+export const TdLightSurfaceAccentHighlightHover: string;
 export const TdLightSurfaceSecondary: string;
 export const TdLightSurfaceSecondaryHighlight: string;
 export const TdLightSurfaceSecondaryHighlightHover: string;
@@ -36,6 +41,9 @@ export const TdLightSurfaceNegativeHighlightHover: string;
 export const TdLightSurfaceNeutral: string;
 export const TdLightSurfaceNeutralHighlight: string;
 export const TdLightSurfaceNeutralHighlightHover: string;
+export const TdLightSurfaceEmphasis: string;
+export const TdLightSurfaceEmphasisHighlight: string;
+export const TdLightSurfaceEmphasisHighlightHover: string;
 export const TdLightTextPrimaryOnBackground: string;
 export const TdLightTextSecondaryOnBackground: string;
 export const TdLightTextHintOnBackground: string;
@@ -64,12 +72,17 @@ export const TdDarkOnBackground: string;
 export const TdDarkOnSurface: string;
 export const TdDarkOnError: string;
 export const TdDarkDivider: string;
+export const TdDarkEmphasis: string;
+export const TdDarkAccent: string;
 export const TdDarkBackground: string;
 export const TdDarkSurface: string;
 export const TdDarkSurfaceCanvas: string;
 export const TdDarkSurfacePrimary: string;
 export const TdDarkSurfacePrimaryHighlight: string;
 export const TdDarkSurfacePrimaryHighlightHover: string;
+export const TdDarkSurfaceAccent: string;
+export const TdDarkSurfaceAccentHighlight: string;
+export const TdDarkSurfaceAccentHighlightHover: string;
 export const TdDarkSurfaceSecondary: string;
 export const TdDarkSurfaceSecondaryHighlight: string;
 export const TdDarkSurfaceSecondaryHighlightHover: string;
@@ -85,6 +98,9 @@ export const TdDarkSurfaceNegativeHighlightHover: string;
 export const TdDarkSurfaceNeutral: string;
 export const TdDarkSurfaceNeutralHighlight: string;
 export const TdDarkSurfaceNeutralHighlightHover: string;
+export const TdDarkSurfaceEmphasis: string;
+export const TdDarkSurfaceEmphasisHighlight: string;
+export const TdDarkSurfaceEmphasisHighlightHover: string;
 export const TdDarkTextPrimaryOnBackground: string;
 export const TdDarkTextSecondaryOnBackground: string;
 export const TdDarkTextHintOnBackground: string;

--- a/libs/tokens/build/js/variables.js
+++ b/libs/tokens/build/js/variables.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Aug 2022 18:24:44 GMT
+ * Generated on Wed, 28 Sep 2022 18:22:21 GMT
  */
 
 export const TdLightPrimary = '#007373';
@@ -15,12 +15,17 @@ export const TdLightOnBackground = 'rgba(0, 0, 0, 0.87)';
 export const TdLightOnSurface = 'rgba(0, 0, 0, 0.87)';
 export const TdLightOnError = 'white';
 export const TdLightDivider = 'rgba(0, 0, 0, 0.12)';
+export const TdLightEmphasis = '#546e7a';
+export const TdLightAccent = '#007373';
 export const TdLightBackground = '#f5f5f5';
 export const TdLightSurface = 'white';
 export const TdLightSurfaceCanvas = '#eee';
 export const TdLightSurfacePrimary = '#85dddc';
 export const TdLightSurfacePrimaryHighlight = 'rgba(#85dddc, 0.1)';
 export const TdLightSurfacePrimaryHighlightHover = 'rgba(#85dddc, 0.2)';
+export const TdLightSurfaceAccent = '#85dddc';
+export const TdLightSurfaceAccentHighlight = 'rgba(#85dddc, 0.1)';
+export const TdLightSurfaceAccentHighlightHover = 'rgba(#85dddc, 0.2)';
 export const TdLightSurfaceSecondary = '#85dddc';
 export const TdLightSurfaceSecondaryHighlight = 'rgba(#85dddc, 0.1)';
 export const TdLightSurfaceSecondaryHighlightHover = 'rgba(#85dddc, 0.2)';
@@ -36,6 +41,9 @@ export const TdLightSurfaceNegativeHighlightHover = 'rgba(#e57373, 0.2)';
 export const TdLightSurfaceNeutral = '#bdbdbd';
 export const TdLightSurfaceNeutralHighlight = 'rgba(#bdbdbd, 0.04)';
 export const TdLightSurfaceNeutralHighlightHover = 'rgba(#bdbdbd, 0.08)';
+export const TdLightSurfaceEmphasis = '#afb6b9';
+export const TdLightSurfaceEmphasisHighlight = 'rgba(#afb6b9, 0.1)';
+export const TdLightSurfaceEmphasisHighlightHover = 'rgba(#afb6b9, 0.2)';
 export const TdLightTextPrimaryOnBackground = 'rgba(0, 0, 0, 0.87)';
 export const TdLightTextSecondaryOnBackground = 'rgba(0, 0, 0, 0.54)';
 export const TdLightTextHintOnBackground = 'rgba(0, 0, 0, 0.38)';
@@ -64,12 +72,17 @@ export const TdDarkOnBackground = 'white';
 export const TdDarkOnSurface = 'white';
 export const TdDarkOnError = 'rgba(0, 0, 0, 0.87)';
 export const TdDarkDivider = 'rgba(255, 255, 255, 0.2)';
+export const TdDarkEmphasis = '#b0bec5';
+export const TdDarkAccent = '#59cecd';
 export const TdDarkBackground = '#161c1f';
 export const TdDarkSurface = '#28353b';
 export const TdDarkSurfaceCanvas = '#101314';
 export const TdDarkSurfacePrimary = '#045c5c';
 export const TdDarkSurfacePrimaryHighlight = 'rgba(#045c5c, 0.4)';
 export const TdDarkSurfacePrimaryHighlightHover = 'rgba(#045c5c, 0.6)';
+export const TdDarkSurfaceAccent = '#045c5c';
+export const TdDarkSurfaceAccentHighlight = 'rgba(#045c5c, 0.4)';
+export const TdDarkSurfaceAccentHighlightHover = 'rgba(#045c5c, 0.6)';
 export const TdDarkSurfaceSecondary = '#045c5c';
 export const TdDarkSurfaceSecondaryHighlight = 'rgba(#045c5c, 0.4)';
 export const TdDarkSurfaceSecondaryHighlightHover = 'rgba(#045c5c, 0.6)';
@@ -85,6 +98,9 @@ export const TdDarkSurfaceNegativeHighlightHover = 'rgba(#883E32, 0.6)';
 export const TdDarkSurfaceNeutral = '#43515a';
 export const TdDarkSurfaceNeutralHighlight = 'rgba(#43515a, 0.4)';
 export const TdDarkSurfaceNeutralHighlightHover = 'rgba(#43515a, 0.6)';
+export const TdDarkSurfaceEmphasis = '#43515a';
+export const TdDarkSurfaceEmphasisHighlight = 'rgba(#43515a, 0.4)';
+export const TdDarkSurfaceEmphasisHighlightHover = 'rgba(#43515a, 0.6)';
 export const TdDarkTextPrimaryOnBackground = 'white';
 export const TdDarkTextSecondaryOnBackground = 'rgba(255, 255, 255, 0.7)';
 export const TdDarkTextHintOnBackground = 'rgba(255, 255, 255, 0.5)';

--- a/libs/tokens/build/json/variables.json
+++ b/libs/tokens/build/json/variables.json
@@ -192,6 +192,38 @@
       },
       "path": ["light", "divider"]
     },
+    "emphasis": {
+      "value": "#546e7a",
+      "type": "color",
+      "filePath": "src/color/base.json",
+      "isSource": true,
+      "original": {
+        "value": "#546e7a",
+        "type": "color"
+      },
+      "name": "emphasis",
+      "attributes": {
+        "category": "light",
+        "type": "emphasis"
+      },
+      "path": ["light", "emphasis"]
+    },
+    "accent": {
+      "value": "#007373",
+      "type": "color",
+      "filePath": "src/color/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{teradata.teal-900}",
+        "type": "color"
+      },
+      "name": "accent",
+      "attributes": {
+        "category": "light",
+        "type": "accent"
+      },
+      "path": ["light", "accent"]
+    },
     "background": {
       "value": "#f5f5f5",
       "type": "color",
@@ -287,6 +319,54 @@
         "type": "surface-primary-highlight-hover"
       },
       "path": ["light", "surface-primary-highlight-hover"]
+    },
+    "surface-accent": {
+      "value": "#85dddc",
+      "type": "color",
+      "filePath": "src/color/palettes/surface.json",
+      "isSource": true,
+      "original": {
+        "value": "{teradata.teal-200}",
+        "type": "color"
+      },
+      "name": "surface-accent",
+      "attributes": {
+        "category": "light",
+        "type": "surface-accent"
+      },
+      "path": ["light", "surface-accent"]
+    },
+    "surface-accent-highlight": {
+      "value": "rgba(#85dddc, 0.1)",
+      "type": "color",
+      "filePath": "src/color/palettes/surface.json",
+      "isSource": true,
+      "original": {
+        "value": "rgba({teradata.teal-200}, 0.1)",
+        "type": "color"
+      },
+      "name": "surface-accent-highlight",
+      "attributes": {
+        "category": "light",
+        "type": "surface-accent-highlight"
+      },
+      "path": ["light", "surface-accent-highlight"]
+    },
+    "surface-accent-highlight-hover": {
+      "value": "rgba(#85dddc, 0.2)",
+      "type": "color",
+      "filePath": "src/color/palettes/surface.json",
+      "isSource": true,
+      "original": {
+        "value": "rgba({teradata.teal-200}, 0.2)",
+        "type": "color"
+      },
+      "name": "surface-accent-highlight-hover",
+      "attributes": {
+        "category": "light",
+        "type": "surface-accent-highlight-hover"
+      },
+      "path": ["light", "surface-accent-highlight-hover"]
     },
     "surface-secondary": {
       "value": "#85dddc",
@@ -527,6 +607,54 @@
         "type": "surface-neutral-highlight-hover"
       },
       "path": ["light", "surface-neutral-highlight-hover"]
+    },
+    "surface-emphasis": {
+      "value": "#afb6b9",
+      "type": "color",
+      "filePath": "src/color/palettes/surface.json",
+      "isSource": true,
+      "original": {
+        "value": "{teradata.slate-200}",
+        "type": "color"
+      },
+      "name": "surface-emphasis",
+      "attributes": {
+        "category": "light",
+        "type": "surface-emphasis"
+      },
+      "path": ["light", "surface-emphasis"]
+    },
+    "surface-emphasis-highlight": {
+      "value": "rgba(#afb6b9, 0.1)",
+      "type": "color",
+      "filePath": "src/color/palettes/surface.json",
+      "isSource": true,
+      "original": {
+        "value": "rgba({teradata.slate-200}, 0.1)",
+        "type": "color"
+      },
+      "name": "surface-emphasis-highlight",
+      "attributes": {
+        "category": "light",
+        "type": "surface-emphasis-highlight"
+      },
+      "path": ["light", "surface-emphasis-highlight"]
+    },
+    "surface-emphasis-highlight-hover": {
+      "value": "rgba(#afb6b9, 0.2)",
+      "type": "color",
+      "filePath": "src/color/palettes/surface.json",
+      "isSource": true,
+      "original": {
+        "value": "rgba({teradata.slate-200}, 0.2)",
+        "type": "color"
+      },
+      "name": "surface-emphasis-highlight-hover",
+      "attributes": {
+        "category": "light",
+        "type": "surface-emphasis-highlight-hover"
+      },
+      "path": ["light", "surface-emphasis-highlight-hover"]
     },
     "text-primary-on-background": {
       "value": "rgba(0, 0, 0, 0.87)",
@@ -978,6 +1106,38 @@
       },
       "path": ["dark", "divider"]
     },
+    "emphasis": {
+      "value": "#b0bec5",
+      "type": "color",
+      "filePath": "src/color/base.json",
+      "isSource": true,
+      "original": {
+        "value": "#b0bec5",
+        "type": "color"
+      },
+      "name": "emphasis",
+      "attributes": {
+        "category": "dark",
+        "type": "emphasis"
+      },
+      "path": ["dark", "emphasis"]
+    },
+    "accent": {
+      "value": "#59cecd",
+      "type": "color",
+      "filePath": "src/color/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{teradata.teal-300}",
+        "type": "color"
+      },
+      "name": "accent",
+      "attributes": {
+        "category": "dark",
+        "type": "accent"
+      },
+      "path": ["dark", "accent"]
+    },
     "background": {
       "value": "#161c1f",
       "type": "color",
@@ -1073,6 +1233,54 @@
         "type": "surface-primary-highlight-hover"
       },
       "path": ["dark", "surface-primary-highlight-hover"]
+    },
+    "surface-accent": {
+      "value": "#045c5c",
+      "type": "color",
+      "filePath": "src/color/palettes/surface.json",
+      "isSource": true,
+      "original": {
+        "value": "{teradata.teal-1200}",
+        "type": "color"
+      },
+      "name": "surface-accent",
+      "attributes": {
+        "category": "dark",
+        "type": "surface-accent"
+      },
+      "path": ["dark", "surface-accent"]
+    },
+    "surface-accent-highlight": {
+      "value": "rgba(#045c5c, 0.4)",
+      "type": "color",
+      "filePath": "src/color/palettes/surface.json",
+      "isSource": true,
+      "original": {
+        "value": "rgba({teradata.teal-1200}, 0.4)",
+        "type": "color"
+      },
+      "name": "surface-accent-highlight",
+      "attributes": {
+        "category": "dark",
+        "type": "surface-accent-highlight"
+      },
+      "path": ["dark", "surface-accent-highlight"]
+    },
+    "surface-accent-highlight-hover": {
+      "value": "rgba(#045c5c, 0.6)",
+      "type": "color",
+      "filePath": "src/color/palettes/surface.json",
+      "isSource": true,
+      "original": {
+        "value": "rgba({teradata.teal-1200}, 0.6)",
+        "type": "color"
+      },
+      "name": "surface-accent-highlight-hover",
+      "attributes": {
+        "category": "dark",
+        "type": "surface-accent-highlight-hover"
+      },
+      "path": ["dark", "surface-accent-highlight-hover"]
     },
     "surface-secondary": {
       "value": "#045c5c",
@@ -1313,6 +1521,54 @@
         "type": "surface-neutral-highlight-hover"
       },
       "path": ["dark", "surface-neutral-highlight-hover"]
+    },
+    "surface-emphasis": {
+      "value": "#43515a",
+      "type": "color",
+      "filePath": "src/color/palettes/surface.json",
+      "isSource": true,
+      "original": {
+        "value": "{teradata.slate-800}",
+        "type": "color"
+      },
+      "name": "surface-emphasis",
+      "attributes": {
+        "category": "dark",
+        "type": "surface-emphasis"
+      },
+      "path": ["dark", "surface-emphasis"]
+    },
+    "surface-emphasis-highlight": {
+      "value": "rgba(#43515a, 0.4)",
+      "type": "color",
+      "filePath": "src/color/palettes/surface.json",
+      "isSource": true,
+      "original": {
+        "value": "rgba({teradata.slate-800}, 0.4)",
+        "type": "color"
+      },
+      "name": "surface-emphasis-highlight",
+      "attributes": {
+        "category": "dark",
+        "type": "surface-emphasis-highlight"
+      },
+      "path": ["dark", "surface-emphasis-highlight"]
+    },
+    "surface-emphasis-highlight-hover": {
+      "value": "rgba(#43515a, 0.6)",
+      "type": "color",
+      "filePath": "src/color/palettes/surface.json",
+      "isSource": true,
+      "original": {
+        "value": "rgba({teradata.slate-800}, 0.6)",
+        "type": "color"
+      },
+      "name": "surface-emphasis-highlight-hover",
+      "attributes": {
+        "category": "dark",
+        "type": "surface-emphasis-highlight-hover"
+      },
+      "path": ["dark", "surface-emphasis-highlight-hover"]
     },
     "text-primary-on-background": {
       "value": "white",

--- a/libs/tokens/build/scss/_variables.scss
+++ b/libs/tokens/build/scss/_variables.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Aug 2022 18:24:44 GMT
+ * Generated on Wed, 28 Sep 2022 18:22:21 GMT
  */
 
 $light-primary: #007373 !default;
@@ -15,12 +15,17 @@ $light-on-background: rgba(0, 0, 0, 0.87) !default;
 $light-on-surface: rgba(0, 0, 0, 0.87) !default;
 $light-on-error: white !default;
 $light-divider: rgba(0, 0, 0, 0.12) !default;
+$light-emphasis: #546e7a !default;
+$light-accent: #007373 !default;
 $light-background: #f5f5f5 !default;
 $light-surface: white !default;
 $light-surface-canvas: #eee !default;
 $light-surface-primary: #85dddc !default;
 $light-surface-primary-highlight: rgba(#85dddc, 0.1) !default;
 $light-surface-primary-highlight-hover: rgba(#85dddc, 0.2) !default;
+$light-surface-accent: #85dddc !default;
+$light-surface-accent-highlight: rgba(#85dddc, 0.1) !default;
+$light-surface-accent-highlight-hover: rgba(#85dddc, 0.2) !default;
 $light-surface-secondary: #85dddc !default;
 $light-surface-secondary-highlight: rgba(#85dddc, 0.1) !default;
 $light-surface-secondary-highlight-hover: rgba(#85dddc, 0.2) !default;
@@ -36,6 +41,9 @@ $light-surface-negative-highlight-hover: rgba(#e57373, 0.2) !default;
 $light-surface-neutral: #bdbdbd !default;
 $light-surface-neutral-highlight: rgba(#bdbdbd, 0.04) !default;
 $light-surface-neutral-highlight-hover: rgba(#bdbdbd, 0.08) !default;
+$light-surface-emphasis: #afb6b9 !default;
+$light-surface-emphasis-highlight: rgba(#afb6b9, 0.1) !default;
+$light-surface-emphasis-highlight-hover: rgba(#afb6b9, 0.2) !default;
 $light-text-primary-on-background: rgba(0, 0, 0, 0.87) !default;
 $light-text-secondary-on-background: rgba(0, 0, 0, 0.54) !default;
 $light-text-hint-on-background: rgba(0, 0, 0, 0.38) !default;
@@ -64,12 +72,17 @@ $dark-on-background: white !default;
 $dark-on-surface: white !default;
 $dark-on-error: rgba(0, 0, 0, 0.87) !default;
 $dark-divider: rgba(255, 255, 255, 0.2) !default;
+$dark-emphasis: #b0bec5 !default;
+$dark-accent: #59cecd !default;
 $dark-background: #161c1f !default;
 $dark-surface: #28353b !default;
 $dark-surface-canvas: #101314 !default;
 $dark-surface-primary: #045c5c !default;
 $dark-surface-primary-highlight: rgba(#045c5c, 0.4) !default;
 $dark-surface-primary-highlight-hover: rgba(#045c5c, 0.6) !default;
+$dark-surface-accent: #045c5c !default;
+$dark-surface-accent-highlight: rgba(#045c5c, 0.4) !default;
+$dark-surface-accent-highlight-hover: rgba(#045c5c, 0.6) !default;
 $dark-surface-secondary: #045c5c !default;
 $dark-surface-secondary-highlight: rgba(#045c5c, 0.4) !default;
 $dark-surface-secondary-highlight-hover: rgba(#045c5c, 0.6) !default;
@@ -85,6 +98,9 @@ $dark-surface-negative-highlight-hover: rgba(#883e32, 0.6) !default;
 $dark-surface-neutral: #43515a !default;
 $dark-surface-neutral-highlight: rgba(#43515a, 0.4) !default;
 $dark-surface-neutral-highlight-hover: rgba(#43515a, 0.6) !default;
+$dark-surface-emphasis: #43515a !default;
+$dark-surface-emphasis-highlight: rgba(#43515a, 0.4) !default;
+$dark-surface-emphasis-highlight-hover: rgba(#43515a, 0.6) !default;
 $dark-text-primary-on-background: white !default;
 $dark-text-secondary-on-background: rgba(255, 255, 255, 0.7) !default;
 $dark-text-hint-on-background: rgba(255, 255, 255, 0.5) !default;
@@ -461,12 +477,17 @@ $tokens: (
     'on-surface': $light-on-surface,
     'on-error': $light-on-error,
     'divider': $light-divider,
+    'emphasis': $light-emphasis,
+    'accent': $light-accent,
     'background': $light-background,
     'surface': $light-surface,
     'surface-canvas': $light-surface-canvas,
     'surface-primary': $light-surface-primary,
     'surface-primary-highlight': $light-surface-primary-highlight,
     'surface-primary-highlight-hover': $light-surface-primary-highlight-hover,
+    'surface-accent': $light-surface-accent,
+    'surface-accent-highlight': $light-surface-accent-highlight,
+    'surface-accent-highlight-hover': $light-surface-accent-highlight-hover,
     'surface-secondary': $light-surface-secondary,
     'surface-secondary-highlight': $light-surface-secondary-highlight,
     'surface-secondary-highlight-hover':
@@ -483,6 +504,9 @@ $tokens: (
     'surface-neutral': $light-surface-neutral,
     'surface-neutral-highlight': $light-surface-neutral-highlight,
     'surface-neutral-highlight-hover': $light-surface-neutral-highlight-hover,
+    'surface-emphasis': $light-surface-emphasis,
+    'surface-emphasis-highlight': $light-surface-emphasis-highlight,
+    'surface-emphasis-highlight-hover': $light-surface-emphasis-highlight-hover,
     'text-primary-on-background': $light-text-primary-on-background,
     'text-secondary-on-background': $light-text-secondary-on-background,
     'text-hint-on-background': $light-text-hint-on-background,
@@ -513,12 +537,17 @@ $tokens: (
     'on-surface': $dark-on-surface,
     'on-error': $dark-on-error,
     'divider': $dark-divider,
+    'emphasis': $dark-emphasis,
+    'accent': $dark-accent,
     'background': $dark-background,
     'surface': $dark-surface,
     'surface-canvas': $dark-surface-canvas,
     'surface-primary': $dark-surface-primary,
     'surface-primary-highlight': $dark-surface-primary-highlight,
     'surface-primary-highlight-hover': $dark-surface-primary-highlight-hover,
+    'surface-accent': $dark-surface-accent,
+    'surface-accent-highlight': $dark-surface-accent-highlight,
+    'surface-accent-highlight-hover': $dark-surface-accent-highlight-hover,
     'surface-secondary': $dark-surface-secondary,
     'surface-secondary-highlight': $dark-surface-secondary-highlight,
     'surface-secondary-highlight-hover': $dark-surface-secondary-highlight-hover,
@@ -534,6 +563,9 @@ $tokens: (
     'surface-neutral': $dark-surface-neutral,
     'surface-neutral-highlight': $dark-surface-neutral-highlight,
     'surface-neutral-highlight-hover': $dark-surface-neutral-highlight-hover,
+    'surface-emphasis': $dark-surface-emphasis,
+    'surface-emphasis-highlight': $dark-surface-emphasis-highlight,
+    'surface-emphasis-highlight-hover': $dark-surface-emphasis-highlight-hover,
     'text-primary-on-background': $dark-text-primary-on-background,
     'text-secondary-on-background': $dark-text-secondary-on-background,
     'text-hint-on-background': $dark-text-hint-on-background,

--- a/libs/tokens/src/color/base.json
+++ b/libs/tokens/src/color/base.json
@@ -11,7 +11,9 @@
     "on-background": { "value": "rgba(0, 0, 0, 0.87)", "type": "color" },
     "on-surface": { "value": "rgba(0, 0, 0, 0.87)", "type": "color" },
     "on-error": { "value": "white", "type": "color" },
-    "divider": { "value": "rgba(0, 0, 0, 0.12)", "type": "color" }
+    "divider": { "value": "rgba(0, 0, 0, 0.12)", "type": "color" },
+    "emphasis": { "value": "#546e7a", "type": "color" },
+    "accent": { "value": "{teradata.teal-900}", "type": "color" }
   },
   "dark": {
     "primary": { "value": "{teradata.teal-300}", "type": "color" },
@@ -25,6 +27,8 @@
     "on-background": { "value": "white", "type": "color" },
     "on-surface": { "value": "white", "type": "color" },
     "on-error": { "value": "rgba(0, 0, 0, 0.87)", "type": "color" },
-    "divider": { "value": "rgba(255, 255, 255, 0.2)", "type": "color" }
+    "divider": { "value": "rgba(255, 255, 255, 0.2)", "type": "color" },
+    "emphasis": { "value": "#b0bec5", "type": "color" },
+    "accent": { "value": "{teradata.teal-300}", "type": "color" }
   }
 }

--- a/libs/tokens/src/color/palettes/surface.json
+++ b/libs/tokens/src/color/palettes/surface.json
@@ -13,6 +13,15 @@
       "value": "rgba({teradata.teal-200}, 0.2)",
       "type": "color"
     },
+    "surface-accent": { "value": "{teradata.teal-200}", "type": "color" },
+    "surface-accent-highlight": {
+      "value": "rgba({teradata.teal-200}, 0.1)",
+      "type": "color"
+    },
+    "surface-accent-highlight-hover": {
+      "value": "rgba({teradata.teal-200}, 0.2)",
+      "type": "color"
+    },
 
     "surface-secondary": { "value": "{teradata.teal-200}", "type": "color" },
     "surface-secondary-highlight": {
@@ -62,6 +71,15 @@
     "surface-neutral-highlight-hover": {
       "value": "rgba({material.grey-400}, 0.08)",
       "type": "color"
+    },
+    "surface-emphasis": { "value": "{teradata.slate-200}", "type": "color" },
+    "surface-emphasis-highlight": {
+      "value": "rgba({teradata.slate-200}, 0.1)",
+      "type": "color"
+    },
+    "surface-emphasis-highlight-hover": {
+      "value": "rgba({teradata.slate-200}, 0.2)",
+      "type": "color"
     }
   },
   "dark": {
@@ -75,6 +93,15 @@
       "type": "color"
     },
     "surface-primary-highlight-hover": {
+      "value": "rgba({teradata.teal-1200}, 0.6)",
+      "type": "color"
+    },
+    "surface-accent": { "value": "{teradata.teal-1200}", "type": "color" },
+    "surface-accent-highlight": {
+      "value": "rgba({teradata.teal-1200}, 0.4)",
+      "type": "color"
+    },
+    "surface-accent-highlight-hover": {
       "value": "rgba({teradata.teal-1200}, 0.6)",
       "type": "color"
     },
@@ -125,6 +152,15 @@
       "type": "color"
     },
     "surface-neutral-highlight-hover": {
+      "value": "rgba({teradata.slate-800}, 0.6)",
+      "type": "color"
+    },
+    "surface-emphasis": { "value": "{teradata.slate-800}", "type": "color" },
+    "surface-emphasis-highlight": {
+      "value": "rgba({teradata.slate-800}, 0.4)",
+      "type": "color"
+    },
+    "surface-emphasis-highlight-hover": {
       "value": "rgba({teradata.slate-800}, 0.6)",
       "type": "color"
     }

--- a/stories/color-use.stories.mdx
+++ b/stories/color-use.stories.mdx
@@ -1,0 +1,532 @@
+<!-- color-use.stories.mdx -->
+
+import { Canvas, Meta, DocsContainer, Story } from '@storybook/addon-docs';
+
+<Meta
+  title="Guides/Color Use"
+  parameters={{
+    layout: 'fullscreen',
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+  }}
+/>
+
+<style>{`
+    {/* EXAMPLE */}
+    
+    td-button {
+      border-radius: 8px;
+    }
+    .textfield-primary {
+      --mdc-text-field-outlined-hover-border-color: var(--mdc-theme-primary);
+      --mdc-text-field-label-ink-color: var(--mdc-theme-primary);
+      --mdc-text-field-fill-color: var(--mdc-theme-primary);
+      --mdc-text-field-idle-line-color: var(--mdc-theme-primary);
+      --mdc-text-field-hover-line-color: var(--mdc-theme-primary);
+      --mdc-text-field-outlined-idle-border-color: var(--mdc-theme-primary);
+      --mdc-notched-outline-stroke-width: 2px;
+    }
+    .textfield-negative {
+      --mdc-text-field-outlined-hover-border-color: var(--mdc-theme-negative);
+      --mdc-text-field-fill-color: var(--mdc-theme-negative);
+      --mdc-text-field-label-ink-color: var(--mdc-theme-negative);
+      --mdc-text-field-idle-line-color: var(--mdc-theme-negative);
+      --mdc-text-field-hover-line-color: var(--mdc-theme-negative);
+      --mdc-text-field-outlined-idle-border-color: var(--mdc-theme-negative);
+      --mdc-text-field-focused-label-color: var(--mdc-theme-negative);
+      --mdc-notched-outline-stroke-width: 2px;
+      --mdc-theme-primary: var(--mdc-theme-negative);
+    }
+    .exampleContainer {
+        display: flex;
+        flex-direction: column;
+        row-gap: 16px;
+        max-width: none;
+        padding: 40px;
+        justify-self: center;
+        justify-content: center;
+        align-items: center;
+        position: relative;
+    }
+    .cardContent {
+        padding: 16px 16px 56px 16px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        column-gap: 8px;
+        max-width: 60%;
+    }
+    .mdc-layout-grid {
+        padding-left: 0;
+        padding-bottom: 0;
+    }
+    .cardContainer {
+        display: flex;
+        column-gap: 16px;
+    }
+    div.cardContainer td-card div {
+        padding: 16px 16px 32px;
+    }
+    .mdc-dialog__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+    .dark {
+        background-color: #161C1F;
+        color: white;
+    }
+    .darkText td-button {
+        --mdc-theme-primary: var(--mdc-theme-text-primary-on-dark);
+        --mdc-button-outline-color: white;
+        margin-right: 8px;
+    }
+    .light {
+        background-color: #F5F5F5;
+    }
+    .lightText td-button {
+        --mdc-theme-primary: var(--mdc-theme-text-primary-on-dark);
+        --mdc-button-outline-color: black;
+        margin-right: 8px;
+    }
+    .dialog {
+      width: 440px;
+      height: 224px;
+      border-radius: 8px;
+      position: absolute;
+      background-color: var(--mdc-theme-background);
+      box-shadow: 
+        0px 16px 24px rgba(0, 0, 0, 0.14), 
+        0px 6px 30px rgba(0, 0, 0, 0.12), 
+        0px 8px 10px rgba(0, 0, 0, 0.2);
+    }
+    .dialog .dialogContainer  {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      height: 64px;
+      padding: 0 16px;
+      border-bottom: solid 1px var(--mdc-theme-border)
+    }
+    .dialogContainer div {
+      font-family: var(--mdc-typography-headline6-font-family);
+      font-size: var(--mdc-typography-headline6-font-size);
+      font-weight: var(--mdc-typography-headline6-font-weight);
+      line-height: var(--mdc-typography-headline6-line-height);
+    }
+    .dialogContent {
+      height: calc(224px - 96px);
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 16px 16px 0 16px;
+    }
+    .darkDialog {
+      background-color: #28353B;
+    }
+    .dialogActions {
+      display: flex;
+      justify-content: flex-end;
+    }
+    {/* FOREGROUND */}
+    
+    .primaryText {
+        color: var(--mdc-theme-text-primary-on-background);
+    }    
+    .secondary {
+        color: var(--mdc-theme-text-secondary-on-background);
+    }
+    .disabled {
+        color: var(--mdc-theme-text-disabled-on-background);
+    }
+    .divider {
+        width: 200px;
+        border-bottom: solid 1px var(--mdc-theme-border);
+    }
+    .positiveFg {
+        color: var(--mdc-theme-positive);
+    }
+    .cautionFg {
+        color: var(--mdc-theme-caution);
+    }
+    .negativeFg {
+        color: var(--mdc-theme-negative);
+    }
+    .primaryFg {
+        color: var(--mdc-theme-primary);
+    }
+    .emphasisFg {
+        color: var(--mdc-theme-emphasis);
+    }
+    
+    {/* BACKGROUND */}
+
+    table tr td:first-of-type div:first-of-type {
+      color: var(--mdc-theme-text-primary-on-background);
+    }
+    table:nth-of-type(2) tr td:nth-of-type(2) div {
+      width: 114px;
+      height: 56px;
+      border-radius: 8px;
+    }
+    .background {
+        background-color: var(--mdc-theme-background);
+        border: solid var(--mdc-theme-border) 1px;
+    }
+    .appbar {}
+    .surface {
+      background-color: var(--mdc-theme-surface);
+    }
+    .canvas {
+        background-color: var(--mdc-theme-surface-canvas);
+    }
+    .positive {
+        background-color: var(--mdc-theme-surface-positive);
+    }
+    .positiveHighlight {
+        background-color: var(--mdc-theme-surface-positive-highlight);
+    }
+    .positiveHighlightHover {
+        background-color: var(--mdc-theme-surface-positive-highlight-hover);
+    }
+    .caution {
+        background-color: var(--mdc-theme-surface-caution);
+    }
+    .cautionHighlight {
+        background-color: var(--mdc-theme-surface-caution-highlight);
+    }
+    .cautionHighlightHover {
+        background-color: var(--mdc-theme-surface-caution-highlight-hover);
+    }
+    .negative {
+        background-color: var(--mdc-theme-surface-negative);
+    }
+    .negativeHighlight {
+        background-color: var(--mdc-theme-surface-negative-highlight);
+    }
+    .negativeHighlightHover {
+        background-color: var(--mdc-theme-surface-negative-highlight-hover);
+    }
+    .neutral {
+        background-color: var(--mdc-theme-surface-neutral);
+    }
+    .neutralHighlight {
+        background-color: var(--mdc-theme-surface-neutral-highlight);
+    }
+    .neutralHighlightHover {
+        background-color: var(--mdc-theme-surface-neutral-highlight-hover);
+    }
+    .primary {
+      background-color: var(--mdc-theme-surface-primary);
+    }
+    .primaryHighlight {
+        background-color: var(--mdc-theme-surface-primary-highlight);
+    }
+    .primaryHighlightHover {
+        background-color: var(--mdc-theme-surface-primary-highlight-hover);
+    }
+    .emphasis {
+        background-color: var(--mdc-theme-surface-emphasis);
+    }
+    .emphasisHighlight {
+        background-color: var(--mdc-theme-surface-emphasis-highlight);
+    }
+    .emphasisHighlightHover {
+        background-color: var(--mdc-theme-surface-emphasis-highlight-hover);
+    }
+
+    {/* CONFIG COLORS */}
+    table:last-of-type tr td:nth-of-type(2) div,
+    table:last-of-type tr td:last-of-type div {
+      width: 324px;
+      height: 56px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      padding-left: 16px;
+      color: #FFFFFFDE;
+    }
+    .td-teal-500 {
+      background-color: #00B2B1;
+    }
+    .accent-background-light {
+      color: var(--mdc-theme-text-primary-on-light) !important;
+      background-color: #85DDDC;
+    }
+    .accent-foreground-light {
+      color: var(--mdc-theme-text-primary-on-light) !important;
+      background-color: #59CECD;
+    }
+    .accent-background-dark {
+      background-color: #007373;
+    }
+    .accent-foreground-dark {
+      background-color: #045C5C;
+    }
+    .td-slate-500 {
+      background-color: #616d73;
+    }
+    .primary-foreground-dark {
+      background-color: #43515A;
+    }
+    .primary-background-dark {
+      background-color: #394851;
+    }
+    .primary-light {
+      color: var(--mdc-theme-text-primary-on-light) !important;
+      background-color: #AFB6B9;
+    }
+    .darkBg {
+      background-color: #28353B;
+    }
+    .sbdocs .sbdocs-table tr th {
+      font-family: var(--mdc-typography-caption-font-family);
+      font-size: var(--mdc-typography-caption-font-size);
+      font-weight: var(--mdc-typography-caption-font-weight);
+      line-height: var(--mdc-typography-caption-line-height);
+      color: var(--mdc-theme-text-secondary-on-background);
+    }
+    table:last-of-type tr td {
+      width: 300px;
+    }
+    table:last-of-type tr td:last-of-type, 
+    table:last-of-type tr th:last-of-type {
+      background: #28353B;
+      color: var(--mdc-theme-text-secondary-on-dark);
+    }
+`}</style>
+
+# Color use
+
+## Basics
+
+- Use “foreground” colors for items such as text or icons.
+- When at all possible, use one of our named colors rather than a Material Design color or a hex code.
+
+---
+
+## Naming
+
+Colors are named based on function. This prevents errors from accumulating when using color codes directly. It also allows us to update a color in one place and see the results wherever it’s used.
+
+---
+
+## Theming
+
+Each color is defined in both a light and dark version. These are designed to work together, and should not be changed. For example, when using the “emphasis” background color in light mode, you cannot use “accent” color in dark mode for the same element.
+
+#### Examples
+
+<div class="light lightText exampleContainer">
+  <td-card cardTitle="Title" class="card">
+    <div slot="card-content" class="cardContent">
+      <div>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commo
+      </div>
+      <div class="mdc-layout-grid">
+        <div class="mdc-layout-grid__inner">
+          <td-textfield
+            label="Label"
+            value="Value"
+            outlined
+            class="mdc-layout-grid__cell--span-6"
+          ></td-textfield>
+          <td-textfield
+            label="Label"
+            value="Value"
+            outlined
+            class="mdc-layout-grid__cell--span-6 textfield-negative"
+          ></td-textfield>
+          <td-textfield
+            label="Label"
+            value="Value"
+            outlined
+            class="mdc-layout-grid__cell--span-6  textfield-primary"
+          ></td-textfield>
+          <td-textfield
+            label="Label"
+            value="Value"
+            outlined
+            class="mdc-layout-grid__cell--span-6"
+          ></td-textfield>
+        </div>
+      </div>
+    </div>
+  </td-card>
+  <div class="cardContainer">
+    <td-card cardTitle="Title">
+      <div slot="card-content">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commo
+      </div>
+    </td-card>
+    <td-card cardTitle="Title">
+      <div slot="card-content">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commo
+      </div>
+    </td-card>
+  </div>
+  <div class="dialog">
+    <div class="dialogContainer">
+      <div>Title</div>
+      <td-icon>close</td-icon>
+    </div>
+    <div class="dialogContent">
+      <div>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </div>
+      <div class="dialogActions">
+        <td-button outlined>BUTTON TEXT</td-button>
+        <td-button class="dark primary">BUTTON TEXT</td-button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="dark darkText exampleContainer">
+  <td-card cardTitle="Title" class="card">
+    <div slot="card-content" class="cardContent">
+      <div>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commo
+      </div>
+      <div class="mdc-layout-grid">
+        <div class="mdc-layout-grid__inner">
+          <td-textfield
+            label="Label"
+            value="Value"
+            outlined
+            class="mdc-layout-grid__cell--span-6"
+          ></td-textfield>
+          <td-textfield
+            label="Label"
+            value="Value"
+            outlined
+            class="mdc-layout-grid__cell--span-6 textfield-negative"
+          ></td-textfield>
+          <td-textfield
+            label="Label"
+            value="Value"
+            outlined
+            class="mdc-layout-grid__cell--span-6 textfield-primary"
+          ></td-textfield>
+          <td-textfield
+            label="Label"
+            value="Value"
+            outlined
+            class="mdc-layout-grid__cell--span-6"
+          ></td-textfield>
+        </div>
+      </div>
+    </div>
+    <div slot="card-actions" class="mdc-card__action-buttons">
+      <td-button outlined class="whiteOutline">
+        BUTTON TEXT
+      </td-button>
+      <td-button class="primary">BUTTON TEXT</td-button>
+    </div>
+  </td-card>
+  <div class="cardContainer">
+    <td-card cardTitle="Title">
+      <div slot="card-content">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commo
+      </div>
+    </td-card>
+    <td-card cardTitle="Title">
+      <div slot="card-content">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commo
+      </div>
+    </td-card>
+  </div>
+  <div class="dialog darkDialog">
+    <div class="dialogContainer">
+      <div>Title</div>
+      <td-icon>close</td-icon>
+    </div>
+    <div class="dialogContent">
+      <div>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </div>
+      <div class="dialogActions">
+        <td-button outlined>BUTTON TEXT</td-button>
+        <td-button class="light primary">BUTTON TEXT</td-button>
+      </div>
+    </div>
+  </div>
+</div>
+
+## Color list
+
+#### Foreground colors
+
+| Name                                                      | Example                                                                                                        | Light mode hexadecimal color | Dark mode hexadecimal color | Covalent variable name                   |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------- | --------------------------- | ---------------------------------------- |
+| <div>Text</div> <div>Default text color</div>             | <div class="primaryText">Lorem ipsum dolor sit amet</div>                                                      | #000000 <br/> 0.87 opacity   | #ffffff <br/> 1.00 opacity  | --mdc-theme-text-primary-on-background   |
+| <div>Secondary text</div> <div>Less emphasized text</div> | <div class="secondary">Lorem ipsum dolor sit amet</div>                                                        | #000000 <br/> 0.54 opacity   | #ffffff <br/> 0.7 opacity   | --mdc-theme-text-secondary-on-background |
+| <div>Disabled text</div>                                  | <div class="disabled">Lorem ipsum dolor sit amet</div>                                                         | #000000 <br/> 0.38 opacity   | #ffffff <br/> 0.5 opacity   | --mdc-theme-text-disabled-on-background  |
+| <div>Icon</div><div>Default icon color</div>              | <td-icon>directions_boat</td-icon>                                                                             | #000000 <br/> 0.54 opacity   | #ffffff <br/> 0.7 opacity   | --mdc-theme-text-secondary-on-background |
+| <div>Disabled icon</div>                                  | <td-icon class="disabled">directions_boat</td-icon>                                                            | #000000 <br/> 0.38 opacity   | #ffffff <br/> 0.5 opacity   | --mdc-theme-text-disabled-on-background  |
+| <div>Divider</div>                                        | <div class="divider"></div>                                                                                    | #000000 <br/> 0.12 opacity   | #ffffff <br/> 0.2 opacity   | --mdc-theme-border                       |
+| <div>Positive</div>                                       | <div class="positiveFg">Lorem ipsum dolor sit amet</div> <td-icon class="positiveFg">directions_boat</td-icon> | #0a7e07                      | #42bd41                     | --mdc-theme-positive                     |
+| <div>Caution</div>                                        | <div class="cautionFg">Lorem ipsum dolor sit amet</div> <td-icon class="cautionFg">directions_boat</td-icon>   | #ff8f00                      | #ffb74d                     | --mdc-theme-caution                      |
+| <div>Negative</div>                                       | <div class="negativeFg">Lorem ipsum dolor sit amet</div> <td-icon class="negativeFg">directions_boat</td-icon> | #b11d00                      | #f46f5a                     | --mdc-theme-negative                     |
+| <div>Primary</div>                                        | <div class="primaryFg">Lorem ipsum dolor sit amet</div> <td-icon class="primaryFg">directions_boat</td-icon>   | #007373                      | #59cecd                     | --mdc-theme-primary                      |
+| <div>Emphasis</div>                                       | <div class="emphasisFg">Lorem ipsum dolor sit amet</div> <td-icon class="emphasisFg">directions_boat</td-icon> | #546e7a                      | #b0bec5                     | --mdc-theme-emphasis                     |
+
+#### Background colors
+
+| Name                                                               | Example                                    | Light mode material color | Light mode hexadecimal color | Dark mode material color | Dark mode hexadecimal Color | Covalent variable name                       |
+| ------------------------------------------------------------------ | ------------------------------------------ | ------------------------- | ---------------------------- | ------------------------ | --------------------------- | -------------------------------------------- |
+| <div>Background</div> <div>The page background</div>               | <div class="background"></div>             | Mat Grey 100              | #f5f5f5                      | TD Slate 1500            | #161c1f                     | --mdc-theme-background                       |
+| <div>Surface</div>                                                 | <div class="surface"></div>                | Mat White                 | #ffffff                      | TD Slate 1100            | #28353b                     | --mdc-theme-surface                          |
+| <div>Canvas</div> <div>Editable workspaces like code windows</div> | <div class="canvas"></div>                 | Mat Grey 200              | #eeeeee                      | TD Slate 1700            | #101314                     | --mdc-theme-surface-canvas                   |
+| <div>Positive</div>                                                | <div class="positive"></div>               | Mat Green 200             | #a5d6a7                      | #336033                  | #336033                     | --mdc-theme-surface-positive                 |
+| <div>Positive (highlight)</div>                                    | <div class="positiveHighlight"></div>      | Positive (10% opaque)     | #a5d6a7<br/> 0.1 opacity     | Positive (40% opaque)    | #336033 <br/> 0.4 opacity   | --mdc-theme-surface-positive-highlight       |
+| <div>Primary (highlight hover)</div>                               | <div class="positiveHighlightHover"></div> | Positive (20% opaque)     | #a5d6a7<br/> 0.2 opacity     | Positive (60% opaque)    | #336033 <br/> 0.6 opacity   | --mdc-theme-surface-positive-highlight-hover |
+| <div>Caution</div>                                                 | <div class="caution"></div>                | Mat Orange 300            | #ffb74d                      | #704c16                  | #704c16                     | --mdc-theme-surface-caution                  |
+| <div>Caution (highlight)</div>                                     | <div class="cautionHighlight"></div>       | Caution (10% opaque)      | #ffb74d<br/> 0.1 opacity     | Caution (40% opaque)     | #704c16 <br/> 0.4 opacity   | --mdc-theme-surface-caution-highlight        |
+| <div>Caution (highlight hover)</div>                               | <div class="cautionHighlightHover"></div>  | Caution (20% opaque)      | #ffb74d <br/> 0.2 opacity    | Caution (60% opaque)     | #704c16 <br/> 0.6 opacity   | --mdc-theme-surface-caution-highlight-hover  |
+| <div>Negative</div>                                                | <div class="negative"></div>               | Mat Red 300               | #e57373                      | #883e32                  | #883e32                     | --mdc-theme-surface-negative                 |
+| <div>Negative (highlight)</div>                                    | <div class="negativeHighlight"></div>      | Negative (10% opaque)     | #e57373<br/> 0.1 opacity     | Negative (40% opaque)    | #883e32 <br/> 0.4 opacity   | --mdc-theme-surface-negative-highlight       |
+| <div>Negative (highlight hover)</div>                              | <div class="negativeHighlightHover"></div> | Negative (20% opaque)     | #e57373<br/> 0.2 opacity     | Negative (60% opaque)    | #883e32 <br/> 0.6 opacity   | --mdc-theme-surface-negative-highlight-hover |
+| <div>Neutral</div>                                                 | <div class="neutral"></div>                | Mat Grey 400              | #bdbdbd                      | TD Slate 800             | #43515a                     | --mdc-theme-surface-neutral                  |
+| <div>Neutral (highlight)</div>                                     | <div class="neutralHighlight"></div>       | Neutral (4% opaque)       | #bdbdbd<br/> 0.04 opacity    | Neutral (40% opaque)     | #43515a <br/> 0.4 opacity   | --mdc-theme-surface-neutral-highlight        |
+| <div>Neutral (highlight hover)</div>                               | <div class="neutralHighlightHover"></div>  | Neutral (8% opaque)       | #bdbdbd<br/> 0.08 opacity    | Neutral (60% opaque)     | #43515a <br/> 0.6 opacity   | --mdc-theme-surface-neutral-highlight-hover  |
+| <div>Primary</div>                                                 | <div class="primary"></div>                | TD Teal 200               | #85dddc                      | TD Teal 1200             | #045c5c                     | --mdc-theme-surface-primary                  |
+| <div>Primary (highlight)</div>                                     | <div class="primaryHighlight"></div>       | Primary (10% opaque)      | #85dddc <br/> 0.1 opacity    | Primary (40% opaque)     | #045c5c <br/> 0.4 opacity   | --mdc-theme-surface-primary-highlight        |
+| <div>Primary (highlight hover)</div>                               | <div class="primaryHighlightHover"></div>  | Primary (20% opaque)      | #85dddc <br/> 0.2 opacity    | Primary (60% opaque)     | #045c5c <br/> 0.6 opacity   | --mdc-theme-surface-primrary-highlight-hover |
+| <div>Emphasis</div>                                                | <div class="emphasis"></div>               | TD Slate 200              | #afb6b9                      | TD Slate 800             | #43515a                     | --mdc-theme-surface-emphasis                 |
+| <div>Emphasis (highlight)</div>                                    | <div class="emphasisHighlight"></div>      | Emphasis (10% opaque)     | #afb6b9 <br/> 0.1 opacity    | Emphasis (40% opaque)    | #43515a <br/> 0.4 opacity   | --mdc-theme-surface-emphasis-highlight       |
+| <div>Emphasis (highlight hover)</div>                              | <div class="emphasisHighlightHover"></div> | Emphasis (20% opaque)     | #afb6b9 <br/> 0.2 opacity    | Emphasis (60% opaque)    | #43515a <br/> 0.6 opacity   | --mdc-theme-surface-emphasis-highlight-hover |
+
+## Config colors for Material Design
+
+You should almost never use these. They're here to explain the initial theme setup in Angular Material. Instead, use the colors above.
+
+| Name                       | Light mode example                                              | Dark mode example                                               |
+| -------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------- |
+| <div>Accent</div>          | <div class="td-teal-500">TD Teal 500</div>                      | <div class="td-teal-500">TD Teal 500</div>                      |
+| <div>Accent (light)</div>  | <div class="accent-background-light">Background - Accent</div>  | <div class="accent-foreground-light">Foreground - Accent</div>  |
+| <div>Accent (dark)</div>   | <div class="accent-background-dark">Foreground - Accent</div>   | <div class="accent-foreground-dark">Background - Accent</div>   |
+| <div>Primary</div>         | <div class="td-slate-500">TD Slate 500</div>                    | <div class="td-slate-500">TD Slate 500</div>                    |
+| <div>Primary (dark)</div>  | <div class="primary-foreground-dark">Foreground - Primary</div> | <div class="primary-background-dark">Background - Primary</div> |
+| <div>Primary (light)</div> | <div class="primary-light">Background - Primary</div>           | <div class="primary-light">Foreground - Primary</div>           |


### PR DESCRIPTION
## Description

### Color use guide

Implemented [this Figma documentation](https://www.figma.com/file/7pzxuLUaKxE4A4uIPB8YUd/Color-use?node-id=337%3A2188) into Storybook.

### What's included?

* --mdc-theme-surface-emphasis, --mdc-theme-surface-emphasis-highlight, and --mdc-theme-surface-emphasis-highlight-hover have been added.
* --mdc-theme-surface-accent, --mdc-theme-surface-accent-highlight, and --mdc-theme-surface-accent-highlight-hover have also been added but they are just aliases for --mdc-theme-surface-primary, --mdc-theme-surface-primary-highlight, and --mdc-theme-surface-primary-highlight-hover.
* Some color values and opacities on the guide were changed to match what the variables actually are.
* App bar background color was removed.
* Card background color was updated to surface.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run storybook`
- [ ] Navigate to "Color use" under "Guides"
- [ ] Compare the story with this [Figma](https://www.figma.com/file/7pzxuLUaKxE4A4uIPB8YUd/Color-use?node-id=337%3A2188)

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

Receiving this error when I run any of these commands:

```
 >  NX   Unhandled error in task executor

TypeError: Cannot read properties of undefined (reading 'tasks')
    at calculateReverseDeps (/Users/eric.ni/node_modules/nx/src/tasks-runner/utils.js:160:27)
    at new TasksSchedule (/Users/eric.ni/node_modules/nx/src/tasks-runner/tasks-schedule.js:16:65)
    at new TaskOrchestrator (/Users/eric.ni/node_modules/nx/src/tasks-runner/task-orchestrator.js:26:30)
    at /Users/eric.ni/node_modules/nx/src/tasks-runner/default-tasks-runner.js:33:30
    at Generator.next (<anonymous>)
    at /Users/eric.ni/node_modules/tslib/tslib.js:118:75
    at new Promise (<anonymous>)
    at Object.__awaiter (/Users/eric.ni/node_modules/tslib/tslib.js:114:16)
    at runAllTasks (/Users/eric.ni/node_modules/nx/src/tasks-runner/default-tasks-runner.js:28:20)
    at /Users/eric.ni/node_modules/nx/src/tasks-runner/default-tasks-runner.js:19:22
```

![ColorUse](https://user-images.githubusercontent.com/47995084/192865231-2d2ebc4f-bbff-4db7-b8de-c731bad9ec9a.gif)


