### PR TITLE
fix(styles): add covalent theming to angular code editor

### DIFF
--- a/apps/docs-app/src/app/content/components/component-demos/code-editor/demos/code-editor-demo-basic/code-editor-demo-basic.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/code-editor/demos/code-editor-demo-basic/code-editor-demo-basic.component.html
@@ -3,7 +3,7 @@
   <td-code-editor
     #editor
     class="editor"
-    theme="vs"
+    theme="cv-light"
     [language]="editorLanguage"
     [(ngModel)]="editorVal"
     flex

--- a/apps/docs-app/src/app/content/components/component-demos/code-editor/demos/code-editor-demo-monaco/code-editor-demo-monaco.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/code-editor/demos/code-editor-demo-monaco/code-editor-demo-monaco.component.html
@@ -14,6 +14,8 @@
   <span flex="none" hide-xs class="push-right mat-body-1">Editor Theme</span>
   <mat-form-field>
     <mat-select [(ngModel)]="editorTheme" placeholder="Editor Theme">
+      <mat-option value="cv-dark">Covalent Dark</mat-option>
+      <mat-option value="cv-light">Covalent Light</mat-option>
       <mat-option value="vs-dark">Dark</mat-option>
       <mat-option value="hc-black">High Contrast</mat-option>
       <mat-option value="vs">Light</mat-option>

--- a/apps/docs-app/src/app/content/components/component-demos/code-editor/demos/code-editor-demo-monaco/code-editor-demo-monaco.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/code-editor/demos/code-editor-demo-monaco/code-editor-demo-monaco.component.ts
@@ -9,7 +9,7 @@ import { editor } from 'monaco-editor';
 export class CodeEditorDemoMonacoComponent {
   private _editor: any;
 
-  editorTheme = 'vs';
+  editorTheme = 'cv-light';
   editorVal = `var rows = prompt("How many rows for your multiplication table?");
 var cols = prompt("How many columns for your multiplication table?");
 if(rows == "" || rows == null)

--- a/libs/angular-code-editor/src/lib/code-editor.component.ts
+++ b/libs/angular-code-editor/src/lib/code-editor.component.ts
@@ -20,12 +20,17 @@ import { fromEvent, merge, timer } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
 // Use esm version to support shipping subset of languages and features
-import { editor, languages, IDisposable } from 'monaco-editor/esm/vs/editor/editor.api';
+import {
+  editor,
+  languages,
+  IDisposable,
+} from 'monaco-editor/esm/vs/editor/editor.api';
 
 import {
   mixinControlValueAccessor,
   mixinDisabled,
 } from '@covalent/core/common';
+import { cvEditorDarkTheme, cvEditorLightTheme } from './editor.theme';
 
 const noop = () => {
   // empty method
@@ -65,7 +70,7 @@ export class TdCodeEditorComponent
 
   private _editorStyle = 'width:100%;height:100%;';
   private _value = '';
-  private _theme = 'vs';
+  private _theme = 'cv-light';
   private _language = 'javascript';
   private _subject: Subject<string> = new Subject();
   private _editorInnerContainer: string =
@@ -326,6 +331,17 @@ export class TdCodeEditorComponent
 
     const containerDiv: HTMLDivElement = this._editorContainer.nativeElement;
     containerDiv.id = this._editorInnerContainer;
+
+    // Add teradata branded themes
+    editor.defineTheme(
+      'cv-light',
+      cvEditorLightTheme as editor.IStandaloneThemeData
+    );
+
+    editor.defineTheme(
+      'cv-dark',
+      cvEditorDarkTheme as editor.IStandaloneThemeData
+    );
 
     this._editor = editor.create(
       containerDiv,

--- a/libs/angular-code-editor/src/lib/editor.theme.ts
+++ b/libs/angular-code-editor/src/lib/editor.theme.ts
@@ -246,7 +246,8 @@ const getTheme = (theme: 'Light' | 'Dark') => {
       'editor.lineHighlightBackground':
         tokens[`CvTheme${theme}ColorsSurfaceContainerLow`],
       'inputValidation.errorBackground': tokens[`Cv${theme}Negative`],
-      'inputValidation.errorBorder': 'rgba(229, 115, 115, 0.1)',
+      'inputValidation.errorBorder':
+        tokens[`CvTheme${theme}PalettesNegative95`],
     },
   };
 };

--- a/libs/angular-code-editor/src/lib/editor.theme.ts
+++ b/libs/angular-code-editor/src/lib/editor.theme.ts
@@ -1,3 +1,5 @@
+import * as tokens from '@covalent/tokens';
+
 export const covalentThemeName = 'tdaa-lite';
 
 export const covalentThemeConf = {
@@ -56,3 +58,200 @@ export const covalentThemeConf = {
     'inputValidation.errorBorder': 'rgba(229, 115, 115, 0.1)',
   },
 };
+
+const getTheme = (theme: 'Light' | 'Dark') => {
+  return {
+    base: theme === 'Light' ? 'vs' : 'vs-dark',
+    inherit: true,
+    rules: [
+      {
+        token: '',
+        foreground: tokens[`Cv${theme}CodeSnippetColor`],
+        background: tokens[`Cv${theme}Surface`],
+      },
+      {
+        token: 'arbitration-variable',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+      {
+        token: 'arbitration-variable.invalid',
+        foreground: tokens[`Cv${theme}Negative`],
+      },
+      {
+        token: 'attribute.name',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+      {
+        token: 'attribute.value',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+      {
+        token: 'attribute.value.number',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+      {
+        token: 'attribute.value.unit',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+      {
+        token: 'attribute.value.html',
+        foreground: tokens[`Cv${theme}CodeSnippetString`],
+      },
+      {
+        token: 'attribute.value.xml',
+        foreground: tokens[`Cv${theme}CodeSnippetLiteral`],
+      },
+      {
+        token: 'builtins',
+        foreground: tokens[`Cv${theme}CodeSnippetClass`],
+      },
+      {
+        token: 'class',
+        foreground: tokens[`Cv${theme}CodeSnippetClass`],
+      },
+      {
+        token: 'comment',
+        foreground: tokens[`Cv${theme}CodeSnippetComment`],
+        fontStyle: 'italic',
+      },
+      {
+        token: 'constant',
+        foreground: tokens[`Cv${theme}CodeSnippetLiteral`],
+      },
+      {
+        token: 'delimiter',
+        foreground: tokens[`CvTheme${theme}ColorsOnSurface`],
+      },
+      {
+        token: 'delimiter.html',
+        foreground: tokens[`Cv${theme}CodeSnippetSelector`],
+      },
+      {
+        token: 'delimiter.xml',
+        foreground: tokens[`Cv${theme}CodeSnippetSelector`],
+      },
+      {
+        token: 'doctag',
+        foreground: tokens[`Cv${theme}CodeSnippetKeyword`],
+      },
+      {
+        token: 'emphasis',
+        fontStyle: 'italic',
+      },
+      {
+        token: 'formula',
+        foreground: tokens[`Cv${theme}CodeSnippetKeyword`],
+      },
+      {
+        token: 'function',
+        foreground: tokens[`Cv${theme}CodeSnippetTitle`],
+      },
+      {
+        token: 'invalid',
+        foreground: tokens[`Cv${theme}Negative`],
+      },
+      { token: 'key', foreground: tokens[`Cv${theme}CodeSnippetString`] },
+      {
+        token: 'keyword',
+        foreground: tokens[`Cv${theme}CodeSnippetKeyword`],
+      },
+      {
+        token: 'keyword.json',
+        foreground: tokens[`Cv${theme}CodeSnippetTitle`],
+        fontStyle: 'bold italic',
+      },
+      {
+        token: 'link',
+        foreground: tokens[`Cv${theme}CodeSnippetTitle`],
+        fontStyle: 'underline',
+      },
+      {
+        token: 'literal',
+        foreground: tokens[`Cv${theme}CodeSnippetLiteral`],
+      },
+      {
+        token: 'meta',
+        foreground: tokens[`Cv${theme}CodeSnippetTitle`],
+      },
+      {
+        token: 'number',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+      {
+        token: 'operator',
+        foreground: tokens[`Cv${theme}CodeSnippetLiteral`],
+      },
+      { token: 'predefined', foreground: tokens[`Cv${theme}CodeSnippetTitle`] },
+      {
+        token: 'predefined.sql',
+        foreground: tokens[`Cv${theme}CodeSnippetTitle`],
+      },
+      {
+        token: 'predefined.python',
+        foreground: tokens[`Cv${theme}CodeSnippetClass`],
+      },
+      {
+        token: 'punctuation',
+        foreground: tokens[`Cv${theme}CodeSnippetColor`],
+      },
+      {
+        token: 'string',
+        foreground: tokens[`Cv${theme}CodeSnippetString`],
+      },
+      {
+        token: 'string.sql',
+        foreground: tokens[`Cv${theme}CodeSnippetString`],
+      },
+      {
+        token: 'string.key.json',
+        foreground: tokens[`Cv${theme}CodeSnippetString`],
+      },
+      {
+        token: 'string.value.json',
+        foreground: tokens[`Cv${theme}CodeSnippetString`],
+      },
+      {
+        token: 'strong',
+        fontStyle: 'bold',
+      },
+      {
+        token: 'tag',
+        foreground: tokens[`Cv${theme}CodeSnippetSelector`],
+      },
+      {
+        token: 'tag.id.jade',
+        foreground: tokens[`Cv${theme}CodeSnippetClass`],
+      },
+      {
+        token: 'tag.class.jade',
+        foreground: tokens[`Cv${theme}CodeSnippetClass`],
+      },
+      {
+        token: 'type',
+        foreground: tokens[`Cv${theme}CodeSnippetClass`],
+      },
+      {
+        token: 'variable',
+        foreground: tokens[`Cv${theme}CodeSnippetVariable`],
+      },
+    ],
+    colors: {
+      comment: tokens[`Cv${theme}CodeSnippetComment`],
+      'editor.background': tokens[`Cv${theme}Surface`],
+      'editor.foreground': tokens[`CvTheme${theme}ColorsOnSurface`],
+      'editorCursor.foreground': tokens[`Cv${theme}TextSecondaryOnBackground`],
+      'editorLineNumber.activeForeground':
+        tokens[`CvTheme${theme}ColorsOnSurface74`],
+      'editorLineNumber.foreground': tokens[`CvTheme${theme}ColorsOnSurface38`],
+      'editor.lineHighlightBackground':
+        tokens[`CvTheme${theme}ColorsSurfaceContainerLow`],
+      'inputValidation.errorBackground': tokens[`Cv${theme}Negative`],
+      'inputValidation.errorBorder': 'rgba(229, 115, 115, 0.1)',
+    },
+  };
+};
+
+// Any changes to these themes should also be reflected in the components/code-editor theme.
+export const cvEditorDarkTheme = getTheme('Dark');
+
+export const cvEditorLightTheme = getTheme('Light');

--- a/libs/components/src/code-editor/code-editor.theme.ts
+++ b/libs/components/src/code-editor/code-editor.theme.ts
@@ -187,7 +187,8 @@ const getTheme = (theme: 'Light' | 'Dark') => {
       'editor.lineHighlightBackground':
         tokens[`CvTheme${theme}ColorsSurfaceContainerLow`],
       'inputValidation.errorBackground': tokens[`Cv${theme}Negative`],
-      'inputValidation.errorBorder': 'rgba(229, 115, 115, 0.1)',
+      'inputValidation.errorBorder':
+        tokens[`CvTheme${theme}PalettesNegative95`],
     },
   };
 };

--- a/libs/components/src/code-editor/code-editor.theme.ts
+++ b/libs/components/src/code-editor/code-editor.theme.ts
@@ -192,6 +192,7 @@ const getTheme = (theme: 'Light' | 'Dark') => {
   };
 };
 
+// Any changes to these themes should also be reflected in the angular-code-editor theme.
 export const cvEditorDarkTheme = getTheme('Dark');
 
 export const cvEditorLightTheme = getTheme('Light');

--- a/libs/components/src/code-editor/code-editor.ts
+++ b/libs/components/src/code-editor/code-editor.ts
@@ -92,20 +92,16 @@ export class CovalentCodeEditor extends LitElement {
 
   createEditor(container: HTMLElement) {
     // uses covalent light colors
-    editor.defineTheme('cv-light', {
-      base: 'vs',
-      inherit: true,
-      rules: cvEditorLightTheme.rules,
-      colors: cvEditorLightTheme.colors,
-    });
+    editor.defineTheme(
+      'cv-light',
+      cvEditorLightTheme as editor.IStandaloneThemeData
+    );
 
     // uses covalent dark colors
-    editor.defineTheme('cv-dark', {
-      base: 'vs-dark',
-      inherit: true,
-      rules: cvEditorDarkTheme.rules,
-      colors: cvEditorDarkTheme.colors,
-    });
+    editor.defineTheme(
+      'cv-dark',
+      cvEditorDarkTheme as editor.IStandaloneThemeData
+    );
 
     this.editor = editor.create(container, {
       ...this.options,


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
Add covalent themes to angular code editor

### What's included?

<!-- List features included in this PR -->

- Add `cv-light` and `cv-dark` themes to angular-code-editor component

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npx nx run docs-app:serve`
- [ ] Navigate to Components -> Examples -> Code Editor with Monaco
- [ ] Change the theme to `Covalent Light` or `Covalent Dark`

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1020" alt="Screenshot 2024-09-06 at 10 24 26 AM" src="https://github.com/user-attachments/assets/99c6f1d1-b6cd-4d67-ba16-dd3d6fec5b06">
<img width="1020" alt="Screenshot 2024-09-06 at 10 24 41 AM" src="https://github.com/user-attachments/assets/986692db-5a6d-414b-b383-3dc074ce40cd">
