### PR TITLE
docs(markdown): add a demo for file url handling

### DIFF
--- a/apps/docs-app/src/app/content/components/component-demos/markdown/demos/markdown-demo-file-url/markdown-demo-file-url.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown/demos/markdown-demo-file-url/markdown-demo-file-url.component.html
@@ -1,0 +1,24 @@
+<td-markdown>
+  {{ description }}
+</td-markdown>
+
+<td-markdown
+  [fileLinkExtensions]="['.ipynb']"
+  (fileLinkClicked)="handleFileLinkClick($event)"
+>
+  * [File URL with fileLinkExtensions provided](docs/GETTING_STARTED.ipynb)
+</td-markdown>
+
+<td-markdown
+  hostedUrl="https://github.com/Teradata/covalent/blob/main/"
+  [fileLinkExtensions]="['.ipynb']"
+  (fileLinkClicked)="handleFileLinkClick($event)"
+>
+  * [File URL with fileLinkExtensions and hostedUrl
+  provided](docs/GETTING_STARTED.ipynb)
+</td-markdown>
+
+<td-markdown>
+  * [Normal file URL without fileLinkExtensions
+  provided](docs/GETTING_STARTED.ipynb)
+</td-markdown>

--- a/apps/docs-app/src/app/content/components/component-demos/markdown/demos/markdown-demo-file-url/markdown-demo-file-url.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown/demos/markdown-demo-file-url/markdown-demo-file-url.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'markdown-demo-file-url',
+  styleUrls: ['./markdown-demo-file-url.component.scss'],
+  templateUrl: './markdown-demo-file-url.component.html',
+})
+export class MarkdownDemoFileUrlComponent {
+  description = `
+    Click events for URLs ending with the extensions specified in
+    \`fileLinkExtensions\` will be intercepted.
+
+    The URL of the clicked file can be
+    captured by the \`fileLinkClicked\` event.
+  `;
+
+  constructor(private _snackBar: MatSnackBar) {}
+
+  handleFileLinkClick(fileURL: URL) {
+    this._snackBar.open(
+      `File link clicked: ${JSON.stringify(fileURL)}`,
+      undefined,
+      {
+        duration: 2000,
+      }
+    );
+  }
+}

--- a/apps/docs-app/src/app/content/components/component-demos/markdown/demos/markdown-demo.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown/demos/markdown-demo.component.html
@@ -17,6 +17,13 @@
 </demo-component>
 
 <demo-component
+  [demoId]="'markdown-demo-file-url'"
+  [demoTitle]="'Handling file URLs'"
+>
+  <markdown-demo-file-url></markdown-demo-file-url>
+</demo-component>
+
+<demo-component
   [demoId]="'markdown-demo-youtube'"
   [demoTitle]="'YouTube video embedding'"
 >

--- a/apps/docs-app/src/app/content/components/component-demos/markdown/demos/markdown-demo.module.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown/demos/markdown-demo.module.ts
@@ -8,6 +8,7 @@ import { DemoModule } from '../../../../../components/shared/demo-tools/demo.mod
 import { MarkdownDemoAnchorJumpingComponent } from './markdown-demo-anchor-jumping/markdown-demo-anchor-jumping.component';
 import { MarkdownDemoHostedUrlComponent } from './markdown-demo-hosted-url/markdown-demo-hosted-url.component';
 import { MarkdownDemoYoutubeComponent } from './markdown-demo-youtube/markdown-demo-youtube.component';
+import { MarkdownDemoFileUrlComponent } from './markdown-demo-file-url/markdown-demo-file-url.component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 
@@ -18,6 +19,7 @@ import { MatCardModule } from '@angular/material/card';
     MarkdownDemoAnchorJumpingComponent,
     MarkdownDemoHostedUrlComponent,
     MarkdownDemoYoutubeComponent,
+    MarkdownDemoFileUrlComponent,
   ],
   imports: [
     DemoModule,

--- a/libs/markdown-flavored/README.md
+++ b/libs/markdown-flavored/README.md
@@ -38,7 +38,7 @@ interface ICopyCodeTooltips {
 
 - buttonClicked: ITdFlavoredMarkdownButtonClickEvent
   - Emitted when a button is clicked
-- fileClicked: URL
+- fileLinkClicked: URL
   - Emitted when an anchor tag is clicked and its 'href' matches one of the extensions in 'fileLinkExtensions'.
 
 #### Events

--- a/libs/markdown/README.md
+++ b/libs/markdown/README.md
@@ -40,7 +40,7 @@ By default, `--dev` build will log the following message in the console to let y
 
   - Event emitted after the markdown content rendering is finished.
 
-- fileClicked: URL
+- fileLinkClicked: URL
   - Emitted when an anchor tag is clicked and its 'href' matches one of the extensions in 'fileLinkExtensions'.
 
 ## Installation


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- Add a demo for file url handling in the `td-markdown` component

### What's included?

<!-- List features included in this PR -->

- Demo for handling file url clicks

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [x] `nx run docs-app:serve`
- [x] Navigate to Components -> Markdown Parser -> Examples
- [x] Scroll down to the section `Handling file URLs`

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1159" alt="Screenshot 2024-08-22 at 10 38 47 AM" src="https://github.com/user-attachments/assets/065d6695-5cf0-4484-bfbc-f58da05527cf">
