### PR TITLE
fix(icon-button-toggle): replace property on with toggledOn

### DIFF
--- a/apps/knapsack/data/blocks/block.F2ROXe7JZl.json
+++ b/apps/knapsack/data/blocks/block.F2ROXe7JZl.json
@@ -2,6 +2,87 @@
   "id": "F2ROXe7JZl",
   "blockType": "text-editor",
   "data": {
-    "content": {}
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "type": "text",
+              "text": "*Note: Due to Angular's restriction on setting properties that start with the prefix "
+            },
+            {
+              "type": "text",
+              "marks": [
+                {
+                  "type": "code"
+                }
+              ],
+              "text": "on"
+            },
+            {
+              "type": "text",
+              "text": ", the property "
+            },
+            {
+              "type": "text",
+              "marks": [
+                {
+                  "type": "code"
+                }
+              ],
+              "text": "on"
+            },
+            {
+              "type": "text",
+              "text": " in "
+            },
+            {
+              "type": "text",
+              "marks": [
+                {
+                  "type": "code"
+                }
+              ],
+              "text": "mwc-icon-button-toggle"
+            },
+            {
+              "type": "text",
+              "text": " has been substituted with "
+            },
+            {
+              "type": "text",
+              "marks": [
+                {
+                  "type": "code"
+                }
+              ],
+              "text": "toggledOn"
+            },
+            {
+              "type": "text",
+              "text": " within "
+            },
+            {
+              "type": "text",
+              "marks": [
+                {
+                  "type": "code"
+                }
+              ],
+              "text": "cv-icon-button-toggle"
+            },
+            {
+              "type": "text",
+              "text": "."
+            }
+          ]
+        }
+      ]
+    }
   }
 }

--- a/apps/knapsack/data/blocks/block.TXAQGWjjCa.json
+++ b/apps/knapsack/data/blocks/block.TXAQGWjjCa.json
@@ -177,7 +177,7 @@
                               "type": "code"
                             }
                           ],
-                          "text": "on"
+                          "text": "toggledOn"
                         },
                         {
                           "type": "text",

--- a/apps/knapsack/data/knapsack.pattern.icon-button-toggle.json
+++ b/apps/knapsack/data/knapsack.pattern.icon-button-toggle.json
@@ -31,7 +31,7 @@
           "type": "object",
           "required": [],
           "properties": {
-            "on": {
+            "toggledOn": {
               "description": "Whether the toggle is activated.",
               "type": "boolean"
             },

--- a/apps/knapsack/dist/meta/icon-button-toggle/icon-button-toggle.web-components-6kGMXrj-eP.spec.d.ts
+++ b/apps/knapsack/dist/meta/icon-button-toggle/icon-button-toggle.web-components-6kGMXrj-eP.spec.d.ts
@@ -12,7 +12,7 @@ export interface IconButtonToggle {
   /**
    * Whether the toggle is activated.
    */
-  on?: boolean;
+  toggledOn?: boolean;
   /**
    * Disabled buttons cannot be interacted with and have no visual interaction effect.
    */

--- a/apps/knapsack/dist/meta/icon-button-toggle/icon-button-toggle.web-components-6kGMXrj-eP.spec.json
+++ b/apps/knapsack/dist/meta/icon-button-toggle/icon-button-toggle.web-components-6kGMXrj-eP.spec.json
@@ -4,7 +4,7 @@
   "type": "object",
   "required": [],
   "properties": {
-    "on": {
+    "toggledOn": {
       "description": "Whether the toggle is activated.",
       "type": "boolean"
     },

--- a/apps/knapsack/dist/meta/knapsack.html-data.json
+++ b/apps/knapsack/dist/meta/knapsack.html-data.json
@@ -797,7 +797,7 @@
       ],
       "attributes": [
         {
-          "name": "on",
+          "name": "toggledOn",
           "description": "boolean Whether the toggle is activated."
         },
         {

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.scss
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.scss
@@ -7,7 +7,7 @@
   background-color: transparent;
 }
 
-:host([on]) {
+:host([toggledOn]) {
   --mdc-ripple-press-opacity: 0.16;
   --mdc-ripple-hover-opacity: 0.12;
   --mdc-ripple-focus-opacity: 0.16;

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.stories.js
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.stories.js
@@ -17,15 +17,15 @@ export default {
     onIcon: 'flashlight_on',
     offIcon: 'flashlight_off',
     disabled: false,
-    on: false,
+    toggledOn: false,
   },
 };
 
-const Template = ({ disabled, onIcon, offIcon, on }) => {
+const Template = ({ disabled, onIcon, offIcon, toggledOn }) => {
   return `
     <cv-icon-button-toggle onIcon="${onIcon}" offIcon="${offIcon}"${
     disabled ? ` disabled` : ``
-  }${on ? ' on' : ''}>
+  }${toggledOn ? ' toggledOn' : ''}>
     </cv-icon-button-toggle>`;
 };
 

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.ts
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.ts
@@ -1,6 +1,8 @@
 import { css, html, unsafeCSS } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { IconButtonToggle } from '@material/mwc-icon-button-toggle/mwc-icon-button-toggle';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import styles from './icon-button-toggle.scss?inline';
 
 declare global {
@@ -11,6 +13,13 @@ declare global {
 
 @customElement('cv-icon-button-toggle')
 export class CovalentIconButtonToggle extends IconButtonToggle {
+  /**
+   * Angular doesn't allow properties that begin with 'on' to be set due to security reasons.
+   * This is an alias for the 'on' property in mwc-icon-button-toggle, which can be used to toggle the button on/off.
+   */
+  @property({ type: Boolean, reflect: true })
+  toggledOn = false;
+
   static override styles = [
     ...IconButtonToggle.styles,
     css`
@@ -18,15 +27,67 @@ export class CovalentIconButtonToggle extends IconButtonToggle {
     `,
   ];
 
-  protected renderRipple() {
+  protected override handleClick(): void {
+    this.toggledOn = !this.toggledOn;
+    this.dispatchEvent(
+      new CustomEvent('icon-button-toggle-change', {
+        detail: { isOn: this.toggledOn },
+        bubbles: true,
+      })
+    );
+  }
+
+  protected override renderRipple() {
     return this.shouldRenderRipple
       ? html` <mwc-ripple
           .disabled="${this.disabled}"
-          .activated="${this.on}"
+          .activated="${this.toggledOn}"
           unbounded
         >
         </mwc-ripple>`
       : '';
+  }
+
+  protected override render() {
+    /** @classMap */
+    const classes = {
+      'mdc-icon-button--on': this.toggledOn,
+    };
+    const hasToggledAriaLabel =
+      this.ariaLabelOn !== undefined && this.ariaLabelOff !== undefined;
+    const ariaPressedValue = hasToggledAriaLabel ? undefined : this.toggledOn;
+    const ariaLabelValue = hasToggledAriaLabel
+      ? this.toggledOn
+        ? this.ariaLabelOn
+        : this.ariaLabelOff
+      : this.ariaLabel;
+    return html`<button
+      class="mdc-icon-button mdc-icon-button--display-flex ${classMap(classes)}"
+      aria-pressed="${ifDefined(ariaPressedValue)}"
+      aria-label="${ifDefined(ariaLabelValue)}"
+      @click="${this.handleClick}"
+      ?disabled="${this.disabled}"
+      @focus="${this.handleRippleFocus}"
+      @blur="${this.handleRippleBlur}"
+      @mousedown="${this.handleRippleMouseDown}"
+      @mouseenter="${this.handleRippleMouseEnter}"
+      @mouseleave="${this.handleRippleMouseLeave}"
+      @touchstart="${this.handleRippleTouchStart}"
+      @touchend="${this.handleRippleDeactivate}"
+      @touchcancel="${this.handleRippleDeactivate}"
+    >
+      ${this.renderRipple()}
+      <span class="mdc-icon-button__icon"
+        ><slot name="offIcon"
+          ><i class="material-icons">${this.offIcon}</i></slot
+        ></span
+      >
+      <span class="mdc-icon-button__icon mdc-icon-button__icon--on"
+        ><slot name="onIcon"
+          ><i class="material-icons">${this.onIcon}</i></slot
+        ></span
+      >
+    </button>`;
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
While using `cv-icon-button-toggle` component in angular, if the property `on` is set in the template, Angular throws an error.
<img width="749" alt="Screenshot 2024-06-11 at 2 38 10 PM" src="https://github.com/Teradata/covalent/assets/148156994/4954a7c4-fa6b-4931-9ee1-6410dd73e1f3">

Link to the discussion on this issue:
https://github.com/angular/angular/issues/11756

### What's included?

<!-- List features included in this PR -->

- Replace `on` with `toggledOn`
- Change storybook and knapsack docs accordingly

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [x] `npm run storybook`
- [x] Navigate to Icon button toggle
- [x] Try toggling the `cv-icon-button-toggle` with the `toggledOn` property

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1024" alt="Screenshot 2024-06-13 at 6 52 58 PM" src="https://github.com/Teradata/covalent/assets/148156994/4a1475bf-a397-412a-ae24-07dc5bca01d1">

<img width="1335" alt="Screenshot 2024-06-13 at 6 53 57 PM" src="https://github.com/Teradata/covalent/assets/148156994/8452b594-354b-4ff5-824d-aa98977ecfa9">
