### PR TITLE
fix(component): add tooltips to show cut-off text in User Profile Component

### DIFF
--- a/libs/angular/user-profile/src/user-profile-menu/user-profile-menu.component.html
+++ b/libs/angular/user-profile/src/user-profile-menu/user-profile-menu.component.html
@@ -3,8 +3,10 @@
   <mat-list td-menu-header>
     <mat-list-item *ngIf="name || email" (click)="_blockEvent($event)">
       <mat-icon matListAvatar>person</mat-icon>
-      <span matLine *ngIf="name" class="mat-body-1">{{ name }}</span>
-      <span matLine *ngIf="email">{{ email }}</span>
+      <span [matTooltip]="name" matLine *ngIf="name" class="mat-body-1">{{
+        name
+      }}</span>
+      <span [matTooltip]="email" matLine *ngIf="email">{{ email }}</span>
     </mat-list-item>
     <ng-content select="[td-user-info-list]"></ng-content>
   </mat-list>

--- a/libs/angular/user-profile/src/user-profile.module.ts
+++ b/libs/angular/user-profile/src/user-profile.module.ts
@@ -8,6 +8,7 @@ import { MatListModule } from '@angular/material/list';
 import { TdUserProfileMenuComponent } from './user-profile-menu/user-profile-menu.component';
 import { TdUserProfileComponent } from './user-profile.component';
 import { CovalentMenuModule } from '@covalent/core/menu';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [TdUserProfileComponent, TdUserProfileMenuComponent],
@@ -18,6 +19,7 @@ import { CovalentMenuModule } from '@covalent/core/menu';
     MatButtonModule,
     MatListModule,
     CovalentMenuModule,
+    MatTooltipModule,
   ],
   providers: [],
   exports: [TdUserProfileComponent, TdUserProfileMenuComponent],


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- added tooltips to show complete text when hovering on email & names to fix text cut-off issue.
- imported & declared matToolTipModule to use inside user-profile component

### What's included?

<!-- List features included in this PR -->

- Show the complete email using tooltip on hovering the displayed email in user-profile component.
- Show the complete name using tooltip on hovering the displayed namein user-profile component.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [x] `npm run start`
- [x] Add a really long email or name to the user profile component demo
- [x] Click on 'Open profile'
- [x] Hover over the cut off email or name
- [x] You can view the tooltip

Screenshot: 
![ss](https://user-images.githubusercontent.com/74547936/220660961-30353c87-94b9-4e1f-a9e4-9f3e366c7da6.png)
