### PR TITLE
feat(components): add delay to app shell navigation hover

### DIFF
--- a/libs/components/src/app-shell/app-shell.ts
+++ b/libs/components/src/app-shell/app-shell.ts
@@ -85,6 +85,9 @@ export class CovalentAppShell extends DrawerBase {
   fullWidth = false;
 
   private hovered = false;
+  private hoverTimeout: number | undefined;
+  private hoverEntryDuration = 250;
+  private hoverExitDuration = 250;
 
   constructor() {
     super();
@@ -229,22 +232,35 @@ export class CovalentAppShell extends DrawerBase {
     this.hovered = false;
   }
 
-  private _handleNavMouseOver() {
-    if (this.open || this.forcedOpen) {
-      return;
-    }
-
+  private _handleNavMouseOver = () => {
     this.hovered = true;
-    this._toggleOpen();
-  }
 
-  private _handleNavMouseOut() {
-    if (!this.open || this.forcedOpen) {
-      return;
+    // clear timeout if user hovers over nav before it closes
+    clearTimeout(this.hoverTimeout);
+
+    if (!this.open && !this.forcedOpen) {
+      this.hoverTimeout = setTimeout(() => {
+        if (this.hovered) {
+          this._toggleOpen();
+        }
+      }, this.hoverEntryDuration);
     }
+  };
 
-    this._toggleOpen();
-  }
+  private _handleNavMouseOut = () => {
+    this.hovered = false;
+
+    // clear timeout if user leaves nav before it opens
+    clearTimeout(this.hoverTimeout);
+
+    if (this.open && !this.forcedOpen) {
+      this.hoverTimeout = setTimeout(() => {
+        if (!this.hovered) {
+          this._toggleOpen();
+        }
+      }, this.hoverExitDuration);
+    }
+  };
 
   private _handleDrawerClosed() {
     this.forcedOpen = false;


### PR DESCRIPTION
## Description

Adding delayed opening when hovering over app shell navigation

### What's included?
- Including a 250ms delay when user now hovers over the app shell when in collapsed mode
- Added same delay for closing app-shell which is also configurable

#### Test Steps

- [ ] `npm run storybook`
- [ ] then navigate to the app-shell story
- [ ] finally test the app shell navigation that is delays properly

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
