### PR TITLE
fix(code-editor): add disable scroll option for code editor

### DIFF
--- a/libs/components/src/code-editor/code-editor.stories.js
+++ b/libs/components/src/code-editor/code-editor.stories.js
@@ -26,13 +26,16 @@ export default {
     theme: 'cv-light',
     code: sqlContent,
     language: 'sql',
+    disableScroll: false,
   },
 };
 
-const Template = ({ theme, language, code }) => {
+const Template = ({ theme, language, code, disableScroll }) => {
   return `
   <div style="width: 800px; height: 100%">
-    <cv-code-editor language="${language}" theme="${theme}" code="${code}">
+    <cv-code-editor language="${language}" theme="${theme}" code="${code}" ${
+    disableScroll ? 'disableScroll' : ''
+  }>
     </cv-code-editor>
   </div>
    `;

--- a/libs/components/src/code-editor/code-editor.ts
+++ b/libs/components/src/code-editor/code-editor.ts
@@ -42,6 +42,10 @@ export class CovalentCodeEditor extends LitElement {
    */
   @property() code?: string;
   /**
+   * Disable scroll bar and set the editor height based on content
+   */
+  @property({ type: Boolean, reflect: true }) disableScroll?: boolean = false;
+  /**
    * Options that can be set for the editor
    */
   @property({ type: Object }) options?: editor.IEditorOptions &
@@ -155,10 +159,12 @@ export class CovalentCodeEditor extends LitElement {
         );
       });
 
-      // Adjust the height of the editor when content changes, to avoid vertical scroll bar
-      this.editor?.onDidContentSizeChange(() => {
-        this.adjustHeight();
-      });
+      if (this.disableScroll) {
+        // Adjust the height of the editor when content changes, to avoid vertical scroll bar
+        this.editor?.onDidContentSizeChange(() => {
+          this.adjustHeight();
+        });
+      }
 
       this.adjustHeight();
 

--- a/libs/components/src/notebook-cell/notebook-cell.ts
+++ b/libs/components/src/notebook-cell/notebook-cell.ts
@@ -227,6 +227,7 @@ export class CovalentNotebookCell extends LitElement {
           .language="${this.language}"
           .options="${this.editorOptions}"
           .theme="${this.editorTheme}"
+          disableScroll
         ></cv-code-editor>`
       : html`<cv-code-snippet hideHeader .language="${this.language}"
           >${this.code}</cv-code-snippet


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
Add a property to disable scroll in the code editor. The editor height will be dynamically set based on the content when this property is set to true.

### What's included?

<!-- List features included in this PR -->

- Add `disableScroll` boolean property in code-editor web component

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run storybook`
- [ ] then set disableScroll to true in code-editor
- [ ] Add content to the editor and verify if the editor height is adjusted.

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![code-editor](https://github.com/user-attachments/assets/c7f02399-a882-4a06-b505-bd751ad5d37e)
