### PR TITLE
fix(components):  background styles to selected nav item

### DIFF
--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -16,6 +16,8 @@
   --cv-list-item-graphic-margin-left: 0;
   --cv-list-menu-height: 0;
   --cv-list-item-expansion-icon-size: 0;
+  --cv-list-item-selected-background-color: var(--cv-theme-primary-24);
+  --cv-list-item-selected-color: var(--cv-theme-primary);
 }
 
 :host([open]) .navigation {
@@ -27,6 +29,10 @@
   --cv-list-item-expansion-icon-margin: -24px;
   --cv-list-item-expansion-icon-size: 24px;
   --cv-list-menu-height: inherit;
+  --cv-list-item-selected-background-color: var(
+    --cv-theme-on-surface-variant-8
+  );
+  --cv-list-item-selected-color: var(--cv-theme-on-surface-variant);
 }
 
 :host([helpOpen]) {

--- a/libs/components/src/list/nav-list-item.scss
+++ b/libs/components/src/list/nav-list-item.scss
@@ -23,6 +23,16 @@
   }
 }
 
+:host([selected]:not([activated])) .expansion-header {
+  transition: background-color 250ms ease-in, color 250ms ease-in;
+  background-color: var(--cv-list-item-selected-background-color);
+  color: var(--cv-list-item-selected-color);
+
+  .mdc-deprecated-list-item__graphic {
+    --mdc-theme-text-icon-on-background: var(--cv-list-item-selected-color);
+  }
+}
+
 :host([subnav]) {
   height: 32px;
   font-weight: var(--mdc-typography-body2-font-weight);


### PR DESCRIPTION
## Description

Adding styles for a nav item that has the child item selected

### What's included?

- Nav item parent styling when child is selected


#### Test Steps

- [ ] `npm run storybook`
- [ ] then go to app shell story 
- [ ] finally click item with subnav paretn

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![Screenshot 2024-07-23 at 1 01 17 PM](https://github.com/user-attachments/assets/c903c6ec-5e6f-4382-9d9b-2deab3ba1221)
![Screenshot 2024-07-23 at 1 01 23 PM](https://github.com/user-attachments/assets/1654da3c-0ca1-450b-959e-6f90c211ad6d)
