### PR TITLE
fix(notebook-cell): fix drag and drop issues

### DIFF
--- a/libs/components/src/code-editor/code-editor.ts
+++ b/libs/components/src/code-editor/code-editor.ts
@@ -121,7 +121,7 @@ export class CovalentCodeEditor extends LitElement {
     this.dispatchEvent(
       new CustomEvent('editor-ready', {
         detail: { editor: this.editor },
-        bubbles: true,
+        bubbles: false,
         composed: true,
       })
     );
@@ -143,7 +143,7 @@ export class CovalentCodeEditor extends LitElement {
       this.editor?.onDidFocusEditorText(() => {
         this.dispatchEvent(
           new CustomEvent('editor-focus', {
-            bubbles: true,
+            bubbles: false,
             composed: true,
           })
         );
@@ -153,7 +153,7 @@ export class CovalentCodeEditor extends LitElement {
       this.editor?.onDidBlurEditorText(() => {
         this.dispatchEvent(
           new CustomEvent('editor-blur', {
-            bubbles: true,
+            bubbles: false,
             composed: true,
           })
         );

--- a/libs/components/src/icon-button/icon-button.scss
+++ b/libs/components/src/icon-button/icon-button.scss
@@ -1,3 +1,7 @@
 :host {
   color: var(--mdc-theme-text-icon-on-background);
+
+  .mdc-icon-button {
+    cursor: var(--cv-icon-button-cursor, pointer);
+  }
 }

--- a/libs/components/src/notebook-cell/notebook-cell.scss
+++ b/libs/components/src/notebook-cell/notebook-cell.scss
@@ -1,5 +1,5 @@
 :host {
-  --mdc-icon-button-size: 24px;
+  --mdc-icon-button-size: 2rem;
 
   font-family: var(--mdc-typography-body1-font-family);
   width: 100%;
@@ -48,6 +48,8 @@ cv-code-editor {
 }
 
 .timesExecuted {
+  --cv-icon-button-cursor: grab;
+
   align-items: center;
   box-sizing: border-box;
   color: var(--cv-theme-on-surface-38);
@@ -62,15 +64,21 @@ cv-code-editor {
     overflow: hidden;
     text-align: right;
     text-overflow: ellipsis;
+    user-select: none;
     white-space: nowrap;
     width: 50px;
   }
 
-  cv-icon {
+  cv-icon-button {
     color: var(--cv-theme-on-surface-variant);
+    cursor: grab;
     padding: 0.5rem;
     visibility: hidden;
     transition: visibility 0.3s ease;
+
+    &:active {
+      --cv-icon-button-cursor: grabbing;
+    }
   }
 }
 
@@ -82,7 +90,7 @@ cv-code-editor {
   }
 
   &:hover {
-    cv-icon {
+    cv-icon-button {
       visibility: visible;
     }
   }

--- a/libs/components/src/notebook-cell/notebook-cell.scss
+++ b/libs/components/src/notebook-cell/notebook-cell.scss
@@ -7,6 +7,7 @@
 
 cv-code-snippet {
   background-color: var(--cv-theme-surface);
+  border-radius: 0;
   box-sizing: border-box;
 }
 

--- a/libs/components/src/notebook-cell/notebook-cell.stories.js
+++ b/libs/components/src/notebook-cell/notebook-cell.stories.js
@@ -15,7 +15,7 @@ export default {
     selected: true,
     hideCount: false,
     hideEditor: false,
-    theme: 'cv-light',
+    editorTheme: 'cv-light',
     timesExecuted: 2,
   },
 };
@@ -28,13 +28,13 @@ const Template = ({
   selected,
   hideCount,
   hideEditor,
-  theme,
+  editorTheme,
   timesExecuted,
   error,
   output,
 }) => {
   return `<div style="width: 60vw;">
-            <cv-notebook-cell code="${code}" index="${index}" language="${language}" timesExecuted="${timesExecuted}" editorTheme="${theme}" ${
+            <cv-notebook-cell code="${code}" index="${index}" language="${language}" timesExecuted="${timesExecuted}" editorTheme="${editorTheme}" ${
     hideEditor ? 'hideEditor' : ''
   } ${selected ? 'selected' : ''} ${loading ? 'loading' : ''} ${
     hideCount ? 'hideCount' : ''

--- a/libs/components/src/notebook-cell/notebook-cell.ts
+++ b/libs/components/src/notebook-cell/notebook-cell.ts
@@ -278,23 +278,19 @@ export class CovalentNotebookCell extends LitElement {
       focused: this._editorFocused,
     };
     return html`
-      <div
-        class="${classMap(classes)}"
-        draggable="true"
-        @contextmenu=${this.showContextMenu}
-      >
-        <div class="selectionIndicatorWrapper" draggable="false">
+      <div class="${classMap(classes)}" @contextmenu=${this.showContextMenu}>
+        <div class="selectionIndicatorWrapper">
           <div class="selectionIndicator"></div>
         </div>
 
-        <div class="timesExecutedWrapper" draggable="false">
+        <div class="timesExecutedWrapper">
           <div class="timesExecuted">
-            <cv-icon>drag_indicator</cv-icon>
+            <cv-icon-button icon="drag_indicator"></cv-icon-button>
             <div class="executionCount">${this.renderExecutionCount()}</div>
           </div>
         </div>
 
-        <div class="cellOutputWrapper" draggable="false">
+        <div class="cellOutputWrapper">
           ${this.renderEditor()} ${this.renderOutput()}
         </div>
       </div>

--- a/libs/components/src/notebook-cell/notebook-cell.ts
+++ b/libs/components/src/notebook-cell/notebook-cell.ts
@@ -2,11 +2,7 @@ import { css, html, LitElement, PropertyValues, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import styles from './notebook-cell.scss?inline';
 import { classMap } from 'lit/directives/class-map.js';
-import {
-  KeyCode,
-  KeyMod,
-  editor,
-} from 'monaco-editor/esm/vs/editor/editor.api.js';
+import { KeyCode, editor } from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 import '../code-editor/code-editor';
 import '../code-snippet/code-snippet';
@@ -17,10 +13,6 @@ declare global {
   interface HTMLElementTagNameMap {
     'cv-notebook-cell': CovalentNotebookCell;
   }
-}
-
-enum CvCellEvents {
-  RUN_CODE = 'cell-run-code',
 }
 
 /**
@@ -145,16 +137,6 @@ export class CovalentNotebookCell extends LitElement {
     this.code = e.detail.code;
   }
 
-  handleRun() {
-    this.dispatchEvent(
-      new CustomEvent(CvCellEvents.RUN_CODE, {
-        detail: { index: this.index, code: this.code },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  }
-
   setEditorFocus(e: CustomEvent, setFocus: boolean) {
     e.stopImmediatePropagation();
     this._editorFocused = setFocus;
@@ -164,8 +146,11 @@ export class CovalentNotebookCell extends LitElement {
   setEditorInstance(e: CustomEvent) {
     e.stopImmediatePropagation();
     this._editor = e.detail.editor;
-    this._editor.addCommand(KeyMod.Shift | KeyCode.Enter, () => {
-      // Prevent the default shift enter action (inserts line below) and do nothing
+    this._editor.onKeyDown((e) => {
+      if (e.shiftKey && e.keyCode === KeyCode.Enter) {
+        e.preventDefault(); // Prevents adding a new line
+        // The event will still propagate and can be capture with an event listener
+      }
     });
   }
 

--- a/libs/components/src/notebook-cell/notebook-cell.ts
+++ b/libs/components/src/notebook-cell/notebook-cell.ts
@@ -79,7 +79,7 @@ export class CovalentNotebookCell extends LitElement {
   hideCount = false;
 
   /**
-   * Whether the execution count is shown
+   * Theme for the code editor
    */
   @property({ type: String })
   editorTheme = '';
@@ -155,12 +155,14 @@ export class CovalentNotebookCell extends LitElement {
     );
   }
 
-  setEditorFocus(setFocus: boolean) {
+  setEditorFocus(e: CustomEvent, setFocus: boolean) {
+    e.stopImmediatePropagation();
     this._editorFocused = setFocus;
     this.requestUpdate();
   }
 
   setEditorInstance(e: CustomEvent) {
+    e.stopImmediatePropagation();
     this._editor = e.detail.editor;
     this._editor.addCommand(KeyMod.Shift | KeyCode.Enter, () => {
       // Prevent the default shift enter action (inserts line below) and do nothing
@@ -234,8 +236,8 @@ export class CovalentNotebookCell extends LitElement {
       ? html`<cv-code-editor
           @code-change="${this.handleCodeChange}"
           @editor-ready="${this.setEditorInstance}"
-          @editor-focus="${() => this.setEditorFocus(true)}"
-          @editor-blur="${() => this.setEditorFocus(false)}"
+          @editor-focus="${(e: CustomEvent) => this.setEditorFocus(e, true)}"
+          @editor-blur="${(e: CustomEvent) => this.setEditorFocus(e, false)}"
           .code="${this.code}"
           .language="${this.language}"
           .options="${this.editorOptions}"


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- Fix drag and drop issues in notebook-cell component

### What's included?

<!-- List features included in this PR -->

- Remove draggable property for elements in the cell. This is causing issues during drag and drop.
- Replace the drag handler icon with an icon-button as per mocks.
- Stop bubbling unwanted editor events past the notebook-cell component which is also causing drag and drop issues.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [x] `npm run storybook`
- [x] Open the Notebook cell story
- [x] Check if the drag handler appears as an icon button

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

https://github.com/user-attachments/assets/e4fcac80-a4fa-41d0-885e-c6db5b7526b3

