### PR TITLE
fix(components): padding adjustment and scrolling fix

### DIFF
--- a/libs/components/src/code-snippet/code-snippet.scss
+++ b/libs/components/src/code-snippet/code-snippet.scss
@@ -13,11 +13,10 @@
 
   pre {
     margin: 0;
-    padding: 16px 0;
     overflow: auto;
 
     code.hljs.cv-code-snippet {
-      padding: 0 16px;
+      padding: 16px;
       display: block;
       overflow-x: auto;
       font-family: var(--cv-theme-code-font-family);

--- a/libs/components/src/code-snippet/code-snippet.ts
+++ b/libs/components/src/code-snippet/code-snippet.ts
@@ -75,9 +75,12 @@ export class CovalentCodeSnippet extends LitElement {
       styleHeight = `max-height: ${this.maxHeight}px`;
     }
 
-    return html`<pre style="${styleHeight} part="container"><code class="${classMap(
-      classes
-    )}">${container}</code></pre><slot class="code-slot"></slot>`;
+    return html`
+      <pre style="${styleHeight}" part="container">
+        <code class="${classMap(classes)}">${container}</code>
+      </pre>
+      <slot class="code-slot"></slot>
+    `;
   }
 
   renderHeader() {


### PR DESCRIPTION
## Description

Padding adjustment and scrolling when a maxHeight is applied

#### Test Steps

- [ ] `npm run storybook`
- [ ] then navigate to the code snippet component with scrolling story
- [ ] finally test scrolling by scrolling the content inside the component

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

https://github.com/Teradata/covalent/assets/3837706/f0c39218-99fc-4a2b-a333-8573b82ed016

