### PR TITLE
fix(docs): adding better dark mode support

### DIFF
--- a/apps/docs-app/src/_teradata-branding.scss
+++ b/apps/docs-app/src/_teradata-branding.scss
@@ -695,6 +695,10 @@ body {
   // Links
   a {
     text-decoration: none;
-    color: #000000de;
+    color: mat-color($accent, darker);
+  }
+
+  .tc-td-secondary {
+    color: map-get($foreground, secondary-text);
   }
 }

--- a/apps/docs-app/src/app/components/home/home.component.html
+++ b/apps/docs-app/src/app/components/home/home.component.html
@@ -32,14 +32,14 @@
                       Covalent
                     </h3>
                     <h1
-                      class="mat-title tc-td-slate push-top-xs push-bottom-xs mat-headline-3"
+                      class="mat-title push-top-xs push-bottom-xs mat-headline-3"
                     >
                       Enterprise UI Platform
                     </h1>
                   </div>
                 </div>
                 <h2
-                  class="mat-title tc-td-slate-600 push-top-xs push-bottom-sm text-center pad-sm push-left push-right mat-headline-6"
+                  class="mat-title tc-td-secondary push-top-xs push-bottom-sm text-center pad-sm push-left push-right mat-headline-6"
                 >
                   Reusable tested tools to build robust Angular Material &
                   Angular applications
@@ -68,14 +68,14 @@
                         <div class="pad-top-xs">
                           <mat-icon
                             svgIcon="assets:github"
-                            class="tc-td-slate-600 push-right push-left"
+                            class="tc-td-secondary push-right push-left"
                           ></mat-icon>
                         </div>
                         <div layout="column" class="pad-bottom">
-                          <div *ngIf="starCount" class="tc-td-slate-700">
+                          <div *ngIf="starCount" class="tc-td-secondary">
                             {{ starCount }}
                           </div>
-                          <div class="mat-caption tc-td-slate-700">
+                          <div class="mat-caption tc-td-secondary">
                             Github Stars
                           </div>
                         </div>
@@ -150,12 +150,12 @@
                     </div>
 
                     <div
-                      class="mat-title push-none text-xxl tc-td-slate push-right"
+                      class="mat-title push-none text-xxl tc-td-secondary push-right"
                     >
                       {{ item.title }}
                     </div>
                   </div>
-                  <div class="mat-subtitle-1 text-wrap text-left tc-grey-700">
+                  <div class="mat-subtitle-1 text-wrap text-left tc-td-secondary">
                     {{ item.description }}
                   </div>
                 </a>
@@ -180,12 +180,12 @@
                   <mat-icon>favorite</mat-icon>
                   on Angular
                 </h2>
-                <h3 class="mat-body-1 tc-td-slate push-top-xs push-bottom-sm">
+                <h3 class="mat-body-1 tc-td-secondary push-top-xs push-bottom-sm">
                   Teradata is acvtively commited to Angular. Our entire product
                   suite is built or revamped on Angular.
                 </h3>
                 <h4
-                  class="mat-body-1 tc-td-slate push-top-xs push-bottom-sm"
+                  class="mat-body-1 tc-td-secondary push-top-xs push-bottom-sm"
                   hide-xs
                 >
                   Teradata developers across the organization, contribute back
@@ -224,12 +224,12 @@
                 >
                   Following the Material Design spec
                 </h2>
-                <h3 class="mat-body-1 tc-td-slate push-top-xs push-bottom-sm">
+                <h3 class="mat-body-1 tc-td-secondary push-top-xs push-bottom-sm">
                   Covalent follows the Material Design specification as closely
                   as possible through the construction of all components.
                 </h3>
                 <h4
-                  class="mat-body-1 tc-td-slate push-top-xs push-bottom-sm"
+                  class="mat-body-1 tc-td-secondary push-top-xs push-bottom-sm"
                   hide-xs
                 >
                   Adopting Material Design as our own spec allows our UI/UX

--- a/apps/docs-app/src/app/components/home/home.component.scss
+++ b/apps/docs-app/src/app/components/home/home.component.scss
@@ -51,6 +51,13 @@
   background-position: right bottom;
 }
 
+@media (prefers-color-scheme: dark) {
+  .banner {
+    background-image: none;
+  }
+
+}
+
 .banner-lg {
   background-size: 80%;
 }

--- a/apps/docs-app/src/app/components/shared/component-details/component-details-wrapper/content-details.component.html
+++ b/apps/docs-app/src/app/components/shared/component-details/component-details-wrapper/content-details.component.html
@@ -20,7 +20,7 @@
     <h1 class="mat-h1 content-title push-bottom-sm text-caps">
       {{ component?.name }}
     </h1>
-    <h3 class="mat-h3 tc-grey-600" [style.maxWidth.px]="500">
+    <h3 class="mat-h3 tc-td-secondary" [style.maxWidth.px]="500">
       {{ component?.description }}
     </h3>
   </div>

--- a/apps/docs-app/src/app/components/shared/component-details/component-hero/component-hero.component.scss
+++ b/apps/docs-app/src/app/components/shared/component-details/component-hero/component-hero.component.scss
@@ -1,7 +1,6 @@
 .content-image-block {
   padding: 24px;
   min-height: 392px;
-  background-color: #f2f2f2;
   overflow: auto;
 }
 

--- a/apps/docs-app/src/app/components/shared/component-overview/component-overview.component.html
+++ b/apps/docs-app/src/app/components/shared/component-overview/component-overview.component.html
@@ -1,6 +1,6 @@
 <div class="pad-right-sm pad-left-sm">
   <h1 class="mat-h1 push-bottom text-caps">{{ category.name }}</h1>
-  <h3 class="mat-h3 tc-grey-600 push-bottom-xl" [style.maxWidth.px]="468">
+  <h3 class="mat-h3 tc-td-secondary push-bottom-xl" [style.maxWidth.px]="468">
     {{ category.description }}
   </h3>
 </div>
@@ -13,7 +13,7 @@
     class="push-bottom-lg pad-bottom-xs"
   >
     <h3
-      class="mat-h3 version-selector tc-grey-600 push-bottom-xs pad-right-sm pad-left-sm"
+      class="mat-h3 version-selector tc-td-secondary push-bottom-xs pad-right-sm pad-left-sm"
     >
       {{ group.name }}
     </h3>
@@ -44,7 +44,7 @@
                 </div>
                 <div
                   *ngIf="item?.description"
-                  class="tc-grey-600 mat-caption component-card-body"
+                  class="tc-td-secondary mat-caption component-card-body"
                 >
                   {{ item.description | truncate }}
                 </div>
@@ -60,7 +60,7 @@
 <section class="pad-bottom-xxl" *ngIf="category.name === 'Components'">
   <div class="pad-right-sm pad-left-sm pad-top-xl">
     <h1 class="mat-h1 push-bottom-md">External Components</h1>
-    <h3 class="mat-h3 tc-grey-600 push-bottom-lg" [style.maxWidth.px]="468">
+    <h3 class="mat-h3 tc-td-secondary push-bottom-lg" [style.maxWidth.px]="468">
       Recommended but not maintained by Covalent
     </h3>
   </div>
@@ -76,7 +76,7 @@
           <mat-icon class="icon-component tc-deep-purple-800">layers</mat-icon>
           <div>
             <div class="mat-subtitle-1 push-bottom-xs">Angular Material</div>
-            <div class="tc-grey-600 mat-caption">
+            <div class="tc-td-secondary mat-caption">
               A short description about the component.
             </div>
           </div>

--- a/apps/docs-app/src/app/components/shared/demo-tools/demo.component.scss
+++ b/apps/docs-app/src/app/components/shared/demo-tools/demo.component.scss
@@ -3,7 +3,6 @@
     0 1px 3px 1px rgba(60, 64, 67, 16%);
 
   .mat-toolbar-row {
-    background-color: #f5f5f5;
     height: 56px;
   }
 }

--- a/apps/docs-app/src/app/components/shared/sidenav-content/sidenav-content.component.html
+++ b/apps/docs-app/src/app/components/shared/sidenav-content/sidenav-content.component.html
@@ -14,7 +14,7 @@
         <ng-container *ngIf="!section.nested; else nested">
           <div
             *ngIf="section.name"
-            class="doc-nav-section-label text-upper tc-grey-500 mat-caption"
+            class="doc-nav-section-label text-upper tc-td-secondary mat-caption"
           >
             {{ section.name }}
           </div>

--- a/apps/docs-app/src/app/content/components/component-demos/file-input/file-input.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/file-input/file-input.component.html
@@ -4,6 +4,6 @@
   [(ngModel)]="files"
   multiple
 >
-  <mat-icon class="tc-grey-600">folder</mat-icon>
+  <mat-icon class="tc-td-secondary">folder</mat-icon>
   <span class="text-upper">Browse...</span>
 </td-file-input>

--- a/apps/docs-app/src/app/content/docs/angular-material/angular-material.component.html
+++ b/apps/docs-app/src/app/content/docs/angular-material/angular-material.component.html
@@ -1,7 +1,7 @@
 <section class="push-bottom-xl">
   <h1 class="push-bottom-sm mat-h1">Angular Material</h1>
 
-  <p class="tc-grey-600 push-bottom-md">Material Design components</p>
+  <p class="tc-td-secondary push-bottom-md">Material Design components</p>
 </section>
 
 <section>

--- a/apps/docs-app/src/app/content/docs/icons/icons.component.html
+++ b/apps/docs-app/src/app/content/docs/icons/icons.component.html
@@ -1,7 +1,7 @@
 <section class="push-bottom-xl">
   <h1 class="push-bottom-sm mat-h1">Material Design Icons</h1>
 
-  <p class="tc-grey-600 push-bottom-md">Access 1000+ SVG or Font icons</p>
+  <p class="tc-td-secondary push-bottom-md">Access 1000+ SVG or Font icons</p>
 </section>
 
 <section class="push-bottom-xxl">

--- a/apps/docs-app/src/app/content/docs/theme/theme.component.html
+++ b/apps/docs-app/src/app/content/docs/theme/theme.component.html
@@ -1,7 +1,7 @@
 <section class="push-bottom-xl">
   <h1 class="push-bottom-sm mat-h1">Custom Theme</h1>
 
-  <p class="tc-grey-600 push-bottom-md">
+  <p class="tc-td-secondary push-bottom-md">
     SCSS variables to customize the color scheme
   </p>
 </section>

--- a/apps/docs-app/src/app/content/utilities/content-details/content-details.component.html
+++ b/apps/docs-app/src/app/content/utilities/content-details/content-details.component.html
@@ -3,7 +3,7 @@
     <h1 class="mat-h1 content-title push-bottom-sm text-caps">
       {{ component?.name }}
     </h1>
-    <h3 class="mat-h3 tc-grey-600" [style.maxWidth.px]="500">
+    <h3 class="mat-h3 tc-td-secondary" [style.maxWidth.px]="500">
       {{ component?.description }}
     </h3>
   </div>

--- a/apps/docs-app/src/app/content/utilities/content-details/content-overview/content-overview.component.scss
+++ b/apps/docs-app/src/app/content/utilities/content-details/content-overview/content-overview.component.scss
@@ -1,5 +1,1 @@
-.content-image-block {
-  padding: 24px;
-  min-height: 392px;
-  background-color: #f2f2f2;
-}
+

--- a/apps/docs-app/src/app/content/utilities/utilities-demos/animations/animations.component.html
+++ b/apps/docs-app/src/app/content/utilities/utilities-demos/animations/animations.component.html
@@ -1,7 +1,7 @@
 <section class="push-bottom-xl">
   <h1 class="push-bottom-sm mat-h1">Animations</h1>
 
-  <p class="tc-grey-600 push-bottom-md">
+  <p class="tc-td-secondary push-bottom-md">
     Utilities to help add simple reusable animations and reduce boilerplate
     code. For custom and complex animations look into the Angular animations
     doc.

--- a/apps/docs-app/src/app/content/utilities/utilities-demos/directives/directives.component.html
+++ b/apps/docs-app/src/app/content/utilities/utilities-demos/directives/directives.component.html
@@ -1,7 +1,7 @@
 <section class="push-bottom-xl">
   <h1 class="push-bottom-sm mat-h1">Directives</h1>
 
-  <p class="tc-grey-600 push-bottom-md">Core Covalent directives</p>
+  <p class="tc-td-secondary push-bottom-md">Core Covalent directives</p>
 </section>
 
 <section class="push-bottom-xxl">

--- a/apps/docs-app/src/app/content/utilities/utilities-demos/functions/functions.component.html
+++ b/apps/docs-app/src/app/content/utilities/utilities-demos/functions/functions.component.html
@@ -1,7 +1,7 @@
 <section class="push-bottom-xl">
   <h1 class="push-bottom-sm mat-h1">Functions</h1>
 
-  <p class="tc-grey-600 push-bottom-md">
+  <p class="tc-td-secondary push-bottom-md">
     Helpful functions for common interactions.
   </p>
 </section>

--- a/apps/docs-app/src/app/content/utilities/utilities-demos/pipes/pipes.component.html
+++ b/apps/docs-app/src/app/content/utilities/utilities-demos/pipes/pipes.component.html
@@ -1,7 +1,7 @@
 <section class="push-bottom-xl">
   <h1 class="push-bottom-sm mat-h1">Pipes</h1>
 
-  <p class="tc-grey-600 push-bottom-md">Custom Angular pipes (filters).</p>
+  <p class="tc-td-secondary push-bottom-md">Custom Angular pipes (filters).</p>
 </section>
 
 <section class="push-bottom-xxl">

--- a/apps/docs-app/src/app/content/utilities/utilities-demos/utility-styles/utility-styles.component.html
+++ b/apps/docs-app/src/app/content/utilities/utilities-demos/utility-styles/utility-styles.component.html
@@ -1,7 +1,7 @@
 <section class="push-bottom-xxl">
   <h1 class="push-bottom-sm mat-h1">CSS Utility Styles &amp; Classes</h1>
 
-  <p class="tc-grey-600 push-bottom-md">
+  <p class="tc-td-secondary push-bottom-md">
     Covalent includes many utility styles to save you time. We've included
     general utilities, padding (pad), margin (push), negative margin (pull),
     sizing, and text classes.

--- a/apps/docs-app/src/styles.scss
+++ b/apps/docs-app/src/styles.scss
@@ -72,6 +72,8 @@ $theme: mat.define-light-theme(
     typography: $my-typography,
   )
 );
+$foreground: map-get($theme, foreground);
+$background: map-get($theme, background);
 
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component
@@ -87,6 +89,10 @@ $theme: mat.define-light-theme(
 @include covalent-guided-tour-theme($theme);
 @include teradata-brand($theme);
 
+.content-image-block {
+  background-color: map-get($background, card);
+}
+
 body .mat-card {
   border-radius: 8px;
 }
@@ -97,6 +103,8 @@ body .mat-card {
   $accent-dark: mat-palette($td-orange, 800, 200, 900);
   $warn-dark: mat-palette($mat-red, 600, 200, 900);
   $theme-dark: mat-dark-theme($primary-dark, $accent-dark, $warn-dark);
+  $background: map-get($theme-dark, background);
+
   @include mat.all-component-themes($theme-dark);
   @include covalent-theme($theme-dark);
   @include covalent-markdown-theme($theme-dark);
@@ -106,11 +114,13 @@ body .mat-card {
   @include covalent-markdown-navigator-theme($theme-dark);
   @include teradata-brand($theme-dark);
   @include covalent-guided-tour-theme($theme-dark);
+
+  .content-image-block {
+    background-color: map-get($background, card);
+  }
 }
 
 /* ------------------------------------------------------------------------------- */
-$foreground: map-get($theme, foreground);
-$background: map-get($theme, background);
 
 // Apply theme for this app
 .bgc-contrast {

--- a/libs/angular/breadcrumbs/src/breadcrumbs.component.spec.ts
+++ b/libs/angular/breadcrumbs/src/breadcrumbs.component.spec.ts
@@ -244,7 +244,7 @@ describe('Component: Breadcrumbs', () => {
         <a td-breadcrumb [routerLink]="'/layouts'">Layouts</a>
         <a td-breadcrumb [routerLink]="'/layouts2'">Layouts2</a>
         <a td-breadcrumb [routerLink]="'/layouts3'">Layouts3</a>
-        <td-breadcrumb class="tc-grey-500">Manage List</td-breadcrumb>
+        <td-breadcrumb class="tc-td-secondary">Manage List</td-breadcrumb>
       </td-breadcrumbs>
     </div>
   `,

--- a/libs/angular/layout/src/navigation-drawer/navigation-drawer.component.scss
+++ b/libs/angular/layout/src/navigation-drawer/navigation-drawer.component.scss
@@ -68,9 +68,9 @@
       }
 
       .td-navigation-drawer-menu-button {
-        height: 24px;
-        line-height: 24px;
         width: 24px;
+        height: 24px;
+        padding: 0;
       }
     }
   }

--- a/libs/angular/side-sheet/_side-sheet.theme.scss
+++ b/libs/angular/side-sheet/_side-sheet.theme.scss
@@ -1,8 +1,12 @@
 @mixin td-side-sheet-theme($theme) {
   $background: map-get($theme, background);
+  $foreground: map-get($theme, foreground);
+
   $dialog: map-get($background, dialog);
+  $text: map-get($foreground, text);
 
   .td-side-sheet-container {
     background-color: $dialog;
+    color: $text;
   }
 }

--- a/libs/angular/side-sheet/src/side-sheet.scss
+++ b/libs/angular/side-sheet/src/side-sheet.scss
@@ -3,7 +3,6 @@ $max-height: 65vh !default;
 $button-margin: 8px !default;
 
 .td-side-sheet-container {
-  background-color: white;
   box-shadow: 0 8px 10px -5px rgba(0, 0, 0, 20%),
     0 16px 24px 2px rgba(0, 0, 0, 14%), 0 6px 30px 5px rgba(0, 0, 0, 12%);
   display: block;


### PR DESCRIPTION
## Description

Adding better dark mode support to address #2023 

### What's included?

- removed a bunch of classes that are calling a color directly and replaced with themed color
- add secondary class to pull theme color

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start`
- [ ] then open the local browser 
- [ ] finally go over the site to ensure accuracy

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.


closes #2023 

##### Screenshots or link to StackBlitz/Plunker

![covalent-dark-mode-fix](https://github.com/Teradata/covalent/assets/3837706/ff1bfdce-aba9-4060-9363-b17af7367055)
