### PR TITLE
fix(app-shell): fix nav-list menu

### DIFF
--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -149,6 +149,14 @@
     }
   }
 
+  :host([resizing]) .resize-handle {
+    display: block;
+  }
+
+  :host(:not([resizing])) .resize-handle {
+    display: none;
+  }
+
   .cov-help--closed & {
     width: 0;
     border: none;

--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -100,6 +100,10 @@
     .cov-drawer--open & {
       margin-left: 256px;
     }
+
+    .cov-help--open & {
+      margin-right: var(--cv-help-width, 320px);
+    }
   }
 
   @media only screen and (max-width: 1600px) {
@@ -113,7 +117,7 @@
   grid-area: help;
   position: fixed;
   right: 0;
-  width: var(--help-width, 320px);
+  width: var(--cv-help-width, 320px);
   height: 100vh;
   overflow-y: auto;
 

--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -68,6 +68,7 @@
   height: 100vh;
   grid-area: main;
   overflow: auto;
+  transition: margin-left 200ms ease-in-out;
 
   .main-wrapper {
     margin: 0 auto;
@@ -291,6 +292,7 @@ nav.navigation {
 
   .mdc-drawer--open {
     width: 256px;
+    transition-duration: 200ms;
   }
 
   .mdc-drawer--opening {

--- a/libs/components/src/app-shell/app-shell.stories.js
+++ b/libs/components/src/app-shell/app-shell.stories.js
@@ -22,6 +22,7 @@ export default {
   args: {
     contained: true,
     fullWidth: false,
+    resizing: true,
   },
   argTypes: {
     navClick: { action: 'clicked' },
@@ -53,6 +54,7 @@ const Template = ({
   forcedOpen = false,
   contained = true,
   fullWidth = false,
+  resizing = true,
 }) => {
   document.addEventListener(
     'DOMContentLoaded',
@@ -102,6 +104,8 @@ const Template = ({
     ${forcedOpen ? `forcedOpen open` : ''}
     ${contained ? `contained` : ''}
     ${fullWidth ? `fullWidth` : ''}
+    ${resizing ? `resizing` : ''}
+    
     >
 
       <cv-icon-button slot="section-action" icon="arrow_back"></cv-icon-button>
@@ -311,4 +315,9 @@ forcedOpen.args = {
 export const fullWidth = Template.bind({});
 fullWidth.args = {
   fullWidth: true,
+};
+
+export const resizing = Template.bind({});
+resizing.args = {
+  resizing: true,
 };

--- a/libs/components/src/app-shell/app-shell.ts
+++ b/libs/components/src/app-shell/app-shell.ts
@@ -61,6 +61,12 @@ export class CovalentAppShell extends DrawerBase {
   helpOpen = false;
 
   /**
+   * Make help resizable with drag/drop handle
+   */
+  @property({ type: Boolean, reflect: true })
+  helpResizable = false;
+
+  /**
    * Wrap the main area with a contained card surface
    */
   @property({ type: Boolean, reflect: true })
@@ -77,12 +83,6 @@ export class CovalentAppShell extends DrawerBase {
    */
   @property({ type: Boolean, reflect: true })
   fullWidth = false;
-
-  /**
-   * Make help resizable
-   */
-  @property({ type: Boolean, reflect: true })
-  resizing = false;
 
   private hovered = false;
 
@@ -148,7 +148,7 @@ export class CovalentAppShell extends DrawerBase {
   }
 
   private _startResizing(event: MouseEvent) {
-    if (!this.resizing) return;
+    if (!this.helpResizable) return;
 
     const resizeHandle = this.shadowRoot?.querySelector('.resize-handle');
     if (event.target === resizeHandle) {
@@ -351,7 +351,9 @@ export class CovalentAppShell extends DrawerBase {
           </div>
         </div>
         <div class="help" @mousedown="${this._startResizing}">
-          ${this.resizing ? html`<div class="resize-handle"></div>` : nothing}
+          ${this.helpResizable
+            ? html`<div class="resize-handle"></div>`
+            : nothing}
           <slot name="help"></slot>
         </div>
       </div>

--- a/libs/components/src/app-shell/app-shell.ts
+++ b/libs/components/src/app-shell/app-shell.ts
@@ -78,6 +78,12 @@ export class CovalentAppShell extends DrawerBase {
   @property({ type: Boolean, reflect: true })
   fullWidth = false;
 
+  /**
+   * Make help resizable
+   */
+  @property({ type: Boolean, reflect: true })
+  resizing = false;
+
   private hovered = false;
 
   constructor() {
@@ -142,6 +148,8 @@ export class CovalentAppShell extends DrawerBase {
   }
 
   private _startResizing(event: MouseEvent) {
+    if (!this.resizing) return;
+
     const resizeHandle = this.shadowRoot?.querySelector('.resize-handle');
     if (event.target === resizeHandle) {
       this._startX = event.clientX;
@@ -343,7 +351,7 @@ export class CovalentAppShell extends DrawerBase {
           </div>
         </div>
         <div class="help" @mousedown="${this._startResizing}">
-          <div class="resize-handle"></div>
+          ${this.resizing ? html`<div class="resize-handle"></div>` : nothing}
           <slot name="help"></slot>
         </div>
       </div>

--- a/libs/components/src/app-shell/app-shell.ts
+++ b/libs/components/src/app-shell/app-shell.ts
@@ -141,26 +141,6 @@ export class CovalentAppShell extends DrawerBase {
     });
   }
 
-  override firstUpdated() {
-    const resizeHandle = this.shadowRoot?.querySelector('.resize-handle');
-    if (resizeHandle) {
-      resizeHandle.addEventListener('mousedown', (event) => {
-        if (event instanceof MouseEvent) {
-          this._startResizing(event);
-        }
-      });
-
-      resizeHandle.addEventListener('dblclick', () => {
-        if (this.helpWidth > 320 || this.helpWidth !== 320) {
-          this.helpWidth = 320;
-          localStorage.setItem('helpWidth', '320');
-          this.updateHelpPanelWidth();
-          this.requestUpdate();
-        }
-      });
-    }
-  }
-
   private _startResizing(event: MouseEvent) {
     const resizeHandle = this.shadowRoot?.querySelector('.resize-handle');
     if (event.target === resizeHandle) {
@@ -170,6 +150,15 @@ export class CovalentAppShell extends DrawerBase {
       document.addEventListener('mouseup', this._stopResize);
       (event.target as HTMLElement).classList.add('resizing');
     }
+
+    resizeHandle?.addEventListener('dblclick', () => {
+      if (this.helpWidth > 320 || this.helpWidth !== 320) {
+        this.helpWidth = 320;
+        localStorage.setItem('helpWidth', '320');
+        this.updateHelpPanelWidth();
+        this.requestUpdate();
+      }
+    });
   }
 
   private _resize(event: MouseEvent) {

--- a/libs/components/src/app-shell/app-shell.ts
+++ b/libs/components/src/app-shell/app-shell.ts
@@ -82,13 +82,13 @@ export class CovalentAppShell extends DrawerBase {
 
   constructor() {
     super();
+    this.resizeEvent();
     this._resize = this._resize.bind(this);
     this._stopResize = this._stopResize.bind(this);
     this._startResizing = this._startResizing.bind(this);
     this._setupEventListeners();
     window.addEventListener('DOMContentLoaded', () => {
       this.setupHelpPanelListeners();
-      this.resizeEvent();
       const storedWidth = localStorage.getItem('helpWidth');
       if (storedWidth) {
         this.helpWidth = parseInt(storedWidth, 10);
@@ -202,13 +202,10 @@ export class CovalentAppShell extends DrawerBase {
   }
 
   private updateHelpPanelWidth() {
-    const helpPanel = this.shadowRoot?.querySelector('.help') as HTMLElement;
-    const mainPanel = this.shadowRoot?.querySelector('.main') as HTMLElement;
-
-    if (helpPanel && mainPanel) {
-      helpPanel.style.setProperty('--help-width', `${this.helpWidth}px`);
-      mainPanel.style.marginRight = `${this.helpWidth}px`;
-    }
+    const appShell = this.shadowRoot?.querySelector(
+      '.app-shell'
+    ) as HTMLElement;
+    appShell?.style.setProperty('--cv-help-width', `${this.helpWidth}px`);
   }
 
   private _handleMenuClick() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "@commitlint/cli": "^18.4.3",
         "@commitlint/config-angular": "^16.2.1",
         "@commitlint/config-conventional": "^16.2.1",
-        "@covalent/tokens": "*",
+        "@covalent/tokens": "latest",
         "@nx/angular": "17.3.1",
         "@nx/cypress": "17.3.1",
         "@nx/eslint": "17.3.1",


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->

### What's included?

There was a conflict in the override firstUpdated() method, which caused a block in closing the nav-list menu. To avoid this blockage, the _startResizing method was removed. This resolved both issues: on one hand, the correct closing of the nav-list menu, and on the other hand, resizing to the default size of 320px for the help panel when double-clicking on the resize line.

<!-- List features included in this PR -->

- Fix the problem with the Hamburger Menu on Nav list Menu. 
- Tested using Covalent 8.12.1

NOTE : It was found that the line setTimeout(updateActionRibbon, 150) in the file app-shell.stories.js ; is causing the error "Uncaught TypeError: Cannot read properties of undefined (reading '0')". This line introduces a delay before executing updateActionRibbon to ensure that all elements and components are fully initialized.

Removing setTimeout(updateActionRibbon, 150); may avoid the current error, but we need to find a way to ensure that updateActionRibbon only executes after dataTable is fully initialized.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
