### PR TITLE
fix(docs): hide side nave on mobile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           node-version: 16
           cache: npm
       - run: npm ci
-      - run: npx nx affected --target=e2e --base=${{ github.event.pull_request.base.sha }}
+      - run: NODE_OPTIONS=--max_old_space_size=4096 npx nx affected --target=e2e --base=${{ github.event.pull_request.base.sha }}
 
   build:
     runs-on: ubuntu-latest

--- a/apps/docs-app/src/app/components/content-container/content-container.component.html
+++ b/apps/docs-app/src/app/components/content-container/content-container.component.html
@@ -1,5 +1,10 @@
 <mat-sidenav-container fullscreen>
-  <mat-sidenav mode="side" [style.width.px]="280" [style.z-index]="1" opened>
+  <mat-sidenav
+    mode="side"
+    [style.width.px]="280"
+    [style.z-index]="1"
+    [opened]="(isSmall | async) === false"
+  >
     <app-sidenav-content></app-sidenav-content>
   </mat-sidenav>
   <mat-sidenav-content>

--- a/apps/docs-app/src/app/components/content-container/content-container.component.ts
+++ b/apps/docs-app/src/app/components/content-container/content-container.component.ts
@@ -1,8 +1,27 @@
-import { Component } from '@angular/core';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { Component, OnDestroy } from '@angular/core';
+import { Observable, Subject, map, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-content-container',
   templateUrl: './content-container.component.html',
   styleUrls: ['./content-container.component.scss'],
 })
-export class ContentContainerComponent {}
+export class ContentContainerComponent implements OnDestroy {
+  isSmall!: Observable<boolean>;
+  destroyed = new Subject<void>();
+
+  constructor(breakpointObserver: BreakpointObserver) {
+    this.isSmall = breakpointObserver
+      .observe([Breakpoints.XSmall, Breakpoints.Small])
+      .pipe(
+        map((result) => result.matches),
+        takeUntil(this.destroyed)
+      );
+  }
+
+  ngOnDestroy() {
+    this.destroyed.next();
+    this.destroyed.complete();
+  }
+}

--- a/apps/docs-app/src/app/components/content-container/content-container.module.ts
+++ b/apps/docs-app/src/app/components/content-container/content-container.module.ts
@@ -2,11 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { MatSidenavModule } from '@angular/material/sidenav';
-
+import { LayoutModule } from '@angular/cdk/layout';
 import { RouterModule } from '@angular/router';
+import { CovalentCommonModule } from '@covalent/core/common';
+
 import { ContentContainerComponent } from './content-container.component';
 import { SidenavContentModule } from '../shared/sidenav-content/sidenav-content.module';
-import { CovalentCommonModule } from '@covalent/core/common';
 
 @NgModule({
   declarations: [ContentContainerComponent],
@@ -17,6 +18,7 @@ import { CovalentCommonModule } from '@covalent/core/common';
     RouterModule,
     /** Material Modules */
     MatSidenavModule,
+    LayoutModule,
     /** Covalent Modules */
     CovalentCommonModule,
     SidenavContentModule,

--- a/libs/angular/layout/src/navigation-drawer/navigation-drawer.component.ts
+++ b/libs/angular/layout/src/navigation-drawer/navigation-drawer.component.ts
@@ -109,7 +109,7 @@ export class TdNavigationDrawerComponent implements OnInit, OnDestroy {
    * toolbar color option: primary | accent | warn.
    * If [color] is not set, default is used.
    */
-  @Input() color?: 'accent' | 'primary' | 'warn';
+  @Input() color: 'accent' | 'primary' | 'warn' = 'primary';
 
   /**
    * navigationRoute?: string


### PR DESCRIPTION
## Description

Hiding the side nav on mobile for the angular docs app

#### Test Steps

- [ ] `npm run start`
- [ ] then open the browser and navigate to a page displaying a component
- [ ] finally this squish the screen till its small size and ensure the side nav disappears

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="538" alt="Screenshot 2023-11-01 at 11 07 45 AM" src="https://github.com/Teradata/covalent/assets/3837706/8e684cbd-18e7-4bc4-a6c6-7cfca721da30">
<img width="905" alt="Screenshot 2023-11-01 at 11 07 37 AM" src="https://github.com/Teradata/covalent/assets/3837706/54bfd79a-3bda-42a8-a802-fe099f42182e">
