### PR TITLE
build(nx): read only tokens visible and write tokens from secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, beta]
 
+env:
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/nx.json
+++ b/nx.json
@@ -57,5 +57,5 @@
       "cache": true
     }
   },
-  "nxCloudAccessToken": "NDIyNTBmNmItZGQyMy00ODRhLWE5NWItZWVjMTFlN2Y0NzhifHJlYWQtd3JpdGU="
+  "nxCloudAccessToken": "ZGI4NjZjMTUtZjViMS00NDNmLTgyMTktNTIyMWViNWJhNDNjfHJlYWQ="
 }


### PR DESCRIPTION
## Description

security update to move from using read-write tokens for build cache in NX.

This new setup will leverage a read only token for consumers and use the read-write token only within the CI build