### PR TITLE
feat: add raw code toggle to highlight component and update highlight theme

### DIFF
--- a/apps/docs-app/src/app/content/components/component-demos/flavored-markdown/flavored-markdown.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/flavored-markdown/flavored-markdown.component.html
@@ -1,1 +1,3 @@
-<td-flavored-markdown>{{ basicFlavoredMarkdown }}</td-flavored-markdown>
+<td-flavored-markdown [copyCodeToClipboard]="true" [toggleRawCode]="true">{{
+  basicFlavoredMarkdown
+}}</td-flavored-markdown>

--- a/apps/docs-app/src/app/content/components/component-demos/flavored-markdown/flavored-markdown.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/flavored-markdown/flavored-markdown.component.ts
@@ -29,5 +29,17 @@ export class FlavoredMarkdownDemoComponent {
 |VantageCloud Enterprise on Azure|Teradata-to-TeradataTo setup and configure the required PrivateLink endpoint on VantageCloud Enterprise, open a [PrivateLink change request](https://www.google.com) on the VantageCloud Enterprise customer support portal.|
 |VantageCore (on-premises)|Teradata-to-Teradata|
 |**This text is bolded**|*this text is italicized*|
+
+
+## Code 
+\`\`\`typescript
+this._renderer.appendChild(this._elementRef.nativeElement, preElement); // long long long long line
+
+import { Component } from '@angular/core';
+export class AppComponent {
+  title = 'my-app';
+  constructor() {}
+}
+\`\`\`
   `;
 }

--- a/apps/docs-app/src/app/content/components/component-demos/highlight/demos/highlight-demo-copy-code/highlight-demo-copy-code.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/highlight/demos/highlight-demo-copy-code/highlight-demo-copy-code.component.html
@@ -1,7 +1,20 @@
 <td-highlight
+  class="push-bottom-md"
   codeLang="css"
   [copyCodeToClipboard]="true"
   [copyCodeTooltips]="tooltipsConfig"
+  [toggleRawButton]="true"
 >
   {{ css }}
 </td-highlight>
+
+<div class="dark-theme">
+  <td-highlight
+    codeLang="css"
+    [copyCodeToClipboard]="true"
+    [copyCodeTooltips]="tooltipsConfig"
+    [toggleRawButton]="true"
+  >
+    {{ css }}
+  </td-highlight>
+</div>

--- a/apps/docs-app/src/app/content/components/component-demos/highlight/demos/highlight-demo-ts/highlight-demo-ts.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/highlight/demos/highlight-demo-ts/highlight-demo-ts.component.html
@@ -1,3 +1,7 @@
-<td-highlight codeLang="typescript">
+<td-highlight
+  codeLang="typescript"
+  [copyCodeToClipboard]="true"
+  [toggleRawButton]="true"
+>
   {{ code }}
 </td-highlight>

--- a/apps/docs-app/src/app/content/components/component-demos/highlight/demos/highlight-demo.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/highlight/demos/highlight-demo.component.html
@@ -10,6 +10,9 @@
   <highlight-demo-ts></highlight-demo-ts>
 </demo-component>
 
-<demo-component [demoId]="'highlight-demo-copy-code'" [demoTitle]="'CopyCode'">
+<demo-component
+  [demoId]="'highlight-demo-copy-code'"
+  [demoTitle]="'CopyCode and ToggleRaw'"
+>
   <highlight-demo-copy-code></highlight-demo-copy-code>
 </demo-component>

--- a/libs/angular-highlight/_highlight-theme.scss
+++ b/libs/angular-highlight/_highlight-theme.scss
@@ -6,14 +6,18 @@
 @mixin covalent-highlight-theme($theme) {
   $foreground: map-get($theme, foreground);
   $background: map-get($theme, background);
+
   .raw-and-copy-buttons {
     border-color: map-get($foreground, divider);
+
     .mat-button-toggle {
       background-color: inherit;
       color: map-get($foreground, text);
+
       mat-icon {
         color: map-get($foreground, icon);
       }
+
       & + .mat-button-toggle {
         border-left-color: map-get($foreground, divider);
       }

--- a/libs/angular-highlight/_highlight-theme.scss
+++ b/libs/angular-highlight/_highlight-theme.scss
@@ -3,7 +3,23 @@
 /**
 * Mimicking VS Dark+ theme as closely as possible
 */
-@mixin covalent-highlight-theme($theme-or-config) {
+@mixin covalent-highlight-theme($theme) {
+  $foreground: map-get($theme, foreground);
+  $background: map-get($theme, background);
+  .raw-and-copy-buttons {
+    border-color: map-get($foreground, divider);
+    .mat-button-toggle {
+      background-color: inherit;
+      color: map-get($foreground, text);
+      mat-icon {
+        color: map-get($foreground, icon);
+      }
+      & + .mat-button-toggle {
+        border-left-color: map-get($foreground, divider);
+      }
+    }
+  }
+
   .dark-theme td-highlight {
     background-color: #1a1c1d;
 

--- a/libs/angular-highlight/_highlight-theme.scss
+++ b/libs/angular-highlight/_highlight-theme.scss
@@ -4,97 +4,141 @@
 * Mimicking VS Dark+ theme as closely as possible
 */
 @mixin covalent-highlight-theme($theme-or-config) {
-  td-highlight {
-    background: #1e1e21;
-
+  .dark-theme td-highlight {
+    background-color: #1a1c1d;
     .highlight {
-      color: $light-primary-text;
+      color: #abb2bf;
     }
-
-    .copy-button {
-      color: $light-primary-text;
+    .raw {
+      color: rgba(255, 255, 255, 0.87);
     }
 
     .hljs-comment,
     .hljs-quote {
-      color: #608b4e;
-    }
-
-    .hljs-tag,
-    .hljs-name,
-    .hljs-selector-tag,
-    .hljs-literal {
-      color: #569cd6;
-    }
-
-    .hljs-keyword {
-      color: #c288bf;
-    }
-
-    .hljs-attr,
-    //.hljs-params, // Remove param color for now
-    .hljs-attribute {
-      color: #9cdcfe;
-    }
-
-    .hljs-string,
-    .hljs-selector-attr,
-    .hljs-regexp,
-    .hljs-link {
-      color: #ce9178;
-    }
-
-    .hljs-selector-id,
-    .hljs-selector-class,
-    .hljs-selector-pseudo {
-      color: #d7ba7d;
-    }
-
-    .hljs-meta {
-      color: #dcdcaa;
-    }
-
-    /* stylelint-disable selector-class-pattern */
-    .hljs-built_in,
-    .hljs-builtin-name,
-    .hljs-type,
-    .hljs-section,
-    .hljs-class .hljs-title,
-    .hljs-symbol,
-    .hljs-bullet {
-      color: #4ec9b0;
-    }
-    /* stylelint-enable selector-class-pattern */
-
-    .hljs-number {
-      color: #b5cea8;
-    }
-
-    .hljs-variable,
-    .hljs-template-variable {
-      color: #9fddfc;
-    }
-
-    .hljs-deletion {
-      color: #ffc8bd;
-    }
-
-    .hljs-addition {
-      background-color: #baeeba;
-    }
-
-    .hljs-emphasis {
+      color: #5c6370;
       font-style: italic;
     }
 
     .hljs-doctag,
-    .hljs-strong {
-      font-weight: bold;
+    .hljs-formula,
+    .hljs-keyword {
+      color: #c678dd;
     }
 
-    .hljs-formula {
-      background-color: #eeeeee;
+    .hljs-deletion,
+    .hljs-name,
+    .hljs-tag,
+    .hljs-section,
+    .hljs-selector-tag,
+    .hljs-subst {
+      color: #e06c75;
+    }
+
+    .hljs-literal {
+      color: #56b6c2;
+    }
+
+    .hljs-addition,
+    .hljs-attribute,
+    .hljs-meta .hljs-string,
+    .hljs-regexp,
+    .hljs-string {
+      color: #98c379;
+    }
+
+    .hljs-attr,
+    .hljs-number,
+    .hljs-selector-attr,
+    .hljs-selector-class,
+    .hljs-selector-pseudo,
+    .hljs-template-variable,
+    .hljs-type,
+    .hljs-variable {
+      color: #d19a66;
+    }
+
+    .hljs-bullet,
+    .hljs-link,
+    .hljs-meta,
+    .hljs-selector-id,
+    .hljs-symbol,
+    .hljs-title {
+      color: #61aeee;
+    }
+
+    .hljs-built_in,
+    .hljs-class .hljs-title,
+    .hljs-title.class_ {
+      color: #e6c07b;
+    }
+  }
+
+  td-highlight {
+    background-color: #eeeeee;
+    .highlight {
+      color: #383a42;
+    }
+    .raw {
+      color: rgba(0, 0, 0, 0.87);
+    }
+
+    .hljs-comment,
+    .hljs-quote {
+      color: #a0a1a7;
       font-style: italic;
+    }
+
+    .hljs-doctag,
+    .hljs-formula,
+    .hljs-keyword {
+      color: #a626a4;
+    }
+
+    .hljs-deletion,
+    .hljs-name,
+    .hljs-tag,
+    .hljs-section,
+    .hljs-selector-tag,
+    .hljs-subst {
+      color: #e45649;
+    }
+
+    .hljs-literal {
+      color: #0184bb;
+    }
+
+    .hljs-addition,
+    .hljs-attribute,
+    .hljs-meta .hljs-string,
+    .hljs-regexp,
+    .hljs-string {
+      color: #50a14f;
+    }
+
+    .hljs-attr,
+    .hljs-number,
+    .hljs-selector-attr,
+    .hljs-selector-class,
+    .hljs-selector-pseudo,
+    .hljs-template-variable,
+    .hljs-type,
+    .hljs-variable {
+      color: #986801;
+    }
+
+    .hljs-bullet,
+    .hljs-link,
+    .hljs-meta,
+    .hljs-selector-id,
+    .hljs-symbol,
+    .hljs-title {
+      color: #4078f2;
+    }
+
+    .hljs-built_in,
+    .hljs-class .hljs-title,
+    .hljs-title.class_ {
+      color: #c18401;
     }
   }
 }

--- a/libs/angular-highlight/_highlight-theme.scss
+++ b/libs/angular-highlight/_highlight-theme.scss
@@ -6,11 +6,13 @@
 @mixin covalent-highlight-theme($theme-or-config) {
   .dark-theme td-highlight {
     background-color: #1a1c1d;
+
     .highlight {
       color: #abb2bf;
     }
+
     .raw {
-      color: rgba(255, 255, 255, 0.87);
+      color: rgba(255, 255, 255, 87%);
     }
 
     .hljs-comment,
@@ -75,11 +77,13 @@
 
   td-highlight {
     background-color: #eeeeee;
+
     .highlight {
       color: #383a42;
     }
+
     .raw {
-      color: rgba(0, 0, 0, 0.87);
+      color: rgba(0, 0, 0, 87%);
     }
 
     .hljs-comment,

--- a/libs/angular-highlight/src/lib/copy-code-button/copy-code-button.component.html
+++ b/libs/angular-highlight/src/lib/copy-code-button/copy-code-button.component.html
@@ -1,10 +1,32 @@
-<button
-  mat-icon-button
-  [cdkCopyToClipboard]="copiedContent"
-  class="copy-button"
-  [matTooltip]="copyTooltip"
-  #tooltip="matTooltip"
-  (cdkCopyToClipboardCopied)="textCopied($event)"
+<mat-button-toggle-group
+  multiple
+  class="raw-and-copy-buttons"
+  *ngIf="toggleRawButton; else button"
 >
-  <mat-icon role="img">content_copy</mat-icon>
-</button>
+  <mat-button-toggle (click)="toggleRawClicked()" #rawButton>{{
+    rawToggleText
+  }}</mat-button-toggle>
+  <mat-button-toggle
+    [cdkCopyToClipboard]="copiedContent"
+    [matTooltip]="copyTooltip"
+    #tooltip="matTooltip"
+    #copyButton
+    (click)="copyClicked()"
+    (cdkCopyToClipboardCopied)="textCopied($event)"
+  >
+    <mat-icon width>content_copy</mat-icon>
+  </mat-button-toggle>
+</mat-button-toggle-group>
+
+<ng-template #button>
+  <button
+    mat-icon-button
+    [cdkCopyToClipboard]="copiedContent"
+    class="copy-button"
+    [matTooltip]="copyTooltip"
+    #tooltip="matTooltip"
+    (cdkCopyToClipboardCopied)="textCopied($event)"
+  >
+    <mat-icon role="img">content_copy</mat-icon>
+  </button>
+</ng-template>

--- a/libs/angular-highlight/src/lib/copy-code-button/copy-code-button.component.scss
+++ b/libs/angular-highlight/src/lib/copy-code-button/copy-code-button.component.scss
@@ -1,0 +1,15 @@
+mat-button-toggle-group.raw-and-copy-buttons {
+  margin-top: -8px;
+  margin-right: -8px;
+  margin-left: 8px;
+
+  ::ng-deep .mat-button-toggle-label-content {
+    font-size: 12px;
+    line-height: 28px;
+    mat-icon {
+      width: 16px;
+      height: 16px;
+      font-size: 16px;
+    }
+  }
+}

--- a/libs/angular-highlight/src/lib/copy-code-button/copy-code-button.component.scss
+++ b/libs/angular-highlight/src/lib/copy-code-button/copy-code-button.component.scss
@@ -6,6 +6,7 @@ mat-button-toggle-group.raw-and-copy-buttons {
   ::ng-deep .mat-button-toggle-label-content {
     font-size: 12px;
     line-height: 28px;
+
     mat-icon {
       width: 16px;
       height: 16px;

--- a/libs/angular-highlight/src/lib/copy-code-button/copy-code-button.component.ts
+++ b/libs/angular-highlight/src/lib/copy-code-button/copy-code-button.component.ts
@@ -1,9 +1,22 @@
-import { Component, Input, ViewChild, HostListener } from '@angular/core';
+import {
+  Component,
+  Input,
+  ViewChild,
+  HostListener,
+  EventEmitter,
+  Output,
+} from '@angular/core';
+import { MatButtonToggle } from '@angular/material/button-toggle';
 import { MatTooltip } from '@angular/material/tooltip';
 
 export interface ICopyCodeTooltips {
   copy?: string;
   copied?: string;
+}
+
+export interface IRawToggleLabels {
+  viewRaw?: string;
+  viewCode?: string;
 }
 
 @Component({
@@ -22,12 +35,30 @@ export class TdCopyCodeButtonComponent {
    */
   @Input() copyCodeTooltips?: ICopyCodeTooltips = {};
 
+  @Input() toggleRawButton = false;
+  @Input() rawToggleLabels?: IRawToggleLabels = {};
+
+  rawToggle = false;
+
+  @Output() toggleRaw = new EventEmitter<boolean>();
+
+  @ViewChild('copyButton') copyButton!: MatButtonToggle;
+  @ViewChild('rawButton') rawButton!: MatButtonToggle;
+
   get copyTooltip(): string {
     return (this.copyCodeTooltips && this.copyCodeTooltips.copy) || 'Copy';
   }
 
   get copiedTooltip(): string {
     return (this.copyCodeTooltips && this.copyCodeTooltips.copied) || 'Copied';
+  }
+
+  get rawToggleText(): string {
+    if (this.rawToggle) {
+      return this.rawToggleLabels?.viewCode || 'View code';
+    } else {
+      return this.rawToggleLabels?.viewRaw || 'Raw';
+    }
   }
 
   @ViewChild('tooltip') tooltip!: MatTooltip;
@@ -44,5 +75,16 @@ export class TdCopyCodeButtonComponent {
     setTimeout(() => {
       this.tooltip.message = this.copyTooltip;
     }, 200);
+  }
+
+  toggleRawClicked(): void {
+    this.rawToggle = !this.rawToggle;
+    this.toggleRaw.emit();
+    this.rawButton.checked = false;
+  }
+
+  copyClicked(): void {
+    console.log('copyClicked');
+    this.copyButton.checked = false;
   }
 }

--- a/libs/angular-highlight/src/lib/highlight.component.html
+++ b/libs/angular-highlight/src/lib/highlight.component.html
@@ -5,6 +5,9 @@
 
   <div #copyComponent *ngIf="copyCodeToClipboard">
     <td-copy-code-button
+      [toggleRawButton]="toggleRawButton"
+      [rawToggleLabels]="rawToggleLabels"
+      (toggleRaw)="toggleRawClicked()"
       [copiedContent]="copyContent"
       [copyCodeToClipboard]="copyCodeToClipboard"
       [copyCodeTooltips]="copyCodeTooltips"

--- a/libs/angular-highlight/src/lib/highlight.component.scss
+++ b/libs/angular-highlight/src/lib/highlight.component.scss
@@ -6,6 +6,7 @@ $padding: 16px;
   overflow-x: auto;
   padding: $padding;
   display: flex;
+  position: relative;
 
   pre,
   code,
@@ -35,6 +36,10 @@ $padding: 16px;
     padding: 0;
     overflow-wrap: break-word;
     white-space: pre-wrap;
+  }
+
+  div.raw {
+    flex-grow: 1;
   }
 
   .highlight {

--- a/libs/angular-highlight/src/lib/highlight.module.ts
+++ b/libs/angular-highlight/src/lib/highlight.module.ts
@@ -5,6 +5,7 @@ import { TdHighlightComponent } from './highlight.component';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { TdCopyCodeButtonComponent } from './copy-code-button/copy-code-button.component';
 
 @NgModule({
@@ -12,6 +13,8 @@ import { TdCopyCodeButtonComponent } from './copy-code-button/copy-code-button.c
     CommonModule,
     ClipboardModule,
     MatIconModule,
+    MatButtonToggleModule,
+    MatButtonModule,
     MatTooltipModule,
     MatButtonModule,
   ],

--- a/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
+++ b/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
@@ -33,7 +33,11 @@ import {
   TdFlavoredListComponent,
   IFlavoredListItem,
 } from './cfm-list/cfm-list.component';
-import { TdHighlightComponent, ICopyCodeTooltips } from '@covalent/highlight';
+import {
+  TdHighlightComponent,
+  ICopyCodeTooltips,
+  IRawToggleLabels,
+} from '@covalent/highlight';
 
 import { TdMarkdownComponent, scrollToAnchor } from '@covalent/markdown';
 
@@ -206,6 +210,20 @@ export class TdFlavoredMarkdownComponent
    * Tooltips for copy button to copy and upon copying.
    */
   @Input() copyCodeTooltips?: ICopyCodeTooltips = {};
+
+  /**
+   * toggleRawCode?: boolean
+   *
+   * Display button to toggle raw code view
+   */
+  @Input() toggleRawCode = false;
+
+  /**
+   * rawToggleLabels?: IRawToggleLabels
+   *
+   * Labels for raw code toggle button
+   */
+  @Input() rawToggleLabels?: IRawToggleLabels = {};
 
   /**
    * useCfmList?: boolean = false;
@@ -466,6 +484,8 @@ export class TdFlavoredMarkdownComponent
         }
         componentRef.instance.copyCodeToClipboard = this.copyCodeToClipboard;
         componentRef.instance.copyCodeTooltips = this.copyCodeTooltips;
+        componentRef.instance.toggleRawButton = this.toggleRawCode;
+        componentRef.instance.rawToggleLabels = this.rawToggleLabels;
         componentRef.instance.content = codeblock;
       }
     );


### PR DESCRIPTION
## Description

Adding ability to toggle between raw and formatted code in syntax highlight component. Also updating theme with new colors and light mode.

### What's included?

<!-- List features included in this PR -->

- Added new parameters `toggleRawCode` and `rawToggleLabels` to flavored markdown
- Added new parameters `toggleRawButton` and `rawToggleLabels` to highlight component
- Added light mode theme to highlight component theme

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="923" alt="Screenshot 2023-08-10 at 11 17 32 AM" src="https://github.com/Teradata/covalent/assets/5451986/20a4b2c9-b11a-4425-988d-fa9ff42a292b">
<img width="976" alt="Screenshot 2023-08-10 at 11 17 26 AM" src="https://github.com/Teradata/covalent/assets/5451986/e4cd7bc9-ddee-4813-b5a0-932a61074f6c">


