### PR TITLE
feat(user-menu): fixed styles for user menu profile

### DIFF
--- a/apps/docs-app/src/app/content/components/component-demos/user-profile/demos/user-profile-demo-basic/user-profile-demo-basic.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/user-profile/demos/user-profile-demo-basic/user-profile-demo-basic.component.html
@@ -3,8 +3,7 @@
 <td-user-profile name="donald duck" email="donald.duck@teradata.com">
   <ng-container td-user-action-list>
     <button mat-list-item>
-      <span matListItemAvatar></span>
-      <span matListItemLine>Sign out</span>
+      <span matListItemTitle>Sign out</span>
     </button>
   </ng-container>
 </td-user-profile>

--- a/apps/docs-app/src/app/content/components/component-demos/user-profile/demos/user-profile-demo-basic/user-profile-demo-basic.component.scss
+++ b/apps/docs-app/src/app/content/components/component-demos/user-profile/demos/user-profile-demo-basic/user-profile-demo-basic.component.scss
@@ -1,0 +1,4 @@
+:host {
+  display: flex;
+  align-items: center;
+}

--- a/apps/docs-app/src/app/content/components/component-demos/user-profile/demos/user-profile-demo-basic/user-profile-demo-basic.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/user-profile/demos/user-profile-demo-basic/user-profile-demo-basic.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'user-profile-demo-basic',
+  styleUrls: ['./user-profile-demo-basic.component.scss'],
   templateUrl: './user-profile-demo-basic.component.html',
 })
 export class UserProfileDemoBasicComponent {}

--- a/apps/docs-app/src/app/content/components/component-demos/user-profile/demos/user-profile-demo-list-items/user-profile-demo-list-items.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/user-profile/demos/user-profile-demo-list-items/user-profile-demo-list-items.component.html
@@ -4,19 +4,18 @@
   <ng-container td-user-info-list>
     <mat-list-item>
       <mat-icon matListItemAvatar>account_balance</mat-icon>
-      <span matListItemLine>default</span>
+      <span matListItemTitle>default</span>
       <span matListItemLine>organization</span>
     </mat-list-item>
   </ng-container>
   <ng-container td-user-action-list>
     <button mat-list-item>
-      <mat-icon matListItemAvatar>brightness_low</mat-icon>
-      <span matListItemLine>Switch to dark mode</span>
+      <mat-icon matListItemAvatar matListItemIcon>brightness_low</mat-icon>
+      <span matListItemTitle>Switch to dark mode</span>
     </button>
     <mat-divider></mat-divider>
     <button mat-list-item>
-      <span matListItemAvatar></span>
-      <span matListItemLine>Sign out</span>
+      <span matListItemTitle>Sign out</span>
     </button>
   </ng-container>
 </td-user-profile>

--- a/apps/docs-app/src/app/content/components/component-demos/user-profile/demos/user-profile-demo-list-items/user-profile-demo-list-items.component.scss
+++ b/apps/docs-app/src/app/content/components/component-demos/user-profile/demos/user-profile-demo-list-items/user-profile-demo-list-items.component.scss
@@ -1,0 +1,4 @@
+:host {
+  display: flex;
+  align-items: center;
+}

--- a/apps/docs-app/src/app/content/components/component-demos/user-profile/demos/user-profile-demo-list-items/user-profile-demo-list-items.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/user-profile/demos/user-profile-demo-list-items/user-profile-demo-list-items.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'user-profile-demo-list-items',
+  styleUrls: ['./user-profile-demo-list-items.component.scss'],
   templateUrl: './user-profile-demo-list-items.component.html',
 })
 export class UserProfileDemoListItemsComponent {}

--- a/libs/angular/common/_common-theme.scss
+++ b/libs/angular/common/_common-theme.scss
@@ -6,6 +6,7 @@
   $background: map-get($theme, background);
 
   mat-list-item,
+  [mat-list-item],
   .mat-list-item-content {
     mat-icon {
       color: mat-color($foreground, icon);

--- a/libs/angular/menu/src/menu.component.html
+++ b/libs/angular/menu/src/menu.component.html
@@ -3,5 +3,4 @@
 <div class="td-menu-content">
   <ng-content></ng-content>
 </div>
-<mat-divider></mat-divider>
 <ng-content select="[td-menu-footer]"></ng-content>

--- a/libs/angular/menu/src/menu.component.scss
+++ b/libs/angular/menu/src/menu.component.scss
@@ -11,11 +11,6 @@ $td-menu-spacing: 8px !default;
 }
 
 :host ::ng-deep {
-  [td-menu-header] {
-    padding: $td-menu-spacing;
-    text-align: center;
-  }
-
   mat-list,
   mat-list[dense],
   mat-nav-list,

--- a/libs/angular/theming/_teradata-theme.scss
+++ b/libs/angular/theming/_teradata-theme.scss
@@ -424,6 +424,10 @@ $td-dark-theme: mat.private-deep-merge-all(
         $background,
         disabled-button
       )};
+    --mdc-list-list-item-leading-icon-color: #{mat-color($foreground, icon)};
+    --mdc-list-list-item-hover-leading-icon-color: var(
+      --mdc-list-list-item-leading-icon-color
+    );
 
     @include css-variable-theme-tokens($td-light-colors);
   }

--- a/libs/angular/user-profile/README.md
+++ b/libs/angular/user-profile/README.md
@@ -32,8 +32,7 @@ export class MyModule {}
 Basic Example:
 
 ```html
-<td-user-profile name="daffy duck" email="daffy.duck@teradata.com">
-</td-user-profile>
+<td-user-profile name="daffy duck" email="daffy.duck@teradata.com"> </td-user-profile>
 ```
 
 Example with all inputs and projected content:
@@ -46,14 +45,13 @@ Example with all inputs and projected content:
   <ng-container td-user-info-list>
     <mat-list-item>
       <mat-icon matListItemAvatar>account_balance</mat-icon>
-      <span matListItemLine>default</span>
+      <span matListItemTitle>default</span>
       <span matListItemLine>organization</span>
     </mat-list-item>
   </ng-container>
   <ng-container td-user-action-list>
     <button mat-list-item>
-      <span matListItemAvatar></span>
-      <span matListItemLine>Sign out</span>
+      <span matListItemTitle>Sign out</span>
     </button>
   </ng-container>
 </td-user-profile>

--- a/libs/angular/user-profile/src/user-profile-menu/user-profile-menu.component.html
+++ b/libs/angular/user-profile/src/user-profile-menu/user-profile-menu.component.html
@@ -3,7 +3,7 @@
   <mat-list td-menu-header>
     <mat-list-item *ngIf="name || email" (click)="_blockEvent($event)">
       <mat-icon matListItemAvatar>person</mat-icon>
-      <span matListItemLine *ngIf="name" class="mat-body-1">{{ name }}</span>
+      <span matListItemTitle *ngIf="name">{{ name }}</span>
       <span matListItemLine *ngIf="email">{{ email }}</span>
     </mat-list-item>
     <ng-content select="[td-user-info-list]"></ng-content>

--- a/libs/angular/user-profile/src/user-profile-menu/user-profile-menu.component.scss
+++ b/libs/angular/user-profile/src/user-profile-menu/user-profile-menu.component.scss
@@ -1,7 +1,7 @@
 ::ng-deep .mat-mdc-list-item-avatar.mdc-list-item__start {
   line-height: 40px;
   text-align: center;
-  margin: 0 16px 0 16px;
+  margin: 0 16px;
 }
 
 ::ng-deep

--- a/libs/angular/user-profile/src/user-profile-menu/user-profile-menu.component.scss
+++ b/libs/angular/user-profile/src/user-profile-menu/user-profile-menu.component.scss
@@ -1,41 +1,11 @@
-.user-profile-menu {
-  [td-menu-header] {
-    text-align: left;
-    padding-bottom: 0;
-  }
+::ng-deep .mat-mdc-list-item-avatar.mdc-list-item__start {
+  line-height: 40px;
+  text-align: center;
+  margin: 0 16px 0 16px;
 }
 
-::ng-deep mat-list-item:not(:first-child),
-::ng-deep [mat-list-item] {
-  .mat-list-item-content .mat-icon[matListItemAvatar] {
-    background: none;
-  }
-}
-
-.mat-action-list {
-  padding-top: 0;
-}
-
-:host ::ng-deep {
-  .mat-action-list .mat-divider,
-  .mat-divider {
-    margin: 8px 0;
-  }
-
-  // TODO remove all styles below when bug gets addressed in td-menu in Covalent
-  mat-divider:last-child {
-    display: none;
-  }
-
-  mat-list .mat-list-item.mat-2-line .mat-list-item-content {
-    height: inherit;
-  }
-
-  mat-list .mat-list-item .mat-list-item-content {
-    padding: 8px;
-  }
-}
-
-td-menu {
-  margin-bottom: 0;
+::ng-deep
+  .mat-mdc-action-list
+  .mdc-list-item:not(.mdc-list-item--with-leading-avatar) {
+  padding-left: 72px;
 }

--- a/libs/markdown-flavored/_flavored-markdown-theme.scss
+++ b/libs/markdown-flavored/_flavored-markdown-theme.scss
@@ -7,8 +7,8 @@
 
   td-flavored-markdown {
     :not(pre) > code {
-      background: #1e1e21;
-      color: mat-color($mat-grey, 50);
+      background: map-get($background, app-bar);
+      color: mat-color($foreground, secondary-text);
     }
 
     .mat-checkbox-disabled {


### PR DESCRIPTION
## Description

Style adjustments for the user menu profile component

### What's included?
- Reduced all previous styles no longer needed since angular material update
- Updated angular demo for user profile component

#### Test Steps

- [ ] `npm run start`
- [ ] then go to Componets -> User profile
- [ ] finally test the examples

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.



##### Before
![Screenshot 2024-10-14 at 6 17 43 PM](https://github.com/user-attachments/assets/24dc1373-af49-419d-8581-edaa4198b98d)

##### Fixed
![Screenshot 2024-10-14 at 6 13 15 PM](https://github.com/user-attachments/assets/79786fc5-6f60-48ee-b09b-dfb096616d0d)
![Screenshot 2024-10-14 at 6 13 29 PM](https://github.com/user-attachments/assets/c8f13f55-5ae1-4d02-a30f-072f9782248a)
