### PR TITLE
fix(markdown): allow relative paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Covalent CI
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, release/4.x.x]
 
 jobs:
   lint:

--- a/libs/markdown/src/lib/markdown.component.spec.ts
+++ b/libs/markdown/src/lib/markdown.component.spec.ts
@@ -56,173 +56,155 @@ function anchorTestNonEnglishMarkdown(): string {
 }
 
 describe('Component: Markdown', () => {
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [CovalentMarkdownModule],
-        declarations: [
-          TdMarkdownEmptyStaticContentTestRenderingComponent,
-          TdMarkdownStaticContentTestRenderingComponent,
-          TdMarkdownDymanicContentTestRenderingComponent,
-          TdMarkdownSimpleLineBreaksTestRenderingComponent,
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [CovalentMarkdownModule],
+      declarations: [
+        TdMarkdownEmptyStaticContentTestRenderingComponent,
+        TdMarkdownStaticContentTestRenderingComponent,
+        TdMarkdownDymanicContentTestRenderingComponent,
+        TdMarkdownSimpleLineBreaksTestRenderingComponent,
 
-          TdMarkdownEmptyStaticContentTestEventsComponent,
-          TdMarkdownStaticContentTestEventsComponent,
-          TdMarkdownDynamicContentTestEventsComponent,
-          TdMarkdownAnchorsTestEventsComponent,
-          TdMarkdownLinksTestEventsComponent,
-        ],
-      });
-      TestBed.compileComponents();
-    })
-  );
+        TdMarkdownEmptyStaticContentTestEventsComponent,
+        TdMarkdownStaticContentTestEventsComponent,
+        TdMarkdownDynamicContentTestEventsComponent,
+        TdMarkdownAnchorsTestEventsComponent,
+        TdMarkdownLinksTestEventsComponent,
+      ],
+    });
+    TestBed.compileComponents();
+  }));
 
   describe('Rendering: ', () => {
-    it(
-      'should render empty static content',
-      waitForAsync(() => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownEmptyStaticContentTestRenderingComponent
-        );
-        const element: HTMLElement = fixture.nativeElement;
+    it('should render empty static content', waitForAsync(() => {
+      const fixture: ComponentFixture<any> = TestBed.createComponent(
+        TdMarkdownEmptyStaticContentTestRenderingComponent
+      );
+      const element: HTMLElement = fixture.nativeElement;
 
-        expect(
-          fixture.debugElement
-            .query(By.css('td-markdown'))
-            .nativeElement.textContent.trim()
-        ).toBe(``);
-        expect(element.querySelector('td-markdown div')).toBeFalsy();
+      expect(
+        fixture.debugElement
+          .query(By.css('td-markdown'))
+          .nativeElement.textContent.trim()
+      ).toBe(``);
+      expect(element.querySelector('td-markdown div')).toBeFalsy();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
         fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          fixture.detectChanges();
-          expect(element.querySelector('td-markdown div')).toBeFalsy();
-          expect(
-            fixture.debugElement
-              .query(By.css('td-markdown'))
-              .nativeElement.textContent.trim()
-          ).toBe('');
-        });
-      })
-    );
-
-    it(
-      'should render markup from static content',
-      waitForAsync(() => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownStaticContentTestRenderingComponent
-        );
-        const element: HTMLElement = fixture.nativeElement;
-
+        expect(element.querySelector('td-markdown div')).toBeFalsy();
         expect(
           fixture.debugElement
             .query(By.css('td-markdown'))
             .nativeElement.textContent.trim()
-        ).toBe(
-          `
+        ).toBe('');
+      });
+    }));
+
+    it('should render markup from static content', waitForAsync(() => {
+      const fixture: ComponentFixture<any> = TestBed.createComponent(
+        TdMarkdownStaticContentTestRenderingComponent
+      );
+      const element: HTMLElement = fixture.nativeElement;
+
+      expect(
+        fixture.debugElement
+          .query(By.css('td-markdown'))
+          .nativeElement.textContent.trim()
+      ).toBe(
+        `
         # title
 
         * list item`.trim()
-        );
-        expect(element.querySelector('td-markdown div')).toBeFalsy();
+      );
+      expect(element.querySelector('td-markdown div')).toBeFalsy();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(element.querySelector('td-markdown div')).toBeTruthy();
+        expect(
+          element.querySelector('td-markdown div h1')?.textContent?.trim()
+        ).toBe('title');
+        expect(
+          element.querySelector('td-markdown div ul li')?.textContent?.trim()
+        ).toBe('list item');
+      });
+    }));
+
+    it('should render newlines as <br/> if simpleLineBreaks is true', waitForAsync(() => {
+      const fixture: ComponentFixture<any> = TestBed.createComponent(
+        TdMarkdownSimpleLineBreaksTestRenderingComponent
+      );
+      const component: TdMarkdownSimpleLineBreaksTestRenderingComponent =
+        fixture.debugElement.componentInstance;
+      component.simpleLineBreaks = true;
+      const element: HTMLElement = fixture.nativeElement;
+
+      expect(
+        fixture.debugElement
+          .query(By.css('td-markdown'))
+          .nativeElement.textContent.trim()
+      ).toBe(
+        `
+        first line
+        second line
+        third line
+        `.trim()
+      );
+      expect(element.querySelector('td-markdown div')).toBeFalsy();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
         fixture.detectChanges();
         fixture.whenStable().then(() => {
           fixture.detectChanges();
           expect(element.querySelector('td-markdown div')).toBeTruthy();
           expect(
-            element.querySelector('td-markdown div h1')?.textContent?.trim()
-          ).toBe('title');
+            element.querySelector('td-markdown')?.querySelectorAll('br').length
+          ).toBe(2);
+        });
+      });
+    }));
+
+    it('should not render newlines as <br/> if simpleLineBreaks is false', waitForAsync(() => {
+      const fixture: ComponentFixture<any> = TestBed.createComponent(
+        TdMarkdownSimpleLineBreaksTestRenderingComponent
+      );
+      const component: TdMarkdownSimpleLineBreaksTestRenderingComponent =
+        fixture.debugElement.componentInstance;
+      component.simpleLineBreaks = false;
+      const element: HTMLElement = fixture.nativeElement;
+
+      expect(
+        fixture.debugElement
+          .query(By.css('td-markdown'))
+          .nativeElement.textContent.trim()
+      ).toBe(
+        `
+        first line
+        second line
+        third line
+        `.trim()
+      );
+      expect(element.querySelector('td-markdown div')).toBeFalsy();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(element.querySelector('td-markdown div')).toBeTruthy();
           expect(
-            element.querySelector('td-markdown div ul li')?.textContent?.trim()
-          ).toBe('list item');
+            element.querySelector('td-markdown')?.querySelectorAll('br').length
+          ).toBe(0);
         });
-      })
-    );
+      });
+    }));
 
-    it(
-      'should render newlines as <br/> if simpleLineBreaks is true',
-      waitForAsync(() => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownSimpleLineBreaksTestRenderingComponent
-        );
-        const component: TdMarkdownSimpleLineBreaksTestRenderingComponent =
-          fixture.debugElement.componentInstance;
-        component.simpleLineBreaks = true;
-        const element: HTMLElement = fixture.nativeElement;
-
-        expect(
-          fixture.debugElement
-            .query(By.css('td-markdown'))
-            .nativeElement.textContent.trim()
-        ).toBe(
-          `
-        first line
-        second line
-        third line
-        `.trim()
-        );
-        expect(element.querySelector('td-markdown div')).toBeFalsy();
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          fixture.detectChanges();
-          fixture.whenStable().then(() => {
-            fixture.detectChanges();
-            expect(element.querySelector('td-markdown div')).toBeTruthy();
-            expect(
-              element.querySelector('td-markdown')?.querySelectorAll('br')
-                .length
-            ).toBe(2);
-          });
-        });
-      })
-    );
-
-    it(
-      'should not render newlines as <br/> if simpleLineBreaks is false',
-      waitForAsync(() => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownSimpleLineBreaksTestRenderingComponent
-        );
-        const component: TdMarkdownSimpleLineBreaksTestRenderingComponent =
-          fixture.debugElement.componentInstance;
-        component.simpleLineBreaks = false;
-        const element: HTMLElement = fixture.nativeElement;
-
-        expect(
-          fixture.debugElement
-            .query(By.css('td-markdown'))
-            .nativeElement.textContent.trim()
-        ).toBe(
-          `
-        first line
-        second line
-        third line
-        `.trim()
-        );
-        expect(element.querySelector('td-markdown div')).toBeFalsy();
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          fixture.detectChanges();
-          fixture.whenStable().then(() => {
-            fixture.detectChanges();
-            expect(element.querySelector('td-markdown div')).toBeTruthy();
-            expect(
-              element.querySelector('td-markdown')?.querySelectorAll('br')
-                .length
-            ).toBe(0);
-          });
-        });
-      })
-    );
-
-    it(
-      'should render markup from dynamic content',
-      waitForAsync(() => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownDymanicContentTestRenderingComponent
-        );
-        const component: TdMarkdownDymanicContentTestRenderingComponent =
-          fixture.debugElement.componentInstance;
-        component.content = `
+    it('should render markup from dynamic content', waitForAsync(() => {
+      const fixture: ComponentFixture<any> = TestBed.createComponent(
+        TdMarkdownDymanicContentTestRenderingComponent
+      );
+      const component: TdMarkdownDymanicContentTestRenderingComponent =
+        fixture.debugElement.componentInstance;
+      component.content = `
       # another title
 
       ## subtitle
@@ -230,149 +212,139 @@ describe('Component: Markdown', () => {
       \`\`\`
       pseudo code
       \`\`\``;
-        const element: HTMLElement = fixture.nativeElement;
+      const element: HTMLElement = fixture.nativeElement;
 
-        expect(
-          fixture.debugElement
-            .query(By.css('td-markdown'))
-            .nativeElement.textContent.trim()
-        ).toBe('');
-        expect(element.querySelector('td-markdown div')).toBeFalsy();
+      expect(
+        fixture.debugElement
+          .query(By.css('td-markdown'))
+          .nativeElement.textContent.trim()
+      ).toBe('');
+      expect(element.querySelector('td-markdown div')).toBeFalsy();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
         fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          fixture.detectChanges();
-          expect(element.querySelector('td-markdown div')).toBeTruthy();
-          expect(
-            element.querySelector('td-markdown div h1')?.textContent?.trim()
-          ).toBe('another title');
-          expect(
-            element.querySelector('td-markdown div h2')?.textContent?.trim()
-          ).toBe('subtitle');
-          expect(
-            element.querySelector('td-markdown div code')?.textContent?.trim()
-          ).toBe('pseudo code');
-        });
-      })
-    );
+        expect(element.querySelector('td-markdown div')).toBeTruthy();
+        expect(
+          element.querySelector('td-markdown div h1')?.textContent?.trim()
+        ).toBe('another title');
+        expect(
+          element.querySelector('td-markdown div h2')?.textContent?.trim()
+        ).toBe('subtitle');
+        expect(
+          element.querySelector('td-markdown div code')?.textContent?.trim()
+        ).toBe('pseudo code');
+      });
+    }));
 
-    it(
-      'should render markup from dynamic content incorrectly',
-      waitForAsync(() => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownDymanicContentTestRenderingComponent
-        );
-        const component: TdMarkdownDymanicContentTestRenderingComponent =
-          fixture.debugElement.componentInstance;
-        component.content = `
+    it('should render markup from dynamic content incorrectly', waitForAsync(() => {
+      const fixture: ComponentFixture<any> = TestBed.createComponent(
+        TdMarkdownDymanicContentTestRenderingComponent
+      );
+      const component: TdMarkdownDymanicContentTestRenderingComponent =
+        fixture.debugElement.componentInstance;
+      component.content = `
       # another title
 
         ## subtitle`;
-        const element: HTMLElement = fixture.nativeElement;
+      const element: HTMLElement = fixture.nativeElement;
 
+      expect(
+        fixture.debugElement
+          .query(By.css('td-markdown'))
+          .nativeElement.textContent.trim()
+      ).toBe('');
+      expect(element.querySelector('td-markdown div')).toBeFalsy();
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(element.querySelector('td-markdown div')).toBeTruthy();
         expect(
-          fixture.debugElement
-            .query(By.css('td-markdown'))
-            .nativeElement.textContent.trim()
-        ).toBe('');
-        expect(element.querySelector('td-markdown div')).toBeFalsy();
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          fixture.detectChanges();
-          expect(element.querySelector('td-markdown div')).toBeTruthy();
-          expect(
-            element.querySelector('td-markdown div h1')?.textContent?.trim()
-          ).toBe('another title');
-          expect(element.querySelector('td-markdown div h2')).toBeFalsy();
-          expect(
-            element.querySelector('td-markdown div')?.textContent?.trim()
-          ).toContain('## subtitle');
-        });
-      })
-    );
+          element.querySelector('td-markdown div h1')?.textContent?.trim()
+        ).toBe('another title');
+        expect(element.querySelector('td-markdown div h2')).toBeFalsy();
+        expect(
+          element.querySelector('td-markdown div')?.textContent?.trim()
+        ).toContain('## subtitle');
+      });
+    }));
 
-    it(
-      'should jump to anchor when anchor input is changed',
-      waitForAsync(async () => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownAnchorsTestEventsComponent
-        );
-        const component: TdMarkdownAnchorsTestEventsComponent =
-          fixture.debugElement.componentInstance;
-        component.content = anchorTestMarkdown();
+    it('should jump to anchor when anchor input is changed', waitForAsync(async () => {
+      const fixture: ComponentFixture<any> = TestBed.createComponent(
+        TdMarkdownAnchorsTestEventsComponent
+      );
+      const component: TdMarkdownAnchorsTestEventsComponent =
+        fixture.debugElement.componentInstance;
+      component.content = anchorTestMarkdown();
 
-        fixture.detectChanges();
-        await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
-        window.scrollTo(0, 0);
-        const originalScrollPos: number = window.scrollY;
-        component.anchor = 'heading 1';
+      window.scrollTo(0, 0);
+      const originalScrollPos: number = window.scrollY;
+      component.anchor = 'heading 1';
 
-        fixture.detectChanges();
-        await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
-        const heading1ScrollPos: number = window.scrollY;
-        expect(heading1ScrollPos).toBeGreaterThanOrEqual(originalScrollPos);
+      const heading1ScrollPos: number = window.scrollY;
+      expect(heading1ScrollPos).toBeGreaterThanOrEqual(originalScrollPos);
 
-        component.anchor = 'heading 2';
+      component.anchor = 'heading 2';
 
-        fixture.detectChanges();
-        await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
-        const heading2ScrollPos: number = window.scrollY;
-        expect(heading2ScrollPos).toBeGreaterThanOrEqual(heading1ScrollPos);
+      const heading2ScrollPos: number = window.scrollY;
+      expect(heading2ScrollPos).toBeGreaterThanOrEqual(heading1ScrollPos);
 
-        component.anchor = 'heading 1';
+      component.anchor = 'heading 1';
 
-        fixture.detectChanges();
-        await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
-        expect(window.scrollY).toBeLessThanOrEqual(heading2ScrollPos);
-      })
-    );
+      expect(window.scrollY).toBeLessThanOrEqual(heading2ScrollPos);
+    }));
 
-    it(
-      'should jump to anchor if an anchor link is clicked',
-      waitForAsync(async () => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownAnchorsTestEventsComponent
-        );
-        const component: TdMarkdownAnchorsTestEventsComponent =
-          fixture.debugElement.componentInstance;
-        component.content = anchorTestMarkdown();
+    it('should jump to anchor if an anchor link is clicked', waitForAsync(async () => {
+      const fixture: ComponentFixture<any> = TestBed.createComponent(
+        TdMarkdownAnchorsTestEventsComponent
+      );
+      const component: TdMarkdownAnchorsTestEventsComponent =
+        fixture.debugElement.componentInstance;
+      component.content = anchorTestMarkdown();
 
-        fixture.detectChanges();
-        await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
-        window.scrollTo(0, 0);
-        const originalScrollPos: number = window.scrollY;
-        const headings: HTMLElement[] =
-          fixture.debugElement.nativeElement.querySelectorAll('a');
-        const heading1: HTMLElement = headings[0];
-        const heading2: HTMLElement = headings[1];
-        heading1.click();
+      window.scrollTo(0, 0);
+      const originalScrollPos: number = window.scrollY;
+      const headings: HTMLElement[] =
+        fixture.debugElement.nativeElement.querySelectorAll('a');
+      const heading1: HTMLElement = headings[0];
+      const heading2: HTMLElement = headings[1];
+      heading1.click();
 
-        fixture.detectChanges();
-        await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
-        const heading1ScrollPos: number = window.scrollY;
-        expect(heading1ScrollPos).toBeGreaterThanOrEqual(originalScrollPos);
+      const heading1ScrollPos: number = window.scrollY;
+      expect(heading1ScrollPos).toBeGreaterThanOrEqual(originalScrollPos);
 
-        heading2.click();
+      heading2.click();
 
-        fixture.detectChanges();
-        await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
-        const heading2ScrollPos: number = window.scrollY;
-        expect(heading2ScrollPos).toBeGreaterThanOrEqual(heading1ScrollPos);
+      const heading2ScrollPos: number = window.scrollY;
+      expect(heading2ScrollPos).toBeGreaterThanOrEqual(heading1ScrollPos);
 
-        heading1.click();
+      heading1.click();
 
-        fixture.detectChanges();
-        await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
-        expect(window.scrollY).toBeLessThanOrEqual(heading2ScrollPos);
-      })
-    );
+      expect(window.scrollY).toBeLessThanOrEqual(heading2ScrollPos);
+    }));
 
     it('should jump to anchor if an anchor link is clicked but should not run change detection', async () => {
       const fixture: ComponentFixture<any> = TestBed.createComponent(
@@ -432,241 +404,232 @@ describe('Component: Markdown', () => {
       expect(contentReadySpy).toHaveBeenCalled();
     }));
 
-    it(
-      'should jump to anchor if an anchor link is clicked regardless of lang',
-      waitForAsync(async () => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownAnchorsTestEventsComponent
+    it('should jump to anchor if an anchor link is clicked regardless of lang', waitForAsync(async () => {
+      const fixture: ComponentFixture<any> = TestBed.createComponent(
+        TdMarkdownAnchorsTestEventsComponent
+      );
+      const component: TdMarkdownAnchorsTestEventsComponent =
+        fixture.debugElement.componentInstance;
+      component.content = anchorTestNonEnglishMarkdown();
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      window.scrollTo(0, 0);
+      const originalScrollPos: number = window.scrollY;
+      const headings: HTMLElement[] =
+        fixture.debugElement.nativeElement.querySelectorAll('a');
+      const heading1: HTMLElement = headings[0];
+      const heading2: HTMLElement = headings[1];
+      heading1.click();
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const heading1ScrollPos: number = window.scrollY;
+      expect(heading1ScrollPos).toBeGreaterThanOrEqual(originalScrollPos);
+
+      heading2.click();
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const heading2ScrollPos: number = window.scrollY;
+      expect(heading2ScrollPos).toBeGreaterThanOrEqual(heading1ScrollPos);
+
+      heading1.click();
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(window.scrollY).toBeLessThanOrEqual(heading2ScrollPos);
+    }));
+
+    it('should generate the proper urls', waitForAsync(async () => {
+      const fixture: ComponentFixture<any> = TestBed.createComponent(
+        TdMarkdownLinksTestEventsComponent
+      );
+      const component: TdMarkdownLinksTestEventsComponent =
+        fixture.debugElement.componentInstance;
+
+      const ANCHOR = '#anchor';
+      const CURRENT_MD_FILE = 'GETTING_STARTED.md';
+      const ROOT_MD_FILE = 'README.md';
+      const NON_RAW_LINK = 'https://github.com/Teradata/covalent/blob/main/';
+      const RAW_LINK =
+        'https://raw.githubusercontent.com/Teradata/covalent/main/';
+      const RELATIVE_LINK = 'assets/covalent/';
+      const EXTERNAL_URL = 'https://angular.io/';
+      const SUB_DIRECTORY = 'docs/';
+      const links: string[][] = [
+        [`${ANCHOR}`, `${ANCHOR}`],
+        [`${NON_RAW_LINK}${ROOT_MD_FILE}`, `${NON_RAW_LINK}${ROOT_MD_FILE}`],
+        [
+          `${NON_RAW_LINK}${ROOT_MD_FILE}${ANCHOR}`,
+          `${NON_RAW_LINK}${ROOT_MD_FILE}${ANCHOR}`,
+        ],
+        [`${RAW_LINK}${ROOT_MD_FILE}`, `${RAW_LINK}${ROOT_MD_FILE}`],
+        [
+          `${RAW_LINK}${ROOT_MD_FILE}${ANCHOR}`,
+          `${RAW_LINK}${ROOT_MD_FILE}${ANCHOR}`,
+        ],
+
+        [`${EXTERNAL_URL}${ROOT_MD_FILE}`, `${EXTERNAL_URL}${ROOT_MD_FILE}`],
+        [
+          `${EXTERNAL_URL}${ROOT_MD_FILE}${ANCHOR}`,
+          `${EXTERNAL_URL}${ROOT_MD_FILE}${ANCHOR}`,
+        ],
+        [`${EXTERNAL_URL}`, `${EXTERNAL_URL}`],
+        [`${EXTERNAL_URL}${ANCHOR}`, `${EXTERNAL_URL}${ANCHOR}`],
+      ];
+
+      let markdown = '';
+
+      links.forEach((link: string[]) => {
+        markdown += `* [${link[0]}](${link[0]}) \n`;
+      });
+      component.content = markdown;
+      const anchorElements: HTMLAnchorElement[] =
+        fixture.debugElement.nativeElement.querySelectorAll('a');
+      function checkAnchors(): void {
+        Array.from<HTMLAnchorElement>(anchorElements).forEach(
+          (anchorElement: HTMLAnchorElement, index: number) => {
+            const href = anchorElement.getAttribute('href');
+            const expectedHref: string = links[index][1];
+            expect(href).toEqual(expectedHref);
+          }
         );
-        const component: TdMarkdownAnchorsTestEventsComponent =
-          fixture.debugElement.componentInstance;
-        component.content = anchorTestNonEnglishMarkdown();
+      }
 
-        fixture.detectChanges();
-        await fixture.whenStable();
+      component.hostedUrl = `${RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      checkAnchors();
 
-        window.scrollTo(0, 0);
-        const originalScrollPos: number = window.scrollY;
-        const headings: HTMLElement[] =
-          fixture.debugElement.nativeElement.querySelectorAll('a');
-        const heading1: HTMLElement = headings[0];
-        const heading2: HTMLElement = headings[1];
-        heading1.click();
+      component.hostedUrl = `${NON_RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      checkAnchors();
 
-        fixture.detectChanges();
-        await fixture.whenStable();
+      component.hostedUrl = `${RELATIVE_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      checkAnchors();
+    }));
 
-        const heading1ScrollPos: number = window.scrollY;
-        expect(heading1ScrollPos).toBeGreaterThanOrEqual(originalScrollPos);
+    it('should generate the proper image urls', waitForAsync(async () => {
+      const fixture: ComponentFixture<any> = TestBed.createComponent(
+        TdMarkdownLinksTestEventsComponent
+      );
+      const component: TdMarkdownLinksTestEventsComponent =
+        fixture.debugElement.componentInstance;
 
-        heading2.click();
+      const CURRENT_MD_FILE = 'readme.md';
+      const SIBLING_IMG = 'typescript.jpg';
+      const ROOT_IMG = 'angular.png';
+      const NON_RAW_LINK = 'https://github.com/Teradata/covalent/blob/main/';
+      const RAW_LINK =
+        'https://raw.githubusercontent.com/Teradata/covalent/main/';
+      const RELATIVE_LINK = 'assets/covalent/';
+      const EXTERNAL_IMG =
+        'https://angular.io/assets/images/logos/angular/angular.svg';
+      const SUB_DIRECTORY = 'dir/';
+      const SVG_IMG = 'src/assets/icons/covalent.svg';
+      // these are not valid image urls
+      const images: string[][] = [
+        [`./${SIBLING_IMG}`, `${RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`],
+        [`${SIBLING_IMG}`, `${RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`],
+        [`../${ROOT_IMG}`, `${RAW_LINK}${ROOT_IMG}`],
+        [`/${ROOT_IMG}`, `${RAW_LINK}${ROOT_IMG}`],
+        [`${RAW_LINK}${ROOT_IMG}`, `${RAW_LINK}${ROOT_IMG}`],
+        [`${EXTERNAL_IMG}`, `${EXTERNAL_IMG}`],
+        [
+          `${NON_RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`,
+          `${RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`,
+        ],
+        [`${NON_RAW_LINK}${SVG_IMG}`, `${RAW_LINK}${SVG_IMG}?sanitize=true`],
+      ];
 
-        fixture.detectChanges();
-        await fixture.whenStable();
+      let markdown = '';
 
-        const heading2ScrollPos: number = window.scrollY;
-        expect(heading2ScrollPos).toBeGreaterThanOrEqual(heading1ScrollPos);
+      images.forEach((link: string[]) => {
+        markdown += `* ![${link[0]}](${link[0]}) \n`;
+      });
+      component.content = markdown;
 
-        heading1.click();
-
-        fixture.detectChanges();
-        await fixture.whenStable();
-
-        expect(window.scrollY).toBeLessThanOrEqual(heading2ScrollPos);
-      })
-    );
-
-    it(
-      'should generate the proper urls',
-      waitForAsync(async () => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownLinksTestEventsComponent
+      const imageElements: HTMLImageElement[] =
+        fixture.debugElement.nativeElement.querySelectorAll('img');
+      function checkImages(): void {
+        Array.from(imageElements).forEach(
+          (imageElement: HTMLImageElement, index: number) => {
+            const src = imageElement.getAttribute('src');
+            const expectedSrc: string = images[index][1];
+            expect(src).toEqual(expectedSrc);
+          }
         );
-        const component: TdMarkdownLinksTestEventsComponent =
-          fixture.debugElement.componentInstance;
+      }
 
-        const ANCHOR = '#anchor';
-        const CURRENT_MD_FILE = 'GETTING_STARTED.md';
-        const ROOT_MD_FILE = 'README.md';
-        const NON_RAW_LINK = 'https://github.com/Teradata/covalent/blob/main/';
-        const RAW_LINK =
-          'https://raw.githubusercontent.com/Teradata/covalent/main/';
-        const EXTERNAL_URL = 'https://angular.io/';
-        const SUB_DIRECTORY = 'docs/';
-        const links: string[][] = [
-          [`${ANCHOR}`, `${ANCHOR}`],
-          [`${NON_RAW_LINK}${ROOT_MD_FILE}`, `${NON_RAW_LINK}${ROOT_MD_FILE}`],
-          [
-            `${NON_RAW_LINK}${ROOT_MD_FILE}${ANCHOR}`,
-            `${NON_RAW_LINK}${ROOT_MD_FILE}${ANCHOR}`,
-          ],
-          [`${RAW_LINK}${ROOT_MD_FILE}`, `${RAW_LINK}${ROOT_MD_FILE}`],
-          [
-            `${RAW_LINK}${ROOT_MD_FILE}${ANCHOR}`,
-            `${RAW_LINK}${ROOT_MD_FILE}${ANCHOR}`,
-          ],
+      component.hostedUrl = `${RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      checkImages();
 
-          [`${EXTERNAL_URL}${ROOT_MD_FILE}`, `${EXTERNAL_URL}${ROOT_MD_FILE}`],
-          [
-            `${EXTERNAL_URL}${ROOT_MD_FILE}${ANCHOR}`,
-            `${EXTERNAL_URL}${ROOT_MD_FILE}${ANCHOR}`,
-          ],
-          [`${EXTERNAL_URL}`, `${EXTERNAL_URL}`],
-          [`${EXTERNAL_URL}${ANCHOR}`, `${EXTERNAL_URL}${ANCHOR}`],
-        ];
+      component.hostedUrl = `${NON_RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      checkImages();
 
-        let markdown = '';
-
-        links.forEach((link: string[]) => {
-          markdown += `* [${link[0]}](${link[0]}) \n`;
-        });
-        component.content = markdown;
-        component.hostedUrl = `${RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
-
-        fixture.detectChanges();
-        await fixture.whenStable();
-
-        const anchorElements: HTMLAnchorElement[] =
-          fixture.debugElement.nativeElement.querySelectorAll('a');
-        function checkAnchors(): void {
-          Array.from<HTMLAnchorElement>(anchorElements).forEach(
-            (anchorElement: HTMLAnchorElement, index: number) => {
-              const href = anchorElement.getAttribute('href');
-              const expectedHref: string = links[index][1];
-              expect(href).toEqual(expectedHref);
-            }
-          );
-        }
-
-        checkAnchors();
-        component.hostedUrl = `${NON_RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
-
-        fixture.detectChanges();
-        await fixture.whenStable();
-
-        checkAnchors();
-      })
-    );
-    it(
-      'should generate the proper image urls',
-      waitForAsync(async () => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownLinksTestEventsComponent
-        );
-        const component: TdMarkdownLinksTestEventsComponent =
-          fixture.debugElement.componentInstance;
-
-        const CURRENT_MD_FILE = 'readme.md';
-        const SIBLING_IMG = 'typescript.jpg';
-        const ROOT_IMG = 'angular.png';
-        const NON_RAW_LINK = 'https://github.com/Teradata/covalent/blob/main/';
-        const RAW_LINK =
-          'https://raw.githubusercontent.com/Teradata/covalent/main/';
-        const EXTERNAL_IMG =
-          'https://angular.io/assets/images/logos/angular/angular.svg';
-        const SUB_DIRECTORY = 'dir/';
-        const SVG_IMG = 'src/assets/icons/covalent.svg';
-        // these are not valid image urls
-        const images: string[][] = [
-          [`./${SIBLING_IMG}`, `${RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`],
-          [`${SIBLING_IMG}`, `${RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`],
-          [`../${ROOT_IMG}`, `${RAW_LINK}${ROOT_IMG}`],
-          [`/${ROOT_IMG}`, `${RAW_LINK}${ROOT_IMG}`],
-          [`${RAW_LINK}${ROOT_IMG}`, `${RAW_LINK}${ROOT_IMG}`],
-          [`${EXTERNAL_IMG}`, `${EXTERNAL_IMG}`],
-          [
-            `${NON_RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`,
-            `${RAW_LINK}${SUB_DIRECTORY}${SIBLING_IMG}`,
-          ],
-          [`${NON_RAW_LINK}${SVG_IMG}`, `${RAW_LINK}${SVG_IMG}?sanitize=true`],
-        ];
-
-        let markdown = '';
-
-        images.forEach((link: string[]) => {
-          markdown += `* ![${link[0]}](${link[0]}) \n`;
-        });
-        component.content = markdown;
-        component.hostedUrl = `${RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
-
-        fixture.detectChanges();
-        await fixture.whenStable();
-
-        const imageElements: HTMLImageElement[] =
-          fixture.debugElement.nativeElement.querySelectorAll('img');
-        function checkImages(): void {
-          Array.from(imageElements).forEach(
-            (imageElement: HTMLImageElement, index: number) => {
-              const src = imageElement.getAttribute('src');
-              const expectedSrc: string = images[index][1];
-              expect(src).toEqual(expectedSrc);
-            }
-          );
-        }
-
-        checkImages();
-        component.hostedUrl = `${NON_RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
-
-        fixture.detectChanges();
-        await fixture.whenStable();
-
-        checkImages();
-      })
-    );
+      component.hostedUrl = `${RELATIVE_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      checkImages();
+    }));
   });
 
   describe('Event bindings: ', () => {
     describe('contentReady event: ', () => {
-      it(
-        'should be fired only once after display renders empty static content',
-        waitForAsync(() => {
-          const fixture: ComponentFixture<any> = TestBed.createComponent(
-            TdMarkdownEmptyStaticContentTestEventsComponent
-          );
-          const component: TdMarkdownEmptyStaticContentTestEventsComponent =
-            fixture.debugElement.componentInstance;
+      it('should be fired only once after display renders empty static content', waitForAsync(() => {
+        const fixture: ComponentFixture<any> = TestBed.createComponent(
+          TdMarkdownEmptyStaticContentTestEventsComponent
+        );
+        const component: TdMarkdownEmptyStaticContentTestEventsComponent =
+          fixture.debugElement.componentInstance;
 
-          jest.spyOn(component, 'tdMarkdownContentIsReady');
+        jest.spyOn(component, 'tdMarkdownContentIsReady');
 
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
           fixture.detectChanges();
-          fixture.whenStable().then(() => {
-            fixture.detectChanges();
-            expect(component.tdMarkdownContentIsReady).toHaveBeenCalledTimes(1);
-          });
-        })
-      );
+          expect(component.tdMarkdownContentIsReady).toHaveBeenCalledTimes(1);
+        });
+      }));
 
-      it(
-        'should be fired only once after display renders markup from static content',
-        waitForAsync(() => {
-          const fixture: ComponentFixture<any> = TestBed.createComponent(
-            TdMarkdownStaticContentTestEventsComponent
-          );
-          const component: TdMarkdownStaticContentTestEventsComponent =
-            fixture.debugElement.componentInstance;
+      it('should be fired only once after display renders markup from static content', waitForAsync(() => {
+        const fixture: ComponentFixture<any> = TestBed.createComponent(
+          TdMarkdownStaticContentTestEventsComponent
+        );
+        const component: TdMarkdownStaticContentTestEventsComponent =
+          fixture.debugElement.componentInstance;
 
-          jest.spyOn(component, 'tdMarkdownContentIsReady');
+        jest.spyOn(component, 'tdMarkdownContentIsReady');
 
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
           fixture.detectChanges();
-          fixture.whenStable().then(() => {
-            fixture.detectChanges();
-            expect(component.tdMarkdownContentIsReady).toHaveBeenCalledTimes(1);
-          });
-        })
-      );
+          expect(component.tdMarkdownContentIsReady).toHaveBeenCalledTimes(1);
+        });
+      }));
 
-      it(
-        'should be fired only once after display renders initial markup from dynamic content',
-        waitForAsync(() => {
-          const fixture: ComponentFixture<any> = TestBed.createComponent(
-            TdMarkdownDynamicContentTestEventsComponent
-          );
-          const component: TdMarkdownDynamicContentTestEventsComponent =
-            fixture.debugElement.componentInstance;
-          jest.spyOn(component, 'tdMarkdownContentIsReady');
+      it('should be fired only once after display renders initial markup from dynamic content', waitForAsync(() => {
+        const fixture: ComponentFixture<any> = TestBed.createComponent(
+          TdMarkdownDynamicContentTestEventsComponent
+        );
+        const component: TdMarkdownDynamicContentTestEventsComponent =
+          fixture.debugElement.componentInstance;
+        jest.spyOn(component, 'tdMarkdownContentIsReady');
 
-          // Inital dynamic content
-          component.content = `
+        // Inital dynamic content
+        component.content = `
         # another title
 
         ## subtitle
@@ -675,25 +638,22 @@ describe('Component: Markdown', () => {
         pseudo code
         \`\`\``;
 
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
           fixture.detectChanges();
-          fixture.whenStable().then(() => {
-            fixture.detectChanges();
-            expect(component.tdMarkdownContentIsReady).toHaveBeenCalledTimes(1);
-          });
-        })
-      );
+          expect(component.tdMarkdownContentIsReady).toHaveBeenCalledTimes(1);
+        });
+      }));
 
-      it(
-        `should be fired twice after changing the initial rendered markup dynamic content`,
-        waitForAsync(() => {
-          const fixture: ComponentFixture<any> = TestBed.createComponent(
-            TdMarkdownDynamicContentTestEventsComponent
-          );
-          const component: TdMarkdownDynamicContentTestEventsComponent =
-            fixture.debugElement.componentInstance;
-          jest.spyOn(component, 'tdMarkdownContentIsReady');
+      it(`should be fired twice after changing the initial rendered markup dynamic content`, waitForAsync(() => {
+        const fixture: ComponentFixture<any> = TestBed.createComponent(
+          TdMarkdownDynamicContentTestEventsComponent
+        );
+        const component: TdMarkdownDynamicContentTestEventsComponent =
+          fixture.debugElement.componentInstance;
+        jest.spyOn(component, 'tdMarkdownContentIsReady');
 
-          component.content = `
+        component.content = `
         # another title
 
         ## subtitle
@@ -702,9 +662,9 @@ describe('Component: Markdown', () => {
         pseudo code
         \`\`\``;
 
-          fixture.detectChanges();
+        fixture.detectChanges();
 
-          component.content = `
+        component.content = `
         # changed title
 
         ## changed subtitle
@@ -713,14 +673,13 @@ describe('Component: Markdown', () => {
         changed pseudo code
         \`\`\``;
 
-          fixture.detectChanges();
+        fixture.detectChanges();
 
-          fixture.whenStable().then(() => {
-            fixture.detectChanges();
-            expect(component.tdMarkdownContentIsReady).toHaveBeenCalledTimes(2);
-          });
-        })
-      );
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expect(component.tdMarkdownContentIsReady).toHaveBeenCalledTimes(2);
+        });
+      }));
     });
   });
 });


### PR DESCRIPTION
## Description

Now markdown will work with both Absolute and Relative paths to allow for offline capabilities

### What's included?

<!-- List features included in this PR -->

- Accept Relative paths as well as Absolute paths

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
