### PR TITLE
docs(components): fix color issues in button and chip

### DIFF
--- a/apps/knapsack/data/knapsack.pattern.button.json
+++ b/apps/knapsack/data/knapsack.pattern.button.json
@@ -28,6 +28,19 @@
               "type": "string",
               "description": "Icon to display, and aria-label value when label is not defined"
             },
+            "color": {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "emphasis",
+                "neutral",
+                "caution",
+                "negative",
+                "positive"
+              ],
+              "description": "Applies the button color"
+            },
             "raised": {
               "description": "Creates a contained button that is elevated above the surface",
               "type": "boolean"
@@ -54,10 +67,6 @@
             },
             "fullwidth": {
               "description": "When true, the button is expanded to fit the entire available space.",
-              "type": "boolean"
-            },
-            "trailingIcon": {
-              "description": "When true, icon will be displayed after label",
               "type": "boolean"
             }
           }

--- a/apps/knapsack/data/knapsack.pattern.button.json
+++ b/apps/knapsack/data/knapsack.pattern.button.json
@@ -68,6 +68,10 @@
             "fullwidth": {
               "description": "When true, the button is expanded to fit the entire available space.",
               "type": "boolean"
+            },
+            "trailingIcon": {
+              "description": "When true, icon will be displayed after label",
+              "type": "boolean"
             }
           }
         }

--- a/apps/knapsack/dist/meta/button/button.web-components-raE1x4tYL.spec.d.ts
+++ b/apps/knapsack/dist/meta/button/button.web-components-raE1x4tYL.spec.d.ts
@@ -56,4 +56,8 @@ export interface Button {
    * When true, the button is expanded to fit the entire available space.
    */
   fullwidth?: boolean;
+  /**
+   * When true, icon will be displayed after label
+   */
+  trailingIcon?: boolean;
 }

--- a/apps/knapsack/dist/meta/button/button.web-components-raE1x4tYL.spec.d.ts
+++ b/apps/knapsack/dist/meta/button/button.web-components-raE1x4tYL.spec.d.ts
@@ -18,6 +18,17 @@ export interface Button {
    */
   icon?: string;
   /**
+   * Applies the button color
+   */
+  color?:
+    | 'primary'
+    | 'secondary'
+    | 'emphasis'
+    | 'neutral'
+    | 'caution'
+    | 'negative'
+    | 'positive';
+  /**
    * Creates a contained button that is elevated above the surface
    */
   raised?: boolean;
@@ -45,8 +56,4 @@ export interface Button {
    * When true, the button is expanded to fit the entire available space.
    */
   fullwidth?: boolean;
-  /**
-   * When true, icon will be displayed after label
-   */
-  trailingIcon?: boolean;
 }

--- a/apps/knapsack/dist/meta/button/button.web-components-raE1x4tYL.spec.json
+++ b/apps/knapsack/dist/meta/button/button.web-components-raE1x4tYL.spec.json
@@ -12,6 +12,19 @@
       "type": "string",
       "description": "Icon to display, and aria-label value when label is not defined"
     },
+    "color": {
+      "type": "string",
+      "enum": [
+        "primary",
+        "secondary",
+        "emphasis",
+        "neutral",
+        "caution",
+        "negative",
+        "positive"
+      ],
+      "description": "Applies the button color"
+    },
     "raised": {
       "description": "Creates a contained button that is elevated above the surface",
       "type": "boolean"
@@ -38,10 +51,6 @@
     },
     "fullwidth": {
       "description": "When true, the button is expanded to fit the entire available space.",
-      "type": "boolean"
-    },
-    "trailingIcon": {
-      "description": "When true, icon will be displayed after label",
       "type": "boolean"
     }
   }

--- a/apps/knapsack/dist/meta/button/button.web-components-raE1x4tYL.spec.json
+++ b/apps/knapsack/dist/meta/button/button.web-components-raE1x4tYL.spec.json
@@ -52,6 +52,10 @@
     "fullwidth": {
       "description": "When true, the button is expanded to fit the entire available space.",
       "type": "boolean"
+    },
+    "trailingIcon": {
+      "description": "When true, icon will be displayed after label",
+      "type": "boolean"
     }
   }
 }

--- a/apps/knapsack/dist/meta/knapsack.html-data.json
+++ b/apps/knapsack/dist/meta/knapsack.html-data.json
@@ -269,6 +269,10 @@
         {
           "name": "fullwidth",
           "description": "boolean When true, the button is expanded to fit the entire available space."
+        },
+        {
+          "name": "trailingIcon",
+          "description": "boolean When true, icon will be displayed after label"
         }
       ]
     },

--- a/apps/knapsack/dist/meta/knapsack.html-data.json
+++ b/apps/knapsack/dist/meta/knapsack.html-data.json
@@ -216,6 +216,33 @@
           "description": "Icon to display, and aria-label value when label is not defined"
         },
         {
+          "name": "color",
+          "values": [
+            {
+              "name": "primary"
+            },
+            {
+              "name": "secondary"
+            },
+            {
+              "name": "emphasis"
+            },
+            {
+              "name": "neutral"
+            },
+            {
+              "name": "caution"
+            },
+            {
+              "name": "negative"
+            },
+            {
+              "name": "positive"
+            }
+          ],
+          "description": "Applies the button color"
+        },
+        {
           "name": "raised",
           "description": "boolean Creates a contained button that is elevated above the surface"
         },
@@ -242,10 +269,6 @@
         {
           "name": "fullwidth",
           "description": "boolean When true, the button is expanded to fit the entire available space."
-        },
-        {
-          "name": "trailingIcon",
-          "description": "boolean When true, icon will be displayed after label"
         }
       ]
     },

--- a/libs/components/src/chips/chip-base.ts
+++ b/libs/components/src/chips/chip-base.ts
@@ -74,6 +74,7 @@ export class ChipBase extends LitElement {
       'mdc-evolution-chip--selectable': this.filter,
       'mdc-evolution-chip--with-avatar': this.avatar,
       secondary: this.state === 'secondary',
+      positive: this.state === 'positive',
       negative: this.state === 'negative',
       caution: this.state === 'caution',
     };

--- a/libs/components/src/chips/chip.scss
+++ b/libs/components/src/chips/chip.scss
@@ -22,6 +22,10 @@
     background-color: var(--mdc-theme-surface-primary);
   }
 
+  &.positive {
+    background-color: var(--cv-theme-surface-positive);
+  }
+
   &.negative {
     background-color: var(--mdc-theme-surface-negative);
   }

--- a/libs/components/src/chips/chips.stories.js
+++ b/libs/components/src/chips/chips.stories.js
@@ -64,6 +64,11 @@ Caution.args = {
   state: 'caution',
 };
 
+export const Positive = Template.bind({});
+Positive.args = {
+  state: 'positive',
+};
+
 export const Negative = Template.bind({});
 Negative.args = {
   state: 'negative',


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
1. Added missing `color` prop in knapsack for button component.
2. Added a `positive` variant for Chip item in storybook.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [x] `npm run storybook`
- [x] Navigate to Button stories
- [x] View the positive variant
- [x] Run `start` task for Knapsack in Nx
- [x] Navigate to Chip Item component
- [x] View the color property for Chip Item

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

<img width="754" alt="Screenshot 2024-04-08 at 6 23 24 PM" src="https://github.com/Teradata/covalent/assets/148156994/9a78cfdd-e917-4b65-8405-eb74aeba0c67">
<img width="1619" alt="Screenshot 2024-04-08 at 6 25 52 PM" src="https://github.com/Teradata/covalent/assets/148156994/f835d410-cf40-4ae8-b46b-42534e6ddee7">

