### PR TITLE
feat(icon-button-toggle): create new web component icon-button-toggle

### DIFF
--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -111,6 +111,11 @@
       "import": "./icon-button.mjs",
       "require": "./icon-button.js"
     },
+    "./icon-button-toggle": {
+      "types": "./icon-button-toggle/icon-button-toggle.d.ts",
+      "import": "./icon-button-toggle.mjs",
+      "require": "./icon-button-toggle.js"
+    },
     "./icon-check-toggle": {
       "types": "./icon-checkbox/icon-checkbox.d.ts",
       "import": "./icon-checkbox.mjs",

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.scss
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.scss
@@ -1,11 +1,6 @@
 :host {
   border-radius: 50%;
   color: var(--cv-theme-on-surface-variant);
-
-  --mdc-ripple-color: var(--cv-theme-primary);
-  --mdc-ripple-press-opacity: 0.16;
-  --mdc-ripple-hover-opacity: 0.12;
-  --mdc-ripple-focus-opacity: 0.16;
 }
 
 :host([disabled]) {
@@ -13,6 +8,10 @@
 }
 
 :host([on]) {
+  --mdc-ripple-press-opacity: 0.16;
+  --mdc-ripple-hover-opacity: 0.12;
+  --mdc-ripple-focus-opacity: 0.16;
+
   background-color: var(--cv-theme-primary-8);
   color: var(--cv-theme-primary);
 }

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.scss
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.scss
@@ -1,0 +1,13 @@
+:host {
+  background-color: var(--cv-theme-primary-8);
+  border-radius: 50%;
+  color: var(--cv-theme-primary);
+
+  --mdc-ripple-press-opacity: 0.16;
+  --mdc-ripple-hover-opacity: 0.12;
+  --mdc-ripple-focus-opacity: 0.16;
+}
+
+:host([disabled]) {
+  background-color: transparent;
+}

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.scss
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.scss
@@ -1,8 +1,8 @@
 :host {
-  background-color: var(--cv-theme-primary-8);
   border-radius: 50%;
-  color: var(--cv-theme-primary);
+  color: var(--cv-theme-on-surface-variant);
 
+  --mdc-ripple-color: var(--cv-theme-primary);
   --mdc-ripple-press-opacity: 0.16;
   --mdc-ripple-hover-opacity: 0.12;
   --mdc-ripple-focus-opacity: 0.16;
@@ -10,4 +10,9 @@
 
 :host([disabled]) {
   background-color: transparent;
+}
+
+:host([on]) {
+  background-color: var(--cv-theme-primary-8);
+  color: var(--cv-theme-primary);
 }

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.spec.ts
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.spec.ts
@@ -1,0 +1,11 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { it, describe, expect } from 'vitest';
+import { CovalentIconButtonToggle } from './icon-button-toggle';
+
+describe('Icon button toggle', () => {
+  it('should work', () => {
+    expect(new CovalentIconButtonToggle()).toBeDefined();
+  });
+});

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.stories.js
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.stories.js
@@ -1,0 +1,33 @@
+import './icon-button-toggle';
+import iconList from '../../../icons/material-codepoints.json';
+import '@material/mwc-icon-button-toggle/mwc-icon-button-toggle';
+
+export default {
+  title: 'Components/Icon Button Toggle',
+  argTypes: {
+    onIcon: {
+      control: 'select',
+      options: Object.keys(iconList),
+    },
+    offIcon: {
+      control: 'select',
+      options: Object.keys(iconList),
+    },
+  },
+  args: {
+    onIcon: 'flashlight_on',
+    offIcon: 'flashlight_off',
+    disabled: false,
+    on: false,
+  },
+};
+
+const Template = ({ disabled, onIcon, offIcon, on }) => {
+  return `
+    <cv-icon-button-toggle onIcon="${onIcon}" offIcon="${offIcon}"${
+    disabled ? ` disabled` : ``
+  }${on ? ' on' : ''}>
+    </cv-icon-button-toggle>`;
+};
+
+export const Basic = Template.bind({});

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.stories.js
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.stories.js
@@ -1,6 +1,5 @@
 import './icon-button-toggle';
 import iconList from '../../../icons/material-codepoints.json';
-import '@material/mwc-icon-button-toggle/mwc-icon-button-toggle';
 
 export default {
   title: 'Components/Icon Button Toggle',

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.ts
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.ts
@@ -1,0 +1,22 @@
+import { css, unsafeCSS } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { IconButtonToggle } from '@material/mwc-icon-button-toggle/mwc-icon-button-toggle';
+import styles from './icon-button-toggle.scss?inline';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cv-icon-button-toggle': CovalentIconButtonToggle;
+  }
+}
+
+@customElement('cv-icon-button-toggle')
+export class CovalentIconButtonToggle extends IconButtonToggle {
+  static override styles = [
+    ...IconButtonToggle.styles,
+    css`
+      ${unsafeCSS(styles)}
+    `,
+  ];
+}
+
+export default CovalentIconButtonToggle;

--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -17,6 +17,7 @@ export * from './expansion-panel/expansion-panel-item';
 export * from './formfield/formfield';
 export * from './icon/icon';
 export * from './icon-button/icon-button';
+export * from './icon-button-toggle/icon-button-toggle';
 export * from './icon-checkbox/icon-check-toggle';
 export * from './icon-radio/icon-radio-toggle';
 export * from './linear-progress/linear-progress';

--- a/libs/components/vite.config.js
+++ b/libs/components/vite.config.js
@@ -29,6 +29,7 @@ module.exports = defineConfig(({ mode }) => {
           'libs/components/src/formfield/formfield',
           'libs/components/src/icon/icon',
           'libs/components/src/icon-button/icon-button',
+          'libs/components/src/icon-button-toggle/icon-button-toggle',
           'libs/components/src/icon-checkbox/icon-check-toggle',
           'libs/components/src/icon-radio/icon-radio-toggle',
           'libs/components/src/linear-progress/linear-progress',

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@material/mwc-formfield": "^0.27.0",
         "@material/mwc-icon": "^0.27.0",
         "@material/mwc-icon-button": "^0.27.0",
+        "@material/mwc-icon-button-toggle": "^0.27.0",
         "@material/mwc-linear-progress": "^0.27.0",
         "@material/mwc-list": "^0.27.0",
         "@material/mwc-radio": "^0.27.0",
@@ -81,7 +82,7 @@
         "@commitlint/cli": "^18.4.3",
         "@commitlint/config-angular": "^16.2.1",
         "@commitlint/config-conventional": "^16.2.1",
-        "@covalent/tokens": "*",
+        "@covalent/tokens": "latest",
         "@nx/angular": "17.3.1",
         "@nx/cypress": "17.3.1",
         "@nx/eslint": "17.3.1",
@@ -8035,6 +8036,18 @@
       "resolved": "https://registry.npmjs.org/@material/mwc-icon-button/-/mwc-icon-button-0.27.0.tgz",
       "integrity": "sha512-wReiPa1UkLaCSPtpkAs1OGKEBtvqPnz9kzuY+RvN5ZQnpo3Uh7n3plHV4y/stsUBfrWtBCcOgYnCdNRaR/r2nQ==",
       "dependencies": {
+        "@material/mwc-ripple": "^0.27.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/mwc-icon-button-toggle": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-icon-button-toggle/-/mwc-icon-button-toggle-0.27.0.tgz",
+      "integrity": "sha512-PLozOm8m96vfPqTvugdCSC6V+sd337rdm/H2ZpnMbV+8gllfIkm1J02hv7rQ1O51ThrpMt4hd0URitIiEeuATg==",
+      "dependencies": {
+        "@material/mwc-base": "^0.27.0",
+        "@material/mwc-icon-button": "^0.27.0",
         "@material/mwc-ripple": "^0.27.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@material/mwc-formfield": "^0.27.0",
     "@material/mwc-icon": "^0.27.0",
     "@material/mwc-icon-button": "^0.27.0",
+    "@material/mwc-icon-button-toggle": "^0.27.0",
     "@material/mwc-linear-progress": "^0.27.0",
     "@material/mwc-list": "^0.27.0",
     "@material/mwc-radio": "^0.27.0",


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
Created a new web component called `cv-icon-button-toggle`.
It extends the functionality from [`mwc-icon-button-toggle`](https://www.npmjs.com/package/@material/mwc-icon-button-toggle/v/0.24.0-canary.8dff8894.0)

### What's included?

<!-- List features included in this PR -->
Icon button toggle component which can be toggled on/off and disabled.
It has the below properties:
- aria-label: Accessible label for the button.
- on: To toggle the button on/off.
- onIcon: Icon to display when on is true.
- offIcon: Icon to display when on is false.
- disabled: To disable the button.
- ariaLabelOn: aria-label of the button when on is true. If set, ariaLabelOff must also be set.
- ariaLabelOff: aria-label of the button when on is false. If set, ariaLabelOn must also be set.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [x] `npm run storybook`
- [x] Navigate to Icon Button Toggle component in the side nav
- [x] Test the component

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots
![icon-button-toggle](https://github.com/Teradata/covalent/assets/148156994/a42b9ecb-eab0-4690-8045-4f2a2fabc7ba)

