### PR TITLE
fix(deps): correct version of @angular/cdk (14.2.7 instead of 14.2.12)

### DIFF
--- a/libs/angular-highlight/package.json
+++ b/libs/angular-highlight/package.json
@@ -23,7 +23,7 @@
     "@angular/common": "0.0.0-NG",
     "@angular/core": "0.0.0-NG",
     "@angular/platform-browser": "0.0.0-NG",
-    "@angular/cdk": "0.0.0-NG",
+    "@angular/cdk": "0.0.0-MATERIAL",
     "@angular/material": "0.0.0-MATERIAL"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

Fix minor issue with @covalent/highlight version 5.0.2 and its dependency on @angular/cdk.

In this case "0.0.0-NG" is converted to 14.2.12, but that version doesn't exist for @angular/cdk.  It should be using 0.0.0-MATERIAL which translates to the expected version 14.2.7.

Making this change will allow us to remove an override in our package.json:
```
"overrides": {
    "@covalent/highlight": {
      "@angular/cdk": "14.2.7"
    }
}
```

I think this same change should also be made to the main branch.


#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
