### PR TITLE
Fix/app shell resizing

### DIFF
--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -70,11 +70,18 @@
   }
 }
 
+.cov-help--resizing {
+  .main,
+  .help {
+    transition-duration: 0ms;
+  }
+}
+
 .main {
   height: 100vh;
   grid-area: main;
   overflow: auto;
-  transition: margin-left 200ms ease-in-out;
+  transition: margin-left 200ms ease-in-out, margin-right 200ms ease-in-out;
 
   .main-wrapper {
     margin: 0 auto;
@@ -124,6 +131,7 @@
   position: fixed;
   right: 0;
   width: var(--cv-help-width, 320px);
+  transition: width 200ms;
   height: 100vh;
   overflow-y: auto;
 

--- a/libs/components/src/app-shell/app-shell.ts
+++ b/libs/components/src/app-shell/app-shell.ts
@@ -169,6 +169,7 @@ export class CovalentAppShell extends DrawerBase {
         this.helpWidth = 320;
         localStorage.setItem('helpWidth', '320');
         this.updateHelpPanelWidth();
+        this.requestUpdate();
       }
     });
 

--- a/libs/components/src/app-shell/app-shell.ts
+++ b/libs/components/src/app-shell/app-shell.ts
@@ -35,6 +35,7 @@ export class CovalentAppShell extends DrawerBase {
   helpWidth = 0;
   private _startX!: number;
   private _startWidth!: number;
+  private _resizing = false;
 
   @queryAssignedElements({ slot: 'navigation' })
   navigationListElements!: HTMLElement[];
@@ -157,6 +158,7 @@ export class CovalentAppShell extends DrawerBase {
     if (event.target === resizeHandle) {
       this._startX = event.clientX;
       this._startWidth = this.helpWidth;
+      this._resizing = true;
       document.addEventListener('mousemove', this._resize);
       document.addEventListener('mouseup', this._stopResize);
       (event.target as HTMLElement).classList.add('helpResizable');
@@ -167,9 +169,10 @@ export class CovalentAppShell extends DrawerBase {
         this.helpWidth = 320;
         localStorage.setItem('helpWidth', '320');
         this.updateHelpPanelWidth();
-        this.requestUpdate();
       }
     });
+
+    this.requestUpdate();
   }
 
   private _resize(event: MouseEvent) {
@@ -192,10 +195,13 @@ export class CovalentAppShell extends DrawerBase {
   private _stopResize() {
     document.removeEventListener('mousemove', this._resize);
     document.removeEventListener('mouseup', this._stopResize);
+    this._resizing = false;
     const resizeHandle = this.shadowRoot?.querySelector('.resize-handle');
     if (resizeHandle) {
       resizeHandle.classList.remove('helpResizable');
     }
+
+    this.requestUpdate();
   }
 
   private _toggleOpen(forcedOpen = false) {
@@ -315,6 +321,7 @@ export class CovalentAppShell extends DrawerBase {
       'cov-drawer--hovered': this.hovered,
       'cov-help--open': this.helpOpen,
       'cov-help--closed': !this.helpOpen,
+      'cov-help--resizing': this._resizing,
       'cov-content--full-width': this.fullWidth,
     };
     const drawerClasses = {


### PR DESCRIPTION
## Description

Styling and transition fix for help window when resizing

#### Test Steps

- [ ] `npm run storybook`
- [ ] then navigate to the app shell resizing story
- [ ] finally test out the app shell help menu opening and resizing

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
