### PR TITLE
fix(styles): correct persistent unneeded vertical scrollbar

### DIFF
--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -106,7 +106,7 @@
   }
 
   cv-card {
-    margin: 0 0 24px;
+    margin: 0 0 12px;
     display: block;
 
     &.wrapper-card {
@@ -119,21 +119,22 @@
     .cov-drawer--hovered &,
     &.cov-drawer--hovered-closing {
       margin-left: 72px;
-      margin-right: 24px;
+      padding-right: 24px;
     }
 
     :not(.cov-drawer--forced-open) & {
       margin-left: 72px;
-      margin-right: 24px;
+      padding-right: 24px;
     }
 
     .cov-drawer--open & {
       margin-left: 256px;
-      margin-right: 24px;
+      padding-right: 24px;
     }
 
     .cov-help--open & {
       margin-right: var(--cv-help-width, 320px);
+      padding-right: 0;
     }
   }
 


### PR DESCRIPTION
## Description

Bottom margin on main card was conflicting with calc values in CSS for the card heights and causing a vertical scrollbar. This reverts that change.

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.