### PR TITLE
fix(components): adjustments to consuming library

### DIFF
--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -4,6 +4,7 @@
   "description": "a catalog of material components for covalent",
   "main": "covalent.umd.js",
   "module": "covalent.mjs",
+  "types": "src/index.d.ts",
   "exports": {
     ".": {
       "import": "./covalent.js",

--- a/libs/components/project.json
+++ b/libs/components/project.json
@@ -8,6 +8,7 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
+          "mkdir -p dist/libs/components/",
           "vite build --config libs/components/vite.config.js  --outDir dist/libs/components",
           "./node_modules/.bin/tsc --project libs/components/tsconfig.lib.json  --declaration --declarationMap --emitDeclarationOnly  --outDir dist/",
           "cp libs/components/package.json dist/libs/components"

--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -43,6 +43,6 @@ import('./tree-list/tree-list');
 import('./tree-list/tree-list-item');
 import('./typography/typography');
 
-import '../theme/theme.scss?raw';
+import '../theme/theme.scss';
 
 export {};


### PR DESCRIPTION
## Description

Adjustments to the build config for consuming the library

### What's included?

- adding typings field to package.json
- creating directory before running build
- styles were not being exported

#### Test Steps

- [ ] `npx nx run build:components`
- [ ]  view generated assets in `/dist` folder 

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
