### PR TITLE
fix(components): set default label text 

### DIFF
--- a/libs/components/src/action-ribbon/action-ribbon.stories.js
+++ b/libs/components/src/action-ribbon/action-ribbon.stories.js
@@ -16,7 +16,12 @@ export default {
   },
 };
 
-export const Neutral = ({ label, color, icon, saveDisabled = false }) => {
+export const Neutral = ({
+  label = 'Neutral',
+  color,
+  icon,
+  saveDisabled = false,
+}) => {
   return `
     <cv-action-ribbon
       labelText="${label}"

--- a/libs/components/src/action-ribbon/action-ribbon.stories.js
+++ b/libs/components/src/action-ribbon/action-ribbon.stories.js
@@ -17,7 +17,7 @@ export default {
 };
 
 export const Neutral = ({
-  label = 'Neutral',
+  label = 'No changes',
   color,
   icon,
   saveDisabled = false,


### PR DESCRIPTION
## Description

This PR adds default label text in for 'Neutral' action ribbon

Fixes #2034 

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run storybook`

##### Screenshots or link to StackBlitz/Plunker

<img width="1505" alt="no-changes-default-text" src="https://github.com/Teradata/covalent/assets/17727069/004d70cf-cea0-4bf2-9a0c-44d5b490869c">
