### PR TITLE
fix(components): adding back ts declaration files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -2,7 +2,14 @@
   "name": "@covalent/components",
   "version": "0.0.0-COVALENT",
   "description": "a catalog of material components for covalent",
-  "main": "index.js",
+  "main": "covalent.umd.js",
+  "module": "covalent.mjs",
+  "exports": {
+    ".": {
+      "import": "./covalent.js",
+      "require": "./covalent.umd.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/teradata/covalent.git"

--- a/libs/components/project.json
+++ b/libs/components/project.json
@@ -9,6 +9,7 @@
       "options": {
         "commands": [
           "vite build --config libs/components/vite.config.js  --outDir dist/libs/components",
+          "./node_modules/.bin/tsc --project libs/components/tsconfig.lib.json  --declaration --declarationMap --emitDeclarationOnly  --outDir dist/",
           "cp libs/components/package.json dist/libs/components"
         ],
         "parallel": false,

--- a/libs/components/types.d.ts
+++ b/libs/components/types.d.ts
@@ -9,3 +9,7 @@ declare module '*.css' {
   const css: CSSResult;
   export default css;
 }
+declare module '*?inline' {
+  const contents:{default: string}
+  export = contents
+}

--- a/libs/components/vite.config.js
+++ b/libs/components/vite.config.js
@@ -10,7 +10,6 @@ module.exports = defineConfig({
       formats: ['es', 'umd'],
     },
     rollupOptions: {
-      external: [/^lit/, /^@material/],
       output: {
         chunkFileNames: '[name].mjs',
       },


### PR DESCRIPTION
## Description

Adding back the typescript declaration files that Vite does not include when compiling ts

### What's included?

- adding back TS declarations
- removing `lit` and `mwc` as external deps so they also get included in the bundle for a better dev experience
- Add vscode setting to us typescript version from workspace over the ide default
 
#### Test Steps

- [ ] `npm run storybook`
- [ ] then wait for the browser to pen
- [ ] finally check around and make sure everything looks ok

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
