### PR TITLE
fix(components): fix to nav item when rendered initially open

### DIFF
--- a/libs/components/src/list/nav-list-item.scss
+++ b/libs/components/src/list/nav-list-item.scss
@@ -154,6 +154,6 @@
 
   .expansion-panel {
     transition-timing-function: animation.$deceleration-curve-timing-function;
-    max-height: var(--cv-list-menu-height, 0);
+    max-height: var(--cv-list-menu-height, inherit);
   }
 }

--- a/libs/components/src/list/nav-list-item.ts
+++ b/libs/components/src/list/nav-list-item.ts
@@ -142,13 +142,15 @@ export class CovalentNavRailListItem extends CovalentListItem {
 
   private _updateMaxHeight(open = this.open) {
     const content = this.shadowRoot?.querySelector('.expansion-panel');
+    let contentHeight = '0';
 
     if (open) {
-      const contentHeight = content?.scrollHeight;
-      this.style.setProperty('--cv-list-menu-height', `${contentHeight}px`);
-    } else {
-      this.style.setProperty('--cv-list-menu-height', `0`);
+      contentHeight = content?.scrollHeight
+        ? `${content.scrollHeight}px`
+        : 'inherit';
     }
+
+    this.style.setProperty('--cv-list-menu-height', contentHeight);
   }
 
   renderExpansionItem() {


### PR DESCRIPTION
## Description

Fix for nav item menu that is open initially when rendered

### What's included?

- using "inherit" value for when the content scrollheight is 0

#### Test Steps

- [ ] `npm run storybook`
- [ ] then this modify the appshell story to have a collapsible nav item open initially
- [ ] finally this check that the menu is open when the "open" property is initially set

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
