### PR TITLE
fix(components): exporting sidesheet in build

### DIFF
--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -22,6 +22,7 @@ export * from './list/radio-list-item';
 export * from './menu/menu';
 export * from './radio/radio';
 export * from './select/select';
+export * from './side-sheet/side-sheet';
 export * from './slider/slider';
 export * from './slider/slider-range';
 export * from './snackbar/snackbar';

--- a/libs/components/webpack.config.js
+++ b/libs/components/webpack.config.js
@@ -32,6 +32,7 @@ module.exports = {
     menu: './libs/components/src/menu/menu.ts',
     radio: './libs/components/src/radio/radio.ts',
     select: './libs/components/src/select/select.ts',
+    sideSheet: './libs/components/src/side-sheet/side-sheet.ts',
     slider: './libs/components/src/slider/slider.ts',
     sliderRange: './libs/components/src/slider/slider-range.ts',
     snackBar: './libs/components/src/snackbar/snackbar.ts',


### PR DESCRIPTION
## Description

fix for the sidesheet web component not being exported in the build

### What's included?

- export as single module 
- export in general index bundle

#### Test Steps

- [ ] `npx nx components:build`
- [ ] then inspect package to see sideSheet.js export

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
