### PR TITLE
fix: add support for markdown syntax in table cells

### DIFF
--- a/apps/docs-app/src/app/content/components/component-demos/flavored-markdown/flavored-markdown.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/flavored-markdown/flavored-markdown.component.ts
@@ -7,19 +7,27 @@ import { Component } from '@angular/core';
 })
 export class FlavoredMarkdownDemoComponent {
   basicFlavoredMarkdown = `
-    ## Checkboxes
+## Checkboxes
 
-    - [x] My checkbox
-    - [x] My second checkbox
-    - [ ] My empty checkbox
+- [x] My checkbox
+- [x] My second checkbox
+- [ ] My empty checkbox
 
-    ## List
+## List
 
-    + One
-      + subline
-    + Two
-    + Three
-      + subline
-      + second subline
++ One
+  + subline
++ Two
++ Three
+  + subline
+  + second subline
+
+## Table
+
+|Connects to|With connector|
+|-----------|--------------|
+|VantageCloud Enterprise on Azure|Teradata-to-TeradataTo setup and configure the required PrivateLink endpoint on VantageCloud Enterprise, open a [PrivateLink change request](https://www.google.com) on the VantageCloud Enterprise customer support portal.|
+|VantageCore (on-premises)|Teradata-to-Teradata|
+|**This text is bolded**|*this text is italicized*|
   `;
 }

--- a/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
+++ b/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
@@ -57,7 +57,9 @@ export interface ITdFlavoredMarkDownTableColumn {
           <mat-header-cell *matHeaderCellDef mat-sort-header>{{
             column.label
           }}</mat-header-cell>
-          <mat-cell *matCellDef="let row">{{ row[column.name] }}</mat-cell>
+          <mat-cell *matCellDef="let row"
+            ><td-markdown>{{ row[column.name] }}</td-markdown></mat-cell
+          >
         </ng-container>
       </ng-template>
       <!-- Header and Row Declarations -->


### PR DESCRIPTION
## Description

We might want to use markdown syntax in table cells to show links, style text, or do other stuff.

This is handle automatically by showdown, but wasn't captured in our custom `TdFlavoredMarkdownTableComponent`.

### What's included?

<!-- List features included in this PR -->
- wrapping table cells in TdFlavoredMarkdownTableComponent with `<td-markdown>`

This fixes https://teradatacloud.atlassian.net/browse/CCP-2488

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [x] `npm run start`
- [ ] check out flavored markdown table
- [ ] table cells contain links and styled text

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

<img width="833" alt="Screenshot 2023-07-10 at 2 46 10 PM" src="https://github.com/Teradata/covalent/assets/5451986/7a594a4e-ff37-4e67-80b8-ac5d62803908">

