### PR TITLE
fix(notebook-cell): prevent shift+enter action in cell editor

### DIFF
--- a/libs/components/src/code-editor/code-editor.ts
+++ b/libs/components/src/code-editor/code-editor.ts
@@ -116,6 +116,15 @@ export class CovalentCodeEditor extends LitElement {
       automaticLayout: true,
       scrollBeyondLastLine: false,
     });
+
+    // Notify when the editor instance is created/ready
+    this.dispatchEvent(
+      new CustomEvent('editor-ready', {
+        detail: { editor: this.editor },
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   override disconnectedCallback(): void {
@@ -161,6 +170,10 @@ export class CovalentCodeEditor extends LitElement {
         .matchMedia('(prefers-color-scheme: dark)')
         .addEventListener('change', this.setTheme);
     }
+  }
+
+  getEditorInstance() {
+    return this.editor;
   }
 
   getValue() {

--- a/libs/components/src/notebook-cell/notebook-cell.stories.js
+++ b/libs/components/src/notebook-cell/notebook-cell.stories.js
@@ -33,7 +33,7 @@ const Template = ({
   error,
   output,
 }) => {
-  return `<div style="width: 80vw;">
+  return `<div style="width: 60vw;">
             <cv-notebook-cell code="${code}" index="${index}" language="${language}" timesExecuted="${timesExecuted}" editorTheme="${theme}" ${
     hideEditor ? 'hideEditor' : ''
   } ${selected ? 'selected' : ''} ${loading ? 'loading' : ''} ${

--- a/libs/components/src/notebook-cell/notebook-cell.ts
+++ b/libs/components/src/notebook-cell/notebook-cell.ts
@@ -2,6 +2,11 @@ import { css, html, LitElement, PropertyValues, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import styles from './notebook-cell.scss?inline';
 import { classMap } from 'lit/directives/class-map.js';
+import {
+  KeyCode,
+  KeyMod,
+  editor,
+} from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 import '../code-editor/code-editor';
 import '../code-snippet/code-snippet';
@@ -79,6 +84,8 @@ export class CovalentNotebookCell extends LitElement {
   @property({ type: String })
   editorTheme = '';
 
+  private _editor!: editor.IStandaloneCodeEditor;
+
   private _editorFocused = false;
 
   @state()
@@ -153,6 +160,13 @@ export class CovalentNotebookCell extends LitElement {
     this.requestUpdate();
   }
 
+  setEditorInstance(e: CustomEvent) {
+    this._editor = e.detail.editor;
+    this._editor.addCommand(KeyMod.Shift | KeyCode.Enter, () => {
+      // Prevent the default shift enter action (inserts line below) and do nothing
+    });
+  }
+
   showContextMenu(e: MouseEvent) {
     e.preventDefault();
     const cells = document.querySelectorAll('cv-notebook-cell');
@@ -219,6 +233,7 @@ export class CovalentNotebookCell extends LitElement {
     const editor = this.selected
       ? html`<cv-code-editor
           @code-change="${this.handleCodeChange}"
+          @editor-ready="${this.setEditorInstance}"
           @editor-focus="${() => this.setEditorFocus(true)}"
           @editor-blur="${() => this.setEditorFocus(false)}"
           .code="${this.code}"


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- Prevent the default action in notebook cell's code editor on pressing `Shift + Enter` keys. The current behavior adds a new line below. This should not happen.
- Consumers can now capture the document's key events and handle the logic for `Shift + Enter` key press.

### What's included?

<!-- List features included in this PR -->

- Do nothing on pressing `Shift + Enter` while focused in the code editor

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [x] `npm run start`
- [x] Open the Notebook cell story
- [x] Focus in the editor and press `Shift + Enter`. Nothing should happen.

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

https://github.com/user-attachments/assets/d96f1b34-e9a1-4210-8e54-36e81aa2b096

