### PR TITLE
feat(components): adding code snippet component

### DIFF
--- a/libs/components/src/code-snippet/code-snippet.scss
+++ b/libs/components/src/code-snippet/code-snippet.scss
@@ -1,0 +1,74 @@
+:host {
+  background-color: var(--mdc-theme-surface-canvas);
+  border-radius: var(--mdc-shape-medium);
+  display: block;
+  position: relative;
+
+  /* For max height*/
+  overflow: hidden;
+
+  pre {
+    margin: 0;
+    padding: 16px 0;
+    overflow: auto;
+    code.hljs.td-code-snippet {
+      background-color: transparent;
+      padding: 0 16px !important;
+    }
+  }
+}
+
+:host([inline]) {
+  border-radius: 0;
+}
+
+:host([theme='light']) {
+  @import 'highlight.js/styles/atom-one-light';
+
+  --mdc-theme-surface-canvas: var(--td-light-surface-canvas);
+  color: var(--mdc-theme-text-primary-on-light);
+
+  ::slotted(td-icon-button) {
+    color: var(--mdc-theme-text-icon-on-light);
+  }
+
+  .header {
+    border-bottom-color: var(--td-light-divider);
+  }
+}
+
+:host([theme='dark']) {
+  @import 'highlight.js/styles/atom-one-dark';
+
+  --mdc-theme-surface-canvas: var(--td-dark-surface-canvas);
+  color: var(--mdc-theme-text-primary-on-dark);
+
+  td-icon-button {
+    color: var(--mdc-theme-text-icon-on-dark);
+  }
+  .header {
+    border-bottom-color: var(--td-dark-divider);
+  }
+}
+
+.header {
+  border-bottom: 1px solid var(--mdc-theme-border);
+  position: sticky;
+  top: -8px;
+  background-color: var(--mdc-theme-surface-canvas);
+
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 8px 4px 16px;
+  align-items: center;
+
+  border-radius: var(--mdc-shape-medium) var(--mdc-shape-medium) 0 0;
+}
+
+.title {
+  font-family: var(--mdc-typography-subtitle2-font-family);
+  font-size: var(--mdc-typography-subtitle2-font-size);
+  font-weight: var(--mdc-typography-subtitle2-font-weight);
+  line-height: var(--mdc-typography-subtitle2-line-height);
+  padding-right: 16px;
+}

--- a/libs/components/src/code-snippet/code-snippet.scss
+++ b/libs/components/src/code-snippet/code-snippet.scss
@@ -18,19 +18,23 @@
       overflow-x: auto;
     }
   }
+
   .hljs {
     color: var(--cov-theme-code-snippet-color, #abb2bf);
   }
+
   .hljs-comment,
   .hljs-quote {
     color: var(--cov-theme-code-snippet-comment, #5c6370);
     font-style: italic;
   }
+
   .hljs-doctag,
   .hljs-formula,
   .hljs-keyword {
     color: var(--cov-theme-code-snippet-keyword, #c678dd);
   }
+
   .hljs-deletion,
   .hljs-name,
   .hljs-section,
@@ -38,9 +42,11 @@
   .hljs-subst {
     color: var(--cov-theme-code-snippet-selector, #e06c75);
   }
+
   .hljs-literal {
     color: var(--cov-theme-code-snippet-literal, #56b6c2);
   }
+
   .hljs-addition,
   .hljs-attribute,
   .hljs-meta .hljs-string,
@@ -48,6 +54,7 @@
   .hljs-string {
     color: var(--cov-theme-code-snippet-string, #98c379);
   }
+
   .hljs-attr,
   .hljs-number,
   .hljs-selector-attr,
@@ -58,6 +65,7 @@
   .hljs-variable {
     color: var(--cov-theme-code-snippet-variable, #d19a66);
   }
+
   .hljs-bullet,
   .hljs-link,
   .hljs-meta,
@@ -66,17 +74,21 @@
   .hljs-title {
     color: var(--cov-theme-code-snippet-title, #61aeee);
   }
+
   .hljs-built_in,
   .hljs-class .hljs-title,
   .hljs-title.class_ {
     color: var(--cov-theme-code-snippet-class, #e6c07b);
   }
+
   .hljs-emphasis {
     font-style: italic;
   }
+
   .hljs-strong {
     font-weight: 700;
   }
+
   .hljs-link {
     text-decoration: underline;
   }

--- a/libs/components/src/code-snippet/code-snippet.scss
+++ b/libs/components/src/code-snippet/code-snippet.scss
@@ -4,17 +4,81 @@
   display: block;
   position: relative;
 
-  /* For max height*/
+  /* For max height */
   overflow: hidden;
 
   pre {
     margin: 0;
     padding: 16px 0;
     overflow: auto;
+
     code.hljs.td-code-snippet {
-      background-color: transparent;
-      padding: 0 16px !important;
+      padding: 0 16px;
+      display: block;
+      overflow-x: auto;
     }
+  }
+  .hljs {
+    color: var(--cov-theme-code-snippet-color, #abb2bf);
+  }
+  .hljs-comment,
+  .hljs-quote {
+    color: var(--cov-theme-code-snippet-comment, #5c6370);
+    font-style: italic;
+  }
+  .hljs-doctag,
+  .hljs-formula,
+  .hljs-keyword {
+    color: var(--cov-theme-code-snippet-keyword, #c678dd);
+  }
+  .hljs-deletion,
+  .hljs-name,
+  .hljs-section,
+  .hljs-selector-tag,
+  .hljs-subst {
+    color: var(--cov-theme-code-snippet-selector, #e06c75);
+  }
+  .hljs-literal {
+    color: var(--cov-theme-code-snippet-literal, #56b6c2);
+  }
+  .hljs-addition,
+  .hljs-attribute,
+  .hljs-meta .hljs-string,
+  .hljs-regexp,
+  .hljs-string {
+    color: var(--cov-theme-code-snippet-string, #98c379);
+  }
+  .hljs-attr,
+  .hljs-number,
+  .hljs-selector-attr,
+  .hljs-selector-class,
+  .hljs-selector-pseudo,
+  .hljs-template-variable,
+  .hljs-type,
+  .hljs-variable {
+    color: var(--cov-theme-code-snippet-variable, #d19a66);
+  }
+  .hljs-bullet,
+  .hljs-link,
+  .hljs-meta,
+  .hljs-selector-id,
+  .hljs-symbol,
+  .hljs-title {
+    color: var(--cov-theme-code-snippet-title, #61aeee);
+  }
+  .hljs-built_in,
+  .hljs-class .hljs-title,
+  .hljs-title.class_ {
+    color: var(--cov-theme-code-snippet-class, #e6c07b);
+  }
+  .hljs-emphasis {
+    font-style: italic;
+  }
+  .hljs-strong {
+    font-weight: 700;
+  }
+  .hljs-link {
+    text-decoration: underline;
   }
 }
 
@@ -22,46 +86,15 @@
   border-radius: 0;
 }
 
-:host([theme='light']) {
-  @import 'highlight.js/styles/atom-one-light';
-
-  --mdc-theme-surface-canvas: var(--td-light-surface-canvas);
-  color: var(--mdc-theme-text-primary-on-light);
-
-  ::slotted(td-icon-button) {
-    color: var(--mdc-theme-text-icon-on-light);
-  }
-
-  .header {
-    border-bottom-color: var(--td-light-divider);
-  }
-}
-
-:host([theme='dark']) {
-  @import 'highlight.js/styles/atom-one-dark';
-
-  --mdc-theme-surface-canvas: var(--td-dark-surface-canvas);
-  color: var(--mdc-theme-text-primary-on-dark);
-
-  td-icon-button {
-    color: var(--mdc-theme-text-icon-on-dark);
-  }
-  .header {
-    border-bottom-color: var(--td-dark-divider);
-  }
-}
-
 .header {
   border-bottom: 1px solid var(--mdc-theme-border);
   position: sticky;
   top: -8px;
   background-color: var(--mdc-theme-surface-canvas);
-
   display: flex;
   justify-content: space-between;
   padding: 4px 8px 4px 16px;
   align-items: center;
-
   border-radius: var(--mdc-shape-medium) var(--mdc-shape-medium) 0 0;
 }
 

--- a/libs/components/src/code-snippet/code-snippet.spec.ts
+++ b/libs/components/src/code-snippet/code-snippet.spec.ts
@@ -1,0 +1,7 @@
+import { CovalentCodeSnippetBase } from './code-snippet';
+
+describe('Code snippet', () => {
+  it('should work', () => {
+    expect(new CovalentCodeSnippetBase()).toBeDefined();
+  });
+});

--- a/libs/components/src/code-snippet/code-snippet.stories.js
+++ b/libs/components/src/code-snippet/code-snippet.stories.js
@@ -1,0 +1,128 @@
+import './code-snippet';
+import '../icon-button/icon-button';
+import '../button/button';
+
+const sqlContent = `
+SELECT * FROM load_to_teradata (
+    ON (
+    SELECT "class" AS class_col,
+            "variable" AS variable_col,
+            "type" AS type_col,
+            category,
+            cnt,
+            "sum" AS sum_col,
+            "sumSq",
+            "totalCnt"
+    FROM aster_nb_modelSC
+    )
+    tdpid ('sdt12432.labs.teradata.com')
+    username ('sample_user')
+    password ('sample_user')
+    target_table ('td_nb_modelSC')
+);
+`;
+
+export default {
+  title: 'Components/Code snippet',
+  argTypes: {
+    hideHeader: {
+      control: 'boolean',
+      defaultValue: false,
+    },
+    isDark: {
+      control: 'boolean',
+      defaultValue: false,
+    },
+    inline: {
+      control: 'boolean',
+      defaultValue: false,
+    },
+    label: {
+      control: 'text',
+      defaultValue: 'Example',
+    },
+    language: {
+      control: 'text',
+      defaultValue: 'sql',
+    },
+    content: {
+      control: 'text',
+      defaultValue: sqlContent,
+    },
+    maxHeight: {
+      control: 'number',
+      defaultValue: 0,
+    },
+  },
+};
+
+const Template = ({
+  isDark,
+  inline,
+  content,
+  hideHeader,
+  label,
+  language,
+  maxHeight,
+}) => {
+  return `
+    <td-code-snippet 
+        label="${label}"
+        maxHeight="${maxHeight}"
+        language="${language}" 
+        theme="${isDark ? 'dark' : 'light'}" 
+        ${hideHeader ? 'hideHeader' : ''}
+        ${inline ? 'inline' : ''}>
+    <td-icon-button slot="actionItems" icon="dark_mode"></td-icon-button>
+    <td-icon-button slot="actionItems" icon="content_copy"></td-icon-button>
+    ${content} 
+    </td-code-snippet>`;
+};
+
+export const Basic = Template.bind();
+Basic.args = {
+  language: 'sql',
+  content: sqlContent,
+};
+
+export const Scrollable = Template.bind();
+Scrollable.args = {
+  maxHeight: 250,
+};
+
+export const HiddenHeader = Template.bind();
+HiddenHeader.args = {
+  hideHeader: true,
+};
+
+const TemplateDialog = (...args) => {
+  return `
+    <style>
+    td-code-snippet {
+        margin:8px -24px -36px;
+    }
+    td-code-snippet::part(container) {
+        padding-left: 8px;
+        padding-right: 8px;
+    }
+    td-code-snippet::part(header) {
+        padding-left: 24px;
+    }
+    </style>
+    <td-dialog heading="Lorem ipsum dolor sit amet" open>
+        <td-typography scale="body1">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Tortor consectetur quis velit donec vel integer diam. Nisl pretium egestas ultrices facilisis sed amet et. Odio elementum ut eu magnis at ullamcorper euismod.</td-typography>
+        ${Template(...args)}
+        <td-button outlined slot="primaryAction">Export</td-button>
+        <td-button slot="secondaryAction">Close</td-button>
+    </td-dialog>
+    `;
+};
+export const Dialog = TemplateDialog.bind();
+Dialog.args = {
+  inline: true,
+};
+Dialog.parameters = {
+  docs: {
+    inlineStories: false,
+  },
+};

--- a/libs/components/src/code-snippet/code-snippet.stories.js
+++ b/libs/components/src/code-snippet/code-snippet.stories.js
@@ -77,9 +77,9 @@ const Template = ({
       // listen to DARK_MODE event
       channel.on(DARK_MODE_EVENT_NAME, (darkMode) => {
         if (darkMode) {
-          themeToggle.setAttribute('icon', 'light_mode');
+          themeToggle.setAttribute('icon', 'brightness_high');
         } else {
-          themeToggle.setAttribute('icon', 'dark_mode');
+          themeToggle.setAttribute('icon', 'brightness_4');
         }
       });
 
@@ -90,15 +90,15 @@ const Template = ({
     { once: true }
   );
   return `
-    <td-code-snippet 
+    <td-code-snippet
         label="${label}"
         maxHeight="${maxHeight}"
-        language="${language}" 
+        language="${language}"
         ${hideHeader ? 'hideHeader' : ''}
         ${inline ? 'inline' : ''}>
     <td-icon-button slot="actionItems" id="theme-toggle"></td-icon-button>
     <td-icon-button slot="actionItems" icon="content_copy"></td-icon-button>
-    ${content} 
+    ${content}
     </td-code-snippet>`;
 };
 

--- a/libs/components/src/code-snippet/code-snippet.stories.js
+++ b/libs/components/src/code-snippet/code-snippet.stories.js
@@ -2,6 +2,15 @@ import './code-snippet';
 import '../icon-button/icon-button';
 import '../button/button';
 
+import addons from '@storybook/addons';
+import {
+  DARK_MODE_EVENT_NAME,
+  UPDATE_DARK_MODE_EVENT_NAME,
+} from 'storybook-dark-mode';
+
+// get channel to listen to event emitter
+const channel = addons.getChannel();
+
 const sqlContent = `
 SELECT * FROM load_to_teradata (
     ON (
@@ -29,10 +38,6 @@ export default {
       control: 'boolean',
       defaultValue: false,
     },
-    isDark: {
-      control: 'boolean',
-      defaultValue: false,
-    },
     inline: {
       control: 'boolean',
       defaultValue: false,
@@ -57,7 +62,6 @@ export default {
 };
 
 const Template = ({
-  isDark,
   inline,
   content,
   hideHeader,
@@ -65,15 +69,34 @@ const Template = ({
   language,
   maxHeight,
 }) => {
+  document.addEventListener(
+    'DOMContentLoaded',
+    () => {
+      const themeToggle = document.querySelector('#theme-toggle');
+
+      // listen to DARK_MODE event
+      channel.on(DARK_MODE_EVENT_NAME, (darkMode) => {
+        if (darkMode) {
+          themeToggle.setAttribute('icon', 'light_mode');
+        } else {
+          themeToggle.setAttribute('icon', 'dark_mode');
+        }
+      });
+
+      themeToggle.addEventListener('click', () => {
+        channel.emit(UPDATE_DARK_MODE_EVENT_NAME);
+      });
+    },
+    { once: true }
+  );
   return `
     <td-code-snippet 
         label="${label}"
         maxHeight="${maxHeight}"
         language="${language}" 
-        theme="${isDark ? 'dark' : 'light'}" 
         ${hideHeader ? 'hideHeader' : ''}
         ${inline ? 'inline' : ''}>
-    <td-icon-button slot="actionItems" icon="dark_mode"></td-icon-button>
+    <td-icon-button slot="actionItems" id="theme-toggle"></td-icon-button>
     <td-icon-button slot="actionItems" icon="content_copy"></td-icon-button>
     ${content} 
     </td-code-snippet>`;

--- a/libs/components/src/code-snippet/code-snippet.ts
+++ b/libs/components/src/code-snippet/code-snippet.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, nothing } from 'lit';
+import { LitElement, html } from 'lit';
 import { customElement, property, queryAssignedNodes } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import styles from './code-snippet.scss';
@@ -19,9 +19,6 @@ export class CovalentCodeSnippetBase extends LitElement {
 
   @property()
   label?: string;
-
-  @property()
-  theme: 'light' | 'dark' = 'light';
 
   @property({ type: Boolean, reflect: true })
   inline = false;

--- a/libs/components/src/code-snippet/code-snippet.ts
+++ b/libs/components/src/code-snippet/code-snippet.ts
@@ -1,0 +1,84 @@
+import { LitElement, html, nothing } from 'lit';
+import { customElement, property, queryAssignedNodes } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import styles from './code-snippet.scss';
+import hljs from 'highlight.js';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'td-code-snippet': CovalentCodeSnippetBase;
+  }
+}
+
+@customElement('td-code-snippet')
+export class CovalentCodeSnippetBase extends LitElement {
+  static override styles = [styles];
+
+  @property()
+  language?: string;
+
+  @property()
+  label?: string;
+
+  @property()
+  theme: 'light' | 'dark' = 'light';
+
+  @property({ type: Boolean, reflect: true })
+  inline = false;
+
+  @property({ type: Boolean, reflect: true })
+  hideHeader = false;
+
+  @queryAssignedNodes({})
+  _codeItems!: Array<Node>;
+
+  @property()
+  maxHeight?: number;
+
+  _code = '';
+
+  firstUpdated() {
+    this._codeItems.forEach((codeEl) => {
+      this._code += hljs.highlight(codeEl.textContent ?? '', {
+        language: this.language ?? '',
+      }).value;
+      this.requestUpdate();
+    });
+  }
+
+  override render() {
+    let container = html`${this.renderContainer()}`;
+    if (!this.hideHeader) {
+      container = html`${this.renderHeader()}${this.renderContainer()}`;
+    }
+    return container;
+  }
+
+  renderContainer() {
+    const classes: { [key: string]: boolean } = {
+      'td-code-snippet': true,
+      hljs: true,
+      inline: this.inline,
+    };
+    classes[`language-${this.language}`] = true;
+    const container = document.createElement('div');
+    container.innerHTML = this._code ? this._code.trim() : '<slot></slot>';
+
+    let styleHeight;
+    if (this.maxHeight && this.maxHeight > 0) {
+      styleHeight = `max-height: ${this.maxHeight}px`;
+    }
+
+    return html`<pre
+      style="${styleHeight}"
+      part="container"
+    ><code class="${classMap(classes)}">${container}</code></pre>`;
+  }
+
+  renderHeader() {
+    return html`<div class="header" part="header">
+      <div class="title">${this.label}</div>
+      <span><slot name="actionItems"></slot></span>
+    </div>`;
+  }
+}

--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -5,6 +5,7 @@ export * from './button/button';
 export * from './checkbox/checkbox';
 export * from './card/card';
 export * from './circular-progress/circular-progress';
+export * from './code-snippet/code-snippet';
 export * from './dialog/dialog';
 export * from './drawer/drawer';
 export * from './empty-state/empty-state';

--- a/libs/components/theme/_mixins.scss
+++ b/libs/components/theme/_mixins.scss
@@ -321,6 +321,17 @@
   --mdc-shape-small: 8px;
   --mdc-shape-medium: 8px;
 
+  // Code snippet colors
+  --cov-theme-code-snippet-color: #{map-get($theme, code-snippet-color)};
+  --cov-theme-code-snippet-comment: #{map-get($theme, code-snippet-comment)};
+  --cov-theme-code-snippet-keyword: #{map-get($theme, code-snippet-keyword)};
+  --cov-theme-code-snippet-selector: #{map-get($theme, code-snippet-selector)};
+  --cov-theme-code-snippet-literal: #{map-get($theme, code-snippet-literal)};
+  --cov-theme-code-snippet-string: #{map-get($theme, code-snippet-string)};
+  --cov-theme-code-snippet-variable: #{map-get($theme, code-snippet-variable)};
+  --cov-theme-code-snippet-title: #{map-get($theme, code-snippet-title)};
+  --cov-theme-code-snippet-class: #{map-get($theme, code-snippet-class)};
+
   @include button.button-theme($theme);
   @include card.card-theme($theme);
   @include checkbox.checkbox-theme($theme);

--- a/libs/components/theme/theme.scss
+++ b/libs/components/theme/theme.scss
@@ -7,7 +7,7 @@
 @include skeleton.core-styles(); // TODO - should include support
 
 // TODO should be moved to consuming app - DOCS NEEDED
-:root {
+.light {
   @include theme.components-theme(
     map-get(variables.$tokens, light),
     map-get(variables.$tokens, typography)
@@ -17,13 +17,6 @@
 .dark {
   @include theme.components-theme(
     map-get(variables.$tokens, dark),
-    map-get(variables.$tokens, typography)
-  );
-}
-
-.light {
-  @include theme.components-theme(
-    map-get(variables.$tokens, light),
     map-get(variables.$tokens, typography)
   );
 }

--- a/libs/components/webpack.config.js
+++ b/libs/components/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
     checkbox: './libs/components/src/checkbox/checkbox.ts',
     circularProgress:
       './libs/components/src/circular-progress/circular-progress.ts',
+    codeSnippet: './libs/components/src/code-snippet/code-snippet.ts',
     dialog: './libs/components/src/dialog/dialog.ts',
     drawer: './libs/components/src/drawer/drawer.ts',
     emptyState: './libs/components/src/empty-state/empty-state.ts',

--- a/libs/tokens/build/css/variables.css
+++ b/libs/tokens/build/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 28 Sep 2022 18:22:21 GMT
+ * Generated on Wed, 30 Nov 2022 18:07:44 GMT
  */
 
 :root {
@@ -18,6 +18,15 @@
   --td-light-divider: rgba(0, 0, 0, 0.12);
   --td-light-emphasis: #546e7a;
   --td-light-accent: #007373;
+  --td-light-code-snippet-color: #383a42;
+  --td-light-code-snippet-comment: #a0a1a7;
+  --td-light-code-snippet-keyword: #a626a4;
+  --td-light-code-snippet-selector: #e45649;
+  --td-light-code-snippet-literal: #0184bb;
+  --td-light-code-snippet-string: #50a14f;
+  --td-light-code-snippet-variable: #986801;
+  --td-light-code-snippet-title: #4078f2;
+  --td-light-code-snippet-class: #c18401;
   --td-light-background: #f5f5f5;
   --td-light-surface: white;
   --td-light-surface-canvas: #eee;
@@ -56,7 +65,7 @@
   --td-light-text-hint-on-light: rgba(0, 0, 0, 0.38);
   --td-light-text-disabled-on-light: rgba(0, 0, 0, 0.38);
   --td-light-text-icon-on-light: rgba(0, 0, 0, 0.54);
-  --td-light-text-primary-on-dark: 255, 255, 255;
+  --td-light-text-primary-on-dark: white;
   --td-light-text-secondary-on-dark: rgba(255, 255, 255, 0.7);
   --td-light-text-hint-on-dark: rgba(255, 255, 255, 0.5);
   --td-light-text-disabled-on-dark: rgba(255, 255, 255, 0.5);
@@ -75,6 +84,15 @@
   --td-dark-divider: rgba(255, 255, 255, 0.2);
   --td-dark-emphasis: #b0bec5;
   --td-dark-accent: #59cecd;
+  --td-dark-code-snippet-color: #abb2bf;
+  --td-dark-code-snippet-comment: #5c6370;
+  --td-dark-code-snippet-keyword: #c678dd;
+  --td-dark-code-snippet-selector: #e06c75;
+  --td-dark-code-snippet-literal: #56b6c2;
+  --td-dark-code-snippet-string: #98c379;
+  --td-dark-code-snippet-variable: #d19a66;
+  --td-dark-code-snippet-title: #61aeee;
+  --td-dark-code-snippet-class: #e6c07b;
   --td-dark-background: #161c1f;
   --td-dark-surface: #28353b;
   --td-dark-surface-canvas: #101314;

--- a/libs/tokens/build/js/variables.d.ts
+++ b/libs/tokens/build/js/variables.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 28 Sep 2022 18:22:21 GMT
+ * Generated on Wed, 30 Nov 2022 18:07:44 GMT
  */
 
 export const TdLightPrimary: string;
@@ -17,6 +17,15 @@ export const TdLightOnError: string;
 export const TdLightDivider: string;
 export const TdLightEmphasis: string;
 export const TdLightAccent: string;
+export const TdLightCodeSnippetColor: string;
+export const TdLightCodeSnippetComment: string;
+export const TdLightCodeSnippetKeyword: string;
+export const TdLightCodeSnippetSelector: string;
+export const TdLightCodeSnippetLiteral: string;
+export const TdLightCodeSnippetString: string;
+export const TdLightCodeSnippetVariable: string;
+export const TdLightCodeSnippetTitle: string;
+export const TdLightCodeSnippetClass: string;
 export const TdLightBackground: string;
 export const TdLightSurface: string;
 export const TdLightSurfaceCanvas: string;
@@ -74,6 +83,15 @@ export const TdDarkOnError: string;
 export const TdDarkDivider: string;
 export const TdDarkEmphasis: string;
 export const TdDarkAccent: string;
+export const TdDarkCodeSnippetColor: string;
+export const TdDarkCodeSnippetComment: string;
+export const TdDarkCodeSnippetKeyword: string;
+export const TdDarkCodeSnippetSelector: string;
+export const TdDarkCodeSnippetLiteral: string;
+export const TdDarkCodeSnippetString: string;
+export const TdDarkCodeSnippetVariable: string;
+export const TdDarkCodeSnippetTitle: string;
+export const TdDarkCodeSnippetClass: string;
 export const TdDarkBackground: string;
 export const TdDarkSurface: string;
 export const TdDarkSurfaceCanvas: string;

--- a/libs/tokens/build/js/variables.js
+++ b/libs/tokens/build/js/variables.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 28 Sep 2022 18:22:21 GMT
+ * Generated on Wed, 30 Nov 2022 18:07:44 GMT
  */
 
 export const TdLightPrimary = '#007373';
@@ -17,6 +17,15 @@ export const TdLightOnError = 'white';
 export const TdLightDivider = 'rgba(0, 0, 0, 0.12)';
 export const TdLightEmphasis = '#546e7a';
 export const TdLightAccent = '#007373';
+export const TdLightCodeSnippetColor = '#383a42';
+export const TdLightCodeSnippetComment = '#a0a1a7';
+export const TdLightCodeSnippetKeyword = '#a626a4';
+export const TdLightCodeSnippetSelector = '#e45649';
+export const TdLightCodeSnippetLiteral = '#0184bb';
+export const TdLightCodeSnippetString = '#50a14f';
+export const TdLightCodeSnippetVariable = '#986801';
+export const TdLightCodeSnippetTitle = '#4078f2';
+export const TdLightCodeSnippetClass = '#c18401';
 export const TdLightBackground = '#f5f5f5';
 export const TdLightSurface = 'white';
 export const TdLightSurfaceCanvas = '#eee';
@@ -55,7 +64,7 @@ export const TdLightTextSecondaryOnLight = 'rgba(0, 0, 0, 0.54)';
 export const TdLightTextHintOnLight = 'rgba(0, 0, 0, 0.38)';
 export const TdLightTextDisabledOnLight = 'rgba(0, 0, 0, 0.38)';
 export const TdLightTextIconOnLight = 'rgba(0, 0, 0, 0.54)';
-export const TdLightTextPrimaryOnDark = '255, 255, 255';
+export const TdLightTextPrimaryOnDark = 'white';
 export const TdLightTextSecondaryOnDark = 'rgba(255, 255, 255, 0.7)';
 export const TdLightTextHintOnDark = 'rgba(255, 255, 255, 0.5)';
 export const TdLightTextDisabledOnDark = 'rgba(255, 255, 255, 0.5)';
@@ -74,6 +83,15 @@ export const TdDarkOnError = 'rgba(0, 0, 0, 0.87)';
 export const TdDarkDivider = 'rgba(255, 255, 255, 0.2)';
 export const TdDarkEmphasis = '#b0bec5';
 export const TdDarkAccent = '#59cecd';
+export const TdDarkCodeSnippetColor = '#abb2bf';
+export const TdDarkCodeSnippetComment = '#5c6370';
+export const TdDarkCodeSnippetKeyword = '#c678dd';
+export const TdDarkCodeSnippetSelector = '#e06c75';
+export const TdDarkCodeSnippetLiteral = '#56b6c2';
+export const TdDarkCodeSnippetString = '#98c379';
+export const TdDarkCodeSnippetVariable = '#d19a66';
+export const TdDarkCodeSnippetTitle = '#61aeee';
+export const TdDarkCodeSnippetClass = '#e6c07b';
 export const TdDarkBackground = '#161c1f';
 export const TdDarkSurface = '#28353b';
 export const TdDarkSurfaceCanvas = '#101314';

--- a/libs/tokens/build/json/variables.json
+++ b/libs/tokens/build/json/variables.json
@@ -224,6 +224,150 @@
       },
       "path": ["light", "accent"]
     },
+    "code-snippet-color": {
+      "value": "#383a42",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#383a42",
+        "type": "color"
+      },
+      "name": "code-snippet-color",
+      "attributes": {
+        "category": "light",
+        "type": "code-snippet-color"
+      },
+      "path": ["light", "code-snippet-color"]
+    },
+    "code-snippet-comment": {
+      "value": "#a0a1a7",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#a0a1a7",
+        "type": "color"
+      },
+      "name": "code-snippet-comment",
+      "attributes": {
+        "category": "light",
+        "type": "code-snippet-comment"
+      },
+      "path": ["light", "code-snippet-comment"]
+    },
+    "code-snippet-keyword": {
+      "value": "#a626a4",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#a626a4",
+        "type": "color"
+      },
+      "name": "code-snippet-keyword",
+      "attributes": {
+        "category": "light",
+        "type": "code-snippet-keyword"
+      },
+      "path": ["light", "code-snippet-keyword"]
+    },
+    "code-snippet-selector": {
+      "value": "#e45649",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#e45649",
+        "type": "color"
+      },
+      "name": "code-snippet-selector",
+      "attributes": {
+        "category": "light",
+        "type": "code-snippet-selector"
+      },
+      "path": ["light", "code-snippet-selector"]
+    },
+    "code-snippet-literal": {
+      "value": "#0184bb",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#0184bb",
+        "type": "color"
+      },
+      "name": "code-snippet-literal",
+      "attributes": {
+        "category": "light",
+        "type": "code-snippet-literal"
+      },
+      "path": ["light", "code-snippet-literal"]
+    },
+    "code-snippet-string": {
+      "value": "#50a14f",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#50a14f",
+        "type": "color"
+      },
+      "name": "code-snippet-string",
+      "attributes": {
+        "category": "light",
+        "type": "code-snippet-string"
+      },
+      "path": ["light", "code-snippet-string"]
+    },
+    "code-snippet-variable": {
+      "value": "#986801",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#986801",
+        "type": "color"
+      },
+      "name": "code-snippet-variable",
+      "attributes": {
+        "category": "light",
+        "type": "code-snippet-variable"
+      },
+      "path": ["light", "code-snippet-variable"]
+    },
+    "code-snippet-title": {
+      "value": "#4078f2",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#4078f2",
+        "type": "color"
+      },
+      "name": "code-snippet-title",
+      "attributes": {
+        "category": "light",
+        "type": "code-snippet-title"
+      },
+      "path": ["light", "code-snippet-title"]
+    },
+    "code-snippet-class": {
+      "value": "#c18401",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#c18401",
+        "type": "color"
+      },
+      "name": "code-snippet-class",
+      "attributes": {
+        "category": "light",
+        "type": "code-snippet-class"
+      },
+      "path": ["light", "code-snippet-class"]
+    },
     "background": {
       "value": "#f5f5f5",
       "type": "color",
@@ -833,12 +977,12 @@
       "path": ["light", "text-icon-on-light"]
     },
     "text-primary-on-dark": {
-      "value": "255, 255, 255",
+      "value": "white",
       "type": "color",
       "filePath": "src/color/text.json",
       "isSource": true,
       "original": {
-        "value": "255, 255, 255",
+        "value": "white",
         "type": "color"
       },
       "name": "text-primary-on-dark",
@@ -1137,6 +1281,150 @@
         "type": "accent"
       },
       "path": ["dark", "accent"]
+    },
+    "code-snippet-color": {
+      "value": "#abb2bf",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#abb2bf",
+        "type": "color"
+      },
+      "name": "code-snippet-color",
+      "attributes": {
+        "category": "dark",
+        "type": "code-snippet-color"
+      },
+      "path": ["dark", "code-snippet-color"]
+    },
+    "code-snippet-comment": {
+      "value": "#5c6370",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#5c6370",
+        "type": "color"
+      },
+      "name": "code-snippet-comment",
+      "attributes": {
+        "category": "dark",
+        "type": "code-snippet-comment"
+      },
+      "path": ["dark", "code-snippet-comment"]
+    },
+    "code-snippet-keyword": {
+      "value": "#c678dd",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#c678dd",
+        "type": "color"
+      },
+      "name": "code-snippet-keyword",
+      "attributes": {
+        "category": "dark",
+        "type": "code-snippet-keyword"
+      },
+      "path": ["dark", "code-snippet-keyword"]
+    },
+    "code-snippet-selector": {
+      "value": "#e06c75",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#e06c75",
+        "type": "color"
+      },
+      "name": "code-snippet-selector",
+      "attributes": {
+        "category": "dark",
+        "type": "code-snippet-selector"
+      },
+      "path": ["dark", "code-snippet-selector"]
+    },
+    "code-snippet-literal": {
+      "value": "#56b6c2",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#56b6c2",
+        "type": "color"
+      },
+      "name": "code-snippet-literal",
+      "attributes": {
+        "category": "dark",
+        "type": "code-snippet-literal"
+      },
+      "path": ["dark", "code-snippet-literal"]
+    },
+    "code-snippet-string": {
+      "value": "#98c379",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#98c379",
+        "type": "color"
+      },
+      "name": "code-snippet-string",
+      "attributes": {
+        "category": "dark",
+        "type": "code-snippet-string"
+      },
+      "path": ["dark", "code-snippet-string"]
+    },
+    "code-snippet-variable": {
+      "value": "#d19a66",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#d19a66",
+        "type": "color"
+      },
+      "name": "code-snippet-variable",
+      "attributes": {
+        "category": "dark",
+        "type": "code-snippet-variable"
+      },
+      "path": ["dark", "code-snippet-variable"]
+    },
+    "code-snippet-title": {
+      "value": "#61aeee",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#61aeee",
+        "type": "color"
+      },
+      "name": "code-snippet-title",
+      "attributes": {
+        "category": "dark",
+        "type": "code-snippet-title"
+      },
+      "path": ["dark", "code-snippet-title"]
+    },
+    "code-snippet-class": {
+      "value": "#e6c07b",
+      "type": "color",
+      "filePath": "src/color/code.json",
+      "isSource": true,
+      "original": {
+        "value": "#e6c07b",
+        "type": "color"
+      },
+      "name": "code-snippet-class",
+      "attributes": {
+        "category": "dark",
+        "type": "code-snippet-class"
+      },
+      "path": ["dark", "code-snippet-class"]
     },
     "background": {
       "value": "#161c1f",

--- a/libs/tokens/build/scss/_variables.scss
+++ b/libs/tokens/build/scss/_variables.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 28 Sep 2022 18:22:21 GMT
+ * Generated on Wed, 30 Nov 2022 18:07:44 GMT
  */
 
 $light-primary: #007373 !default;
@@ -17,6 +17,15 @@ $light-on-error: white !default;
 $light-divider: rgba(0, 0, 0, 0.12) !default;
 $light-emphasis: #546e7a !default;
 $light-accent: #007373 !default;
+$light-code-snippet-color: #383a42 !default;
+$light-code-snippet-comment: #a0a1a7 !default;
+$light-code-snippet-keyword: #a626a4 !default;
+$light-code-snippet-selector: #e45649 !default;
+$light-code-snippet-literal: #0184bb !default;
+$light-code-snippet-string: #50a14f !default;
+$light-code-snippet-variable: #986801 !default;
+$light-code-snippet-title: #4078f2 !default;
+$light-code-snippet-class: #c18401 !default;
 $light-background: #f5f5f5 !default;
 $light-surface: white !default;
 $light-surface-canvas: #eee !default;
@@ -55,7 +64,7 @@ $light-text-secondary-on-light: rgba(0, 0, 0, 0.54) !default;
 $light-text-hint-on-light: rgba(0, 0, 0, 0.38) !default;
 $light-text-disabled-on-light: rgba(0, 0, 0, 0.38) !default;
 $light-text-icon-on-light: rgba(0, 0, 0, 0.54) !default;
-$light-text-primary-on-dark: 255, 255, 255 !default;
+$light-text-primary-on-dark: white !default;
 $light-text-secondary-on-dark: rgba(255, 255, 255, 0.7) !default;
 $light-text-hint-on-dark: rgba(255, 255, 255, 0.5) !default;
 $light-text-disabled-on-dark: rgba(255, 255, 255, 0.5) !default;
@@ -74,6 +83,15 @@ $dark-on-error: rgba(0, 0, 0, 0.87) !default;
 $dark-divider: rgba(255, 255, 255, 0.2) !default;
 $dark-emphasis: #b0bec5 !default;
 $dark-accent: #59cecd !default;
+$dark-code-snippet-color: #abb2bf !default;
+$dark-code-snippet-comment: #5c6370 !default;
+$dark-code-snippet-keyword: #c678dd !default;
+$dark-code-snippet-selector: #e06c75 !default;
+$dark-code-snippet-literal: #56b6c2 !default;
+$dark-code-snippet-string: #98c379 !default;
+$dark-code-snippet-variable: #d19a66 !default;
+$dark-code-snippet-title: #61aeee !default;
+$dark-code-snippet-class: #e6c07b !default;
 $dark-background: #161c1f !default;
 $dark-surface: #28353b !default;
 $dark-surface-canvas: #101314 !default;
@@ -479,6 +497,15 @@ $tokens: (
     'divider': $light-divider,
     'emphasis': $light-emphasis,
     'accent': $light-accent,
+    'code-snippet-color': $light-code-snippet-color,
+    'code-snippet-comment': $light-code-snippet-comment,
+    'code-snippet-keyword': $light-code-snippet-keyword,
+    'code-snippet-selector': $light-code-snippet-selector,
+    'code-snippet-literal': $light-code-snippet-literal,
+    'code-snippet-string': $light-code-snippet-string,
+    'code-snippet-variable': $light-code-snippet-variable,
+    'code-snippet-title': $light-code-snippet-title,
+    'code-snippet-class': $light-code-snippet-class,
     'background': $light-background,
     'surface': $light-surface,
     'surface-canvas': $light-surface-canvas,
@@ -539,6 +566,15 @@ $tokens: (
     'divider': $dark-divider,
     'emphasis': $dark-emphasis,
     'accent': $dark-accent,
+    'code-snippet-color': $dark-code-snippet-color,
+    'code-snippet-comment': $dark-code-snippet-comment,
+    'code-snippet-keyword': $dark-code-snippet-keyword,
+    'code-snippet-selector': $dark-code-snippet-selector,
+    'code-snippet-literal': $dark-code-snippet-literal,
+    'code-snippet-string': $dark-code-snippet-string,
+    'code-snippet-variable': $dark-code-snippet-variable,
+    'code-snippet-title': $dark-code-snippet-title,
+    'code-snippet-class': $dark-code-snippet-class,
     'background': $dark-background,
     'surface': $dark-surface,
     'surface-canvas': $dark-surface-canvas,

--- a/libs/tokens/src/color/code.json
+++ b/libs/tokens/src/color/code.json
@@ -1,0 +1,24 @@
+{
+  "light": {
+    "code-snippet-color": { "value": "#383a42", "type": "color" },
+    "code-snippet-comment": { "value": "#a0a1a7", "type": "color" },
+    "code-snippet-keyword": { "value": "#a626a4", "type": "color" },
+    "code-snippet-selector": { "value": "#e45649", "type": "color" },
+    "code-snippet-literal": { "value": "#0184bb", "type": "color" },
+    "code-snippet-string": { "value": "#50a14f", "type": "color" },
+    "code-snippet-variable": { "value": "#986801", "type": "color" },
+    "code-snippet-title": { "value": "#4078f2", "type": "color" },
+    "code-snippet-class": { "value": "#c18401", "type": "color" }
+  },
+  "dark": {
+    "code-snippet-color": { "value": "#abb2bf", "type": "color" },
+    "code-snippet-comment": { "value": "#5c6370", "type": "color" },
+    "code-snippet-keyword": { "value": "#c678dd", "type": "color" },
+    "code-snippet-selector": { "value": "#e06c75", "type": "color" },
+    "code-snippet-literal": { "value": "#56b6c2", "type": "color" },
+    "code-snippet-string": { "value": "#98c379", "type": "color" },
+    "code-snippet-variable": { "value": "#d19a66", "type": "color" },
+    "code-snippet-title": { "value": "#61aeee", "type": "color" },
+    "code-snippet-class": { "value": "#e6c07b", "type": "color" }
+  }
+}

--- a/libs/tokens/src/color/text.json
+++ b/libs/tokens/src/color/text.json
@@ -35,7 +35,7 @@
       "type": "color"
     },
     "text-icon-on-light": { "value": "rgba(0, 0, 0, 0.54)", "type": "color" },
-    "text-primary-on-dark": { "value": "255, 255, 255", "type": "color" },
+    "text-primary-on-dark": { "value": "white", "type": "color" },
     "text-secondary-on-dark": {
       "value": "rgba(255, 255, 255, 0.7)",
       "type": "color"


### PR DESCRIPTION
## Description

Adding Code snippet web component to the web component library


Figma (needs td login)
https://www.figma.com/file/4qn8W9GCuhyNxEMBhMeahz/Code-samples?node-id=0%3A1&t=Rs15lTIuTGzTzrxQ-1


### What's included?

- Adding code snippet using [highlight.js](https://highlightjs.org/)
- Supports the common [34](https://highlightjs.org/static/demo) languages 
- Uses atom one light and dark theme
- Supports adding a title in the header and a slot for action

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npx run components:storybook`
- [ ] then wait for the browser window open
- [ ] finally navigate to the code snipppets story

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![code-snippet](https://user-images.githubusercontent.com/3837706/204646599-e40f6c1e-dda0-4f63-a015-2cc2ad6bbc7b.gif)
