### PR TITLE
feat(components): adding fill to toggled on icon button

### DIFF
--- a/libs/components/index.html
+++ b/libs/components/index.html
@@ -124,18 +124,23 @@
           slot="actionItems"
           icon="notifications"
         ></cv-icon-button>
-        <cv-icon-button
+        <cv-icon-button-toggle
           slot="actionItems"
-          icon="help"
+          onIcon="help"
+          offIcon="help"
           class="help-item"
-        ></cv-icon-button>
+        ></cv-icon-button-toggle>
         <cv-icon-button slot="actionItems" icon="person"></cv-icon-button>
       </cv-toolbar>
 
       <div slot="help" class="mdc-typography">
         <cv-toolbar sticky>
           <span slot="title">Help</span>
-          <cv-icon-button slot="actionItems" icon="undock"></cv-icon-button>
+          <cv-icon-button
+            slot="actionItems"
+            icon="undock"
+            iconFont="covalent-icons"
+          ></cv-icon-button>
           <cv-icon-button
             slot="actionItems"
             icon="close"
@@ -261,14 +266,16 @@
       var appShell = document.querySelector('cv-app-shell');
       var sectionMenu = document.querySelector('#section-menu');
       var sectionSelector = document.querySelector('.section-selector');
+      var helpClose = document.querySelector('.help-close');
+      var helpItem = document.querySelector('.help-item');
 
-      document.querySelector('.help-item').addEventListener('click', () => {
+      helpItem.addEventListener('click', () => {
         appShell.helpOpen = !appShell.helpOpen;
-        alert;
       });
 
-      document.querySelector('.help-close').addEventListener('click', () => {
+      helpClose.addEventListener('click', () => {
         appShell.helpOpen = false;
+        helpItem.on = false;
       });
 
       sectionSelector.addEventListener('click', function () {

--- a/libs/components/src/app-shell/app-shell.stories.js
+++ b/libs/components/src/app-shell/app-shell.stories.js
@@ -4,6 +4,7 @@ import '../data-table/data-table.stories.scss';
 import './app-shell';
 import '../action-ribbon/action-ribbon';
 import '../icon/icon';
+import '../icon-button-toggle/icon-button-toggle';
 import '../select/select';
 import '../list/list';
 import '../list/list-item';
@@ -55,16 +56,18 @@ const Template = ({
     'DOMContentLoaded',
     () => {
       const dataTableEl = document.querySelector('.mdc-data-table');
+      const helpItem = document.querySelector('.help-item');
       appShell = document.querySelector('cv-app-shell');
       banner = document.querySelector('cv-action-ribbon');
       dataTable = new MDCDataTable(dataTableEl);
 
-      document.querySelector('.help-item').addEventListener('click', () => {
+      helpItem.addEventListener('click', () => {
         appShell.helpOpen = !appShell.helpOpen;
       });
 
       document.querySelector('.help-close').addEventListener('click', () => {
         appShell.helpOpen = false;
+        helpItem.on = false;
       });
 
       setTimeout(updateActionRibbon, 150);
@@ -165,7 +168,7 @@ const Template = ({
        
        <cv-textfield slot="actionItems" icon="forum" placeholder="Message ask.ai" dense></cv-textfield>
        <cv-icon-button slot="actionItems" icon="notifications"></cv-icon-button>
-       <cv-icon-button slot="actionItems" icon="help" class="help-item"></cv-icon-button>
+       <cv-icon-button-toggle slot="actionItems" onIcon="help" offIcon="help" class="help-item"></cv-icon-button-toggle>
        <cv-icon-button slot="actionItems" icon="person"></cv-icon-button>
       </cv-toolbar>
 

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.scss
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.scss
@@ -14,4 +14,8 @@
 
   background-color: var(--cv-theme-primary-8);
   color: var(--cv-theme-primary);
+
+  .material-icons {
+    font-variation-settings: 'FILL' 1;
+  }
 }

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.ts
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.ts
@@ -1,4 +1,4 @@
-import { css, unsafeCSS } from 'lit';
+import { css, html, unsafeCSS } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { IconButtonToggle } from '@material/mwc-icon-button-toggle/mwc-icon-button-toggle';
 import styles from './icon-button-toggle.scss?inline';
@@ -17,6 +17,17 @@ export class CovalentIconButtonToggle extends IconButtonToggle {
       ${unsafeCSS(styles)}
     `,
   ];
+
+  protected renderRipple() {
+    return this.shouldRenderRipple
+      ? html` <mwc-ripple
+          .disabled="${this.disabled}"
+          .activated="${this.on}"
+          unbounded
+        >
+        </mwc-ripple>`
+      : '';
+  }
 }
 
 export default CovalentIconButtonToggle;

--- a/libs/components/src/list/list-item.scss
+++ b/libs/components/src/list/list-item.scss
@@ -40,3 +40,10 @@
   display: flex;
   align-items: center;
 }
+
+
+:host([selected]), :host([activated]) {
+  .material-icons {
+    font-variation-settings: 'FILL' 1;
+  }
+}

--- a/libs/components/src/list/list-item.scss
+++ b/libs/components/src/list/list-item.scss
@@ -40,10 +40,3 @@
   display: flex;
   align-items: center;
 }
-
-
-:host([selected]), :host([activated]) {
-  .material-icons {
-    font-variation-settings: 'FILL' 1;
-  }
-}

--- a/libs/components/src/list/nav-list-item.scss
+++ b/libs/components/src/list/nav-list-item.scss
@@ -41,6 +41,13 @@
   height: 48px;
 }
 
+:host([selected]),
+:host([activated]) {
+  .mdc-deprecated-list-item__graphic.material-icons {
+    font-variation-settings: 'FILL' 1;
+  }
+}
+
 :host(.beta-list-item) {
   --mdc-theme-primary: var(--mdc-theme-surface-caution);
   --mdc-list-item-meta-size: 20px;


### PR DESCRIPTION
## Description

Setting icon toggle button to be "filled" when toggled on

### What's included?

- icon filled when selected
- adding icon toggle to app shell story

#### Test Steps

- [ ] `npm run storybook`
- [ ] then navigate to the icon toggle button story
- [ ] finally click the icon toggle on/off to observe fill change

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

https://github.com/Teradata/covalent/assets/3837706/8a597b69-228d-4960-9556-544a26ed6e22

