### PR TITLE
fix: issue 2074 - tables are rendered differently in a list

### DIFF
--- a/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
+++ b/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
@@ -492,6 +492,7 @@ export class TdFlavoredMarkdownComponent
   }
 
   private _replaceTables(markdown: string): string {
+    markdown = markdown.replaceAll('    |', '');
     const tableRgx =
       /^ {0,3}\|?.+\|.+\n[ \t]{0,3}\|?[ \t]*:?[ \t]*(?:-|=){2,}[ \t]*:?[ \t]*\|[ \t]*:?[ \t]*(?:-|=){2,}[\s\S]+?(?:\n\n|~0)/gm;
     return this._replaceComponent(


### PR DESCRIPTION
## Description
Correction to display correctly the tables when they are located inside a list

### What's included?
The change to render the tables correctly

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshot
![Screenshot 2023-12-12 at 23 23 35](https://github.com/Teradata/covalent/assets/84464875/1d9e521b-1e78-40ec-9b53-8330122ec787)


closes #2074
