### PR TITLE
fix(components): adjusting textfield placeholder size

### DIFF
--- a/libs/components/src/textfield/textfield.scss
+++ b/libs/components/src/textfield/textfield.scss
@@ -10,7 +10,6 @@
   --mdc-text-field-outlined-hover-border-color: var(
     --mdc-theme-text-icon-on-background
   );
-
   --mdc-typography-subtitle1-font-family: var(
     --mdc-typography-body1-font-family
   );

--- a/libs/components/src/textfield/textfield.scss
+++ b/libs/components/src/textfield/textfield.scss
@@ -10,6 +10,18 @@
   --mdc-text-field-outlined-hover-border-color: var(
     --mdc-theme-text-icon-on-background
   );
+
+  --mdc-typography-subtitle1-font-family: var(
+    --mdc-typography-body1-font-family
+  );
+  --mdc-typography-subtitle1-font-size: var(
+    --mdc-typography-body1-font-size,
+    1rem
+  );
+  --mdc-typography-subtitle1-font-weight: var(
+    --mdc-typography-body1-font-weight,
+    400
+  );
 }
 
 :host([dense]) {


### PR DESCRIPTION
## Description

Text size adjustment to place holder text size 

### What's included?

- adjusting placeholder text size
- this also fixes the issue where the floating label gets cutoff

#### Test Steps

- [ ] `npm run storybook`
- [ ] then navigate to the text field stories
- [ ] finally navigate to the helper text story and see the long text not cut off while active

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Before
![Screenshot 2024-07-16 at 2 21 44 PM](https://github.com/user-attachments/assets/57d56f91-3383-4dca-a55e-6ba3f946aa6d)
##### After
![Screenshot 2024-07-16 at 2 21 05 PM](https://github.com/user-attachments/assets/5e1e7f7a-2051-4116-b4e9-aa180369bb1f)
