### PR TITLE
fix(markdown):  allow relative paths

### DIFF
--- a/libs/markdown/src/lib/markdown.component.spec.ts
+++ b/libs/markdown/src/lib/markdown.component.spec.ts
@@ -81,9 +81,10 @@ describe('Component: Markdown', () => {
     it(
       'should render empty static content',
       waitForAsync(() => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownEmptyStaticContentTestRenderingComponent
-        );
+        const fixture: ComponentFixture<TdMarkdownEmptyStaticContentTestRenderingComponent> =
+          TestBed.createComponent(
+            TdMarkdownEmptyStaticContentTestRenderingComponent
+          );
         const element: HTMLElement = fixture.nativeElement;
 
         expect(
@@ -108,9 +109,10 @@ describe('Component: Markdown', () => {
     it(
       'should render markup from static content',
       waitForAsync(() => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownStaticContentTestRenderingComponent
-        );
+        const fixture: ComponentFixture<TdMarkdownStaticContentTestRenderingComponent> =
+          TestBed.createComponent(
+            TdMarkdownStaticContentTestRenderingComponent
+          );
         const element: HTMLElement = fixture.nativeElement;
 
         expect(
@@ -141,9 +143,10 @@ describe('Component: Markdown', () => {
     it(
       'should render newlines as <br/> if simpleLineBreaks is true',
       waitForAsync(() => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownSimpleLineBreaksTestRenderingComponent
-        );
+        const fixture: ComponentFixture<TdMarkdownSimpleLineBreaksTestRenderingComponent> =
+          TestBed.createComponent(
+            TdMarkdownSimpleLineBreaksTestRenderingComponent
+          );
         const component: TdMarkdownSimpleLineBreaksTestRenderingComponent =
           fixture.debugElement.componentInstance;
         component.simpleLineBreaks = true;
@@ -179,9 +182,10 @@ describe('Component: Markdown', () => {
     it(
       'should not render newlines as <br/> if simpleLineBreaks is false',
       waitForAsync(() => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownSimpleLineBreaksTestRenderingComponent
-        );
+        const fixture: ComponentFixture<TdMarkdownSimpleLineBreaksTestRenderingComponent> =
+          TestBed.createComponent(
+            TdMarkdownSimpleLineBreaksTestRenderingComponent
+          );
         const component: TdMarkdownSimpleLineBreaksTestRenderingComponent =
           fixture.debugElement.componentInstance;
         component.simpleLineBreaks = false;
@@ -217,9 +221,10 @@ describe('Component: Markdown', () => {
     it(
       'should render markup from dynamic content',
       waitForAsync(() => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownDymanicContentTestRenderingComponent
-        );
+        const fixture: ComponentFixture<TdMarkdownDymanicContentTestRenderingComponent> =
+          TestBed.createComponent(
+            TdMarkdownDymanicContentTestRenderingComponent
+          );
         const component: TdMarkdownDymanicContentTestRenderingComponent =
           fixture.debugElement.componentInstance;
         component.content = `
@@ -258,9 +263,10 @@ describe('Component: Markdown', () => {
     it(
       'should render markup from dynamic content incorrectly',
       waitForAsync(() => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownDymanicContentTestRenderingComponent
-        );
+        const fixture: ComponentFixture<TdMarkdownDymanicContentTestRenderingComponent> =
+          TestBed.createComponent(
+            TdMarkdownDymanicContentTestRenderingComponent
+          );
         const component: TdMarkdownDymanicContentTestRenderingComponent =
           fixture.debugElement.componentInstance;
         component.content = `
@@ -293,9 +299,8 @@ describe('Component: Markdown', () => {
     it(
       'should jump to anchor when anchor input is changed',
       waitForAsync(async () => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownAnchorsTestEventsComponent
-        );
+        const fixture: ComponentFixture<TdMarkdownAnchorsTestEventsComponent> =
+          TestBed.createComponent(TdMarkdownAnchorsTestEventsComponent);
         const component: TdMarkdownAnchorsTestEventsComponent =
           fixture.debugElement.componentInstance;
         component.content = anchorTestMarkdown();
@@ -333,9 +338,8 @@ describe('Component: Markdown', () => {
     it(
       'should jump to anchor if an anchor link is clicked',
       waitForAsync(async () => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownAnchorsTestEventsComponent
-        );
+        const fixture: ComponentFixture<TdMarkdownAnchorsTestEventsComponent> =
+          TestBed.createComponent(TdMarkdownAnchorsTestEventsComponent);
         const component: TdMarkdownAnchorsTestEventsComponent =
           fixture.debugElement.componentInstance;
         component.content = anchorTestMarkdown();
@@ -375,9 +379,8 @@ describe('Component: Markdown', () => {
     );
 
     it('should jump to anchor if an anchor link is clicked but should not run change detection', async () => {
-      const fixture: ComponentFixture<any> = TestBed.createComponent(
-        TdMarkdownAnchorsTestEventsComponent
-      );
+      const fixture: ComponentFixture<TdMarkdownAnchorsTestEventsComponent> =
+        TestBed.createComponent(TdMarkdownAnchorsTestEventsComponent);
       const component: TdMarkdownAnchorsTestEventsComponent =
         fixture.debugElement.componentInstance;
       component.content = anchorTestMarkdown();
@@ -407,9 +410,8 @@ describe('Component: Markdown', () => {
 
     it('should emit `contentReady` and should not run change detection', fakeAsync(() => {
       const contentReadySpy: jest.Mock = jest.fn();
-      const fixture: ComponentFixture<any> = TestBed.createComponent(
-        TdMarkdownAnchorsTestEventsComponent
-      );
+      const fixture: ComponentFixture<TdMarkdownAnchorsTestEventsComponent> =
+        TestBed.createComponent(TdMarkdownAnchorsTestEventsComponent);
       const component: TdMarkdownAnchorsTestEventsComponent =
         fixture.debugElement.componentInstance;
       component.anchor = 'heading 1';
@@ -435,9 +437,8 @@ describe('Component: Markdown', () => {
     it(
       'should jump to anchor if an anchor link is clicked regardless of lang',
       waitForAsync(async () => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownAnchorsTestEventsComponent
-        );
+        const fixture: ComponentFixture<TdMarkdownAnchorsTestEventsComponent> =
+          TestBed.createComponent(TdMarkdownAnchorsTestEventsComponent);
         const component: TdMarkdownAnchorsTestEventsComponent =
           fixture.debugElement.componentInstance;
         component.content = anchorTestNonEnglishMarkdown();
@@ -479,9 +480,8 @@ describe('Component: Markdown', () => {
     it(
       'should generate the proper urls',
       waitForAsync(async () => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownLinksTestEventsComponent
-        );
+        const fixture: ComponentFixture<TdMarkdownLinksTestEventsComponent> =
+          TestBed.createComponent(TdMarkdownLinksTestEventsComponent);
         const component: TdMarkdownLinksTestEventsComponent =
           fixture.debugElement.componentInstance;
 
@@ -491,6 +491,7 @@ describe('Component: Markdown', () => {
         const NON_RAW_LINK = 'https://github.com/Teradata/covalent/blob/main/';
         const RAW_LINK =
           'https://raw.githubusercontent.com/Teradata/covalent/main/';
+        const RELATIVE_LINK = 'assets/covalent/';
         const EXTERNAL_URL = 'https://angular.io/';
         const SUB_DIRECTORY = 'docs/';
         const links: string[][] = [
@@ -521,11 +522,6 @@ describe('Component: Markdown', () => {
           markdown += `* [${link[0]}](${link[0]}) \n`;
         });
         component.content = markdown;
-        component.hostedUrl = `${RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
-
-        fixture.detectChanges();
-        await fixture.whenStable();
-
         const anchorElements: HTMLAnchorElement[] =
           fixture.debugElement.nativeElement.querySelectorAll('a');
         function checkAnchors(): void {
@@ -538,21 +534,28 @@ describe('Component: Markdown', () => {
           );
         }
 
-        checkAnchors();
-        component.hostedUrl = `${NON_RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
-
+        component.hostedUrl = `${RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
         fixture.detectChanges();
         await fixture.whenStable();
+        checkAnchors();
 
+        component.hostedUrl = `${NON_RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
+        fixture.detectChanges();
+        await fixture.whenStable();
+        checkAnchors();
+
+        component.hostedUrl = `${RELATIVE_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
+        fixture.detectChanges();
+        await fixture.whenStable();
         checkAnchors();
       })
     );
+
     it(
       'should generate the proper image urls',
       waitForAsync(async () => {
-        const fixture: ComponentFixture<any> = TestBed.createComponent(
-          TdMarkdownLinksTestEventsComponent
-        );
+        const fixture: ComponentFixture<TdMarkdownLinksTestEventsComponent> =
+          TestBed.createComponent(TdMarkdownLinksTestEventsComponent);
         const component: TdMarkdownLinksTestEventsComponent =
           fixture.debugElement.componentInstance;
 
@@ -562,6 +565,7 @@ describe('Component: Markdown', () => {
         const NON_RAW_LINK = 'https://github.com/Teradata/covalent/blob/main/';
         const RAW_LINK =
           'https://raw.githubusercontent.com/Teradata/covalent/main/';
+        const RELATIVE_LINK = 'assets/covalent/';
         const EXTERNAL_IMG =
           'https://angular.io/assets/images/logos/angular/angular.svg';
         const SUB_DIRECTORY = 'dir/';
@@ -587,10 +591,6 @@ describe('Component: Markdown', () => {
           markdown += `* ![${link[0]}](${link[0]}) \n`;
         });
         component.content = markdown;
-        component.hostedUrl = `${RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
-
-        fixture.detectChanges();
-        await fixture.whenStable();
 
         const imageElements: HTMLImageElement[] =
           fixture.debugElement.nativeElement.querySelectorAll('img');
@@ -604,12 +604,19 @@ describe('Component: Markdown', () => {
           );
         }
 
-        checkImages();
-        component.hostedUrl = `${NON_RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
-
+        component.hostedUrl = `${RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
         fixture.detectChanges();
         await fixture.whenStable();
+        checkImages();
 
+        component.hostedUrl = `${NON_RAW_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
+        fixture.detectChanges();
+        await fixture.whenStable();
+        checkImages();
+
+        component.hostedUrl = `${RELATIVE_LINK}${SUB_DIRECTORY}${CURRENT_MD_FILE}`;
+        fixture.detectChanges();
+        await fixture.whenStable();
         checkImages();
       })
     );
@@ -620,9 +627,10 @@ describe('Component: Markdown', () => {
       it(
         'should be fired only once after display renders empty static content',
         waitForAsync(() => {
-          const fixture: ComponentFixture<any> = TestBed.createComponent(
-            TdMarkdownEmptyStaticContentTestEventsComponent
-          );
+          const fixture: ComponentFixture<TdMarkdownEmptyStaticContentTestEventsComponent> =
+            TestBed.createComponent(
+              TdMarkdownEmptyStaticContentTestEventsComponent
+            );
           const component: TdMarkdownEmptyStaticContentTestEventsComponent =
             fixture.debugElement.componentInstance;
 
@@ -639,9 +647,8 @@ describe('Component: Markdown', () => {
       it(
         'should be fired only once after display renders markup from static content',
         waitForAsync(() => {
-          const fixture: ComponentFixture<any> = TestBed.createComponent(
-            TdMarkdownStaticContentTestEventsComponent
-          );
+          const fixture: ComponentFixture<TdMarkdownStaticContentTestEventsComponent> =
+            TestBed.createComponent(TdMarkdownStaticContentTestEventsComponent);
           const component: TdMarkdownStaticContentTestEventsComponent =
             fixture.debugElement.componentInstance;
 
@@ -658,9 +665,10 @@ describe('Component: Markdown', () => {
       it(
         'should be fired only once after display renders initial markup from dynamic content',
         waitForAsync(() => {
-          const fixture: ComponentFixture<any> = TestBed.createComponent(
-            TdMarkdownDynamicContentTestEventsComponent
-          );
+          const fixture: ComponentFixture<TdMarkdownDynamicContentTestEventsComponent> =
+            TestBed.createComponent(
+              TdMarkdownDynamicContentTestEventsComponent
+            );
           const component: TdMarkdownDynamicContentTestEventsComponent =
             fixture.debugElement.componentInstance;
           jest.spyOn(component, 'tdMarkdownContentIsReady');
@@ -686,9 +694,10 @@ describe('Component: Markdown', () => {
       it(
         `should be fired twice after changing the initial rendered markup dynamic content`,
         waitForAsync(() => {
-          const fixture: ComponentFixture<any> = TestBed.createComponent(
-            TdMarkdownDynamicContentTestEventsComponent
-          );
+          const fixture: ComponentFixture<TdMarkdownDynamicContentTestEventsComponent> =
+            TestBed.createComponent(
+              TdMarkdownDynamicContentTestEventsComponent
+            );
           const component: TdMarkdownDynamicContentTestEventsComponent =
             fixture.debugElement.componentInstance;
           jest.spyOn(component, 'tdMarkdownContentIsReady');


### PR DESCRIPTION
## Description

Now markdown will work with both Absolute and Relative paths to allow for offline capabilities

### What's included?

<!-- List features included in this PR -->

- Accept Relative paths as well as Absolute paths

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker