### PR TITLE
fix(flavored-markdown): list display fixes, CRLF fix

### DIFF
--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-basic/markdown-navigator-demo-basic.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-basic/markdown-navigator-demo-basic.component.html
@@ -1,5 +1,5 @@
 <td-markdown-navigator
   [items]="items"
   [copyCodeToClipboard]="true"
-  [style.height.px]="300"
+  [style.height.px]="700"
 ></td-markdown-navigator>

--- a/apps/docs-app/src/app/documentation-tools/readme-loader/readme-loader.component.html
+++ b/apps/docs-app/src/app/documentation-tools/readme-loader/readme-loader.component.html
@@ -1,1 +1,4 @@
-<td-flavored-markdown-loader [url]="resourceUrl"></td-flavored-markdown-loader>
+<td-flavored-markdown-loader
+  [url]="resourceUrl"
+  [useCfmList]="true"
+></td-flavored-markdown-loader>

--- a/libs/markdown-flavored/src/lib/flavored-markdown-loader/flavored-markdown-loader.component.html
+++ b/libs/markdown-flavored/src/lib/flavored-markdown-loader/flavored-markdown-loader.component.html
@@ -12,6 +12,7 @@
   [anchor]="anchor ?? ''"
   [copyCodeToClipboard]="copyCodeToClipboard"
   [copyCodeTooltips]="copyCodeTooltips"
+  [useCfmList]="useCfmList"
   (contentReady)="contentReady.emit()"
   (buttonClicked)="buttonClicked.emit($event)"
 ></td-flavored-markdown>

--- a/libs/markdown-flavored/src/lib/flavored-markdown-loader/flavored-markdown-loader.component.ts
+++ b/libs/markdown-flavored/src/lib/flavored-markdown-loader/flavored-markdown-loader.component.ts
@@ -55,6 +55,12 @@ export class TdFlavoredMarkdownLoaderComponent implements OnChanges {
   @Input() copyCodeTooltips?: ICopyCodeTooltips = {};
 
   /**
+   * useCfmList?: boolean = false;
+   * Use CFM list component instead of vanilla markdown list. Used in covalent documentation app.
+   */
+  @Input() useCfmList? = false;
+
+  /**
    * contentReady: void
    * Emitted when markdown rendering is finished.
    */

--- a/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
+++ b/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
@@ -533,7 +533,7 @@ export class TdFlavoredMarkdownComponent
       listRegExp,
       (componentRef: ComponentRef<TdFlavoredListComponent>, match: string) => {
         const matchIndex =
-          match.indexOf('+') !== -1 ? match.indexOf('+') : match.indexOf('*');
+          match.indexOf('*') !== -1 ? match.indexOf('*') : match.indexOf('+');
 
         const lineTexts: string[] = match.split(
           new RegExp(
@@ -560,7 +560,6 @@ export class TdFlavoredMarkdownComponent
             }),
           });
         });
-
         componentRef.instance.lines = lines;
       }
     );


### PR DESCRIPTION
## Description

Fixing an issue with markdown navigator which doesn't display links within lists if the links contain a `+` in their query params.

### What's included?

- Adding back `-` as a list character for CFM lists
- Making CFM lists opt-in via `useCfmList` input parameter. By default vanilla list will be used.
     - using cfm within readme viewer for docs app
- Fix for #1987 - removing `/r` characters from markdown before parsing/conversion

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

Broken:

<img width="649" alt="Screen Shot 2022-11-07 at 6 30 39 PM" src="https://user-images.githubusercontent.com/5451986/200394418-2456d34b-78b9-46ff-b23a-5c3d6720c29e.png">

Fixed:
<img width="648" alt="Screen Shot 2022-11-07 at 6 28 53 PM" src="https://user-images.githubusercontent.com/5451986/200394454-1ab4978c-07e0-4f98-b0dc-76832b77cbf6.png">


