### PR TITLE
fix(markdown): relative href links in md and minor styling

### DIFF
--- a/libs/angular/dialogs/src/dialog.component.scss
+++ b/libs/angular/dialogs/src/dialog.component.scss
@@ -33,7 +33,6 @@
     }
 
     ::ng-deep button {
-      text-transform: uppercase;
       margin-left: 8px;
 
       [dir='rtl'] & {

--- a/libs/angular/dialogs/src/resizable-draggable-dialog/resizable-draggable-dialog.ts
+++ b/libs/angular/dialogs/src/resizable-draggable-dialog/resizable-draggable-dialog.ts
@@ -144,7 +144,7 @@ export class ResizableDraggableDialog {
         rightLeft = horizontalAlignment.right;
 
         const icon: HTMLElement = this._renderer2.createElement('i');
-        this._renderer2.addClass(icon, 'material-icons');
+        this._renderer2.addClass(icon, 'material-icons-outlined');
         this._renderer2.appendChild(
           icon,
           this._renderer2.createText('filter_list')

--- a/libs/markdown/src/lib/markdown.component.ts
+++ b/libs/markdown/src/lib/markdown.component.ts
@@ -91,13 +91,14 @@ function normalizeHtmlHrefs(html: string, currentHref: string): string {
             const hrefWithoutHash: string = removeTrailingHash(
               link.getAttribute('href')
             );
-
-            url.href = generateHref(currentHref, hrefWithoutHash);
+            // since this might be a relative path, don't assign it to url.href
+            // relative path won't be a valid href to assign to URL
+            const newHref = generateHref(currentHref, hrefWithoutHash);
 
             if (originalHash) {
               url.hash = genHeadingId(originalHash);
             }
-            link.href = url.href;
+            link.href = newHref;
           }
           link.target = '_blank';
         } else {


### PR DESCRIPTION
## Description

Fixes small bugs in 4.17.0 release

### What's included?

- Fixed another issue with markdown where links in a markdown file that link to other markdown files were not working when offline
- Fixed undesired uppercase of buttons for dialogs
- Fixed handle for markdown navigator window that wasn't displaying properly

#### Test Steps

- [ ] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
