### PR TITLE
feat(flavored-markdown): add suuport for file url clicks

### DIFF
--- a/libs/components/src/code-editor/code-editor.scss
+++ b/libs/components/src/code-editor/code-editor.scss
@@ -10,10 +10,6 @@
       width: var(--cv-editor-width);
     }
   }
-
-  .monaco-editor-background {
-    background-color: var(--cv-theme-surface);
-  }
 }
 
 .editor {

--- a/libs/components/src/code-editor/code-editor.theme.ts
+++ b/libs/components/src/code-editor/code-editor.theme.ts
@@ -1,94 +1,197 @@
 import * as tokens from '@covalent/tokens';
 
-export const cvEditorDarkTheme = {
-  base: 'vs-dark',
-  inherit: true,
-  rules: [
-    {
-      token: '',
-      foreground: tokens.CvDarkCodeSnippetColor,
-      background: tokens.CvThemeDarkColorsSurface,
+const getTheme = (theme: 'Light' | 'Dark') => {
+  return {
+    base: theme === 'Light' ? 'vs' : 'vs-dark',
+    inherit: true,
+    rules: [
+      {
+        token: '',
+        foreground: tokens[`Cv${theme}CodeSnippetColor`],
+        background: tokens[`Cv${theme}Surface`],
+      },
+      {
+        token: 'arbitration-variable',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+      {
+        token: 'arbitration-variable.invalid',
+        foreground: tokens[`Cv${theme}Negative`],
+      },
+      {
+        token: 'attribute.name',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+      {
+        token: 'attribute.value',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+      {
+        token: 'attribute.value.number',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+      {
+        token: 'attribute.value.unit',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+      {
+        token: 'attribute.value.html',
+        foreground: tokens[`Cv${theme}CodeSnippetString`],
+      },
+      {
+        token: 'attribute.value.xml',
+        foreground: tokens[`Cv${theme}CodeSnippetLiteral`],
+      },
+      {
+        token: 'builtins',
+        foreground: tokens[`Cv${theme}CodeSnippetClass`],
+      },
+      {
+        token: 'class',
+        foreground: tokens[`Cv${theme}CodeSnippetClass`],
+      },
+      {
+        token: 'comment',
+        foreground: tokens[`Cv${theme}CodeSnippetComment`],
+        fontStyle: 'italic',
+      },
+      {
+        token: 'constant',
+        foreground: tokens[`Cv${theme}CodeSnippetLiteral`],
+      },
+      {
+        token: 'delimiter',
+        foreground: tokens[`CvTheme${theme}ColorsOnSurface`],
+      },
+      {
+        token: 'delimiter.html',
+        foreground: tokens[`Cv${theme}CodeSnippetSelector`],
+      },
+      {
+        token: 'delimiter.xml',
+        foreground: tokens[`Cv${theme}CodeSnippetSelector`],
+      },
+      {
+        token: 'doctag',
+        foreground: tokens[`Cv${theme}CodeSnippetKeyword`],
+      },
+      {
+        token: 'emphasis',
+        fontStyle: 'italic',
+      },
+      {
+        token: 'formula',
+        foreground: tokens[`Cv${theme}CodeSnippetKeyword`],
+      },
+      {
+        token: 'function',
+        foreground: tokens[`Cv${theme}CodeSnippetTitle`],
+      },
+      {
+        token: 'invalid',
+        foreground: tokens[`Cv${theme}Negative`],
+      },
+      { token: 'key', foreground: tokens[`Cv${theme}CodeSnippetString`] },
+      {
+        token: 'keyword',
+        foreground: tokens[`Cv${theme}CodeSnippetKeyword`],
+      },
+      {
+        token: 'keyword.json',
+        foreground: tokens[`Cv${theme}CodeSnippetTitle`],
+        fontStyle: 'bold italic',
+      },
+      {
+        token: 'link',
+        foreground: tokens[`Cv${theme}CodeSnippetTitle`],
+        fontStyle: 'underline',
+      },
+      {
+        token: 'literal',
+        foreground: tokens[`Cv${theme}CodeSnippetLiteral`],
+      },
+      {
+        token: 'meta',
+        foreground: tokens[`Cv${theme}CodeSnippetTitle`],
+      },
+      {
+        token: 'number',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+      {
+        token: 'operator',
+        foreground: tokens[`Cv${theme}CodeSnippetLiteral`],
+      },
+      { token: 'predefined', foreground: tokens[`Cv${theme}CodeSnippetTitle`] },
+      {
+        token: 'predefined.sql',
+        foreground: tokens[`Cv${theme}CodeSnippetTitle`],
+      },
+      {
+        token: 'predefined.python',
+        foreground: tokens[`Cv${theme}CodeSnippetClass`],
+      },
+      {
+        token: 'punctuation',
+        foreground: tokens[`Cv${theme}CodeSnippetColor`],
+      },
+      {
+        token: 'string',
+        foreground: tokens[`Cv${theme}CodeSnippetString`],
+      },
+      {
+        token: 'string.sql',
+        foreground: tokens[`Cv${theme}CodeSnippetString`],
+      },
+      {
+        token: 'string.key.json',
+        foreground: tokens[`Cv${theme}CodeSnippetString`],
+      },
+      {
+        token: 'string.value.json',
+        foreground: tokens[`Cv${theme}CodeSnippetString`],
+      },
+      {
+        token: 'strong',
+        fontStyle: 'bold',
+      },
+      {
+        token: 'tag',
+        foreground: tokens[`Cv${theme}CodeSnippetSelector`],
+      },
+      {
+        token: 'tag.id.jade',
+        foreground: tokens[`Cv${theme}CodeSnippetClass`],
+      },
+      {
+        token: 'tag.class.jade',
+        foreground: tokens[`Cv${theme}CodeSnippetClass`],
+      },
+      {
+        token: 'type',
+        foreground: tokens[`Cv${theme}CodeSnippetClass`],
+      },
+      {
+        token: 'variable',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+    ],
+    colors: {
+      comment: tokens[`Cv${theme}CodeSnippetComment`],
+      'editor.background': tokens[`Cv${theme}Surface`],
+      'editor.foreground': tokens[`CvTheme${theme}ColorsOnSurface`],
+      'editorCursor.foreground': tokens[`Cv${theme}TextSecondaryOnBackground`],
+      'editorLineNumber.activeForeground':
+        tokens[`CvTheme${theme}ColorsOnSurface74`],
+      'editorLineNumber.foreground': tokens[`CvTheme${theme}ColorsOnSurface38`],
+      'editor.lineHighlightBackground':
+        tokens[`CvTheme${theme}ColorsSurfaceContainerLow`],
+      'inputValidation.errorBackground': tokens[`Cv${theme}Negative`],
+      'inputValidation.errorBorder': 'rgba(229, 115, 115, 0.1)',
     },
-    {
-      token: 'comment',
-      foreground: tokens.CvDarkCodeSnippetComment,
-      fontStyle: 'italic',
-    },
-    { token: 'keyword', foreground: tokens.CvDarkCodeSnippetKeyword },
-    { token: 'variable', foreground: tokens.CvDarkCodeSnippetVariable },
-    { token: 'string', foreground: tokens.CvDarkCodeSnippetString },
-    { token: 'number', foreground: tokens.CvDarkCodeSnippetVariable },
-    { token: 'type', foreground: tokens.CvDarkCodeSnippetClass },
-    { token: 'class', foreground: tokens.CvDarkCodeSnippetClass },
-    { token: 'function', foreground: tokens.CvDarkCodeSnippetTitle },
-    { token: 'operator', foreground: tokens.CvDarkCodeSnippetLiteral },
-    { token: 'constant', foreground: tokens.CvDarkCodeSnippetLiteral },
-    { token: 'builtin', foreground: tokens.CvDarkCodeSnippetClass },
-    { token: 'punctuation', foreground: tokens.CvDarkCodeSnippetColor },
-    { token: 'meta', foreground: tokens.CvDarkCodeSnippetTitle },
-    { token: 'tag', foreground: tokens.CvDarkCodeSnippetSelector },
-    { token: 'attribute.name', foreground: tokens.CvDarkCodeSnippetVariable },
-    { token: 'attribute.value', foreground: tokens.CvDarkCodeSnippetString },
-    { token: 'invalid', foreground: tokens.CvDarkNegative },
-    { token: 'strong', fontStyle: 'bold' },
-    { token: 'emphasis', fontStyle: 'italic' },
-    {
-      token: 'link',
-      foreground: tokens.CvDarkCodeSnippetTitle,
-      fontStyle: 'underline',
-    },
-  ],
-  colors: {
-    'editor.background': tokens.CvThemeDarkColorsSurface,
-    'editor.foreground': tokens.CvDarkCodeSnippetColor,
-    'editorCursor.foreground': tokens.CvDarkTextSecondaryOnBackground,
-  },
+  };
 };
 
-export const cvEditorLightTheme = {
-  base: 'vs',
-  inherit: true,
-  rules: [
-    {
-      token: '',
-      foreground: tokens.CvLightCodeSnippetColor,
-      background: tokens.CvLightSurfaceCanvas,
-    },
-    {
-      token: 'comment',
-      foreground: tokens.CvLightCodeSnippetComment,
-      fontStyle: 'italic',
-    },
-    { token: 'keyword', foreground: tokens.CvLightCodeSnippetKeyword },
-    { token: 'doctag', foreground: tokens.CvLightCodeSnippetKeyword },
-    { token: 'formula', foreground: tokens.CvLightCodeSnippetKeyword },
-    { token: 'variable', foreground: tokens.CvLightCodeSnippetVariable },
-    { token: 'string', foreground: tokens.CvLightCodeSnippetString },
-    { token: 'number', foreground: tokens.CvLightCodeSnippetVariable },
-    { token: 'type', foreground: tokens.CvLightCodeSnippetClass },
-    { token: 'class', foreground: tokens.CvLightCodeSnippetClass },
-    { token: 'function', foreground: tokens.CvLightCodeSnippetTitle },
-    { token: 'literal', foreground: tokens.CvLightCodeSnippetLiteral },
-    { token: 'operator', foreground: tokens.CvLightCodeSnippetLiteral },
-    { token: 'constant', foreground: tokens.CvLightCodeSnippetLiteral },
-    { token: 'builtin', foreground: tokens.CvLightCodeSnippetClass },
-    { token: 'punctuation', foreground: tokens.CvLightCodeSnippetColor },
-    { token: 'meta', foreground: tokens.CvLightCodeSnippetTitle },
-    { token: 'tag', foreground: tokens.CvLightCodeSnippetSelector },
-    { token: 'attribute.name', foreground: tokens.CvLightCodeSnippetVariable },
-    { token: 'attribute.value', foreground: tokens.CvLightCodeSnippetString },
-    { token: 'invalid', foreground: tokens.CvLightNegative },
-    { token: 'strong', fontStyle: 'bold' },
-    { token: 'emphasis', fontStyle: 'italic' },
-    {
-      token: 'link',
-      foreground: tokens.CvLightCodeSnippetTitle,
-      fontStyle: 'underline',
-    },
-  ],
-  colors: {
-    'editor.background': tokens.CvThemeLightColorsSurface,
-    'editor.foreground': tokens.CvLightCodeSnippetColor,
-    'editorCursor.foreground': tokens.CvLightTextSecondaryOnBackground,
-  },
-};
+export const cvEditorDarkTheme = getTheme('Dark');
+
+export const cvEditorLightTheme = getTheme('Light');

--- a/libs/components/src/notebook-cell/notebook-cell.ts
+++ b/libs/components/src/notebook-cell/notebook-cell.ts
@@ -98,6 +98,7 @@ export class CovalentNotebookCell extends LitElement {
     lineNumbers: 'off',
     lineDecorationsWidth: 0,
     lineNumbersMinChars: 0,
+    renderIndentGuides: false,
     renderLineHighlight: 'none',
     overviewRulerLanes: 0,
     hideCursorInOverviewRuler: true,

--- a/libs/markdown-flavored/README.md
+++ b/libs/markdown-flavored/README.md
@@ -21,6 +21,9 @@ This component uses `<td-markdown>` to render the markdown. See `<td-markdown>`'
   - Display copy button on code snippets to copy code to clipboard.
 - copyCodeTooltips?: ICopyCodeTooltips
   - Tooltips for copy button to copy and upon copying.
+- fileLinkExtensions?: string[]
+  - The file extensions to monitor within anchor tags.
+  - Clicking links that end with these extensions will prevent the default action and emit 'fileClicked' event.
 
 For reference:
 
@@ -35,6 +38,8 @@ interface ICopyCodeTooltips {
 
 - buttonClicked: ITdFlavoredMarkdownButtonClickEvent
   - Emitted when a button is clicked
+- fileClicked: URL
+  - Emitted when an anchor tag is clicked and its 'href' matches one of the extensions in 'fileLinkExtensions'.
 
 #### Events
 
@@ -99,9 +104,7 @@ $theme: mat.define-light-theme($primary, $accent, $warn);
 ## Example
 
 ```html
-<td-flavored-markdown>
-  - [x] checked action - [ ] unchecked action + list item + list item
-</td-flavored-markdown>
+<td-flavored-markdown> - [x] checked action - [ ] unchecked action + list item + list item </td-flavored-markdown>
 ```
 
 ## TdFlavoredMarkdownLoaderComponent: td-flavored-markdown-loader
@@ -140,8 +143,5 @@ A component that fetches markdown from a GitHub url and renders it using `<td-fl
 ## Example
 
 ```html
-<td-flavored-markdown-loader
-  [url]="'https://github.com/Teradata/covalent/blob/main/README.md'"
->
-</td-flavored-markdown-loader>
+<td-flavored-markdown-loader [url]="'https://github.com/Teradata/covalent/blob/main/README.md'"> </td-flavored-markdown-loader>
 ```

--- a/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
+++ b/libs/markdown-flavored/src/lib/flavored-markdown.component.ts
@@ -232,6 +232,20 @@ export class TdFlavoredMarkdownComponent
   @Input() useCfmList? = false;
 
   /**
+   * The file extension to monitor for in anchor tags. If an anchor's `href` ends
+   * with this extension, an event will be triggered insetad of performing the default action.
+   * Example values: ".ipynb", ".zip", ".docx"
+   */
+  @Input()
+  fileLinkExtensions?: string[];
+
+  /**
+   * Event emitted when an anchor tag with an `href` matching the specified
+   * file link extension is clicked. The emitted value is the `href` of the clicked anchor.
+   */
+  @Output() fileLinkClicked = new EventEmitter<URL>();
+
+  /**
    * contentReady?: function
    * Event emitted after the markdown content rendering is finished.
    */
@@ -377,6 +391,13 @@ export class TdFlavoredMarkdownComponent
       contentRef.instance.content = markdown;
       contentRef.instance.hostedUrl = this._hostedUrl;
       contentRef.instance.simpleLineBreaks = this._simpleLineBreaks;
+      contentRef.instance.fileLinkExtensions = this.fileLinkExtensions;
+      contentRef.instance.fileLinkClicked
+        .pipe(takeUntil(this._destroy$))
+        .subscribe((url: URL) => {
+          console.log(url);
+          this.fileLinkClicked.emit(url);
+        });
       contentRef.instance.refresh();
       this.container.viewContainerRef.insert(
         contentRef.hostView,

--- a/libs/markdown/README.md
+++ b/libs/markdown/README.md
@@ -27,12 +27,21 @@ By default, `--dev` build will log the following message in the console to let y
   - If markdown contains relative paths, this is required to generate correct urls.
 
 - anchor?: string
+
   - Anchor to jump to.
+
+- fileLinkExtensions?: string[]
+  - The file extensions to monitor within anchor tags.
+  - Clicking links that end with these extensions will prevent the default action and emit 'fileClicked' event.
 
 #### Events
 
 - contentReady: undefined
+
   - Event emitted after the markdown content rendering is finished.
+
+- fileClicked: URL
+  - Emitted when an anchor tag is clicked and its 'href' matches one of the extensions in 'fileLinkExtensions'.
 
 ## Installation
 

--- a/libs/markdown/src/lib/markdown-utils/markdown-utils.ts
+++ b/libs/markdown/src/lib/markdown-utils/markdown-utils.ts
@@ -16,6 +16,7 @@ export function genHeadingId(str: string): string {
   if (str) {
     return removeLeadingHash(
       str
+        .replace(/<[^>]+>/g, '') // remove html tags from heading ids
         .replace(/(_|-|\s)+/g, '')
         // Remove certain special chars to create heading ids similar to those in github
         // borrowed from showdown
@@ -63,6 +64,22 @@ export function isAnchorLink(anchor?: HTMLAnchorElement): boolean {
   }
   return false;
 }
+
+export function isFileLink(
+  anchor: HTMLAnchorElement,
+  fileExtensions: string[] | undefined
+): boolean {
+  if (fileExtensions && fileExtensions.length) {
+    const href = anchor.getAttribute('href');
+    if (href) {
+      return fileExtensions.some((fileExtension) =>
+        href.endsWith(fileExtension)
+      );
+    }
+  }
+  return false;
+}
+
 const RAW_GITHUB_HOSTNAME = 'raw.githubusercontent.com';
 
 export function rawGithubHref(githubHref?: string): string {


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- File url click support in `Markdown` and `FlavoredMarkdown` components
- Theming for code-editor web component 

### What's included?

<!-- List features included in this PR -->

- Add an input property called `fileLinkExtensions` and an output event called `fileClicked` in `Markdown` and `FlavoredMarkdown` components.
- For all the links which end with the provided file extensions the default click behavior will be prevented and an output event will be emitted. Consumers can capture this event and handle the click logic.
- When the `hostedUrl` property is set, this will be prepended to all file links.
- Theming for code-editor web component. Note: We might need to create custom themes for supported languages.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [x] `npm run start`
- [x] Run the docs app
- [x] Open `Markdown` or `FlavoredMarkdown` component demos and pass the `hostedURL` and `fileLinkExtensions` properties. Add links which end with these extensions in the markdown content and verify the click action.

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
File links
![filelinks](https://github.com/user-attachments/assets/f77cb583-6e9d-4175-98d4-e3ba4a337b84)

Code-editor
<img width="906" alt="Screenshot 2024-08-15 at 5 34 53 PM" src="https://github.com/user-attachments/assets/5123c718-0868-489d-8208-624e79a54470">
<img width="906" alt="Screenshot 2024-08-15 at 5 35 06 PM" src="https://github.com/user-attachments/assets/128750cf-2d42-421c-b974-a4bbe773c54f">
