### PR TITLE
feat(components): adding sidesheet component

### DIFF
--- a/libs/components/src/side-sheet/side-sheet.scss
+++ b/libs/components/src/side-sheet/side-sheet.scss
@@ -1,5 +1,5 @@
 :host {
-  --td-side-sheet-width: 400px;
+  --td-side-sheet-width: 800px;
 }
 
 .mdc-dialog {

--- a/libs/components/src/side-sheet/side-sheet.scss
+++ b/libs/components/src/side-sheet/side-sheet.scss
@@ -1,0 +1,48 @@
+:host {
+  --td-side-sheet-width: 400px;
+}
+
+.mdc-dialog {
+  justify-content: flex-end;
+
+  .mdc-dialog__surface {
+    border-radius: 0;
+    height: 100%;
+    min-height: inherit;
+    max-height: inherit;
+    min-width: var(--td-side-sheet-width, 400px);
+  }
+}
+
+.mdc-dialog--opening {
+  .mdc-dialog__container {
+    transform: translate(100%, 0);
+    transition: transform 150ms cubic-bezier(0.4, 0, 1, 1);
+  }
+}
+
+.mdc-dialog--open {
+  .mdc-dialog__container {
+    transform: translate(0);
+  }
+}
+
+.mdc-dialog--closing {
+  .mdc-dialog__container {
+    opacity: 1;
+    transform: translate(100%, 0);
+    transition: transform 150ms cubic-bezier(0, 0, 0.2, 1);
+  }
+}
+
+:host([pushed]) {
+  .mdc-dialog__surface {
+    min-width: 100vw;
+  }
+}
+
+:host([noPadding]) {
+  .mdc-dialog .mdc-dialog__content {
+    padding: 0;
+  }
+}

--- a/libs/components/src/side-sheet/side-sheet.stories.js
+++ b/libs/components/src/side-sheet/side-sheet.stories.js
@@ -1,6 +1,6 @@
 import './side-sheet';
 import '../button/button';
-import { Active as ActiveStatusHeader } from '../status-header/status-header.stories';
+//import { Active as ActiveStatusHeader } from '../status-header/status-header.stories';
 import * as tableRowSelectionContent from '../../stories/demos/table-row-selection.content.html';
 
 export default {
@@ -85,11 +85,6 @@ export const StatusHeader = () => {
         </style>
         <td-button raised>Open side sheet</td-button>
         <td-side-sheet noPadding>
-            ${ActiveStatusHeader({
-              state: 'active',
-              status: 'Running',
-              title: 'Active item details',
-            })}
             ${tableRowSelectionContent}
         </td-side-sheet>
     `;

--- a/libs/components/src/side-sheet/side-sheet.stories.js
+++ b/libs/components/src/side-sheet/side-sheet.stories.js
@@ -1,0 +1,96 @@
+import './side-sheet';
+import '../button/button';
+import { Active as ActiveStatusHeader } from '../status-header/status-header.stories';
+import * as tableRowSelectionContent from '../../stories/demos/table-row-selection.content.html';
+
+export default {
+  title: 'Components/Side sheet',
+  argTypes: { onClick: { action: 'clicked' } },
+  parameters: {
+    actions: {
+      handles: ['click td-button'],
+    },
+  },
+};
+
+export const Basic = () => {
+  document.addEventListener(
+    'DOMContentLoaded',
+    () => {
+      const sideSheet = document.querySelector('td-side-sheet');
+      document
+        .querySelector('td-button')
+        ?.addEventListener('click', () =>
+          sideSheet?.open ? sideSheet.close() : sideSheet?.show()
+        );
+    },
+    { once: true }
+  );
+  return `
+        <td-button raised>Open side sheet</td-button>
+        <td-side-sheet heading="Sample side sheet">
+        </td-side-sheet>
+    `;
+};
+
+export const Multiple = () => {
+  document.addEventListener(
+    'DOMContentLoaded',
+    () => {
+      const sideSheet = document.querySelector('#parentSideSheet');
+      const childSideSheet = document.querySelector('#childSideSheet');
+
+      document
+        .querySelector('#parentTarget')
+        ?.addEventListener('click', () =>
+          sideSheet?.open ? sideSheet.close() : sideSheet?.show()
+        );
+      document
+        .querySelector('#childTarget')
+        ?.addEventListener('click', () =>
+          childSideSheet?.open ? childSideSheet.close() : childSideSheet?.show()
+        );
+    },
+    { once: true }
+  );
+  return `
+        <td-button id="parentTarget" raised>Open side sheet</td-button>
+        <td-side-sheet id="parentSideSheet" heading="Sample side sheet">
+            <td-button id="childTarget" raised>Open child</td-button>
+        </td-side-sheet>
+        <td-side-sheet id="childSideSheet" heading="Child side sheet" >
+        </td-side-sheet>
+    `;
+};
+
+export const StatusHeader = () => {
+  document.addEventListener(
+    'DOMContentLoaded',
+    () => {
+      const sideSheet = document.querySelector('td-side-sheet');
+      console.log(sideSheet);
+      document
+        .querySelector('td-button')
+        ?.addEventListener('click', () =>
+          sideSheet?.open ? sideSheet.close() : sideSheet?.show()
+        );
+    },
+    { once: true }
+  );
+  return `
+        <style>
+            td-side-sheet {
+                --td-side-sheet-width: 800px;
+            }
+        </style>
+        <td-button raised>Open side sheet</td-button>
+        <td-side-sheet noPadding>
+            ${ActiveStatusHeader({
+              state: 'active',
+              status: 'Running',
+              title: 'Active item details',
+            })}
+            ${tableRowSelectionContent}
+        </td-side-sheet>
+    `;
+};

--- a/libs/components/src/side-sheet/side-sheet.ts
+++ b/libs/components/src/side-sheet/side-sheet.ts
@@ -1,0 +1,31 @@
+import { customElement, property } from 'lit/decorators.js';
+import { styles } from '@material/mwc-dialog/mwc-dialog.css';
+import { CovalentDialogBase } from '../dialog/dialog';
+import baseStyles from './side-sheet.scss';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'td-side-sheet': CovalentSideSheet;
+  }
+}
+
+/**
+ * Side sheet element.
+ *
+ * @slot - This element has a slot
+ */
+@customElement('td-side-sheet')
+export class CovalentSideSheet extends CovalentDialogBase {
+  static override styles = [styles, baseStyles];
+
+  @property({ type: Boolean, reflect: true })
+  pushed = false;
+
+  @property({ type: Boolean, reflect: true })
+  noPadding = false;
+
+  constructor() {
+    super();
+    this.hideActions = true;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ghpages:deploy": "VERSION=$(echo v${npm_package_version} | cut -c1-2) && npm run build docs-app -- --base-href=/covalent/$VERSION/ && bash scripts/ghpages-deploy $VERSION",
     "release:prepare": "npx nx run-many --target=build --all && npx nx run-many --target=build-scss --all && node ./scripts/version-placeholder ./dist",
     "style-dictionary": "cd libs/tokens && style-dictionary build",
-    "storybook": "npx storybook -c libs/components/.storybook",
+    "storybook": "npx start-storybook -c libs/components/.storybook",
     "build-storybook": "npx build-storybook -c libs/components/.storybook -o dist/storybook/components",
     "chromatic": "npx chromatic"
   },


### PR DESCRIPTION
## Description

Adding side sheet component to the web component library

### What's included?

- Added sidesheet component to the components library
- Added storybook for side sheet component

#### Test Steps

- [ ] `npm run storybook`
- [ ] then log in an scroll to the side sheet story in the side bar
- [ ] finally test the side sheet component

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

![sidesheet](https://user-images.githubusercontent.com/3837706/199563754-ecf8c851-abee-4f9d-8f47-a380c9d1ea34.gif)
