### PR TITLE
fix(components): card and toolbar style adjustments

### DIFF
--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -98,11 +98,6 @@ nav.navigation {
   }
 }
 
-td-top-app-bar-fixed {
-  --mdc-theme-primary: var(--mdc-theme-surface);
-  --mdc-theme-on-primary: var(--mdc-theme-on-surface);
-}
-
 [divider] {
   border-bottom: 1px solid;
   margin: 16px;
@@ -110,7 +105,7 @@ td-top-app-bar-fixed {
 }
 
 /* Open/Collapse Animation in Desktop */
-@media only screen and (min-width: 800px) {
+@media only screen and (min-width: 768px) {
   nav.navigation {
     display: flex;
     flex-direction: column;
@@ -145,7 +140,7 @@ td-top-app-bar-fixed {
   }
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 768px) {
   .app-shell {
     grid-template-columns: 1fr;
     grid-template-areas: 'header' 'main' 'mini-list' 'help';

--- a/libs/components/src/card/card-base.ts
+++ b/libs/components/src/card/card-base.ts
@@ -19,6 +19,10 @@ export class CardBase extends LitElement {
    */
   @property({ type: Boolean }) actionBar = false;
   /**
+   * Displays the ripple affect in primary area
+   */
+  @property({ type: Boolean }) interactive = false;
+  /**
    * Style the card as an outline variant
    */
   @property({ type: Boolean }) outlined = false;
@@ -36,8 +40,8 @@ export class CardBase extends LitElement {
           `
         : ''}
       <div class="mdc-card__primary-action">
-        <slot name="card-content"></slot>
-        <slot name="empty-state"></slot>
+        <slot></slot>
+        ${this.interactive ? html`<div class="mdc-card__ripple"></div>` : ''}
       </div>
       ${this.actionBar
         ? html`

--- a/libs/components/src/card/cards.stories.js
+++ b/libs/components/src/card/cards.stories.js
@@ -26,7 +26,7 @@ export const Basic = ({ outlined, actionBar, cardTitle }) => {
     ${actionBar ? 'actionBar' : ''}
     ${outlined ? 'outlined' : ''}
   >
-    <div slot="card-content">${tableContent}</div>
+    ${tableContent}
     <div slot="card-actions" class="mdc-card__action-buttons">
       <button class="mdc-button mdc-card__action mdc-card__action--button">
         <div class="mdc-button__ripple"></div>

--- a/libs/components/src/status-header/status-header-item.scss
+++ b/libs/components/src/status-header/status-header-item.scss
@@ -1,7 +1,9 @@
 :host {
   --td-status-header-item-width: 178px;
 
-  display: block;
+  display: flex;
+  padding: 14px 16px;
+  align-items: center;
   font-family: var(--mdc-typography-body2-font-family);
   font-size: var(--mdc-typography-body2-font-size);
   font-weight: var(--mdc-typography-body2-font-weight);

--- a/libs/components/src/toolbar/toolbar.scss
+++ b/libs/components/src/toolbar/toolbar.scss
@@ -4,6 +4,10 @@
   display: block;
 }
 
+.mdc-top-app-bar__title {
+  padding-left: 0;
+}
+
 @media screen and (max-width: 768px) {
   .mdc-top-app-bar__title {
     font-family: var(--mdc-typography-subtitle2-font-family);
@@ -16,6 +20,8 @@
 .mdc-top-app-bar {
   position: static;
   background-color: transparent;
+  background-color: var(--mdc-theme-surface);
+  color: var(--mdc-theme-on-surface);
 }
 
 .mdc-top-app-bar--fixed-adjust,

--- a/libs/components/src/top-app-bar/top-app-bar-fixed.ts
+++ b/libs/components/src/top-app-bar/top-app-bar-fixed.ts
@@ -1,6 +1,7 @@
+import { customElement } from 'lit/decorators.js';
 import { TopAppBarFixedBase } from '@material/mwc-top-app-bar-fixed/mwc-top-app-bar-fixed-base';
 import { styles } from '@material/mwc-top-app-bar/mwc-top-app-bar.css.js';
-import { customElement } from 'lit/decorators.js';
+import baseStyles from './top-app-bar.scss';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -10,5 +11,5 @@ declare global {
 
 @customElement('td-top-app-bar-fixed')
 export class CovalentTopAppBaraFixedBase extends TopAppBarFixedBase {
-  static override styles = [styles];
+  static override styles = [styles, baseStyles];
 }

--- a/libs/components/src/top-app-bar/top-app-bar.scss
+++ b/libs/components/src/top-app-bar/top-app-bar.scss
@@ -1,0 +1,4 @@
+.mdc-top-app-bar {
+  background: var(--mdc-theme-surface);
+  color: var(--mdc-theme-on-surface);
+}

--- a/libs/components/src/top-app-bar/top-app-bar.ts
+++ b/libs/components/src/top-app-bar/top-app-bar.ts
@@ -1,6 +1,7 @@
+import { customElement } from 'lit/decorators.js';
 import { TopAppBarBase } from '@material/mwc-top-app-bar/mwc-top-app-bar-base';
 import { styles } from '@material/mwc-top-app-bar/mwc-top-app-bar.css';
-import { customElement } from 'lit/decorators.js';
+import baseStyles from './top-app-bar.scss';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -10,5 +11,5 @@ declare global {
 
 @customElement('td-top-app-bar')
 export class CovalentTopAppBarBase extends TopAppBarBase {
-  static override styles = [styles];
+  static override styles = [styles, baseStyles];
 }


### PR DESCRIPTION
## Description

More style updates to the web components project

### What's included?

- Adding card ripple affect 
- Toolbar color and padding adjustments

#### Test Steps

- [ ] `npm run storybook`
- [ ] then open browser and inpsect card, app shell, and toolbar stories

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
