### PR TITLE
fix(components): list item disabled

### DIFF
--- a/libs/components/src/list/list-item.scss
+++ b/libs/components/src/list/list-item.scss
@@ -13,6 +13,13 @@
 
 :host([disabled]) {
   color: var(--cv-theme-on-surface-38);
+
+  &:host([graphic='avatar']) .mdc-deprecated-list-item__graphic,
+  .mdc-deprecated-list-item__meta {
+    --mdc-theme-text-icon-on-background: var(
+      --cv-theme-on-primary-container-16
+    );
+  }
 }
 
 .mdc-deprecated-list-item__meta.material-icons ::slotted(cv-icon) {

--- a/libs/components/src/list/list-item.scss
+++ b/libs/components/src/list/list-item.scss
@@ -16,9 +16,7 @@
 
   &:host([graphic='avatar']) .mdc-deprecated-list-item__graphic,
   .mdc-deprecated-list-item__meta {
-    --mdc-theme-text-icon-on-background: var(
-      --cv-theme-on-primary-container-16
-    );
+    --mdc-theme-text-icon-on-background: var(--cv-theme-on-surface-38);
   }
 }
 

--- a/libs/components/src/list/list-item.scss
+++ b/libs/components/src/list/list-item.scss
@@ -11,6 +11,10 @@
   border-radius: 9999px;
 }
 
+:host([disabled]) {
+  color: var(--cv-theme-on-surface-38);
+}
+
 .mdc-deprecated-list-item__meta.material-icons ::slotted(cv-icon) {
   font-family: var(--mdc-icon-font);
   font-size: var(--mdc-icon-size, 24px);

--- a/libs/components/src/list/list.stories.js
+++ b/libs/components/src/list/list.stories.js
@@ -23,10 +23,10 @@ const BasicTemplate = ({ selected, disabled }) => {
     </cv-list>`;
 };
 
-const IconTemplate = ({ icon, iconStyle = 'avatar' }) => {
+const IconTemplate = ({ icon, iconStyle = 'avatar', disabled }) => {
   return `
     <cv-list>
-        <cv-list-item graphic="${iconStyle}">
+        <cv-list-item graphic="${iconStyle}" ${disabled ? `disabled` : null}>
             <span>${iconStyle} 0</span>
             <cv-icon slot="graphic">${icon}</cv-icon>
         </cv-list-item>
@@ -49,10 +49,10 @@ const IconTemplate = ({ icon, iconStyle = 'avatar' }) => {
     </cv-list>`;
 };
 
-const TwoLineTemplate = ({ icon, style, required, helper }) => {
+const TwoLineTemplate = ({ icon, style, required, helper, disabled }) => {
   return `
     <cv-list>
-        <cv-list-item twoline>
+        <cv-list-item twoline ${disabled ? `disabled` : null}>
             <span>Item 0</span>
             <span slot="secondary">Secondary line</span>
         </cv-list-item>
@@ -71,10 +71,12 @@ const TwoLineTemplate = ({ icon, style, required, helper }) => {
     </cv-list>`;
 };
 
-const CheckRadioTemplate = ({ listType = 'check' }) => {
+const CheckRadioTemplate = ({ listType = 'check', disabled }) => {
   return `
     <cv-list multi>
-        <cv-${listType}-list-item selected>Item 0</cv-${listType}-list-item>
+        <cv-${listType}-list-item selected ${
+    disabled ? `disabled` : null
+  }>Item 0</cv-${listType}-list-item>
         <cv-${listType}-list-item selected>Item 1</cv-${listType}-list-item>
         <li divider role="separator" padded></li>
         <cv-${listType}-list-item left selected>Item 2 (left)</cv-${listType}-list-item>
@@ -92,6 +94,7 @@ export const WithAvatar = IconTemplate.bind({});
 WithAvatar.args = {
   icon: 'folder',
   iconStyle: 'avatar',
+  disabled: false,
 };
 WithAvatar.argTypes = {
   iconStyle: {
@@ -101,8 +104,14 @@ WithAvatar.argTypes = {
 };
 
 export const TwoLine = TwoLineTemplate.bind({});
+TwoLine.args = {
+  disabled: false,
+};
 
 export const ChecksAndRadios = CheckRadioTemplate.bind({});
+ChecksAndRadios.args = {
+  disabled: false,
+};
 ChecksAndRadios.argTypes = {
   listType: {
     options: ['check', 'radio'],

--- a/libs/components/src/list/list.stories.js
+++ b/libs/components/src/list/list.stories.js
@@ -11,10 +11,10 @@ export default {
   },
 };
 
-const BasicTemplate = ({ selected }) => {
+const BasicTemplate = ({ selected, disabled }) => {
   return `
     <cv-list activatable>
-        <cv-list-item>Item 0</cv-list-item>
+        <cv-list-item ${disabled ? `disabled` : null}>Item 0</cv-list-item>
         <cv-list-item ${
           selected ? `selected activated` : null
         }>Item 1</cv-list-item>
@@ -85,6 +85,7 @@ const CheckRadioTemplate = ({ listType = 'check' }) => {
 export const Basic = BasicTemplate.bind({});
 Basic.args = {
   selected: false,
+  disabled: false,
 };
 
 export const WithAvatar = IconTemplate.bind({});


### PR DESCRIPTION
## Description

Adding style to a list item with a disable property added

### What's included?

- styling in the base list component to set the color to us `--cv-theme-on-surface-38` when disabled
- icons use `--cv-theme-on-primary-container-16` token when disabled
- adjusted list stories in storybook


#### Test Steps

- [ ] `npm run storybook`
- [ ] then navigate to the list item story
- [ ] finally select `disabled` under the story controls to see the changes

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![Screenshot 2024-07-12 at 12 28 37 PM](https://github.com/user-attachments/assets/db455b8d-687e-4d0c-aafc-270036ebeb6b)
![Screenshot 2024-07-12 at 12 49 18 PM](https://github.com/user-attachments/assets/2ec03c55-fa4e-44fe-9c7b-bf19e7a97014)
