### PR TITLE
fix(components): color for disabled state

### DIFF
--- a/libs/components/src/textarea/textarea.stories.js
+++ b/libs/components/src/textarea/textarea.stories.js
@@ -10,15 +10,17 @@ export default {
   },
   args: {
     style: 'outlined',
+    disabled: false,
   },
 };
 
-const Template = ({ label, style, required, helper }) => {
+const Template = ({ label, style, disabled, required, helper }) => {
   return `
         <cv-textarea 
             label="${label ?? style}"
             ${style}
             ${helper ? `helper="${helper}"` : null}
+            ${disabled ? `disabled` : null}
             ${required ? `required` : null}>
         </cv-textarea>`;
 };

--- a/libs/components/src/textfield/textfield.scss
+++ b/libs/components/src/textfield/textfield.scss
@@ -10,6 +10,8 @@
   --mdc-text-field-outlined-hover-border-color: var(
     --mdc-theme-text-icon-on-background
   );
+  --mdc-text-field-outlined-disabled-border-color: var(--cv-theme-outline-12);
+  --mdc-text-field-disabled-ink-color: var(--cv-theme-on-surface-38);
   --mdc-typography-subtitle1-font-family: var(
     --mdc-typography-body1-font-family
   );

--- a/libs/components/src/textfield/textfield.stories.js
+++ b/libs/components/src/textfield/textfield.stories.js
@@ -10,10 +10,19 @@ export default {
   },
   args: {
     style: 'outlined',
+    disabled: false,
   },
 };
 
-const Template = ({ icon, iconTrailing, label, style, required, helper }) => {
+const Template = ({
+  icon,
+  iconTrailing,
+  label,
+  style,
+  disabled,
+  required,
+  helper,
+}) => {
   return `
         <cv-textfield 
             label="${label ?? style}"
@@ -26,6 +35,7 @@ const Template = ({ icon, iconTrailing, label, style, required, helper }) => {
                 : null
             }
             ${helper ? `helper="${helper}"` : null}
+            ${disabled ? `disabled` : null}
             ${required ? `required` : null}>
         </cv-textfield>`;
 };


### PR DESCRIPTION
## Description

Fixing the disabled state for the outlined text field and area components

### What's included?

- Setting the outlined disabled state variables according to our [design principles ](https://www.figma.com/design/KvXVAmYdCVAS7hzkOa73Em/Covalent-Principles?m=auto&node-id=8066-24227)

#### Test Steps

- [ ] `npm run storybook`
- [ ] then navigate to the text field and area stories
- [ ] finally turn on the disabled control to see the state change and the theme switcher button at the top

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.


##### Broken
![Screenshot 2024-09-04 at 1 31 28 PM](https://github.com/user-attachments/assets/24ce2374-7ff7-4b1b-94c9-af1ecde2129c)

##### Fixed
![Screenshot 2024-09-04 at 2 00 45 PM](https://github.com/user-attachments/assets/446e5a24-943f-4b45-98df-ffe0c9fd3dc1)
