### PR TITLE
fix(components): build fix for components not publishing to npm

### DIFF
--- a/libs/components/project.json
+++ b/libs/components/project.json
@@ -8,7 +8,8 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          "vite build --config libs/components/vite.config.js  --outDir dist/libs/components"
+          "vite build --config libs/components/vite.config.js  --outDir dist/libs/components",
+          "cp libs/components/package.json dist/libs/components"
         ],
         "parallel": false,
         "outputPath": "dist/libs/components"


### PR DESCRIPTION
## Description

Vite was not copying the package.json asset like was webpack before.

Adding basic step to copy package.json into dist folder after building so npm knows to publish this directory