### PR TITLE
feat(components): adding full width attribute to the appshell

### DIFF
--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -70,6 +70,17 @@
   overflow: auto;
   transition: margin 200ms ease-in-out;
 
+  .main-wrapper {
+    margin: 0 auto;
+    max-width: 1200px;
+
+    .cov-content--full-width & {
+      margin: 0;
+      width: 100%;
+      max-width: 100%;
+    }
+  }
+
   cv-card {
     margin: 0 12px 12px;
     display: block;
@@ -92,6 +103,12 @@
 
     .cov-help--open & {
       margin-right: 320px;
+    }
+  }
+
+  @media only screen and (max-width: 1600px) {
+    .main-wrapper {
+      max-width: 960px;
     }
   }
 }

--- a/libs/components/src/app-shell/app-shell.stories.js
+++ b/libs/components/src/app-shell/app-shell.stories.js
@@ -20,6 +20,7 @@ export default {
   title: 'Patterns/App Shell',
   args: {
     contained: true,
+    fullWidth: false,
   },
   argTypes: {
     navClick: { action: 'clicked' },
@@ -50,6 +51,7 @@ const Template = ({
   sectionTitle = '',
   forcedOpen = false,
   contained = true,
+  fullWidth = false
 }) => {
   document.addEventListener(
     'DOMContentLoaded',
@@ -96,6 +98,7 @@ const Template = ({
     ${sectionTitle ? `sectionName="${sectionTitle}"` : ''}
     ${forcedOpen ? `forcedOpen open` : ''}
     ${contained ? `contained` : ''}
+    ${fullWidth ? `fullWidth` : ''}
     >
 
       <cv-icon-button slot="section-action" icon="arrow_back"></cv-icon-button>

--- a/libs/components/src/app-shell/app-shell.stories.js
+++ b/libs/components/src/app-shell/app-shell.stories.js
@@ -51,7 +51,7 @@ const Template = ({
   sectionTitle = '',
   forcedOpen = false,
   contained = true,
-  fullWidth = false
+  fullWidth = false,
 }) => {
   document.addEventListener(
     'DOMContentLoaded',
@@ -303,4 +303,9 @@ sectionTitle.args = {
 export const forcedOpen = Template.bind({});
 forcedOpen.args = {
   forcedOpen: true,
+};
+
+export const fullWidth = Template.bind({});
+fullWidth.args = {
+  fullWidth: true,
 };

--- a/libs/components/src/app-shell/app-shell.ts
+++ b/libs/components/src/app-shell/app-shell.ts
@@ -67,6 +67,12 @@ export class CovalentAppShell extends DrawerBase {
   @property({ type: Boolean, reflect: true })
   forcedOpen = false;
 
+  /**
+   * Make the content area full width
+   */
+  @property({ type: Boolean, reflect: true })
+  fullWidth = false;
+
   private hovered = false;
 
   constructor() {
@@ -172,6 +178,7 @@ export class CovalentAppShell extends DrawerBase {
       'cov-drawer--hovered': this.hovered,
       'cov-help--open': this.helpOpen,
       'cov-help--closed': !this.helpOpen,
+      'cov-content--full-width': this.fullWidth,
     };
     const drawerClasses = {
       'mdc-drawer--dismissible': dismissible,
@@ -217,8 +224,10 @@ export class CovalentAppShell extends DrawerBase {
         ${scrim}
         <slot name="mini-list"></slot>
         <div class="main mdc-drawer-app-content">
-          <slot name="user-menu"></slot>
-          ${this.renderMain()}
+          <div class="main-wrapper">
+            <slot name="user-menu"></slot>
+            ${this.renderMain()}
+          </div>
         </div>
         <div class="help">
           <slot name="help"></slot>

--- a/libs/components/src/app-shell/app-shell.ts
+++ b/libs/components/src/app-shell/app-shell.ts
@@ -133,7 +133,7 @@ export class CovalentAppShell extends DrawerBase {
 
   resizeEvent() {
     // TODO should be configurable outside appshell
-    const mql = window.matchMedia('(max-width: 800px)');
+    const mql = window.matchMedia('(max-width: 767px)');
     if (mql.matches && this.type !== 'modal') {
       this.type = 'modal';
     } else if (!mql.matches && this.type !== 'dismissible') {


### PR DESCRIPTION
## Description

Adjustments to the appshell component to set a max width on the main content. Specs for the responsive appshell container can viewed [here](https://www.figma.com/file/KvXVAmYdCVAS7hzkOa73Em/Covalent-principles?type=design&node-id=7568-13372&mode=design&t=0FYXipNjcRzvzFCf-0). 


### What's included?
- Added a `fullWidth` attribute to allow the consumer to let the main content be 100% width
- Set a max width that is responsive 

#### Test Steps

- [ ] `npm run storybook `
- [ ] then go to the app shell story and click the "launch in new window" icon
- [ ] finally resize your screen from largest to small to see the max width assigned and responsive behavior

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plun
<img width="1528" alt="Screenshot 2024-04-12 at 9 40 03 AM" src="https://github.com/Teradata/covalent/assets/3837706/eeee8cf7-b588-41c1-a92a-d79bf764bdf5">

