### PR TITLE
fix(docs): angular docs code highlight theme

### DIFF
--- a/apps/docs-app/src/styles.scss
+++ b/apps/docs-app/src/styles.scss
@@ -90,7 +90,6 @@ $background: map-get($theme, background);
 @include covalent-theme($theme);
 @include covalent-markdown-theme($theme);
 @include covalent-highlight-theme($theme);
-@import 'highlight.js/styles/vs.css';
 @include covalent-flavored-markdown-theme($theme);
 @include covalent-markdown-navigator-theme($theme);
 @include covalent-markdown-navigator-typography($custom-typography);
@@ -123,8 +122,7 @@ body .mat-card {
   @include mat.all-component-themes($theme-dark);
   @include covalent-theme($theme-dark);
   @include covalent-markdown-theme($theme-dark);
-  @include covalent-highlight-theme($theme);
-  @import 'highlight.js/styles/dark';
+  @include covalent-highlight-theme($theme-dark);
   @include covalent-flavored-markdown-theme($theme-dark);
   @include covalent-markdown-navigator-theme($theme-dark);
   @include teradata-brand($theme-dark);


### PR DESCRIPTION
## Description

Fix for the code highlight in docs using only the light theme

#### Test Steps

- [ ] `npm run start`
- [ ] then open the localhost:4200
- [ ] finally go to any code snippet and set system settings to use dark mode

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
