### PR TITLE
fix(breadcrumbs): fix rendering issues on load

### DIFF
--- a/libs/angular/breadcrumbs/src/breadcrumb/breadcrumb.component.scss
+++ b/libs/angular/breadcrumbs/src/breadcrumb/breadcrumb.component.scss
@@ -5,7 +5,7 @@
     flex-direction: row;
     align-items: center;
     align-content: center;
-    max-width: 100%;
+    flex-shrink: 0;
     justify-content: flex-end;
 
     ::ng-deep > * {

--- a/libs/angular/breadcrumbs/src/breadcrumbs.component.ts
+++ b/libs/angular/breadcrumbs/src/breadcrumbs.component.ts
@@ -71,9 +71,7 @@ export class TdBreadcrumbsComponent
   }
 
   ngAfterViewInit(): void {
-    setTimeout(() => {
-      this._calculateVisibility();
-    });
+    this._waitToCalculateVisibility();
   }
 
   ngAfterContentInit(): void {
@@ -82,6 +80,7 @@ export class TdBreadcrumbsComponent
     this._breadcrumbs.changes
       .pipe(startWith(this._breadcrumbs))
       .subscribe(() => {
+        this._waitToCalculateVisibility();
         this.setCrumbIcons();
         this._changeDetectorRef.markForCheck();
       });
@@ -162,5 +161,11 @@ export class TdBreadcrumbsComponent
 
     this.hiddenBreadcrumbs = hiddenCrumbs;
     this._changeDetectorRef.markForCheck();
+  }
+
+  private _waitToCalculateVisibility(): void {
+    setTimeout(() => {
+      this._calculateVisibility();
+    });
   }
 }

--- a/libs/angular/breadcrumbs/src/breadcrumbs.component.ts
+++ b/libs/angular/breadcrumbs/src/breadcrumbs.component.ts
@@ -10,6 +10,7 @@ import {
   ElementRef,
   Input,
   HostBinding,
+  AfterViewInit,
 } from '@angular/core';
 
 import { fromEvent, Subject } from 'rxjs';
@@ -24,7 +25,7 @@ import { TdBreadcrumbComponent } from './breadcrumb/breadcrumb.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TdBreadcrumbsComponent
-  implements OnInit, AfterContentInit, OnDestroy
+  implements OnInit, AfterContentInit, AfterViewInit, OnDestroy
 {
   private _resizing = false;
   private _separatorIcon = 'chevron_right';
@@ -67,6 +68,12 @@ export class TdBreadcrumbsComponent
           }, 100);
         }
       });
+  }
+
+  ngAfterViewInit(): void {
+    setTimeout(() => {
+      this._calculateVisibility();
+    });
   }
 
   ngAfterContentInit(): void {


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
Overflowing breadcrumbs are not hidden on page load.

### What's included?

<!-- List features included in this PR -->

- Hide breadcrumbs based on the parent container size on page load

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [x] Run `nx: nx run docs-app:serve`
- [x] Open the breadcrumbs demo
- [x] Shrink the window size such that breadcrumbs overflow
- [x] Reload the page and check if breadcrumbs render correctly 
- [x] Verify that resizing breadcrumbs works too 

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

#### Screenshots or link to StackBlitz/Plunker

##### Before
<img width="516" alt="Screenshot 2024-09-05 at 3 27 26 PM" src="https://github.com/user-attachments/assets/83b5d8d4-2674-48c9-88d0-06a3f5a294e5">

##### After
<img width="516" alt="Screenshot 2024-09-05 at 3 28 00 PM" src="https://github.com/user-attachments/assets/eeb1fb8a-f56d-4147-bd03-0ad54e4707db">

##### Resizing
![breadcrumbs](https://github.com/user-attachments/assets/4aea31f3-b6f9-440c-a706-b4948387ccaf)
