### PR TITLE
feat(components): adding text lockup component

### DIFF
--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -34,6 +34,7 @@ export * from './tab/tab';
 export * from './tab/tab-bar';
 export * from './textarea/textarea';
 export * from './textfield/textfield';
+export * from './text-lockup/text-lockup';
 export * from './toolbar/toolbar';
 export * from './top-app-bar/top-app-bar';
 export * from './top-app-bar/top-app-bar-fixed';

--- a/libs/components/src/text-lockup/text-lockup.scss
+++ b/libs/components/src/text-lockup/text-lockup.scss
@@ -1,0 +1,66 @@
+.subtext--trailing {
+  display: flex;
+  flex-direction: column-reverse;
+}
+
+.subtext {
+  display: flex;
+  align-items: center;
+
+  --mdc-icon-size: 16px;
+
+  color: var(--mdc-theme-text-secondary-on-background);
+  font-family: var(--mdc-typography-caption-font-family);
+  font-size: var(--mdc-typography-caption-font-size);
+  font-weight: var(--mdc-typography-caption-font-weight);
+  line-height: var(--mdc-typography-caption-line-height);
+  margin-bottom: 2px;
+
+  td-icon {
+    margin-right: 8px;
+  }
+}
+
+slot {
+  font-family: var(--mdc-typography-body1-font-family);
+  font-size: var(--mdc-typography-body1-font-size);
+  font-weight: var(--mdc-typography-body1-font-weight);
+  line-height: var(--mdc-typography-body1-line-height);
+  margin-bottom: 8px;
+}
+
+.scale--large {
+  .subtext {
+    --mdc-icon-size: 24px;
+
+    font-family: var(--mdc-typography-body1-font-family);
+    font-size: var(--mdc-typography-body1-font-size);
+    font-weight: var(--mdc-typography-body1-font-weight);
+    line-height: var(--mdc-typography-body1-line-height);
+    margin-bottom: 2px;
+  }
+
+  slot {
+    font-family: var(--mdc-typography-headline4-font-family);
+    font-size: var(--mdc-typography-headline4-font-size);
+    font-weight: var(--mdc-typography-headline4-font-weight);
+    line-height: var(--mdc-typography-headline4-line-height);
+    margin-bottom: 8px;
+  }
+}
+
+.subtext-state--positive .subtext {
+  color: var(--mdc-theme-positive);
+}
+
+.subtext-state--negative .subtext {
+  color: var(--mdc-theme-negative);
+}
+
+.subtext-state--caution .subtext {
+  color: var(--mdc-theme-caution);
+}
+
+.subtext-state--active .subtext {
+  color: var(--mdc-theme-accent);
+}

--- a/libs/components/src/text-lockup/text-lockup.spec.ts
+++ b/libs/components/src/text-lockup/text-lockup.spec.ts
@@ -1,0 +1,7 @@
+import { CovalentTextLockup } from './text-lockup';
+
+describe('Text lockup', () => {
+  it('should work', () => {
+    expect(new CovalentTextLockup()).toBeDefined();
+  });
+});

--- a/libs/components/src/text-lockup/text-lockup.stories.js
+++ b/libs/components/src/text-lockup/text-lockup.stories.js
@@ -1,0 +1,74 @@
+import './text-lockup';
+import iconList from '../../../icons/material-codepoints.json';
+
+const MAT_ICON_LIST = Object.keys(iconList);
+
+export default {
+  title: 'Components/Text lockup',
+  argTypes: {
+    scale: {
+      options: ['large', 'small'],
+      control: { type: 'radio' },
+      defaultValue: 'small',
+    },
+    text: {
+      control: 'text',
+      defaultValue: 'TDICAM-8523411',
+    },
+    icon: {
+      options: MAT_ICON_LIST,
+      control: { type: 'select' },
+    },
+    subText: {
+      control: 'text',
+      defaultValue: 'environment Id',
+    },
+    subTextState: {
+      options: ['active', 'positive', 'negative', 'caution'],
+      control: { type: 'select' },
+    },
+    subTextTrailing: {
+      control: 'boolean',
+      defaultValue: false,
+    },
+  },
+};
+
+export const textLockup = ({
+  icon,
+  scale,
+  subText,
+  subTextState,
+  subTextTrailing,
+  text,
+}) => {
+  return `
+    <td-text-lockup
+      subtext="${subText}"
+      scale="${scale}"
+      ${icon ? `icon="${icon}"` : ''}
+      ${subTextState ? `state="${subTextState}"` : ''}
+      ${subTextTrailing ? 'trailingSubText' : ''}>${text}</td-text-lockup>
+  `;
+};
+
+export const textLockupLarge = textLockup.bind({});
+textLockupLarge.args = {
+  scale: 'large',
+};
+
+export const textLockupTrailing = textLockup.bind({});
+textLockupTrailing.args = {
+  text: 'Jan 12th, 2022 at 5:10pm',
+  subText: 'Date last ran successfully',
+  subTextTrailing: true,
+};
+
+export const textLockupWithIcon = textLockup.bind({});
+textLockupWithIcon.args = {
+  icon: 'warning',
+  text: 'Daily production backup job',
+  subText: 'completed with issues',
+  subTextState: 'caution',
+  subTextTrailing: true,
+};

--- a/libs/components/src/text-lockup/text-lockup.ts
+++ b/libs/components/src/text-lockup/text-lockup.ts
@@ -1,0 +1,49 @@
+import { html, LitElement, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import styles from './text-lockup.scss';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'td-text-lockup': CovalentTextLockup;
+  }
+}
+
+@customElement('td-text-lockup')
+export class CovalentTextLockup extends LitElement {
+  static override styles = [styles];
+
+  @property()
+  subText!: string;
+
+  @property()
+  icon?: string;
+
+  @property()
+  state?: 'active' | 'positive' | 'negative' | 'caution';
+
+  @property()
+  scale: 'large' | 'small' = 'small';
+
+  @property({ type: Boolean, reflect: true })
+  trailingSubText = false;
+
+  override render() {
+    const classes: { [key: string]: boolean } = {
+      'subtext--trailing': this.trailingSubText,
+    };
+    classes[`scale--${this.scale}`] = true;
+
+    if (this.state) {
+      classes[`subtext-state--${this.state}`] = true;
+    }
+    return html`<span class="${classMap(classes)}"
+      ><span class="subtext">${this.renderIcon()}${this.subText}</span
+      ><slot></slot
+    ></span>`;
+  }
+
+  renderIcon() {
+    return this.icon ? html`<td-icon>${this.icon}</td-icon>` : nothing;
+  }
+}

--- a/libs/components/webpack.config.js
+++ b/libs/components/webpack.config.js
@@ -45,6 +45,7 @@ module.exports = {
     tabBar: './libs/components/src/tab/tab-bar.ts',
     textArea: './libs/components/src/textarea/textarea.ts',
     textField: './libs/components/src/textfield/textfield.ts',
+    textLockup: './libs/components/src/text-lockup/text-lockup.ts',
     toolbar: './libs/components/src/toolbar/toolbar.ts',
     topAppBar: './libs/components/src/top-app-bar/top-app-bar.ts',
     topAppBarFixed: './libs/components/src/top-app-bar/top-app-bar-fixed.ts',


### PR DESCRIPTION
## Description

Adding text lock up component to display basic key value text anywhere

_**Using visuals pulled from this [figma](https://www.figma.com/file/ltYM4aeDULd3ec6Sd8Xvpk/Typography?node-id=2233%3A1034) (not official) **_
### What's included?

- Text lockup component with support for small and large scale
- Icon support for subtext
- State support for `active, positive, negative, caution`
- Trailing subtext support for to see the subtext on the bottom of the main text 

#### Test Steps

- [ ] `npx nx run components:storybook`
- [ ] then locate the text lockup story under Components -> Text lockup
- [ ] finally test the different storys and parameters configured

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

![text-lockup](https://user-images.githubusercontent.com/3837706/205680633-09c8c594-9f5e-4bb1-b851-5912ef07222d.gif)
