### PR TITLE
fix(components): adjusted import location of scss theme file

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,6 +16,8 @@ jobs:
   chromatic-deployment:
     # Operating System
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
     # Job steps
     steps:
       # 👇 Version 2 of the action

--- a/libs/components/.storybook/main.js
+++ b/libs/components/.storybook/main.js
@@ -6,7 +6,11 @@ const { mergeConfig } = require('vite');
   (rootMain.core = { builder: '@storybook/builder-vite' });
 module.exports = {
   ...rootMain,
-  async viteFinal(config) {
+  async viteFinal(config, { configType }) {
+    if (configType === 'PRODUCTION') {
+      // Set base URL for where it will be served in production
+      config.base = './';
+    }
     // Merge custom configuration into the default config
     return mergeConfig(config, {
       //root: '../../',

--- a/libs/components/.storybook/preview-head.html
+++ b/libs/components/.storybook/preview-head.html
@@ -11,11 +11,7 @@
   href="https://cdn.jsdelivr.net/npm/@covalent/components@4.12.2/icons/covalent-icons.css"
   rel="stylesheet"
 />
-<!-- Required styles for Covalent themes -->
-<link
-  href="../theme/theme.scss"
-  rel="stylesheet"
-/>
+
 <script>
   window.global = window;
   window.process = {

--- a/libs/components/.storybook/preview.js
+++ b/libs/components/.storybook/preview.js
@@ -2,6 +2,9 @@ import anysort from 'anysort';
 
 import { parameters as mainParameters } from '../../../.storybook/preview';
 
+import '../theme/theme.scss';
+import '../../../.storybook/theme/markdown-elements.scss';
+
 export const parameters = {
   options: {
     storySort: (previous, next) => {

--- a/libs/components/src/snackbar/snackbar.scss
+++ b/libs/components/src/snackbar/snackbar.scss
@@ -1,5 +1,4 @@
 :host {
-
   --mdc-snackbar-action-color: var(--mdc-theme-text-primary-on-dark);
 
   ::slotted(cv-icon-button) {


### PR DESCRIPTION
## Description

Fixing the import path of the theme file for the components storybook preview. 

Note: see the broken css here https://teradata.github.io/covalent/docs/components/

#### Test Steps

- [ ] `npm run storybook`
- [ ] then wait for the browser window to pop open
- [ ] then observe that css now looks correct

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
