### PR TITLE
build(components): storybook preview css path

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -6,16 +6,14 @@
   href="https://fonts.googleapis.com/css?family=Material+Icons|Poppins:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap"
   rel="stylesheet"
 />
-
-<!-- Required styles for Covalent icons -->
-<link href="icons/covalent-icons.css" rel="stylesheet" />
-
 <!-- Required styles for Material Web -->
 <link
   rel="stylesheet"
   href="https://unpkg.com/material-components-web@13.0.0/dist/material-components-web.min.css"
 />
+<!-- Required styles for Covalent icons -->
+<link href="libs/icons/covalent-icons.css" rel="stylesheet" />
 <!-- Required styles for Covalent Themes -->
-<link href="styles.css" rel="stylesheet" />
+<link href="libs/components/styles.css" rel="stylesheet" />
 <!-- Required styles for Covalent Themes -->
-<link href="theme.css" rel="stylesheet" />
+<link href="libs/components/theme.css" rel="stylesheet" />


### PR DESCRIPTION
## Description

fix the theme and style css path used for story book previews

<img width="1518" alt="Screen Shot 2022-09-29 at 4 10 59 PM" src="https://user-images.githubusercontent.com/3837706/193132177-b5c33b73-9f7a-4b89-b341-5720f503c684.png">
