### PR TITLE
fix(app-shell): small fix to works fine the resizable

### DIFF
--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -144,16 +144,16 @@
     }
 
     &:hover::after,
-    &.resizing::after {
+    &.helpResizable::after {
       opacity: 1;
     }
   }
 
-  :host([resizing]) .resize-handle {
+  :host([helpResizable]) .resize-handle {
     display: block;
   }
 
-  :host(:not([resizing])) .resize-handle {
+  :host(:not([helpResizable])) .resize-handle {
     display: none;
   }
 

--- a/libs/components/src/app-shell/app-shell.stories.js
+++ b/libs/components/src/app-shell/app-shell.stories.js
@@ -22,7 +22,7 @@ export default {
   args: {
     contained: true,
     fullWidth: false,
-    resizing: true,
+    helpResizable: true,
   },
   argTypes: {
     navClick: { action: 'clicked' },
@@ -54,7 +54,7 @@ const Template = ({
   forcedOpen = false,
   contained = true,
   fullWidth = false,
-  resizing = true,
+  helpResizable = true,
 }) => {
   document.addEventListener(
     'DOMContentLoaded',
@@ -104,7 +104,7 @@ const Template = ({
     ${forcedOpen ? `forcedOpen open` : ''}
     ${contained ? `contained` : ''}
     ${fullWidth ? `fullWidth` : ''}
-    ${resizing ? `resizing` : ''}
+    ${helpResizable ? `helpResizable` : ''}
     
     >
 
@@ -317,7 +317,7 @@ fullWidth.args = {
   fullWidth: true,
 };
 
-export const resizing = Template.bind({});
-resizing.args = {
-  resizing: true,
+export const helpResizable = Template.bind({});
+helpResizable.args = {
+  helpResizable: true,
 };

--- a/libs/components/src/app-shell/app-shell.ts
+++ b/libs/components/src/app-shell/app-shell.ts
@@ -156,7 +156,7 @@ export class CovalentAppShell extends DrawerBase {
       this._startWidth = this.helpWidth;
       document.addEventListener('mousemove', this._resize);
       document.addEventListener('mouseup', this._stopResize);
-      (event.target as HTMLElement).classList.add('resizing');
+      (event.target as HTMLElement).classList.add('helpResizable');
     }
 
     resizeHandle?.addEventListener('dblclick', () => {
@@ -191,7 +191,7 @@ export class CovalentAppShell extends DrawerBase {
     document.removeEventListener('mouseup', this._stopResize);
     const resizeHandle = this.shadowRoot?.querySelector('.resize-handle');
     if (resizeHandle) {
-      resizeHandle.classList.remove('resizing');
+      resizeHandle.classList.remove('helpResizable');
     }
   }
 


### PR DESCRIPTION
## Description

Small fixes to works fine the Help Resizable  property..

### What's included?

<!-- List features included in this PR -->

- change the variable helpResizable instead resizing into the app-shell.stories.js

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

![app-shell-fixes](https://github.com/Teradata/covalent/assets/73868044/3aa1a7c1-17d1-4e04-acdf-b37a2c226ed4)

