### PR TITLE
fix(notebook-cell): add a slot for drag handle

### DIFF
--- a/libs/components/src/notebook-cell/notebook-cell.scss
+++ b/libs/components/src/notebook-cell/notebook-cell.scss
@@ -70,10 +70,9 @@ cv-code-editor {
     width: 50px;
   }
 
-  cv-icon-button {
+  .dragHandle {
     color: var(--cv-theme-on-surface-variant);
     cursor: grab;
-    padding: 0.5rem;
     visibility: hidden;
     transition: visibility 0.3s ease;
 
@@ -91,7 +90,7 @@ cv-code-editor {
   }
 
   &:hover {
-    cv-icon-button {
+    .dragHandle {
       visibility: visible;
     }
   }

--- a/libs/components/src/notebook-cell/notebook-cell.stories.js
+++ b/libs/components/src/notebook-cell/notebook-cell.stories.js
@@ -58,6 +58,7 @@ const Template = ({
           <cv-typography scale="body1">Tables are created and populated using SQL</cv-typography>
         </div>`
       }
+      <cv-icon-button slot="drag-handle" icon="drag_indicator" style="padding: 0.5rem"></cv-icon-button>
       <div slot="context-menu" style="background-color: white;">
         <cv-list activatable>
           <cv-list-item>Cut</cv-list-item>

--- a/libs/components/src/notebook-cell/notebook-cell.ts
+++ b/libs/components/src/notebook-cell/notebook-cell.ts
@@ -272,7 +272,7 @@ export class CovalentNotebookCell extends LitElement {
 
         <div class="timesExecutedWrapper">
           <div class="timesExecuted">
-            <cv-icon-button icon="drag_indicator"></cv-icon-button>
+            <slot class="dragHandle" name="drag-handle"></slot>
             <div class="executionCount">${this.renderExecutionCount()}</div>
           </div>
         </div>


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- With the current implementation, drag logic will be applied to the entire cell. This is causing issues with text selection, or scrolling of outputs.
- In order to prevent the entire cell component from being dragged, add a slot for drag handle where users can pass any component. They can add the drag logic to this slot.

### What's included?

<!-- List features included in this PR -->

- Add a slot called `drag-handle` in the notebook cell component
- Update notebook cell story 

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run storybook`
- [ ] Open notebook cell story
- [ ] Make sure drag handle is rendered correctly

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1252" alt="Screenshot 2024-08-29 at 3 28 16 PM" src="https://github.com/user-attachments/assets/c6bf08c5-5ab3-4c08-8126-a43c7a3f77ae">
