### PR TITLE
fix(app-shell): enhancement to be resizable app-shell

### DIFF
--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -68,7 +68,6 @@
   height: 100vh;
   grid-area: main;
   overflow: auto;
-  transition: margin 200ms ease-in-out;
 
   .main-wrapper {
     margin: 0 auto;
@@ -111,14 +110,11 @@
 
 .help {
   grid-area: help;
-  position: relative;
+  position: fixed;
   right: 0;
-  overflow: hidden;
-  width: 320px;
+  width: var(--help-width, 320px);
   height: 100vh;
   overflow-y: auto;
-  transition-property: width;
-  transition-duration: 200ms;
 
   .resize-handle {
     position: absolute;
@@ -142,7 +138,8 @@
       opacity: 0;
     }
 
-    &:hover::after {
+    &:hover::after,
+    &.resizing::after {
       opacity: 1;
     }
   }
@@ -176,7 +173,7 @@
 
   .current-section-name {
     opacity: 0;
-    transition: opacity 150ms;
+    transition: opacity 200ms;
 
     :host([open]) & {
       opacity: 1;

--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -100,10 +100,6 @@
     .cov-drawer--open & {
       margin-left: 256px;
     }
-
-    .cov-help--open & {
-      margin-right: 320px;
-    }
   }
 
   @media only screen and (max-width: 1600px) {
@@ -115,13 +111,41 @@
 
 .help {
   grid-area: help;
-  position: fixed;
+  position: relative;
   right: 0;
+  overflow: hidden;
   width: 320px;
   height: 100vh;
   overflow-y: auto;
   transition-property: width;
   transition-duration: 200ms;
+
+  .resize-handle {
+    position: absolute;
+    left: 0;
+    width: 10px;
+    height: 100vh;
+    cursor: ew-resize;
+    z-index: 1100;
+    user-select: none;
+
+    &::after {
+      content: '';
+      position: absolute;
+      left: 50%;
+      top: 0;
+      width: 2px;
+      height: 100%;
+      background-color: var(--mdc-theme-primary);
+      transform: translateX(-50%);
+      transition: opacity 0.3s ease;
+      opacity: 0;
+    }
+
+    &:hover::after {
+      opacity: 1;
+    }
+  }
 
   .cov-help--closed & {
     width: 0;

--- a/libs/components/src/app-shell/app-shell.ts
+++ b/libs/components/src/app-shell/app-shell.ts
@@ -174,7 +174,13 @@ export class CovalentAppShell extends DrawerBase {
 
   private _resize(event: MouseEvent) {
     const diff = event.clientX - this._startX;
-    const newWidth = Math.max(320, Math.min(600, this._startWidth - diff));
+    const windowWidth = window.innerWidth;
+    const mainMinWidth = 600;
+    const maxWidthForHelp = Math.max(320, windowWidth - mainMinWidth);
+    const newWidth = Math.max(
+      320,
+      Math.min(maxWidthForHelp, this._startWidth - diff)
+    );
     if (this.helpWidth !== newWidth) {
       this.helpWidth = newWidth;
       localStorage.setItem('helpWidth', this.helpWidth.toString());


### PR DESCRIPTION
## Description

The help option panel is now resizable to the left, it can now scroll with a maximum width of 600 px. Help panel text wraps automatically

### What's included?

- This PR includes the functionality to make the Help Panel resizable

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
