### PR TITLE
fix(tokens): adding index as pkg.json export

### DIFF
--- a/libs/tokens/package.json
+++ b/libs/tokens/package.json
@@ -17,6 +17,9 @@
       "style": "./index.css",
       "types": "./index.d.ts",
       "default": "./index.js"
+    },
+    "./index.css": {
+      "default": "./index.css"
     }
   }
 }


### PR DESCRIPTION
## Description

adding index.css as export path for tokens to allow importing for tokens through  commonJS system with `node_modules`


### example
```javascript
import '@covalent/tokens/index.css';
```