### PR TITLE
build(knapsack): fixing knapsack deploy

### DIFF
--- a/apps/knapsack/project.json
+++ b/apps/knapsack/project.json
@@ -1,49 +1,49 @@
 {
-    "name": "knapsack",
-    "$schema": "../../node_modules/nx/schemas/project-schema.json",
-    "sourceRoot": "apps/knapsack",
-    "projectType": "application",
-    "targets": {
-      "build": {
-        "executor": "nx:run-commands",
-        "outputs": ["{workspaceRoot}/dist/apps/knapsack"],
-        "options": {
-          "commands": [
-            "knapsack --config apps/knapsack/knapsack.config.js build"
-          ],
-          "parallel": false
-        }
-      },
-      "start": {
-        "executor": "nx:run-commands",
-        "outputs": ["{workspaceRoot}/dist/apps/knapsack"],
-        "options": {
-          "commands": [
-            "knapsack --config apps/knapsack/knapsack.config.js start"
-          ],
-          "parallel": false
-        }
-      },
-      "serve": {
-        "executor": "nx:run-commands",
-        "outputs": ["{workspaceRoot}/dist/apps/knapsack"],
-        "options": {
-          "commands": [
-            "NODE_ENV=production knapsack --config apps/knapsack/knapsack.config.js serve"
-          ],
-          "parallel": false
-        }
-      },
-      "test": {
-        "executor": "nx:run-commands",
-        "outputs": ["{workspaceRoot}/dist/apps/knapsack"],
-        "options": {
-          "commands": [
-            "knapsack --config apps/knapsack/knapsack.config.js test"
-          ],
-          "parallel": false
-        }
+  "name": "knapsack",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/knapsack",
+  "projectType": "application",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/apps/knapsack"],
+      "options": {
+        "commands": [
+          "npx knapsack --config apps/knapsack/knapsack.config.js build"
+        ],
+        "parallel": false
       }
     },
-    "tags": []
-  }
+    "start": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/apps/knapsack"],
+      "options": {
+        "commands": [
+          "npx knapsack --config apps/knapsack/knapsack.config.js start"
+        ],
+        "parallel": false
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/apps/knapsack"],
+      "options": {
+        "commands": [
+          "NODE_ENV=production npx knapsack --config apps/knapsack/knapsack.config.js serve"
+        ],
+        "parallel": false
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/apps/knapsack"],
+      "options": {
+        "commands": [
+          "npx knapsack --config apps/knapsack/knapsack.config.js test"
+        ],
+        "parallel": false
+      }
+    }
+  },
+  "tags": []
+}


### PR DESCRIPTION
## Description

fixing the knapsack build when using the NX commands

#### Test Steps

- [ ] run `npx nx run knapsack:build` 
- [ ] run `npx nx run knapsack:serve`
- [ ] verify the site comes up!

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.