### PR TITLE
fix(componets): deploy to npm & chromatic ci

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,7 +7,10 @@ name: 'Chromatic'
 on:
   pull_request:
     branches: [main]
-
+    paths:
+      - 'libs/components/**'
+      - 'libs/icons/**'
+      - 'libs/tokens/**'
 # List of jobs
 jobs:
   chromatic-deployment:
@@ -26,10 +29,5 @@ jobs:
           node-version: 16
           cache: npm
       - run: npm ci --legacy-peer-deps
-        # 👇 Adds Chromatic as a step in the workflow
-      - name: Publish to Chromatic
-        uses: chromaui/action@v1
-        # Chromatic GitHub Action options
-        with:
-          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      # 👇 Adds Chromatic as a step in the workflow
+      - run: npx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --exit-once-uploaded

--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,5 @@ testem.log
 Thumbs.db
 
 .angular
-storybook
+storybook-static
 build-storybook.log

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@covalent/components",
-  "version": "1.0.13",
+  "version": "0.0.0-COVALENT",
   "description": "a catalog of material components for covalent",
-  "main": "index.js"
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/teradata/covalent.git"
+  },
+  "bugs": {
+    "url": "https://github.com/teradata/covalent/issues"
+  },
+  "license": "MIT",
+  "author": "Teradata UX"
 }

--- a/libs/components/project.json
+++ b/libs/components/project.json
@@ -3,6 +3,14 @@
   "sourceRoot": "libs/components/src",
   "projectType": "library",
   "targets": {
+    "build": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "commands": ["webpack -c libs/components/webpack.config.js"],
+        "parallel": false,
+        "outputPath": "dist/libs/components"
+      }
+    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/libs/components/webpack.config.js
+++ b/libs/components/webpack.config.js
@@ -44,6 +44,10 @@ module.exports = {
     treeList: './libs/components/src/tree-list/tree-list.ts',
     treeListItem: './libs/components/src/tree-list/tree-list-item.ts',
   },
+  output: {
+    filename: 'libs/components/[name].js',
+    clean: true,
+  },
   resolve: {
     // Add `.ts` and `.tsx` as a resolvable extension.
     extensions: ['.ts', '.tsx', '.js'],
@@ -81,7 +85,7 @@ module.exports = {
           {
             loader: 'file-loader',
             options: {
-              name: '[name].css',
+              name: 'libs/components/[name].css',
             },
           },
           'extract-loader',
@@ -94,13 +98,28 @@ module.exports = {
   plugins: [
     new CopyPlugin({
       patterns: [
-        './libs/components/package.json',
-        { from: './libs/icons/covalent-icons.css', to: './icons' },
-        { from: './libs/icons/covalent-icons.eot', to: './icons' },
-        { from: './libs/icons/covalent-icons.svg', to: './icons' },
-        { from: './libs/icons/covalent-icons.ttf', to: './icons' },
-        { from: './libs/icons/covalent-icons.woff', to: './icons' },
-        { from: './libs/icons/favicon.ico', to: './icons' },
+        { from: './libs/components/package.json', to: './libs/components' },
+        {
+          from: './libs/icons/covalent-icons.css',
+          to: './libs/components/icons',
+        },
+        {
+          from: './libs/icons/covalent-icons.eot',
+          to: './libs/components/icons',
+        },
+        {
+          from: './libs/icons/covalent-icons.svg',
+          to: './libs/components/icons',
+        },
+        {
+          from: './libs/icons/covalent-icons.ttf',
+          to: './libs/components/icons',
+        },
+        {
+          from: './libs/icons/covalent-icons.woff',
+          to: './libs/components/icons',
+        },
+        { from: './libs/icons/favicon.ico', to: './libs/components/icons' },
       ],
     }),
   ],


### PR DESCRIPTION
## Description

Fixing the build stage for the components library

### What's included?

- @covalent/components will now build with the rest of the libraries to also be published
- fixing the chromatic workflow to only run when certain libs change (components, tokens, icons)
- also using npx cli command for chromatic instead of action since its not verified by github marketplace

#### Test Steps

- [ ] `nx build components`

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
