### PR TITLE
fix(markdown): external icon for target _blank

### DIFF
--- a/libs/markdown/src/lib/markdown.component.scss
+++ b/libs/markdown/src/lib/markdown.component.scss
@@ -5,6 +5,21 @@
       background-color: transparent;
     }
 
+    a[target='_blank'] {
+      display: inline-flex;
+      align-items: center;
+
+      &::after {
+        content: 'open_in_new';
+        font-family: 'Material Icons', sans-serif;
+        padding-left: 2px;
+
+        &:hover {
+          text-decoration: none;
+        }
+      }
+    }
+
     a:active,
     a:hover {
       outline-width: 0;

--- a/libs/markdown/src/lib/markdown.component.scss
+++ b/libs/markdown/src/lib/markdown.component.scss
@@ -8,15 +8,17 @@
     a[target='_blank'] {
       display: inline-flex;
       align-items: center;
+      position: relative;
+      padding-right: 16px;
 
       &::after {
         content: 'open_in_new';
-        font-family: 'Material Icons', sans-serif;
+        font-family: var(--mdc-icon-font, 'Material Symbols Outlined');
         padding-left: 2px;
-
-        &:hover {
-          text-decoration: none;
-        }
+        text-decoration: none;
+        position: absolute;
+        right: 0;
+        top: 1px;
       }
     }
 


### PR DESCRIPTION
## Description

closes #2063 

Adding external link icon for links in markdown parsers that use `target="_blank"`

#### Test Steps

- [ ] `npm run start`
- [ ] then open the docs in browser
- [ ] finally look at any documentation file that external links and verify the icon is there

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

![Screenshot 2023-11-06 at 11 01 06 AM](https://github.com/Teradata/covalent/assets/3837706/67fa3352-5f61-4532-afb9-086fa5c95341)