### PR TITLE
fix(components): adjusting whitespace causing style issue

### DIFF
--- a/libs/components/src/code-snippet/code-snippet.ts
+++ b/libs/components/src/code-snippet/code-snippet.ts
@@ -75,12 +75,11 @@ export class CovalentCodeSnippet extends LitElement {
       styleHeight = `max-height: ${this.maxHeight}px`;
     }
 
-    return html`
-      <pre style="${styleHeight}" part="container">
-        <code class="${classMap(classes)}">${container}</code>
-      </pre>
-      <slot class="code-slot"></slot>
-    `;
+    return html` <pre
+        style="${styleHeight}"
+        part="container"
+      ><code class="${classMap(classes)}">${container}</code></pre>
+      <slot class="code-slot"></slot>`;
   }
 
   renderHeader() {


### PR DESCRIPTION
## Description

Removing white space from covalent code component that was causing extra space.

### Before
<img width="385" alt="Screenshot 2024-04-12 at 4 44 22 PM" src="https://github.com/Teradata/covalent/assets/3837706/b48827e0-b8f5-4fd6-b8c7-7b51aee3b2be">

### After
<img width="368" alt="Screenshot 2024-04-12 at 4 44 48 PM" src="https://github.com/Teradata/covalent/assets/3837706/06f1ff16-948d-4071-9765-b745e24af504">
