### PR TITLE
fix: correction in markdown table alignment

### DIFF
--- a/libs/markdown/src/lib/markdown.component.scss
+++ b/libs/markdown/src/lib/markdown.component.scss
@@ -631,5 +631,17 @@
       margin: 0 0.2em 0.25em -1.6em;
       vertical-align: middle;
     }
+
+    td.markdown-align-center {
+      text-align: center;
+    }
+
+    td.markdown-align-left {
+      text-align: left;
+    }
+
+    td.markdown-align-right {
+      text-align: right;
+    }
   }
 }

--- a/libs/markdown/src/lib/markdown.component.ts
+++ b/libs/markdown/src/lib/markdown.component.ts
@@ -157,6 +157,26 @@ function addIdsToHeadings(html: string): string {
   return html;
 }
 
+function changeStyleAlignmentToClass(html: string) {
+  if (html) {
+    const document: Document = new DOMParser().parseFromString(
+      html,
+      'text/html'
+    );
+    ['right', 'center', 'left'].forEach((alignment: string) => {
+      document
+        .querySelectorAll(`[style*='text-align:${alignment}']`)
+        .forEach((style: Element) => {
+          style.setAttribute('class', `markdown-align-${alignment}`);
+        });
+    });
+
+    return new XMLSerializer().serializeToString(document);
+  }
+
+  return html;
+}
+
 @Component({
   selector: 'td-markdown',
   styleUrls: ['./markdown.component.scss'],
@@ -328,8 +348,12 @@ export class TdMarkdownComponent
     // to parse the string into DOM element for now.
     const div: HTMLDivElement = this._renderer.createElement('div');
     this._renderer.appendChild(this._elementRef.nativeElement, div);
+
     const html: string =
-      this._domSanitizer.sanitize(SecurityContext.HTML, markupStr) ?? '';
+      this._domSanitizer.sanitize(
+        SecurityContext.HTML,
+        changeStyleAlignmentToClass(markupStr)
+      ) ?? '';
     const htmlWithAbsoluteHrefs: string = normalizeHtmlHrefs(
       html,
       this._hostedUrl


### PR DESCRIPTION
## Description
Correction for markdown tables alignment

### What's included?
Fix for the alignment in the markdown tables

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

![Screenshot 2023-11-29 at 23 54 43](https://github.com/Teradata/covalent/assets/84464875/cc49befc-5f9d-4e09-8931-a05407e331aa)
