### PR TITLE
fix(tokens): updating logo on background

### DIFF
--- a/libs/tokens/src/color/deprecated/text.json
+++ b/libs/tokens/src/color/deprecated/text.json
@@ -20,7 +20,7 @@
       "value": "{theme.light.colors.on-surface-variant}",
       "type": "color"
     },
-    "text-logo-on-background": { "value": "#354145", "type": "color" },
+    "text-logo-on-background": { "value": "#FF5F02", "type": "color" },
     "text-primary-on-light": {
       "value": "{theme.light.colors.on-surface}",
       "type": "color"
@@ -83,7 +83,7 @@
       "value": "{theme.dark.colors.on-surface-variant}",
       "type": "color"
     },
-    "text-logo-on-background": { "value": "#354145", "type": "color" },
+    "text-logo-on-background": { "value": "#ffffff", "type": "color" },
     "text-primary-on-light": {
       "value": "{theme.light.colors.on-surface}",
       "type": "color"


### PR DESCRIPTION
## Description

Updating the tokens value for the logo on background token

#### Test Steps

- [ ] `npm run storybook`
- [ ] then open the app shell story
- [ ] verify the logo is orange in light mode and white in dark mode

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
