### PR TITLE
Fix/app shell frame tweaks

### DIFF
--- a/.storybook/theme/theme.scss
+++ b/.storybook/theme/theme.scss
@@ -30,7 +30,7 @@ $dark-colors: map-merge($dark-colors, map-get(tokens.$tokens, dark));
 
 .sb-show-main {
   background-color: var(--mdc-theme-surface);
-  color: var(--cv-theme-on-surface);
+  color: var(--cv-theme-on-surface-variant);
 
   .sbdocs-wrapper {
     padding-top: 0;
@@ -41,6 +41,19 @@ $dark-colors: map-merge($dark-colors, map-get(tokens.$tokens, dark));
     background-size: auto 24rem;
     color: var(--mdc-theme-text-secondary-on-background);
     padding: 4rem 1.5rem 1.5rem;
+  }
+
+  // Header typography should be darker color
+  cv-typography[scale='headline1'],
+  cv-typography[scale='headline2'],
+  cv-typography[scale='headline3'],
+  cv-typography[scale='headline4'],
+  cv-typography[scale='headline5'],
+  cv-typography[scale='headline6'],
+  cv-typography[scale='subtitle1'],
+  cv-typography[scale='subtitle2'],
+  cv-typography[scale='button'] {
+    color: var(--cv-theme-on-surface);
   }
 }
 .dark .sbdocs-wrapper {

--- a/.storybook/theme/theme.scss
+++ b/.storybook/theme/theme.scss
@@ -30,7 +30,6 @@ $dark-colors: map-merge($dark-colors, map-get(tokens.$tokens, dark));
 
 .sb-show-main {
   background-color: var(--mdc-theme-surface);
-  color: var(--cv-theme-on-surface-variant);
 
   .sbdocs-wrapper {
     padding-top: 0;
@@ -41,19 +40,6 @@ $dark-colors: map-merge($dark-colors, map-get(tokens.$tokens, dark));
     background-size: auto 24rem;
     color: var(--mdc-theme-text-secondary-on-background);
     padding: 4rem 1.5rem 1.5rem;
-  }
-
-  // Header typography should be darker color
-  cv-typography[scale='headline1'],
-  cv-typography[scale='headline2'],
-  cv-typography[scale='headline3'],
-  cv-typography[scale='headline4'],
-  cv-typography[scale='headline5'],
-  cv-typography[scale='headline6'],
-  cv-typography[scale='subtitle1'],
-  cv-typography[scale='subtitle2'],
-  cv-typography[scale='button'] {
-    color: var(--cv-theme-on-surface);
   }
 }
 .dark .sbdocs-wrapper {

--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -52,6 +52,7 @@
 
 .app-shell {
   --mdc-theme-surface: var(--mdc-theme-background);
+
   background-color: var(--mdc-theme-background);
   display: grid;
   grid-template: 'nav mini-list main help' min-content / auto auto 1fr;
@@ -104,7 +105,7 @@
   }
 
   cv-card {
-    margin: 0 0 24px 0;
+    margin: 0 0 24px;
     display: block;
 
     &.wrapper-card {

--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -95,7 +95,7 @@
   }
 
   cv-card {
-    margin: 0 12px 12px;
+    margin: 0 0 24px 0;
     display: block;
   }
 
@@ -104,14 +104,17 @@
     .cov-drawer--hovered &,
     &.cov-drawer--hovered-closing {
       margin-left: 72px;
+      margin-right: 24px;
     }
 
     :not(.cov-drawer--forced-open) & {
       margin-left: 72px;
+      margin-right: 24px;
     }
 
     .cov-drawer--open & {
       margin-left: 256px;
+      margin-right: 24px;
     }
 
     .cov-help--open & {

--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -6,6 +6,10 @@
 @include drawer.dismissible-core-styles();
 @include drawer.modal-core-styles();
 
+:host {
+  --cv-border-radius-outer: 28px;
+}
+
 :host .navigation {
   --mdc-theme-surface: var(--mdc-theme-background);
   --mdc-list-vertical-padding: 0;
@@ -47,7 +51,8 @@
 }
 
 .app-shell {
-  background-color: var(--mdc-theme-surface);
+  --mdc-theme-surface: var(--mdc-theme-background);
+  background-color: var(--mdc-theme-background);
   display: grid;
   grid-template: 'nav mini-list main help' min-content / auto auto 1fr;
   min-height: 100%;
@@ -67,6 +72,10 @@
   @media only screen and (min-width: 768px) {
     position: fixed;
     width: 100%;
+  }
+
+  .main-wrapper > :host(cv-card) .mdc-card {
+    border-radius: var(--cv-border-radius-outer);
   }
 }
 
@@ -97,6 +106,10 @@
   cv-card {
     margin: 0 0 24px 0;
     display: block;
+
+    &.wrapper-card {
+      --mdc-shape-medium: var(--cv-border-radius-outer);
+    }
   }
 
   /* Desktop only styles */
@@ -141,7 +154,7 @@
   .resize-handle {
     position: absolute;
     left: 0;
-    width: 10px;
+    width: 8px;
     height: 100vh;
     cursor: ew-resize;
     z-index: 1100;
@@ -150,9 +163,9 @@
     &::after {
       content: '';
       position: absolute;
-      left: 50%;
+      left: 1px;
       top: 0;
-      width: 2px;
+      width: 4px;
       height: 100%;
       background-color: var(--mdc-theme-primary);
       transform: translateX(-50%);
@@ -247,7 +260,7 @@ nav.navigation {
   overflow-y: auto;
   border-right: 0;
   position: fixed;
-  background-color: var(--mdc-theme-surface);
+  background-color: var(--mdc-theme-background);
 
   .toggle-drawer {
     margin: 8px auto;
@@ -258,7 +271,7 @@ nav.navigation {
     align-items: center;
     position: sticky;
     top: 0;
-    background-color: var(--mdc-theme-surface);
+    background-color: var(--mdc-theme-background);
     z-index: 2;
   }
 

--- a/libs/components/src/app-shell/app-shell.stories.js
+++ b/libs/components/src/app-shell/app-shell.stories.js
@@ -105,7 +105,7 @@ const Template = ({
     ${contained ? `contained` : ''}
     ${fullWidth ? `fullWidth` : ''}
     ${helpResizable ? `helpResizable` : ''}
-    
+
     >
 
       <cv-icon-button slot="section-action" icon="arrow_back"></cv-icon-button>
@@ -188,7 +188,7 @@ const Template = ({
           ></cv-icon-button>
           <cv-icon-button
             slot="actionItems"
-            icon="close"I
+            icon="close"
             class="help-close"
           ></cv-icon-button>
         </cv-toolbar>

--- a/libs/components/src/app-shell/app-shell.stories.js
+++ b/libs/components/src/app-shell/app-shell.stories.js
@@ -179,8 +179,8 @@ const Template = ({
       </cv-toolbar>
 
       <div slot="help" class="help-panel mdc-typography">
-        <cv-toolbar sticky style="padding-left: 12px; margin-right: -8px;">
-          <span slot="title">Help</span>
+        <cv-toolbar sticky>
+          <span slot="title" style="padding-left: 12px;">Help</span>
           <cv-icon-button
             slot="actionItems"
             icon="undock"
@@ -190,6 +190,7 @@ const Template = ({
             slot="actionItems"
             icon="close"
             class="help-close"
+            style="margin-right: -4px;"
           ></cv-icon-button>
         </cv-toolbar>
         <div class="help-content" style="padding: 16px 24px 24px">

--- a/libs/components/src/app-shell/app-shell.stories.js
+++ b/libs/components/src/app-shell/app-shell.stories.js
@@ -88,7 +88,7 @@ const Template = ({
     .hidden-large {
         display: none;
     }
- 
+
     @media only screen and (max-width: 800px) {
         .hidden-large {
             display:flex;
@@ -98,8 +98,8 @@ const Template = ({
         }
     }
     </style>
-    <cv-app-shell 
-    ${appName ? `appName="${appName}"` : ''} 
+    <cv-app-shell
+    ${appName ? `appName="${appName}"` : ''}
     ${sectionTitle ? `sectionName="${sectionTitle}"` : ''}
     ${forcedOpen ? `forcedOpen open` : ''}
     ${contained ? `contained` : ''}
@@ -111,11 +111,11 @@ const Template = ({
       <cv-icon-button slot="section-action" icon="arrow_back"></cv-icon-button>
 
       <svg
-        slot="logo" 
-        width="103" 
+        slot="logo"
+        width="103"
         height="20"
         viewBox="0 0 103 20"
-        style="fill: var(--cv-theme-text-logo-on-background)" 
+        style="fill: var(--cv-theme-text-logo-on-background)"
         fill="none">
         <path d="M0 2.30182H3.53561V5.6615H7.47898V8.88045H3.53561V14.5072C3.53561 15.9632 4.26909 16.4391 5.30341 16.4391H7.47898V19.658H5.30341C1.68575 19.658 0 18.0358 0 14.5072V2.30182Z" />
         <path d="M15.9376 19.9907C11.5865 19.9907 8.67492 17.0506 8.67492 12.6854C8.67492 8.32008 11.5318 5.32374 15.7461 5.32374C19.9605 5.32374 22.708 8.17934 22.708 12.5446C22.708 12.9643 22.6806 13.4121 22.5986 13.9443H12.3746C12.7003 15.9043 13.8714 16.828 15.9923 16.828C17.325 16.828 18.3046 16.2395 18.685 15.4565H22.33C21.5145 18.1714 19.2295 19.9907 15.9376 19.9907ZM12.4293 10.9787H19.0107C18.6577 9.21565 17.6233 8.37637 15.7461 8.37637C13.9783 8.37637 12.8371 9.27194 12.4293 10.9787Z" />
@@ -127,7 +127,7 @@ const Template = ({
         <path d="M89.2555 19.8218C86.7542 19.8218 84.7676 18.3096 84.7676 15.1751C84.7676 12.6009 86.3439 10.8379 89.8795 10.8379H92.9527V10.4183C92.9527 9.13121 92.1645 8.59898 90.2053 8.59898C88.8999 8.59898 87.8656 8.73972 86.4509 9.15936V5.88412C87.5399 5.57706 88.8999 5.38004 90.5036 5.38004C94.5837 5.38004 96.4858 6.97416 96.4858 10.4183V19.6555H93.0323V18.8443L92.2441 19.1795C91.2371 19.5992 90.2053 19.8244 89.253 19.8244L89.2555 19.8218ZM91.1874 16.5466L92.9552 15.7636V13.6935H90.2624C89.0392 13.6935 88.3032 14.282 88.3032 15.2058C88.3032 16.2984 89.0367 16.828 89.9616 16.828C90.342 16.828 90.7771 16.7154 91.1849 16.5491L91.1874 16.5466Z" />
         <path d="M98.5296 18.0588C98.5296 16.9943 99.3451 16.1551 100.407 16.1551C101.468 16.1551 102.284 16.9943 102.284 18.0588C102.284 19.1233 101.441 19.9907 100.407 19.9907C99.3725 19.9907 98.5296 19.1233 98.5296 18.0588Z" />
       </svg>
-      
+
       <cv-list
         class="navigation-rail"
         slot="navigation"
@@ -171,15 +171,15 @@ const Template = ({
         <cv-typography scale="body1">All environments</cv-typography>
         <cv-icon>arrow_drop_down</cv-icon>
        </span>
-       
-       <cv-textfield slot="actionItems" icon="forum" placeholder="Message ask.ai" dense></cv-textfield>
+
+       <cv-textfield slot="actionItems" icon="forum" placeholder="Message ask.ai" style="margin-right: 8px" dense></cv-textfield>
        <cv-icon-button slot="actionItems" icon="notifications"></cv-icon-button>
        <cv-icon-button-toggle slot="actionItems" onIcon="help" offIcon="help" class="help-item"></cv-icon-button-toggle>
-       <cv-icon-button slot="actionItems" icon="person"></cv-icon-button>
+       <cv-icon-button slot="actionItems" icon="person" style="margin-right: -12px"></cv-icon-button>
       </cv-toolbar>
 
-      <div slot="help" class="mdc-typography">
-        <cv-toolbar sticky>
+      <div slot="help" class="help-panel mdc-typography">
+        <cv-toolbar sticky style="padding-left: 12px; margin-right: -8px;">
           <span slot="title">Help</span>
           <cv-icon-button
             slot="actionItems"
@@ -188,11 +188,11 @@ const Template = ({
           ></cv-icon-button>
           <cv-icon-button
             slot="actionItems"
-            icon="close"
+            icon="close"I
             class="help-close"
           ></cv-icon-button>
         </cv-toolbar>
-        <div style="padding: 16px">
+        <div class="help-content" style="padding: 16px 24px 24px">
           <cv-typography scale="headline5">
             Ultricies nunc massa, id ut felis sed varius accumsan platea.
           </cv-typography><br />

--- a/libs/components/src/app-shell/app-shell.ts
+++ b/libs/components/src/app-shell/app-shell.ts
@@ -309,7 +309,7 @@ export class CovalentAppShell extends DrawerBase {
 
   protected renderMain() {
     return this.contained
-      ? html`<cv-card><slot></slot></cv-card>`
+      ? html`<cv-card class="wrapper-card"><slot></slot></cv-card>`
       : html`<slot></slot>`;
   }
 

--- a/libs/components/src/card/card.scss
+++ b/libs/components/src/card/card.scss
@@ -9,6 +9,7 @@
 
 .mdc-card {
   --mdc-theme-surface: var(--cv-theme-surface-container-lowest, #ffffff);
+
   box-shadow: none;
 
   &.cv-height-full {

--- a/libs/components/src/card/card.scss
+++ b/libs/components/src/card/card.scss
@@ -9,6 +9,7 @@
 
 .mdc-card {
   --mdc-theme-surface: var(--cv-theme-surface-container-lowest, #ffffff);
+  box-shadow: none;
 
   &.cv-height-full {
     height: 100%;

--- a/libs/components/src/empty-state/empty-state.scss
+++ b/libs/components/src/empty-state/empty-state.scss
@@ -24,7 +24,11 @@
   width: 96px;
   height: 96px;
   border-radius: 50%;
-  background-color: var(--mdc-theme-surface-neutral-highlight);
+  background-color: color-mix(
+    in srgb,
+    var(--mdc-theme-on-surface) 4%,
+    transparent
+  );
   margin-left: auto;
   margin-right: auto;
 }
@@ -43,11 +47,11 @@
   margin: 16px 0 8px;
 }
 
-.mdc-typography--caption {
-  font-family: var(--mdc-typography-caption-font-family);
-  font-size: var(--mdc-typography-caption-font-size);
-  font-weight: var(--mdc-typography-caption-font-weight);
-  line-height: var(--mdc-typography-caption-line-height);
+.mdc-typography--body2 {
+  font-family: var(--mdc-typography-body2-font-family);
+  font-size: var(--mdc-typography-body2-font-size);
+  font-weight: var(--mdc-typography-body2-font-weight);
+  line-height: var(--mdc-typography-body2-line-height);
   color: var(--mdc-theme-text-secondary-on-background);
   margin: 0;
 }

--- a/libs/components/src/empty-state/empty-state.ts
+++ b/libs/components/src/empty-state/empty-state.ts
@@ -39,7 +39,7 @@ export class CovalentEmptyState extends LitElement {
         ${this.subtitle
           ? html` <p
               key="{line}"
-              class="mdc-typography--caption"
+              class="mdc-typography--body2"
               style=${this.headline ? '' : 'margin-top:16px;'}
             >
               ${this.subtitle.split(/\n/).map((line) => {

--- a/libs/components/src/icon-button-toggle/icon-button-toggle.scss
+++ b/libs/components/src/icon-button-toggle/icon-button-toggle.scss
@@ -8,12 +8,10 @@
 }
 
 :host([on]) {
-  --mdc-ripple-press-opacity: 0.16;
-  --mdc-ripple-hover-opacity: 0.12;
-  --mdc-ripple-focus-opacity: 0.16;
+  --mdc-ripple-color: var(--cv-theme-on-surface);
 
-  background-color: var(--cv-theme-primary-8);
-  color: var(--cv-theme-primary);
+  background-color: var(--cv-theme-secondary-container);
+  color: var(--cv-theme-on-secondary-container);
 
   .material-icons {
     font-variation-settings: 'FILL' 1;

--- a/libs/components/src/list/_list.theme.scss
+++ b/libs/components/src/list/_list.theme.scss
@@ -3,7 +3,7 @@
 
 :host {
   $border: var(--mdc-theme-border);
-  $text: var(--mdc-theme-text-primary-on-background);
+  $text: var(--mdc-theme-on-surface-variant);
 
   --mdc-list-single-line-height: 48px;
   --mdc-list-two-line-height: 72px;

--- a/libs/components/src/list/list-item.scss
+++ b/libs/components/src/list/list-item.scss
@@ -4,10 +4,10 @@
 }
 
 :host([graphic='avatar']) .mdc-deprecated-list-item__graphic {
-  --mdc-theme-text-icon-on-background: var(--cv-theme-on-primary-container);
+  --mdc-theme-text-icon-on-background: var(--cv-theme-on-secondary-container);
 
-  color: var(--cv-theme-on-primary-container);
-  background-color: var(--cv-theme-primary-container);
+  color: var(--cv-theme-on-secondary-container);
+  background-color: var(--cv-theme-secondary-container);
   border-radius: 9999px;
 }
 

--- a/libs/components/src/list/list.scss
+++ b/libs/components/src/list/list.scss
@@ -3,6 +3,22 @@
   padding-left: var(--cv-list-padding-left, 0);
 }
 
+:host(.subnav) ::slotted(*),
+:host([subnav]) ::slotted(*) {
+  height: 32px;
+  font-weight: var(--mdc-typography-body2-font-weight);
+  border-radius: var(--cv-list-item-border-radius, 100px);
+  padding-right: var(--cv-list-padding-right, 16px);
+  padding-left: var(--cv-list-padding-left, 16px);
+}
+
+:host(.subnav),
+:host([subnav]) {
+  padding-left: 32px;
+  --cv-list-padding-right: 0;
+  --cv-list-padding-left: 16px;
+}
+
 .mdc-deprecated-list {
   width: 100%;
 }

--- a/libs/components/src/list/list.scss
+++ b/libs/components/src/list/list.scss
@@ -14,9 +14,10 @@
 
 :host(.subnav),
 :host([subnav]) {
-  padding-left: 32px;
   --cv-list-padding-right: 0;
   --cv-list-padding-left: 16px;
+
+  padding-left: 32px;
 }
 
 .mdc-deprecated-list {

--- a/libs/components/src/list/nav-list-item.scss
+++ b/libs/components/src/list/nav-list-item.scss
@@ -7,6 +7,11 @@
   border-radius: var(--cv-list-item-border-radius, 100px);
   transition: border-radius 100ms ease-out;
   width: var(--cv-list-item-width, 100%);
+  color: var(--cv-theme-on-surface-variant);
+
+  ::slotted(cv-icon[slot='graphic']) {
+    color: var(--cv-theme-on-surface-variant);
+  }
 
   --mdc-list-item-graphic-margin: 4px;
 }
@@ -14,12 +19,14 @@
 ::slotted(*) {
   --cv-list-padding-right: 0;
   --cv-list-padding-left: 0;
-  --cv-list-item-text-padding: 48px;
+  --cv-list-item-text-padding: 16px;
 }
 
 :host([activated]) {
+  color: var(--cv-theme-on-secondary-container);
+
   ::slotted(cv-icon[slot='graphic']) {
-    color: var(--mdc-theme-primary);
+    color: var(--cv-theme-on-secondary-container);
   }
 }
 
@@ -40,6 +47,7 @@
   padding: 0;
   padding-right: var(--cv-list-padding-right, 12px);
   padding-left: var(--cv-list-padding-left, 12px);
+  --cv-list-item-text-padding: 16px;
 }
 
 :host([graphic='avatar']) .mdc-deprecated-list-item__graphic {
@@ -93,6 +101,10 @@
 
   --mdc-list-side-padding: 0;
   --cv-list-item-graphic-margin-left: 0;
+
+  ::slotted(cv-list) {
+    padding-left: 32px;
+  }
 }
 
 :host([hasChildren][open]:hover:not([activated])) {
@@ -100,7 +112,7 @@
     --mdc-ripple-color: transparent;
 
     &:hover {
-      --mdc-ripple-color: var(--mdc-theme-primary);
+      --mdc-ripple-color: var(--mdc-theme-on-surface-variant);
     }
   }
 }

--- a/libs/components/src/list/nav-list-item.scss
+++ b/libs/components/src/list/nav-list-item.scss
@@ -41,13 +41,14 @@
 }
 
 :host([subnav]) {
+  --cv-list-item-text-padding: 16px;
+
   height: 32px;
   font-weight: var(--mdc-typography-body2-font-weight);
   border-radius: var(--cv-list-item-border-radius, 100px);
   padding: 0;
   padding-right: var(--cv-list-padding-right, 12px);
   padding-left: var(--cv-list-padding-left, 12px);
-  --cv-list-item-text-padding: 16px;
 }
 
 :host([graphic='avatar']) .mdc-deprecated-list-item__graphic {

--- a/libs/components/src/theme/_index.scss
+++ b/libs/components/src/theme/_index.scss
@@ -262,6 +262,7 @@
       $typography,
       button-line-height
     )};
+  --mdc-typography-button-letter-spacing: 0;
   --mdc-typography-button-text-transform: none;
   --mdc-typography-caption-font-family: var(--mdc-typography-font-family);
   --mdc-typography-caption-font-size: #{map-get($typography, caption-font-size)};

--- a/libs/components/src/toolbar/toolbar.scss
+++ b/libs/components/src/toolbar/toolbar.scss
@@ -27,6 +27,8 @@
   background-color: transparent;
   background-color: var(--mdc-theme-surface);
   color: var(--mdc-theme-on-surface);
+  border-top-left-radius: var(--cv-border-radius-outer);
+  border-top-right-radius: var(--cv-border-radius-outer);
 }
 
 .mdc-top-app-bar--fixed-adjust,

--- a/libs/components/src/top-app-bar/top-app-bar.scss
+++ b/libs/components/src/top-app-bar/top-app-bar.scss
@@ -11,8 +11,4 @@
 .mdc-top-app-bar {
   background: var(--mdc-theme-surface);
   color: var(--mdc-theme-on-surface);
-
-  #navigation {
-    padding-left: 16px;
-  }
 }

--- a/libs/components/src/top-app-bar/top-app-bar.scss
+++ b/libs/components/src/top-app-bar/top-app-bar.scss
@@ -1,5 +1,3 @@
-
-
 :host {
   --mdc-theme-primary: var(--mdc-theme-surface);
   --mdc-theme-on-primary: var(--mdc-theme-text-primary-on-background);
@@ -13,4 +11,8 @@
 .mdc-top-app-bar {
   background: var(--mdc-theme-surface);
   color: var(--mdc-theme-on-surface);
+
+  #navigation {
+    padding-left: 16px;
+  }
 }

--- a/libs/components/src/typography/typography.scss
+++ b/libs/components/src/typography/typography.scss
@@ -27,9 +27,8 @@ $dark-colors: map-merge($dark-colors, map-get(tokens.$tokens, dark));
 }
 
 :host {
-  display: block;
-
   color: var(--cv-theme-on-surface-variant);
+  display: block;
 }
 
 // Header typography should be darker color

--- a/libs/components/src/typography/typography.scss
+++ b/libs/components/src/typography/typography.scss
@@ -1,5 +1,46 @@
 @use '@material/typography/mdc-typography';
+@use '@covalent/tokens' as tokens;
+@use '../theme' as theme;
+
+$theme-tokens: map-get(tokens.$tokens, 'theme');
+$light-tokens: map-get($theme-tokens, 'light');
+$light-colors: map-get($light-tokens, 'colors');
+$dark-tokens: map-get($theme-tokens, 'dark');
+$dark-colors: map-get($dark-tokens, 'colors');
+// Merge deprecated tokens
+$light-colors: map-merge($light-colors, map-get(tokens.$tokens, light));
+$dark-colors: map-merge($dark-colors, map-get(tokens.$tokens, dark));
+
+// For convience re-define theme tokens scoped to a light/dark class
+:root {
+  @include theme.components-theme(
+    map-merge($light-colors, map-get(tokens.$tokens, light)),
+    map-get(tokens.$tokens, typography)
+  );
+}
+
+.dark {
+  @include theme.components-theme(
+    map-merge($dark-colors, map-get(tokens.$tokens, dark)),
+    map-get(tokens.$tokens, typography)
+  );
+}
 
 :host {
   display: block;
+
+  color: var(--cv-theme-on-surface-variant);
+}
+
+// Header typography should be darker color
+:host([scale='headline1']),
+:host([scale='headline2']),
+:host([scale='headline3']),
+:host([scale='headline4']),
+:host([scale='headline5']),
+:host([scale='headline6']),
+:host([scale='subtitle1']),
+:host([scale='subtitle2']),
+:host([scale='button']) {
+  color: var(--cv-theme-on-surface);
 }

--- a/libs/tokens/src/color/covalent-m3.json
+++ b/libs/tokens/src/color/covalent-m3.json
@@ -2,9357 +2,3900 @@
   "theme": {
     "light": {
       "palettes": {
-        "digital blue 100": {
-          "type": "color",
-          "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34425",
-              "exportKey": "variables"
-            }
-          }
-        },
         "digital blue 98": {
           "type": "color",
           "value": "#fbf8ffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34426",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
+        },
+        "digital blue 100": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
         },
         "digital blue 95": {
           "type": "color",
           "value": "#f0efffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34427",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 90": {
           "type": "color",
           "value": "#dee0ffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34428",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 80": {
           "type": "color",
           "value": "#bac3ffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34429",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 70": {
           "type": "color",
           "value": "#96a5ffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34430",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 60": {
           "type": "color",
           "value": "#7187ffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34431",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 50": {
           "type": "color",
           "value": "#4967ffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34432",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 40": {
           "type": "color",
           "value": "#3053f4ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34433",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 30": {
           "type": "color",
           "value": "#0436d3ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34434",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 20": {
           "type": "color",
           "value": "#00208eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34435",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 10": {
           "type": "color",
           "value": "#00115aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34436",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34437",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 98": {
           "type": "color",
           "value": "#fff8f6ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34438",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 95": {
           "type": "color",
           "value": "#ffede7ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34439",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 90": {
           "type": "color",
           "value": "#ffdbceff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34440",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 80": {
           "type": "color",
           "value": "#ffc0a8ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34441",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 70": {
           "type": "color",
           "value": "#ffa47eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34442",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 60": {
           "type": "color",
           "value": "#ff986dff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34443",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 50": {
           "type": "color",
           "value": "#ff7a42ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34444",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 40": {
           "type": "color",
           "value": "#ff5f02ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34445",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 30": {
           "type": "color",
           "value": "#cf4b00ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34446",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 20": {
           "type": "color",
           "value": "#8d3001ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34447",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 10": {
           "type": "color",
           "value": "#481300ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34448",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34449",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34450",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "navy 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34451",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
-        "navy 98": {
+        "navy 99": {
           "type": "color",
-          "value": "#e9f1f9ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34452",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#fbfcfeff",
+          "blendMode": "normal"
         },
         "navy 95": {
           "type": "color",
-          "value": "#c1d1e2ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34453",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#eef4fcff",
+          "blendMode": "normal"
         },
         "navy 90": {
           "type": "color",
-          "value": "#99b9d8ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34454",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#deeafaff",
+          "blendMode": "normal"
         },
         "navy 80": {
           "type": "color",
-          "value": "#73a1c9ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34455",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#bcd5f6ff",
+          "blendMode": "normal"
         },
         "navy 70": {
           "type": "color",
-          "value": "#39719aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34456",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#95bff1ff",
+          "blendMode": "normal"
         },
         "navy 60": {
           "type": "color",
-          "value": "#0d4264ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34457",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#60a9edff",
+          "blendMode": "normal"
         },
         "navy 50": {
           "type": "color",
-          "value": "#033251ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34458",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#458fcfff",
+          "blendMode": "normal"
         },
         "navy 40": {
           "type": "color",
-          "value": "#012640ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34459",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#3672a8ff",
+          "blendMode": "normal"
         },
         "navy 30": {
           "type": "color",
-          "value": "#011829ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34460",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#26547cff",
+          "blendMode": "normal"
         },
         "navy 20": {
           "type": "color",
-          "value": "#011829ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34461",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#14324cff",
+          "blendMode": "normal"
         },
         "navy 10": {
           "type": "color",
-          "value": "#02121fff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34462",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#001d33ff",
+          "blendMode": "normal"
         },
         "navy 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34463",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34464",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 98": {
           "type": "color",
           "value": "#ffdcdbff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34465",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 95": {
           "type": "color",
           "value": "#ffc9c7ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34466",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 90": {
           "type": "color",
           "value": "#ffb2aeff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34467",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 80": {
           "type": "color",
           "value": "#e0938eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34468",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 70": {
           "type": "color",
           "value": "#c65953ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34469",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 60": {
           "type": "color",
           "value": "#be413aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34470",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 50": {
           "type": "color",
           "value": "#b62a22ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34471",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 40": {
           "type": "color",
           "value": "#ae1209ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34472",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 30": {
           "type": "color",
           "value": "#7a0d06ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34473",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 20": {
           "type": "color",
           "value": "#460704ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34474",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 10": {
           "type": "color",
           "value": "#110201ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34475",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34476",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34477",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 98": {
           "type": "color",
           "value": "#fef3e6ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34478",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 95": {
           "type": "color",
           "value": "#ffdcb0ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34479",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 90": {
           "type": "color",
           "value": "#ffcc8cff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34480",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 80": {
           "type": "color",
           "value": "#f8b866ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34481",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 70": {
           "type": "color",
           "value": "#f7ac4dff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34482",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 60": {
           "type": "color",
           "value": "#f5a033ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34483",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 50": {
           "type": "color",
           "value": "#f4941aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34484",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 40": {
           "type": "color",
           "value": "#f38800ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34485",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 30": {
           "type": "color",
           "value": "#aa5f00ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34486",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 20": {
           "type": "color",
           "value": "#613600ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34487",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 10": {
           "type": "color",
           "value": "#180e00ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34488",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34489",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34490",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 98": {
           "type": "color",
           "value": "#daf6daff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34491",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 95": {
           "type": "color",
           "value": "#b5e8b3ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34492",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 90": {
           "type": "color",
           "value": "#8fcc8eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34493",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 80": {
           "type": "color",
           "value": "#68a366ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34494",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 70": {
           "type": "color",
           "value": "#4f944dff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34495",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 60": {
           "type": "color",
           "value": "#358533ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34496",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 50": {
           "type": "color",
           "value": "#1c751aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34497",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 40": {
           "type": "color",
           "value": "#036600ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34498",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 30": {
           "type": "color",
           "value": "#024700ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34499",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 20": {
           "type": "color",
           "value": "#012900ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34500",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 10": {
           "type": "color",
           "value": "#000a00ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34501",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34502",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34503",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 98": {
           "type": "color",
           "value": "#f7e6ecff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34504",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 95": {
           "type": "color",
           "value": "#efccd9ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34505",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 90": {
           "type": "color",
           "value": "#e8b3c6ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34506",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 80": {
           "type": "color",
           "value": "#d880a1ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34507",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 70": {
           "type": "color",
           "value": "#c84d7bff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34508",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 60": {
           "type": "color",
           "value": "#c13468ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34509",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 50": {
           "type": "color",
           "value": "#b91a55ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34510",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 40": {
           "type": "color",
           "value": "#b10142ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34511",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 30": {
           "type": "color",
           "value": "#7c012eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34512",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 20": {
           "type": "color",
           "value": "#47001aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34513",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 10": {
           "type": "color",
           "value": "#120007ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34514",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34515",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 80": {
           "type": "color",
-          "value": "#c3c5ddff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34516",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 80}"
         },
         "secondary 20": {
           "type": "color",
-          "value": "#303245ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34517",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 20}"
         },
         "secondary 30": {
           "type": "color",
-          "value": "#484b5fff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34518",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 30}"
         },
         "secondary 90": {
           "type": "color",
-          "value": "#dfe1f9ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34519",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 90}"
         },
         "secondary 10": {
           "type": "color",
-          "value": "#171a2cff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34520",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 10}"
         },
         "neutral 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34521",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 98": {
           "type": "color",
-          "value": "#fdf9fcff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34522",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#f8f9fbff",
+          "blendMode": "normal"
         },
         "neutral 95": {
           "type": "color",
-          "value": "#f6f3f6ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34523",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#f1f3f8ff",
+          "blendMode": "normal"
         },
         "neutral 90": {
           "type": "color",
-          "value": "#ebe8ecff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34524",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#e6e9f3ff",
+          "blendMode": "normal"
         },
         "neutral 80": {
           "type": "color",
-          "value": "#d5d3d8ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34525",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#d1d5e7ff",
+          "blendMode": "normal"
         },
         "neutral 70": {
           "type": "color",
-          "value": "#bebdc3ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34526",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#bbc1d9ff",
+          "blendMode": "normal"
         },
         "neutral 60": {
           "type": "color",
-          "value": "#a6a6adff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34527",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#a4adc8ff",
+          "blendMode": "normal"
         },
         "neutral 50": {
           "type": "color",
-          "value": "#8f8e97ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34528",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#8e98b4ff",
+          "blendMode": "normal"
         },
         "neutral 40": {
           "type": "color",
-          "value": "#76757dff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34529",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#727d9cff",
+          "blendMode": "normal"
         },
         "neutral 30": {
           "type": "color",
-          "value": "#5c5b5fff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34530",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#59627bff",
+          "blendMode": "normal"
         },
         "neutral 20": {
           "type": "color",
-          "value": "#3e3e41ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34531",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#3e4557ff",
+          "blendMode": "normal"
         },
         "neutral 10": {
           "type": "color",
-          "value": "#1e1d1eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34532",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#1f232eff",
+          "blendMode": "normal"
         },
         "neutral 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34533",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 87": {
           "type": "color",
-          "value": "#e5e2e6ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34534",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#e0e3efff",
+          "blendMode": "normal"
         },
         "neutral 96": {
           "type": "color",
-          "value": "#f8f5f8ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34535",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#f3f5f9ff",
+          "blendMode": "normal"
         },
         "neutral 94": {
           "type": "color",
-          "value": "#f4f1f4ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34536",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#eff1f7ff",
+          "blendMode": "normal"
         },
         "neutral 92": {
           "type": "color",
-          "value": "#f0edf0ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34537",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#ebedf5ff",
+          "blendMode": "normal"
         },
         "secondary 100": {
           "type": "color",
-          "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34538",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 100}"
         },
         "secondary 98": {
           "type": "color",
-          "value": "#f4f5fdff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34539",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 98}"
         },
         "secondary 95": {
           "type": "color",
-          "value": "#eaebfbff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34540",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 95}"
         },
         "secondary 70": {
           "type": "color",
-          "value": "#aaadc4ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34541",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 70}"
         },
         "secondary 60": {
           "type": "color",
-          "value": "#9294aaff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34542",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 60}"
         },
         "secondary 50": {
           "type": "color",
-          "value": "#797c91ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34543",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 50}"
         },
         "secondary 40": {
           "type": "color",
-          "value": "#616378ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34544",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 40}"
         },
         "secondary 0": {
           "type": "color",
-          "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34545",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 0}"
         },
         "neutral 99": {
           "type": "color",
-          "value": "#fffbfeff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34546",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#fcfcfdff",
+          "blendMode": "normal"
         },
         "neutral 35": {
           "type": "color",
-          "value": "#68686eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34547",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#66708cff",
+          "blendMode": "normal"
         },
         "neutral 25": {
           "type": "color",
-          "value": "#4d4d50ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34548",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#4c546aff",
+          "blendMode": "normal"
         },
         "neutral 97": {
           "type": "color",
-          "value": "#faf7faff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34549",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#f6f7fbff",
+          "blendMode": "normal"
         },
         "neutral 93": {
           "type": "color",
-          "value": "#f2eff2ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34550",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#edeff6ff",
+          "blendMode": "normal"
         },
         "neutral 91": {
           "type": "color",
-          "value": "#eeeaeeff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34551",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#e8ebf4ff",
+          "blendMode": "normal"
         },
         "neutral 2": {
           "type": "color",
-          "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34552",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#05060aff",
+          "blendMode": "normal"
         },
         "neutral 3": {
           "type": "color",
-          "value": "#020202ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34553",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#080a0fff",
+          "blendMode": "normal"
         },
         "neutral 4": {
           "type": "color",
-          "value": "#060506ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34554",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#0a0d12ff",
+          "blendMode": "normal"
         },
         "neutral 5": {
           "type": "color",
-          "value": "#0a090aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34555",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#0d1016ff",
+          "blendMode": "normal"
         },
         "neutral 6": {
           "type": "color",
-          "value": "#0e0e0eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34556",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#10141aff",
+          "blendMode": "normal"
         },
         "neutral 7": {
           "type": "color",
-          "value": "#121212ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34557",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#14181fff",
+          "blendMode": "normal"
         },
         "neutral 8": {
           "type": "color",
-          "value": "#161616ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34558",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#171b24ff",
+          "blendMode": "normal"
         },
         "neutral 9": {
           "type": "color",
-          "value": "#1a191aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34559",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#1b1f29ff",
+          "blendMode": "normal"
         },
         "neutral 11": {
           "type": "color",
-          "value": "#222122ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34560",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#222633ff",
+          "blendMode": "normal"
         },
         "neutral 12": {
           "type": "color",
-          "value": "#252426ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34561",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#252a37ff",
+          "blendMode": "normal"
         },
         "neutral 13": {
           "type": "color",
-          "value": "#292829ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34562",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#292e3cff",
+          "blendMode": "normal"
         },
         "neutral 14": {
           "type": "color",
-          "value": "#2c2b2dff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34563",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#2c313fff",
+          "blendMode": "normal"
         },
         "neutral 15": {
           "type": "color",
-          "value": "#2f2e30ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34564",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#2f3443ff",
+          "blendMode": "normal"
         },
         "neutral 16": {
           "type": "color",
-          "value": "#323134ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34565",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#333847ff",
+          "blendMode": "normal"
         },
         "neutral 17": {
           "type": "color",
-          "value": "#353537ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34566",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#353b4bff",
+          "blendMode": "normal"
         },
         "neutral 18": {
           "type": "color",
-          "value": "#38383bff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34567",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#383e4fff",
+          "blendMode": "normal"
         },
         "neutral 19": {
           "type": "color",
-          "value": "#3b3b3eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34568",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#3b4153ff",
+          "blendMode": "normal"
         },
         "neutral 21": {
           "type": "color",
-          "value": "#414144ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34569",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#41485bff",
+          "blendMode": "normal"
         },
         "neutral 22": {
           "type": "color",
-          "value": "#444447ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34570",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#444b5fff",
+          "blendMode": "normal"
         },
         "neutral 23": {
           "type": "color",
-          "value": "#47474aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34571",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#474e62ff",
+          "blendMode": "normal"
         },
         "neutral 24": {
           "type": "color",
-          "value": "#4a4a4dff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34572",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#495166ff",
+          "blendMode": "normal"
         },
         "digital blue 91": {
           "type": "color",
           "value": "#e1e3fdff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34573",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 92": {
           "type": "color",
           "value": "#e5e5feff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34574",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 93": {
           "type": "color",
           "value": "#e8e9feff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34575",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 94": {
           "type": "color",
           "value": "#ececfeff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34576",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
+        },
+        "digital blue 99": {
+          "type": "color",
+          "value": "#fefbffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 100": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 99": {
+          "type": "color",
+          "value": "#fcfcffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 98": {
+          "type": "color",
+          "value": "#f9f9fdff",
+          "blendMode": "normal"
+        },
+        "neutral variant 97": {
+          "type": "color",
+          "value": "#f5f5faff",
+          "blendMode": "normal"
+        },
+        "neutral variant 96": {
+          "type": "color",
+          "value": "#f2f2f7ff",
+          "blendMode": "normal"
+        },
+        "neutral variant 95": {
+          "type": "color",
+          "value": "#f0f0f4ff",
+          "blendMode": "normal"
+        },
+        "neutral variant 94": {
+          "type": "color",
+          "value": "#ededf1ff",
+          "blendMode": "normal"
+        },
+        "neutral variant 93": {
+          "type": "color",
+          "value": "#eaeaefff",
+          "blendMode": "normal"
+        },
+        "neutral variant 92": {
+          "type": "color",
+          "value": "#e7e7ecff",
+          "blendMode": "normal"
+        },
+        "neutral variant 91": {
+          "type": "color",
+          "value": "#e4e4e9ff",
+          "blendMode": "normal"
+        },
+        "neutral variant 90": {
+          "type": "color",
+          "value": "#e2e2e6ff",
+          "blendMode": "normal"
+        },
+        "neutral variant 80": {
+          "type": "color",
+          "value": "#c6c6caff",
+          "blendMode": "normal"
+        },
+        "neutral variant 70": {
+          "type": "color",
+          "value": "#aaabafff",
+          "blendMode": "normal"
+        },
+        "neutral variant 60": {
+          "type": "color",
+          "value": "#8f9194ff",
+          "blendMode": "normal"
+        },
+        "neutral variant 50": {
+          "type": "color",
+          "value": "#76777aff",
+          "blendMode": "normal"
+        },
+        "neutral variant 40": {
+          "type": "color",
+          "value": "#5d5e62ff",
+          "blendMode": "normal"
+        },
+        "neutral variant 35": {
+          "type": "color",
+          "value": "#515256ff",
+          "blendMode": "normal"
+        },
+        "neutral variant 30": {
+          "type": "color",
+          "value": "#45474aff",
+          "blendMode": "normal"
+        },
+        "neutral variant 25": {
+          "type": "color",
+          "value": "#3a3b3fff",
+          "blendMode": "normal"
+        },
+        "neutral variant 20": {
+          "type": "color",
+          "value": "#2f3033ff",
+          "blendMode": "normal"
+        },
+        "neutral variant 15": {
+          "type": "color",
+          "value": "#242629ff",
+          "blendMode": "normal"
+        },
+        "neutral variant 10": {
+          "type": "color",
+          "value": "#1a1c1eff",
+          "blendMode": "normal"
+        },
+        "neutral variant 5": {
+          "type": "color",
+          "value": "#0f1114ff",
+          "blendMode": "normal"
+        },
+        "neutral variant 0": {
+          "type": "color",
+          "value": "#000000ff",
+          "blendMode": "normal"
+        },
+        "neutral 1": {
+          "type": "color",
+          "value": "#020305ff",
+          "blendMode": "normal"
+        },
+        "navy 13": {
+          "type": "color",
+          "value": "#00233cff",
+          "blendMode": "normal"
+        },
+        "navy 98": {
+          "type": "color",
+          "value": "#f8fafdff",
+          "blendMode": "normal"
         }
       },
       "colors": {
         "primary": {
           "type": "color",
-          "value": "{theme.light.palettes.digital blue 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34733",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.digital blue 40}"
         },
         "primary-container": {
           "type": "color",
-          "value": "{theme.light.palettes.digital blue 94}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34734",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.digital blue 94}"
         },
         "on-primary": {
           "type": "color",
-          "value": "{theme.light.palettes.digital blue 100}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34735",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.digital blue 100}"
         },
         "secondary": {
           "type": "color",
-          "value": "{theme.light.palettes.secondary 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34736",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 13}"
         },
         "secondary-container": {
           "type": "color",
-          "value": "{theme.light.palettes.secondary 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34737",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.secondary 90}"
         },
         "on-secondary": {
           "type": "color",
-          "value": "{theme.light.palettes.secondary 100}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34738",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.secondary 100}"
         },
         "on-secondary-container": {
           "type": "color",
-          "value": "{theme.light.palettes.secondary 10}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34739",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.secondary 10}"
         },
         "tertiary": {
           "type": "color",
-          "value": "{theme.light.palettes.orange 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34740",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.orange 40}"
         },
         "tertiary-container": {
           "type": "color",
-          "value": "{theme.light.palettes.orange 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34741",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.orange 90}"
         },
         "on-tertiary": {
           "type": "color",
-          "value": "{theme.light.palettes.orange 100}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34742",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.orange 100}"
         },
         "on-tertiary-container": {
           "type": "color",
-          "value": "{theme.light.palettes.orange 10}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34743",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.orange 10}"
         },
         "surface": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 98}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34744",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 98}"
         },
         "surface-dim": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 87}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34745",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 87}"
         },
         "surface-bright": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 98}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34746",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 98}"
         },
         "surface-container-lowest": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 100}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34747",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 100}"
         },
         "surface-container-low": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 97}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34748",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 96}"
         },
         "surface-container": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 96}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34749",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 94}"
         },
         "surface-container-high": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 95}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34750",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 92}"
         },
         "surface-container-highest": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 94}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34751",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 90}"
         },
         "on-surface": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 10}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34752",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.navy 13}"
         },
         "on-surface-variant": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 30}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34753",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 30}"
         },
         "inverse-surface": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 20}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34754",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 20}"
         },
         "inverse-on-surface": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 95}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34755",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 95}"
         },
         "negative": {
           "type": "color",
-          "value": "{theme.light.palettes.negative 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34756",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.negative 40}"
         },
         "negative-container": {
           "type": "color",
-          "value": "{theme.light.palettes.negative 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34757",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.negative 90}"
         },
         "on-negative": {
           "type": "color",
-          "value": "{theme.light.palettes.negative 100}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34758",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.negative 100}"
         },
         "on-negative-container": {
           "type": "color",
-          "value": "{theme.light.palettes.negative 10}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34759",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.negative 10}"
         },
         "positive": {
           "type": "color",
-          "value": "{theme.light.palettes.positive 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34760",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.positive 40}"
         },
         "positive-container": {
           "type": "color",
-          "value": "{theme.light.palettes.positive 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34761",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.positive 90}"
         },
         "on-positive": {
           "type": "color",
-          "value": "{theme.light.palettes.positive 100}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34762",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.positive 100}"
         },
         "on-positive-container": {
           "type": "color",
-          "value": "{theme.light.palettes.positive 10}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34763",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.positive 10}"
         },
         "caution": {
           "type": "color",
-          "value": "{theme.light.palettes.caution 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34764",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.caution 40}"
         },
         "caution-container": {
           "type": "color",
-          "value": "{theme.light.palettes.caution 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34765",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.caution 90}"
         },
         "on-caution": {
           "type": "color",
-          "value": "{theme.light.palettes.caution 100}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34766",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.caution 100}"
         },
         "on-caution-container": {
           "type": "color",
-          "value": "{theme.light.palettes.caution 10}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34767",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.caution 10}"
         },
         "outline": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34768",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 40}"
         },
         "outline-variant": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 80}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34769",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 80}"
         },
         "shadow": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 0}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34770",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 0}"
         },
         "scrim": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 0}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34771",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00000052",
+          "blendMode": "normal"
         },
         "primary-fixed": {
           "type": "color",
-          "value": "{theme.light.palettes.digital blue 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34772",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.digital blue 90}"
         },
         "primary-fixed-dim": {
           "type": "color",
-          "value": "{theme.light.palettes.digital blue 80}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34773",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.digital blue 80}"
         },
         "secondary-fixed": {
           "type": "color",
-          "value": "{theme.light.palettes.secondary 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34774",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.secondary 90}"
         },
         "secondary-fixed-dim": {
           "type": "color",
-          "value": "{theme.light.palettes.secondary 80}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34775",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.secondary 80}"
         },
         "tertiary-fixed": {
           "type": "color",
-          "value": "{theme.light.palettes.orange 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34776",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.orange 90}"
         },
         "tertiary-fixed-dim": {
           "type": "color",
-          "value": "{theme.light.palettes.orange 80}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34777",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.orange 80}"
         },
         "primary-8": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#3053f414",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34778",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "primary-12": {
           "type": "color",
           "value": "#3053f41f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34779",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-8": {
           "type": "color",
-          "value": "#1e1d1e14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34780",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00233c14",
+          "blendMode": "normal"
         },
         "on-surface-12": {
           "type": "color",
-          "value": "#1e1d1e1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34781",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00233c1f",
+          "blendMode": "normal"
         },
         "on-primary-container": {
           "type": "color",
-          "value": "{theme.light.palettes.digital blue 10}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34782",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.digital blue 10}"
         },
         "inverse-primary": {
           "type": "color",
-          "value": "{theme.light.palettes.digital blue 80}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34783",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.digital blue 80}"
         },
         "on-surface-38": {
           "type": "color",
-          "value": "#1e1d1e61",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34784",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00233c61",
+          "blendMode": "normal"
         },
         "on-surface-16": {
           "type": "color",
-          "value": "#1e1d1e29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34785",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00233c29",
+          "blendMode": "normal"
         },
         "on-primary-12": {
           "type": "color",
           "value": "#ffffff1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34786",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-8": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#ffffff14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34787",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "primary-16": {
           "type": "color",
           "value": "#3053f429",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34788",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-variant-8": {
           "type": "color",
-          "value": "#5c5b5f14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34789",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#59627b14",
+          "blendMode": "normal"
         },
         "on-tertiary-container-8": {
           "type": "color",
           "value": "#48130014",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34790",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-container-12": {
           "type": "color",
           "value": "#4813001f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34791",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-container-12": {
           "type": "color",
           "value": "#00115a1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34792",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-variant-12": {
           "type": "color",
-          "value": "#5c5b5f1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34793",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#59627b1f",
+          "blendMode": "normal"
         },
         "on-secondary-container-8": {
           "type": "color",
-          "value": "#171a2c14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34794",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#001d3314",
+          "blendMode": "normal"
         },
         "on-secondary-container-16": {
           "type": "color",
-          "value": "#171a2c29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["STROKE_COLOR", "TEXT_FILL", "SHAPE_FILL"],
-              "variableId": "VariableID:6809:34795",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#001d3329",
+          "blendMode": "normal"
         },
         "outline-8": {
           "type": "color",
-          "value": "#76757d14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34796",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#727d9c14",
+          "blendMode": "normal"
         },
         "outline-12": {
           "type": "color",
-          "value": "#76757d1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34797",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#727d9c1f",
+          "blendMode": "normal"
         },
         "outline-16": {
           "type": "color",
-          "value": "#76757d29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34798",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#727d9c29",
+          "blendMode": "normal"
         },
         "surface-variant": {
           "type": "color",
-          "value": "{theme.light.palettes.neutral 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34799",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 98}"
         },
         "emphasis": {
           "type": "color",
-          "value": "{theme.light.palettes.emphasis 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34800",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.emphasis 40}"
         },
         "emphasis-container": {
           "type": "color",
-          "value": "{theme.light.palettes.emphasis 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34801",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.emphasis 90}"
         },
         "on-emphasis": {
           "type": "color",
-          "value": "{theme.light.palettes.emphasis 100}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34802",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.emphasis 100}"
         },
         "on-emphasis-container": {
           "type": "color",
-          "value": "{theme.light.palettes.emphasis 10}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34803",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.emphasis 10}"
         },
         "positive-16": {
           "type": "color",
           "value": "#03660029",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34804",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution-16": {
           "type": "color",
           "value": "#f3880029",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34805",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative-12": {
           "type": "color",
           "value": "#ae12091f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34806",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-container-12": {
           "type": "color",
-          "value": "#171a2c1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34807",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#001d331f",
+          "blendMode": "normal"
         },
         "on-primary-16": {
           "type": "color",
           "value": "#ffffff29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34808",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-container-8": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#00115a14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34809",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-container-16": {
           "type": "color",
           "value": "#00115a29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34810",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-8": {
           "type": "color",
           "value": "#ffffff14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34811",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-12": {
           "type": "color",
           "value": "#ffffff1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34812",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-16": {
           "type": "color",
           "value": "#ffffff29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34813",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-8": {
           "type": "color",
           "value": "#ffffff14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34814",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-12": {
           "type": "color",
           "value": "#ffffff1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34815",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-16": {
           "type": "color",
           "value": "#ffffff29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34816",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-container-16": {
           "type": "color",
           "value": "#48130029",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34817",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-variant-16": {
           "type": "color",
-          "value": "#5c5b5f29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34818",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#59627b29",
+          "blendMode": "normal"
         },
         "negative-8": {
           "type": "color",
           "value": "#ae120914",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34819",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative-16": {
           "type": "color",
           "value": "#ae120929",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34820",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive-12": {
           "type": "color",
           "value": "#0366001f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34821",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive-8": {
           "type": "color",
           "value": "#03660014",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34822",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-8": {
           "type": "color",
           "value": "#ffffff14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34823",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-12": {
           "type": "color",
           "value": "#ffffff1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34824",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-16": {
           "type": "color",
           "value": "#ffffff29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34825",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-container-8": {
           "type": "color",
           "value": "#000a0014",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34826",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-container-12": {
           "type": "color",
           "value": "#000a001f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34827",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-container-16": {
           "type": "color",
           "value": "#000a0029",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34828",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution-12": {
           "type": "color",
           "value": "#f388001f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34829",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution-8": {
           "type": "color",
           "value": "#f3880014",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34830",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-8": {
           "type": "color",
           "value": "#ffffff14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34831",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-12": {
           "type": "color",
           "value": "#ffffff1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34832",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-16": {
           "type": "color",
           "value": "#ffffff29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34833",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-8": {
           "type": "color",
           "value": "#ffffff14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34834",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-12": {
           "type": "color",
           "value": "#ffffff1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34835",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-16": {
           "type": "color",
           "value": "#ffffff29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34836",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-container-8": {
           "type": "color",
           "value": "#180e0014",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34837",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-container-12": {
           "type": "color",
           "value": "#180e001f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34838",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-container-16": {
           "type": "color",
           "value": "#180e0029",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34839",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis-8": {
           "type": "color",
           "value": "#b1014214",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34840",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis-12": {
           "type": "color",
           "value": "#b101421f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34841",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis-16": {
           "type": "color",
           "value": "#b1014229",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34842",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-8": {
           "type": "color",
           "value": "#ffffff14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34843",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-12": {
           "type": "color",
           "value": "#ffffff1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34844",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-16": {
           "type": "color",
           "value": "#ffffff29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34845",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-container-8": {
           "type": "color",
           "value": "#12000714",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34846",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-container-12": {
           "type": "color",
           "value": "#1200071f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34847",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-container-16": {
           "type": "color",
           "value": "#180e0029",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34848",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-on-surface-12": {
           "type": "color",
           "value": "#f6f3f61f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34849",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-primary-12": {
           "type": "color",
           "value": "#bac3ff1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34850",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-on-surface-8": {
           "type": "color",
           "value": "#f6f3f614",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34851",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-primary-8": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#bac3ff14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34852",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-primary-16": {
           "type": "color",
           "value": "#bac3ff29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34853",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-on-surface-16": {
           "type": "color",
           "value": "#f6f3f61f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34854",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-74": {
           "type": "color",
           "value": "#ffffffbd",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34855",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-74": {
           "type": "color",
-          "value": "#1e1d1ebd",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34856",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00233cbd",
+          "blendMode": "normal"
         },
         "tertiary-8": {
           "type": "color",
           "value": "#ff5f0214",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34857",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "tertiary-12": {
           "type": "color",
           "value": "#ff5f021f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34858",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "tertiary-16": {
           "type": "color",
           "value": "#ff5f0229",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34859",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary-8": {
           "type": "color",
-          "value": "#61637814",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34872",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00233c14",
+          "blendMode": "normal"
         },
         "secondary-12": {
           "type": "color",
-          "value": "#6163781f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34873",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00233c1f",
+          "blendMode": "normal"
         },
         "secondary-16": {
           "type": "color",
-          "value": "#61637829",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34874",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00233c29",
+          "blendMode": "normal"
         },
         "on-secondary-74": {
           "type": "color",
           "value": "#ffffffbd",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34875",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-secondary": {
           "type": "color",
-          "value": "{theme.light.palettes.secondary 80}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34876",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.secondary 80}"
         },
         "inverse-secondary-8": {
           "type": "color",
-          "value": "#c3c5dd14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34877",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#bcd5f614",
+          "blendMode": "normal"
         },
         "inverse-secondary-12": {
           "type": "color",
-          "value": "#c3c5dd1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34878",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#bcd5f61f",
+          "blendMode": "normal"
         },
         "inverse-secondary-16": {
           "type": "color",
           "value": "#c3c5dd29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34879",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-74": {
           "type": "color",
           "value": "#ffffffbd",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34880",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-tertiary": {
           "type": "color",
-          "value": "{theme.light.palettes.orange 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34881",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.orange 40}"
         },
         "inverse-tertiary-8": {
           "type": "color",
           "value": "#ff5f0214",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34882",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-tertiary-12": {
           "type": "color",
           "value": "#ff5f021f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34883",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-tertiary-16": {
           "type": "color",
           "value": "#ff5f0229",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34884",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-container-8": {
           "type": "color",
           "value": "#11020114",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34885",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-container-12": {
           "type": "color",
           "value": "#1102011f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34886",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-container-16": {
           "type": "color",
           "value": "#11020129",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34887",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-4": {
           "type": "color",
-          "value": "#1e1d1e0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43976",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00233c0a",
+          "blendMode": "normal"
         },
         "on-surface-variant-4": {
           "type": "color",
-          "value": "#5c5b5f0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43977",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#59627b0a",
+          "blendMode": "normal"
         },
         "inverse-on-surface-4": {
           "type": "color",
           "value": "#f6f3f60a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43978",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "primary-4": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#3053f40a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43979",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-4": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#ffffff0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43980",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-container-4": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#00115a0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43981",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-primary-4": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#bac3ff0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43982",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary-4": {
           "type": "color",
-          "value": "#6163780a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43983",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00233c0a",
+          "blendMode": "normal"
         },
         "on-secondary-4": {
           "type": "color",
           "value": "#ffffff0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43984",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-container-4": {
           "type": "color",
-          "value": "#171a2c0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43985",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#001d330a",
+          "blendMode": "normal"
         },
         "inverse-secondary-4": {
           "type": "color",
-          "value": "#c3c5dd0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43986",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#bcd5f60a",
+          "blendMode": "normal"
         },
         "tertiary-4": {
           "type": "color",
           "value": "#ff5f020a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43987",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-4": {
           "type": "color",
           "value": "#ffffff0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43988",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-container-4": {
           "type": "color",
           "value": "#4813000a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43989",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-tertiary-4": {
           "type": "color",
           "value": "#ff5f020a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43990",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative-4": {
           "type": "color",
           "value": "#ae12090a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43991",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-4": {
           "type": "color",
           "value": "#ffffff0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43992",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-container-4": {
           "type": "color",
           "value": "#1102010a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43993",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive-4": {
           "type": "color",
           "value": "#0366000a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43994",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-4": {
           "type": "color",
           "value": "#ffffff0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43995",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-container-4": {
           "type": "color",
           "value": "#000a000a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43996",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution-4": {
           "type": "color",
           "value": "#f388000a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43997",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-4": {
           "type": "color",
           "value": "#ffffff0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43998",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-container-4": {
           "type": "color",
           "value": "#180e000a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43999",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis-4": {
           "type": "color",
           "value": "#b101420a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:44000",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
-        "on-emphasis-4-4": {
+        "on-emphasis-4": {
           "type": "color",
           "value": "#ffffff0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:44001",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-container-4": {
           "type": "color",
           "value": "#1200070a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:44002",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-20": {
           "type": "color",
-          "value": "#1e1d1e33",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6889:52131",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00233c33",
+          "blendMode": "normal"
         },
         "primary-20": {
           "type": "color",
           "value": "#3053f433",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6889:52132",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative-20": {
           "type": "color",
           "value": "#ae120933",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6889:52133",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive-20": {
           "type": "color",
           "value": "#03660033",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6889:52134",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution-20": {
           "type": "color",
           "value": "#f3880033",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6889:52136",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis-20": {
           "type": "color",
           "value": "#b1014233",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6889:52137",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "primary-24": {
           "type": "color",
           "value": "#3053f43d",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6891:52847",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative-24": {
           "type": "color",
           "value": "#ae12093d",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6891:52848",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive-24": {
           "type": "color",
           "value": "#0366003d",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6891:52849",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution-24": {
           "type": "color",
           "value": "#f388003d",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6891:52850",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis-24": {
           "type": "color",
           "value": "#b101423d",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6891:52851",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "background": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 98}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6946:19969",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.light.palettes.neutral 98}"
         },
         "surface-variant-8": {
           "type": "color",
-          "value": "#fdf9fc14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:7088:40630",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#f8f9fb14",
+          "blendMode": "normal"
         },
         "surface-variant-12": {
           "type": "color",
-          "value": "#fdf9fc1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:7088:40631",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#f8f9fb1f",
+          "blendMode": "normal"
         },
         "surface-variant-16": {
           "type": "color",
           "value": "#fdf9fc29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Light",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:7088:43618",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
+        },
+        "on-surface-variant-38%": {
+          "type": "color",
+          "value": "#59627b61",
+          "blendMode": "normal"
+        },
+        "on-primary-38": {
+          "type": "color",
+          "value": "#ffffff61",
+          "blendMode": "normal"
+        },
+        "on-secondary-38": {
+          "type": "color",
+          "value": "#ffffff61",
+          "blendMode": "normal"
+        },
+        "on-secondary-container-38": {
+          "type": "color",
+          "value": "#001d3361",
+          "blendMode": "normal"
+        },
+        "on-secondary-container-74": {
+          "type": "color",
+          "value": "#001d33bd",
+          "blendMode": "normal"
+        },
+        "on-tertiary-38": {
+          "type": "color",
+          "value": "#ffffff61",
+          "blendMode": "normal"
+        },
+        "on-tertiary-container-38": {
+          "type": "color",
+          "value": "#48130061",
+          "blendMode": "normal"
+        },
+        "on-tertiary-container-74": {
+          "type": "color",
+          "value": "#481300bd",
+          "blendMode": "normal"
+        },
+        "inverse-tertiary-38": {
+          "type": "color",
+          "value": "#ff5f0261",
+          "blendMode": "normal"
+        },
+        "inverse-tertiary-74": {
+          "type": "color",
+          "value": "#ff5f02bd",
+          "blendMode": "normal"
+        },
+        "negative-38": {
+          "type": "color",
+          "value": "#ae120961",
+          "blendMode": "normal"
+        },
+        "negative-74": {
+          "type": "color",
+          "value": "#ae1209bd",
+          "blendMode": "normal"
+        },
+        "on-negative-38": {
+          "type": "color",
+          "value": "#ffffff61",
+          "blendMode": "normal"
+        },
+        "on-negative-74": {
+          "type": "color",
+          "value": "#ffffffbd",
+          "blendMode": "normal"
+        },
+        "on-negative-container-38": {
+          "type": "color",
+          "value": "#11020161",
+          "blendMode": "normal"
+        },
+        "on-negative-container-74": {
+          "type": "color",
+          "value": "#110201bd",
+          "blendMode": "normal"
+        },
+        "positive-38": {
+          "type": "color",
+          "value": "#03660061",
+          "blendMode": "normal"
+        },
+        "positive-74": {
+          "type": "color",
+          "value": "#036600bd",
+          "blendMode": "normal"
+        },
+        "on-positive-38": {
+          "type": "color",
+          "value": "#ffffff61",
+          "blendMode": "normal"
+        },
+        "on-positive-74": {
+          "type": "color",
+          "value": "#ffffffbd",
+          "blendMode": "normal"
+        },
+        "on-positive-container-38": {
+          "type": "color",
+          "value": "#000a0061",
+          "blendMode": "normal"
+        },
+        "on-positive-container-74": {
+          "type": "color",
+          "value": "#000a00bd",
+          "blendMode": "normal"
+        },
+        "caution-38": {
+          "type": "color",
+          "value": "#f3880061",
+          "blendMode": "normal"
+        },
+        "caution-74": {
+          "type": "color",
+          "value": "#f38800bd",
+          "blendMode": "normal"
+        },
+        "on-caution-38": {
+          "type": "color",
+          "value": "#ffffff61",
+          "blendMode": "normal"
+        },
+        "on-caution-74": {
+          "type": "color",
+          "value": "#ffffffbd",
+          "blendMode": "normal"
+        },
+        "on-caution-container-38": {
+          "type": "color",
+          "value": "#180e0061",
+          "blendMode": "normal"
+        },
+        "on-caution-container-74": {
+          "type": "color",
+          "value": "#180e00bd",
+          "blendMode": "normal"
+        },
+        "emphasis-38": {
+          "type": "color",
+          "value": "#b1014261",
+          "blendMode": "normal"
+        },
+        "emphasis-74": {
+          "type": "color",
+          "value": "#b10142bd",
+          "blendMode": "normal"
+        },
+        "on-emphasis-38": {
+          "type": "color",
+          "value": "#ffffff61",
+          "blendMode": "normal"
+        },
+        "on-emphasis-74": {
+          "type": "color",
+          "value": "#ffffffbd",
+          "blendMode": "normal"
+        },
+        "on-emphasis-container-38": {
+          "type": "color",
+          "value": "#180e0061",
+          "blendMode": "normal"
+        },
+        "on-emphasis-container-74": {
+          "type": "color",
+          "value": "#180e00bd",
+          "blendMode": "normal"
         }
       }
     },
     "dark": {
       "palettes": {
-        "digital blue 100": {
-          "type": "color",
-          "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34425",
-              "exportKey": "variables"
-            }
-          }
-        },
         "digital blue 98": {
           "type": "color",
           "value": "#efefffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34426",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
+        },
+        "digital blue 100": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
         },
         "digital blue 95": {
           "type": "color",
           "value": "#dde1ffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34427",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 90": {
           "type": "color",
           "value": "#bac3ffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34428",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 80": {
           "type": "color",
           "value": "#889fffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34429",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 70": {
           "type": "color",
           "value": "#7388d9ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34430",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 60": {
           "type": "color",
           "value": "#5d71b4ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34431",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 50": {
           "type": "color",
           "value": "#485a8eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34432",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 40": {
           "type": "color",
           "value": "#324369ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34433",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 30": {
           "type": "color",
           "value": "#1d2c43ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34434",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 20": {
           "type": "color",
           "value": "#111a28ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34435",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 10": {
           "type": "color",
           "value": "#0c121bff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34436",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34437",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 98": {
           "type": "color",
           "value": "#fef1ecff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34438",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 95": {
           "type": "color",
           "value": "#fdc4a4ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34439",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 90": {
           "type": "color",
           "value": "#f79e79ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34440",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 80": {
           "type": "color",
           "value": "#f37440ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34441",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 70": {
           "type": "color",
           "value": "#db683aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34442",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 60": {
           "type": "color",
           "value": "#c25d33ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34443",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 50": {
           "type": "color",
           "value": "#aa512dff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34444",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 40": {
           "type": "color",
           "value": "#612e1aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34445",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 30": {
           "type": "color",
           "value": "#492313ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34446",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 20": {
           "type": "color",
           "value": "#331300ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34447",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 10": {
           "type": "color",
           "value": "#190900ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34448",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "orange 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34449",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34450",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "navy 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34451",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
-        "navy 98": {
+        "navy 99": {
           "type": "color",
-          "value": "#f7f9ffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34452",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#fcfcffff",
+          "blendMode": "normal"
         },
         "navy 95": {
           "type": "color",
           "value": "#e8f2ffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34453",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "navy 90": {
           "type": "color",
           "value": "#cfe5ffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34454",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "navy 80": {
           "type": "color",
-          "value": "#98cbffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34455",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#acc9e9ff",
+          "blendMode": "normal"
         },
         "navy 70": {
           "type": "color",
-          "value": "#66b1f4ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34456",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#91aecdff",
+          "blendMode": "normal"
         },
         "navy 60": {
           "type": "color",
-          "value": "#4896d7ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34457",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#7793b1ff",
+          "blendMode": "normal"
         },
         "navy 50": {
           "type": "color",
-          "value": "#257cbcff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34458",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#5e7a97ff",
+          "blendMode": "normal"
         },
         "navy 40": {
           "type": "color",
-          "value": "#00639cff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34459",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#45617dff",
+          "blendMode": "normal"
         },
         "navy 30": {
           "type": "color",
-          "value": "#004a77ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34460",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#2d4964ff",
+          "blendMode": "normal"
         },
         "navy 20": {
           "type": "color",
-          "value": "#003354ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34461",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#14324cff",
+          "blendMode": "normal"
         },
         "navy 10": {
           "type": "color",
           "value": "#001d33ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34462",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "navy 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34463",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34464",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 98": {
           "type": "color",
           "value": "#fff2f0ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34465",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 95": {
           "type": "color",
           "value": "#ffd2cbff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34466",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 90": {
           "type": "color",
           "value": "#ffac9fff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34467",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 80": {
           "type": "color",
           "value": "#fd7d69ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34468",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 70": {
           "type": "color",
           "value": "#e4715fff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34469",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 60": {
           "type": "color",
           "value": "#ca6454ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34470",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 50": {
           "type": "color",
           "value": "#b1584aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34471",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 40": {
           "type": "color",
           "value": "#984b3fff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34472",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 30": {
           "type": "color",
           "value": "#65322aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34473",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 20": {
           "type": "color",
           "value": "#331915ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34474",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 10": {
           "type": "color",
           "value": "#190c0aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34475",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34476",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34477",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 98": {
           "type": "color",
           "value": "#fff8f1ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34478",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 95": {
           "type": "color",
           "value": "#ffe2c8ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34479",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 90": {
           "type": "color",
           "value": "#ffcd9eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34480",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 80": {
           "type": "color",
           "value": "#ffb775ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34481",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 70": {
           "type": "color",
           "value": "#e6a569ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34482",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 60": {
           "type": "color",
           "value": "#cc925eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34483",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 50": {
           "type": "color",
           "value": "#b38052ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34484",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 40": {
           "type": "color",
           "value": "#996e46ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34485",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 30": {
           "type": "color",
           "value": "#66492fff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34486",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 20": {
           "type": "color",
           "value": "#332517ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34487",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 10": {
           "type": "color",
           "value": "#19120cff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34488",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34489",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34490",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 98": {
           "type": "color",
           "value": "#eef8eeff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34491",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 95": {
           "type": "color",
           "value": "#bbe4bbff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34492",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 90": {
           "type": "color",
           "value": "#91d890ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34493",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 80": {
           "type": "color",
           "value": "#55bc54ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34494",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 70": {
           "type": "color",
           "value": "#4da94cff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34495",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 60": {
           "type": "color",
           "value": "#449643ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34496",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 50": {
           "type": "color",
           "value": "#3b843bff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34497",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 40": {
           "type": "color",
           "value": "#337132ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34498",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 30": {
           "type": "color",
           "value": "#224b22ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34499",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 20": {
           "type": "color",
           "value": "#112611ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34500",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 10": {
           "type": "color",
           "value": "#081308ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34501",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34502",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34503",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 98": {
           "type": "color",
           "value": "#fff6f9ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34504",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 95": {
           "type": "color",
           "value": "#ffd9e7ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34505",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 90": {
           "type": "color",
           "value": "#ffbdd5ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34506",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 80": {
           "type": "color",
           "value": "#ffa0c3ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34507",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 70": {
           "type": "color",
           "value": "#e690b0ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34508",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 60": {
           "type": "color",
           "value": "#cc809cff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34509",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 50": {
           "type": "color",
           "value": "#b37089ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34510",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 40": {
           "type": "color",
           "value": "#66404eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34511",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 30": {
           "type": "color",
           "value": "#4c303aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34512",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 20": {
           "type": "color",
           "value": "#332027ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34513",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 10": {
           "type": "color",
           "value": "#191013ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34514",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34515",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 80": {
           "type": "color",
           "value": "#c3c5ddff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34516",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 20": {
           "type": "color",
           "value": "#2c2f42ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34517",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 30": {
           "type": "color",
           "value": "#434659ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34518",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 90": {
           "type": "color",
           "value": "#dfe1f9ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34519",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 10": {
           "type": "color",
           "value": "#171a2cff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34520",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34521",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 98": {
           "type": "color",
           "value": "#fdf9fcff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34522",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 95": {
           "type": "color",
           "value": "#f6f3f6ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34523",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 90": {
           "type": "color",
           "value": "#ebe8ecff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34524",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 80": {
           "type": "color",
           "value": "#d5d3d8ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34525",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 70": {
           "type": "color",
           "value": "#bebdc3ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34526",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 60": {
           "type": "color",
           "value": "#a6a6adff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34527",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 50": {
           "type": "color",
           "value": "#8f8e97ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34528",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 40": {
           "type": "color",
           "value": "#76757dff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34529",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 30": {
           "type": "color",
           "value": "#5c5b5fff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34530",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 20": {
           "type": "color",
           "value": "#3e3e41ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34531",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 10": {
           "type": "color",
           "value": "#1e1d1eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34532",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34533",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 87": {
           "type": "color",
           "value": "#e5e2e6ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34534",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 96": {
           "type": "color",
           "value": "#f8f5f8ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34535",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 94": {
           "type": "color",
           "value": "#f4f1f4ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34536",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 92": {
           "type": "color",
           "value": "#f0edf0ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34537",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 100": {
           "type": "color",
           "value": "#ffffffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34538",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 98": {
           "type": "color",
           "value": "#fbf8ffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34539",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 95": {
           "type": "color",
           "value": "#f0efffff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34540",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 70": {
           "type": "color",
           "value": "#a8aac1ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34541",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 60": {
           "type": "color",
           "value": "#8d8fa6ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34542",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 50": {
           "type": "color",
           "value": "#73768bff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34543",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 40": {
           "type": "color",
           "value": "#5b5d72ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34544",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary 0": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34545",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 99": {
           "type": "color",
           "value": "#fffbfeff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34546",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 35": {
           "type": "color",
           "value": "#68686eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34547",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 25": {
           "type": "color",
           "value": "#4d4d50ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34548",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 97": {
           "type": "color",
           "value": "#faf7faff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34549",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 93": {
           "type": "color",
           "value": "#f2eff2ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34550",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 91": {
           "type": "color",
           "value": "#eeeaeeff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34551",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 2": {
           "type": "color",
           "value": "#000000ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34552",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 3": {
           "type": "color",
           "value": "#020202ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34553",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 4": {
           "type": "color",
           "value": "#060506ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34554",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 5": {
           "type": "color",
           "value": "#0a090aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34555",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 6": {
           "type": "color",
           "value": "#0e0e0eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34556",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 7": {
           "type": "color",
           "value": "#121212ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34557",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 8": {
           "type": "color",
           "value": "#161616ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34558",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 9": {
           "type": "color",
           "value": "#1a191aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34559",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 11": {
           "type": "color",
           "value": "#222122ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34560",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 12": {
           "type": "color",
           "value": "#252426ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34561",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 13": {
           "type": "color",
           "value": "#292829ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34562",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 14": {
           "type": "color",
           "value": "#2c2b2dff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34563",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 15": {
           "type": "color",
           "value": "#2f2e30ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34564",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 16": {
           "type": "color",
           "value": "#323134ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34565",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 17": {
           "type": "color",
           "value": "#353537ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34566",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 18": {
           "type": "color",
           "value": "#38383bff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34567",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 19": {
           "type": "color",
           "value": "#3b3b3eff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34568",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 21": {
           "type": "color",
           "value": "#414144ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34569",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 22": {
           "type": "color",
           "value": "#444447ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34570",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 23": {
           "type": "color",
           "value": "#47474aff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34571",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "neutral 24": {
           "type": "color",
           "value": "#4a4a4dff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34572",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 91": {
           "type": "color",
           "value": "#bec9feff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34573",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 92": {
           "type": "color",
           "value": "#c6cffdff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34574",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 93": {
           "type": "color",
           "value": "#ced5feff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34575",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "digital blue 94": {
           "type": "color",
           "value": "#d5dbfeff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34576",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
+        },
+        "digital blue 99": {
+          "type": "color",
+          "value": "#fafaffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 100": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 99": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 98": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 97": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 96": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 95": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 94": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 93": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 92": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 91": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 90": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 80": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 70": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 60": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 50": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 40": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 35": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 30": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 25": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 20": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 15": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 10": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 5": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral variant 0": {
+          "type": "color",
+          "value": "#ffffffff",
+          "blendMode": "normal"
+        },
+        "neutral 1": {
+          "type": "color",
+          "value": "#000000ff",
+          "blendMode": "normal"
+        },
+        "navy 13": {
+          "type": "color",
+          "value": "#00233cff",
+          "blendMode": "normal"
+        },
+        "navy 98": {
+          "type": "color",
+          "value": "#f8fafdff",
+          "blendMode": "normal"
         }
       },
       "colors": {
         "primary": {
           "type": "color",
-          "value": "{theme.dark.palettes.digital blue 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34733",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.digital blue 90}"
         },
         "primary-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.digital blue 30}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34734",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.digital blue 30}"
         },
         "on-primary": {
           "type": "color",
-          "value": "{theme.dark.palettes.digital blue 20}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34735",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.digital blue 20}"
         },
         "secondary": {
           "type": "color",
-          "value": "{theme.dark.palettes.secondary 80}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34736",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.secondary 80}"
         },
         "secondary-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.secondary 30}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34737",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.secondary 30}"
         },
         "on-secondary": {
           "type": "color",
-          "value": "{theme.dark.palettes.secondary 10}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34738",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.secondary 10}"
         },
         "on-secondary-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.secondary 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34739",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.secondary 90}"
         },
         "tertiary": {
           "type": "color",
           "value": "#ff5f02ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34740",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "tertiary-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.orange 60}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34741",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.orange 60}"
         },
         "on-tertiary": {
           "type": "color",
-          "value": "{theme.dark.palettes.orange 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34742",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.orange 40}"
         },
         "on-tertiary-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.orange 98}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34743",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.orange 98}"
         },
         "surface": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 8}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34744",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 8}"
         },
         "surface-dim": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 6}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34745",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 6}"
         },
         "surface-bright": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 24}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34746",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 24}"
         },
         "surface-container-lowest": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 10}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34747",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 10}"
         },
         "surface-container-low": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 12}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34748",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 12}"
         },
         "surface-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 14}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34749",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 14}"
         },
         "surface-container-high": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 16}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34750",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 16}"
         },
         "surface-container-highest": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 18}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34751",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 18}"
         },
         "on-surface": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34752",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 90}"
         },
         "on-surface-variant": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34753",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 80}"
         },
         "inverse-surface": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34754",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 90}"
         },
         "inverse-on-surface": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 20}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34755",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 20}"
         },
         "negative": {
           "type": "color",
-          "value": "{theme.dark.palettes.negative 80}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34756",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.negative 80}"
         },
         "negative-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.negative 30}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34757",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.negative 30}"
         },
         "on-negative": {
           "type": "color",
-          "value": "{theme.dark.palettes.negative 20}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34758",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.negative 20}"
         },
         "on-negative-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.negative 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34759",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.negative 90}"
         },
         "positive": {
           "type": "color",
-          "value": "{theme.dark.palettes.positive 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34760",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.positive 90}"
         },
         "positive-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.positive 30}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34761",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.positive 30}"
         },
         "on-positive": {
           "type": "color",
-          "value": "{theme.dark.palettes.positive 20}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34762",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.positive 20}"
         },
         "on-positive-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.positive 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34763",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.positive 90}"
         },
         "caution": {
           "type": "color",
-          "value": "{theme.dark.palettes.caution 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34764",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.caution 90}"
         },
         "caution-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.caution 30}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34765",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.caution 30}"
         },
         "on-caution": {
           "type": "color",
-          "value": "{theme.dark.palettes.caution 30}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34766",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.caution 30}"
         },
         "on-caution-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.caution 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34767",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.caution 90}"
         },
         "outline": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 50}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34768",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 50}"
         },
         "outline-variant": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 20}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34769",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 20}"
         },
         "shadow": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 0}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34770",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 0}"
         },
         "scrim": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 0}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34771",
-              "exportKey": "variables"
-            }
-          }
+          "value": "#00000052",
+          "blendMode": "normal"
         },
         "primary-fixed": {
           "type": "color",
-          "value": "{theme.dark.palettes.digital blue 95}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34772",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.digital blue 95}"
         },
         "primary-fixed-dim": {
           "type": "color",
-          "value": "{theme.dark.palettes.digital blue 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34773",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.digital blue 90}"
         },
         "secondary-fixed": {
           "type": "color",
-          "value": "{theme.dark.palettes.secondary 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34774",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.secondary 90}"
         },
         "secondary-fixed-dim": {
           "type": "color",
-          "value": "{theme.dark.palettes.secondary 80}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34775",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.secondary 80}"
         },
         "tertiary-fixed": {
           "type": "color",
-          "value": "{theme.dark.palettes.orange 90}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34776",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.orange 90}"
         },
         "tertiary-fixed-dim": {
           "type": "color",
-          "value": "{theme.dark.palettes.orange 80}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34777",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.orange 80}"
         },
         "primary-8": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#bac3ff14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34778",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "primary-12": {
           "type": "color",
           "value": "#bac3ff1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34779",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-8": {
           "type": "color",
           "value": "#ebe8ec14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34780",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-12": {
           "type": "color",
           "value": "#ebe8ec1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34781",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.digital blue 95}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34782",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.digital blue 95}"
         },
         "inverse-primary": {
           "type": "color",
           "value": "#3053f4ff",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34783",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-38": {
           "type": "color",
           "value": "#ebe8ec61",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34784",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-16": {
           "type": "color",
           "value": "#ebe8ec29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34785",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-12": {
           "type": "color",
           "value": "#111a281f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34786",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-8": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#111a2814",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34787",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "primary-16": {
           "type": "color",
           "value": "#bac3ff29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34788",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-variant-8": {
           "type": "color",
           "value": "#d5d3d814",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34789",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-container-8": {
           "type": "color",
           "value": "#fef1ec14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34790",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-container-12": {
           "type": "color",
           "value": "#fef1ec1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34791",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-container-12": {
           "type": "color",
           "value": "#dde1ff1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34792",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-variant-12": {
           "type": "color",
           "value": "#d5d3d81f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34793",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-container-8": {
           "type": "color",
           "value": "#5b5d7214",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34794",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-container-16": {
           "type": "color",
           "value": "#61637829",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["STROKE_COLOR", "TEXT_FILL", "SHAPE_FILL"],
-              "variableId": "VariableID:6809:34795",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "outline-8": {
           "type": "color",
           "value": "#8f8e9714",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34796",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "outline-12": {
           "type": "color",
           "value": "#8f8e971f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34797",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "outline-16": {
           "type": "color",
           "value": "#8f8e9729",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34798",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "surface-variant": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 0}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34799",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 0}"
         },
         "emphasis": {
           "type": "color",
-          "value": "{theme.dark.palettes.emphasis 60}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34800",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.emphasis 60}"
         },
         "emphasis-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.emphasis 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34801",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.emphasis 40}"
         },
         "on-emphasis": {
           "type": "color",
-          "value": "{theme.dark.palettes.emphasis 10}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34802",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.emphasis 10}"
         },
         "on-emphasis-container": {
           "type": "color",
-          "value": "{theme.dark.palettes.emphasis 95}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34803",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.emphasis 95}"
         },
         "positive-16": {
           "type": "color",
           "value": "#91d89029",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34804",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution-16": {
           "type": "color",
           "value": "#ffb77529",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34805",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative-12": {
           "type": "color",
           "value": "#fd7d691f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34806",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-container-12": {
           "type": "color",
           "value": "#5b5d721f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34807",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-16": {
           "type": "color",
           "value": "#111a2829",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34808",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-container-8": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#dde1ff14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34809",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-container-16": {
           "type": "color",
           "value": "#dde1ff29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34810",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-8": {
           "type": "color",
           "value": "#171a2c14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34811",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-12": {
           "type": "color",
           "value": "#171a2c1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34812",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-16": {
           "type": "color",
           "value": "#171a2c29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34813",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-8": {
           "type": "color",
           "value": "#612e1a14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34814",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-12": {
           "type": "color",
           "value": "#612e1a1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34815",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-16": {
           "type": "color",
           "value": "#612e1a29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34816",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-container-16": {
           "type": "color",
           "value": "#fef1ec29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34817",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-variant-16": {
           "type": "color",
           "value": "#d5d3d829",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34818",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative-8": {
           "type": "color",
           "value": "#fd7d6914",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34819",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative-16": {
           "type": "color",
           "value": "#fd7d6929",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34820",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive-12": {
           "type": "color",
           "value": "#91d8901f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34821",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive-8": {
           "type": "color",
           "value": "#91d89014",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34822",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-8": {
           "type": "color",
           "value": "#11261114",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34823",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-12": {
           "type": "color",
           "value": "#1126111f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34824",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-16": {
           "type": "color",
           "value": "#11261129",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34825",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-container-8": {
           "type": "color",
           "value": "#91d89014",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34826",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-container-12": {
           "type": "color",
           "value": "#91d8901f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34827",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-container-16": {
           "type": "color",
           "value": "#91d89029",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34828",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution-12": {
           "type": "color",
           "value": "#ffb7751f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34829",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution-8": {
           "type": "color",
           "value": "#ffb77514",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34830",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-8": {
           "type": "color",
           "value": "#66492f14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34831",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-12": {
           "type": "color",
           "value": "#66492f1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34832",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-16": {
           "type": "color",
           "value": "#66492f29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34833",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-8": {
           "type": "color",
           "value": "#33191514",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34834",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-12": {
           "type": "color",
           "value": "#3319151f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34835",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-16": {
           "type": "color",
           "value": "#33191529",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34836",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-container-8": {
           "type": "color",
           "value": "#19120c14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34837",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-container-12": {
           "type": "color",
           "value": "#19120c1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34838",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-container-16": {
           "type": "color",
           "value": "#19120c29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34839",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis-8": {
           "type": "color",
           "value": "#cc809c14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34840",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis-12": {
           "type": "color",
           "value": "#cc809c1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34841",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis-16": {
           "type": "color",
           "value": "#cc809c29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34842",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-8": {
           "type": "color",
           "value": "#19101314",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34843",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-12": {
           "type": "color",
           "value": "#1910131f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34844",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-16": {
           "type": "color",
           "value": "#19101329",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34845",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-container-8": {
           "type": "color",
           "value": "#ffd9e714",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34846",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-container-12": {
           "type": "color",
           "value": "#ffd9e71f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34847",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-container-16": {
           "type": "color",
           "value": "#ffd9e729",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34848",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-on-surface-12": {
           "type": "color",
           "value": "#3e3e411f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34849",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-primary-12": {
           "type": "color",
           "value": "#3053f41f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34850",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-on-surface-8": {
           "type": "color",
           "value": "#3e3e4114",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34851",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-primary-8": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#3053f414",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34852",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-primary-16": {
           "type": "color",
           "value": "#3053f429",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34853",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-on-surface-16": {
           "type": "color",
           "value": "#3e3e4129",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34854",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-74": {
           "type": "color",
           "value": "#111a28bd",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34855",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-74": {
           "type": "color",
           "value": "#ebe8ecbd",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34856",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "tertiary-8": {
           "type": "color",
           "value": "#ff5f0214",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34857",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "tertiary-12": {
           "type": "color",
           "value": "#ff5f021f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34858",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "tertiary-16": {
           "type": "color",
           "value": "#ff5f0229",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34859",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary-8": {
           "type": "color",
           "value": "#c3c5dd14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34872",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary-12": {
           "type": "color",
           "value": "#c3c5dd1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34873",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary-16": {
           "type": "color",
           "value": "#c3c5dd29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34874",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-74": {
           "type": "color",
           "value": "#171a2cbd",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34875",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-secondary": {
           "type": "color",
-          "value": "{theme.dark.palettes.secondary 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34876",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.secondary 40}"
         },
         "inverse-secondary-8": {
           "type": "color",
           "value": "#61637814",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34877",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-secondary-12": {
           "type": "color",
           "value": "#6163781f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34878",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-secondary-16": {
           "type": "color",
           "value": "#61637829",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34879",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-74": {
           "type": "color",
           "value": "#612e1abd",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34880",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-tertiary": {
           "type": "color",
-          "value": "{theme.dark.palettes.orange 40}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6809:34881",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.orange 40}"
         },
         "inverse-tertiary-8": {
           "type": "color",
           "value": "#ff5f0214",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34882",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-tertiary-12": {
           "type": "color",
           "value": "#ff5f021f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34883",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-tertiary-16": {
           "type": "color",
           "value": "#ff5f0229",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34884",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-container-8": {
           "type": "color",
           "value": "#ffac9f14",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34885",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-container-12": {
           "type": "color",
           "value": "#ffac9f1f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34886",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-container-16": {
           "type": "color",
           "value": "#ffac9f29",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6809:34887",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-4": {
           "type": "color",
           "value": "#ebe8ec0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43976",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-variant-4": {
           "type": "color",
           "value": "#d5d3d80a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43977",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-on-surface-4": {
           "type": "color",
           "value": "#3e3e410a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43978",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "primary-4": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#bac3ff0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43979",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-4": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#111a280a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43980",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-primary-container-4": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#dde1ff0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43981",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-primary-4": {
           "description": "Use for hover states",
           "type": "color",
           "value": "#3053f40a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43982",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "secondary-4": {
           "type": "color",
           "value": "#c3c5dd0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43983",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-4": {
           "type": "color",
           "value": "#171a2c0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43984",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-secondary-container-4": {
           "type": "color",
           "value": "#5b5d720a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43985",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-secondary-4": {
           "type": "color",
           "value": "#6163780a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43986",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "tertiary-4": {
           "type": "color",
           "value": "#ff5f020a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43987",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-4": {
           "type": "color",
           "value": "#612e1a0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43988",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-tertiary-container-4": {
           "type": "color",
           "value": "#fef1ec0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43989",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "inverse-tertiary-4": {
           "type": "color",
           "value": "#ff5f020a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43990",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative-4": {
           "type": "color",
           "value": "#fd7d690a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43991",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-4": {
           "type": "color",
           "value": "#3319150a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43992",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-negative-container-4": {
           "type": "color",
           "value": "#ffac9f0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43993",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive-4": {
           "type": "color",
           "value": "#91d8900a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43994",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-4": {
           "type": "color",
           "value": "#1126110a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43995",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-positive-container-4": {
           "type": "color",
           "value": "#91d8900a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43996",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution-4": {
           "type": "color",
           "value": "#ffb7750a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43997",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-4": {
           "type": "color",
           "value": "#66492f0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43998",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-caution-container-4": {
           "type": "color",
           "value": "#19120c0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:43999",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis-4": {
           "type": "color",
           "value": "#cc809c0a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:44000",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
-        "on-emphasis-4-4": {
+        "on-emphasis-4": {
           "type": "color",
           "value": "#1910130a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:44001",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-emphasis-container-4": {
           "type": "color",
           "value": "#ffd9e70a",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6887:44002",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "on-surface-20": {
           "type": "color",
           "value": "#ebe8ec33",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6889:52131",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "primary-20": {
           "type": "color",
           "value": "#bac3ff33",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6889:52132",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative-20": {
           "type": "color",
           "value": "#fd7d6933",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6889:52133",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive-20": {
           "type": "color",
           "value": "#91d89033",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6889:52134",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution-20": {
           "type": "color",
           "value": "#ffb77533",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6889:52136",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis-20": {
           "type": "color",
           "value": "#cc809c33",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6889:52137",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "primary-24": {
           "type": "color",
           "value": "#bac3ff3d",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6891:52847",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "negative-24": {
           "type": "color",
           "value": "#fd7d693d",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6891:52848",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "positive-24": {
           "type": "color",
           "value": "#91d8903d",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6891:52849",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "caution-24": {
           "type": "color",
           "value": "#ffb7753d",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6891:52850",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "emphasis-24": {
           "type": "color",
           "value": "#cc809c3d",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:6891:52851",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "background": {
           "type": "color",
-          "value": "{theme.dark.palettes.neutral 0}",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES", "ALL_SCOPES"],
-              "variableId": "VariableID:6946:19969",
-              "exportKey": "variables"
-            }
-          }
+          "value": "{theme.dark.palettes.neutral 0}"
         },
         "surface-variant-8": {
           "type": "color",
           "value": "#00000014",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:7088:40630",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "surface-variant-12": {
           "type": "color",
           "value": "#0000001f",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:7088:40631",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
         },
         "surface-variant-16": {
           "type": "color",
           "value": "#00000029",
-          "blendMode": "normal",
-          "extensions": {
-            "org.lukasoppermann.figmaDesignTokens": {
-              "mode": "Dark",
-              "collection": "Theme",
-              "scopes": ["ALL_SCOPES"],
-              "variableId": "VariableID:7088:43618",
-              "exportKey": "variables"
-            }
-          }
+          "blendMode": "normal"
+        },
+        "on-surface-variant-38%": {
+          "type": "color",
+          "value": "#d5d3d861",
+          "blendMode": "normal"
+        },
+        "on-primary-38": {
+          "type": "color",
+          "value": "#111a2861",
+          "blendMode": "normal"
+        },
+        "on-secondary-38": {
+          "type": "color",
+          "value": "#171a2c61",
+          "blendMode": "normal"
+        },
+        "on-secondary-container-38": {
+          "type": "color",
+          "value": "#61637861",
+          "blendMode": "normal"
+        },
+        "on-secondary-container-74": {
+          "type": "color",
+          "value": "#616378bd",
+          "blendMode": "normal"
+        },
+        "on-tertiary-38": {
+          "type": "color",
+          "value": "#612e1a61",
+          "blendMode": "normal"
+        },
+        "on-tertiary-container-38": {
+          "type": "color",
+          "value": "#fef1ec61",
+          "blendMode": "normal"
+        },
+        "on-tertiary-container-74": {
+          "type": "color",
+          "value": "#fef1ecbd",
+          "blendMode": "normal"
+        },
+        "inverse-tertiary-38": {
+          "type": "color",
+          "value": "#ff5f0261",
+          "blendMode": "normal"
+        },
+        "inverse-tertiary-74": {
+          "type": "color",
+          "value": "#ff5f02bd",
+          "blendMode": "normal"
+        },
+        "negative-38": {
+          "type": "color",
+          "value": "#fd7d6961",
+          "blendMode": "normal"
+        },
+        "negative-74": {
+          "type": "color",
+          "value": "#fd7d69bd",
+          "blendMode": "normal"
+        },
+        "on-negative-38": {
+          "type": "color",
+          "value": "#33191561",
+          "blendMode": "normal"
+        },
+        "on-negative-74": {
+          "type": "color",
+          "value": "#331915bd",
+          "blendMode": "normal"
+        },
+        "on-negative-container-38": {
+          "type": "color",
+          "value": "#ffac9f61",
+          "blendMode": "normal"
+        },
+        "on-negative-container-74": {
+          "type": "color",
+          "value": "#ffac9fbd",
+          "blendMode": "normal"
+        },
+        "positive-38": {
+          "type": "color",
+          "value": "#91d89061",
+          "blendMode": "normal"
+        },
+        "positive-74": {
+          "type": "color",
+          "value": "#91d890bd",
+          "blendMode": "normal"
+        },
+        "on-positive-38": {
+          "type": "color",
+          "value": "#11261161",
+          "blendMode": "normal"
+        },
+        "on-positive-74": {
+          "type": "color",
+          "value": "#112611bd",
+          "blendMode": "normal"
+        },
+        "on-positive-container-38": {
+          "type": "color",
+          "value": "#91d89061",
+          "blendMode": "normal"
+        },
+        "on-positive-container-74": {
+          "type": "color",
+          "value": "#91d890bd",
+          "blendMode": "normal"
+        },
+        "caution-38": {
+          "type": "color",
+          "value": "#ffb77561",
+          "blendMode": "normal"
+        },
+        "caution-74": {
+          "type": "color",
+          "value": "#ffb775bd",
+          "blendMode": "normal"
+        },
+        "on-caution-38": {
+          "type": "color",
+          "value": "#66492f61",
+          "blendMode": "normal"
+        },
+        "on-caution-74": {
+          "type": "color",
+          "value": "#66492fbd",
+          "blendMode": "normal"
+        },
+        "on-caution-container-38": {
+          "type": "color",
+          "value": "#19120c61",
+          "blendMode": "normal"
+        },
+        "on-caution-container-74": {
+          "type": "color",
+          "value": "#19120cbd",
+          "blendMode": "normal"
+        },
+        "emphasis-38": {
+          "type": "color",
+          "value": "#cc809c61",
+          "blendMode": "normal"
+        },
+        "emphasis-74": {
+          "type": "color",
+          "value": "#cc809cbd",
+          "blendMode": "normal"
+        },
+        "on-emphasis-38": {
+          "type": "color",
+          "value": "#19101361",
+          "blendMode": "normal"
+        },
+        "on-emphasis-74": {
+          "type": "color",
+          "value": "#191013bd",
+          "blendMode": "normal"
+        },
+        "on-emphasis-container-38": {
+          "type": "color",
+          "value": "#ffd9e761",
+          "blendMode": "normal"
+        },
+        "on-emphasis-container-74": {
+          "type": "color",
+          "value": "#ffd9e7bd",
+          "blendMode": "normal"
         }
       }
     }


### PR DESCRIPTION
## Description

General theme tweaks, mostly changing base surface color from pinkish to blueish.

### What's included?

<!-- List features included in this PR -->

- Change surface and foreground colors to a more blue tint (as opposed to the pinkish previously)
- Change default color of non-selected nav items
- Change default color of non-header body text
- Remove extra tracking from button typography

#### Test Steps

- [ ] `npm run storybook`
- [ ] then navigate to the app shell story
- [ ] compare against live product 

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

#### Screenshots

##### Before
![app-shell-frame-tweaks_before](https://github.com/user-attachments/assets/bf2350b1-7d0c-4c71-b9e2-f004ec8197b5)

##### After
![app-shell-frame-tweaks_after](https://github.com/user-attachments/assets/b39e87f9-b111-4b12-aca3-67fd21f8f5cf)
