### PR TITLE
style(text-editor): overriding default mde styles

### DIFF
--- a/libs/angular-text-editor/src/lib/text-editor.component.scss
+++ b/libs/angular-text-editor/src/lib/text-editor.component.scss
@@ -3,4 +3,27 @@
   // see: https://stackoverflow.com/questions/48806765/import-styles-in-angular-components-styles-with-ng-deep
   /* stylelint-disable-next-line no-invalid-position-at-import-rule */
   @import 'easymde/dist/easymde.min';
+
+  .editor-toolbar {
+    background-color: inherit;
+
+    i.separator {
+      border-left: none;
+    }
+
+    button .fa {
+      color: var(--mat-app-text-color, inherit);
+    }
+
+    button:hover,
+    button.active {
+      background-color: transparent;
+      border: 1px solid inherit;
+    }
+  }
+
+  .EasyMDEContainer .CodeMirror {
+    background-color: inherit;
+    color: inherit;
+  }
 }


### PR DESCRIPTION
## Description

Style adjustment for text editor component to respect the light/dark themes

#### Test Steps

- [ ] `npm run start`
- [ ] then navigate to the text component documentation
- [ ] finally toggle themes to ensure the text component is visually changing

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Before
<img width="950" alt="Screenshot 2024-04-05 at 2 21 07 PM" src="https://github.com/Teradata/covalent/assets/3837706/59634426-09ab-49c9-9ab2-588e019a6bb4">

##### After
<img width="955" alt="Screenshot 2024-04-05 at 2 20 45 PM" src="https://github.com/Teradata/covalent/assets/3837706/dcf969a5-e43a-43ff-a4f8-3d9228012849">

