### PR TITLE
feat(icon-lockup): add icon lockup component

### DIFF
--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -136,6 +136,11 @@
       "import": "./icon-checkbox.mjs",
       "require": "./icon-checkbox.js"
     },
+    "./icon-lockup": {
+      "types": "./icon-lockup/icon-lockup.d.ts",
+      "import": "./icon-lockup.mjs",
+      "require": "./icon-lockup.js"
+    },
     "./icon-radio-toggle": {
       "types": "./icon-radio-toggle/icon-radio-toggle.d.ts",
       "import": "./icon-radio-toggle.mjs",

--- a/libs/components/src/icon-lockup/icon-lockup.scss
+++ b/libs/components/src/icon-lockup/icon-lockup.scss
@@ -1,0 +1,47 @@
+.filled {
+  font-variation-settings: 'FILL' 1;
+}
+
+.hidden {
+  display: none;
+}
+
+.icon-lockup {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+  max-width: 100%;
+
+  cv-typography {
+    flex: 1 0 0;
+  }
+}
+
+.icon-lockup--primary,
+.icon-lockup--loading {
+  color: var(--cv-theme-primary);
+}
+
+.icon-lockup--positive {
+  color: var(--cv-theme-positive);
+}
+
+.icon-lockup--negative {
+  color: var(--cv-theme-negative);
+}
+
+.icon-lockup--caution {
+  color: var(--cv-theme-caution);
+}
+
+.text {
+  font-feature-settings: 'liga' off, 'clig' off;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trailing-icon {
+  flex-direction: row-reverse;
+}

--- a/libs/components/src/icon-lockup/icon-lockup.spec.ts
+++ b/libs/components/src/icon-lockup/icon-lockup.spec.ts
@@ -1,0 +1,11 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { it, describe, expect } from 'vitest';
+import { CovalentIconLockup } from './icon-lockup';
+
+describe('Icon lockup', () => {
+  it('should work', () => {
+    expect(new CovalentIconLockup()).toBeDefined();
+  });
+});

--- a/libs/components/src/icon-lockup/icon-lockup.stories.js
+++ b/libs/components/src/icon-lockup/icon-lockup.stories.js
@@ -1,0 +1,93 @@
+import './icon-lockup';
+import '../circular-progress/circular-progress';
+
+export default {
+  title: 'Components/Icon lockup',
+  argTypes: {
+    scale: {
+      options: [
+        'headline1',
+        'headline2',
+        'headline3',
+        'headline4',
+        'headline5',
+        'headline6',
+        'subtitle1',
+        'subtitle2',
+        'button',
+        'caption',
+        'overline',
+        'body1',
+        'body2',
+      ],
+      control: { type: 'select' },
+    },
+    state: {
+      options: ['primary', 'positive', 'negative', 'caution', null],
+      control: { type: 'select' },
+    },
+  },
+  args: {
+    covalentIcon: false,
+    filledIcon: false,
+    icon: 'houseboat',
+    scale: 'body1',
+    state: 'null',
+    trailingIcon: false,
+  },
+};
+
+const Template = ({
+  icon,
+  scale,
+  trailingIcon,
+  state,
+  covalentIcon,
+  filledIcon,
+}) => {
+  return `<cv-icon-lockup icon="${icon}" scale="${scale}"${
+    trailingIcon ? ' trailingIcon' : ''
+  }${covalentIcon ? ' covalentIcon' : ''}${filledIcon ? ' filledIcon' : ''}${
+    state ? ` state=${state}` : ''
+  }>Lorem ipsum dolor sit amet</cv-icon-lockup>`;
+};
+
+const LoadingTemplate = ({ scale, trailingIcon, state }) => {
+  return `<cv-icon-lockup scale="${scale}"${
+    trailingIcon ? ' trailingIcon' : ''
+  }${state ? ` state=${state}` : ''}>Lorem ipsum dolor sit amet
+    <cv-circular-progress indeterminate slot="icon" density="-6"></cv-circular-progress>
+  </cv-icon-lockup>`;
+};
+
+export const Basic = Template.bind({});
+
+export const Primary = Template.bind({});
+Primary.args = {
+  state: 'primary',
+};
+
+export const Positive = Template.bind({});
+Positive.args = {
+  state: 'positive',
+  icon: 'check',
+};
+
+export const Negative = Template.bind({});
+Negative.args = {
+  state: 'negative',
+  icon: 'error',
+  filledIcon: true,
+};
+
+export const Caution = Template.bind({});
+Caution.args = {
+  state: 'caution',
+  icon: 'warning',
+  filledIcon: true,
+};
+
+export const Loading = LoadingTemplate.bind({});
+Loading.args = {
+  state: 'primary',
+};

--- a/libs/components/src/icon-lockup/icon-lockup.ts
+++ b/libs/components/src/icon-lockup/icon-lockup.ts
@@ -1,0 +1,125 @@
+import { LitElement, html, css, unsafeCSS, PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import styles from './icon-lockup.scss?inline';
+import '../typography/typography';
+import '../icon/icon';
+
+/**
+ * Icon lockup
+ *
+ * @slot icon - Slot for a custom icon. If provided, this slot content replaces the `icon` property.
+ */
+@customElement('cv-icon-lockup')
+export class CovalentIconLockup extends LitElement {
+  static override styles = [
+    css`
+      ${unsafeCSS(styles)}
+    `,
+  ];
+
+  /**
+   * Whether the icon is a covalent icon.
+   */
+  @property({ type: Boolean, reflect: true })
+  covalentIcon = false;
+
+  /**
+   * Whether the icon is filled.
+   */
+  @property({ type: Boolean, reflect: true })
+  filledIcon = false;
+
+  /**
+   * The icon to display.
+   */
+  @property({ type: String })
+  icon = '';
+
+  /**
+   * Scale of the component, controlling font-size and icon size.
+   * Default is "1", but it can be set to other values to scale the component.
+   */
+  @property({ type: String })
+  scale = 'body1';
+
+  /**
+   * State of the component, used to apply different styles based on status.
+   * Example values might include "success", "error", etc.
+   */
+  @property({ type: String })
+  state = 'neutral';
+
+  /**
+   * If true, the icon is displayed after the text (trailing).
+   * If false, the icon is displayed before the text.
+   */
+  @property({ type: Boolean })
+  trailingIcon = false;
+
+  /**
+   * Tracks if the icon slot has content.
+   */
+  @state() private _hasIconSlot = false;
+
+  /**
+   * Checks if there is content in the icon slot and updates `hasIconSlot`.
+   */
+  private checkIconSlot() {
+    const slot = this.shadowRoot?.querySelector(
+      'slot[name="icon"]'
+    ) as HTMLSlotElement;
+    this._hasIconSlot = slot && slot.assignedNodes().length > 0;
+  }
+
+  /**
+   * Template method for rendering the icon. If content is provided in the
+   * `icon` slot, it is displayed instead of the `icon` property.
+   */
+  private iconTemplate() {
+    const classes = {
+      'covalent-icon': this.covalentIcon,
+      filled: this.filledIcon,
+      hidden: this._hasIconSlot,
+    };
+    return html`<slot name="icon"></slot>
+      <cv-icon
+        class=${classMap(classes)}
+        style="${`font-size: var(--cv-typography-${this.scale}-line-height, 16px)`}"
+      >
+        ${this.icon}
+      </cv-icon>`;
+  }
+
+  /**
+   * Renders the component with icon and text. If `trailingIcon` is true,
+   * the icon is displayed after the text. Otherwise, it is displayed before.
+   */
+  render() {
+    const classes = {
+      'icon-lockup': true,
+      [`icon-lockup--${this.state}`]: this.state,
+      'trailing-icon': this.trailingIcon,
+    };
+
+    return html`
+      <cv-typography class=${classMap(classes)} scale="${this.scale}">
+        ${this.iconTemplate()}
+        <div class="text"><slot></slot></div>
+      </cv-typography>
+    `;
+  }
+
+  protected override updated(_changedProperties: PropertyValues): void {
+    super.updated(_changedProperties);
+    this.checkIconSlot();
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cv-icon-lockup': CovalentIconLockup;
+  }
+}
+
+export default CovalentIconLockup;

--- a/libs/components/src/index.ts
+++ b/libs/components/src/index.ts
@@ -22,6 +22,7 @@ export * from './icon/icon';
 export * from './icon-button/icon-button';
 export * from './icon-button-toggle/icon-button-toggle';
 export * from './icon-checkbox/icon-check-toggle';
+export * from './icon-lockup/icon-lockup';
 export * from './icon-radio/icon-radio-toggle';
 export * from './linear-progress/linear-progress';
 export * from './list/check-list-item';

--- a/libs/components/vite.config.js
+++ b/libs/components/vite.config.js
@@ -34,6 +34,7 @@ module.exports = defineConfig(({ mode }) => {
           'libs/components/src/icon-button/icon-button',
           'libs/components/src/icon-button-toggle/icon-button-toggle',
           'libs/components/src/icon-checkbox/icon-check-toggle',
+          'libs/components/src/icon-lockup/icon-lockup',
           'libs/components/src/icon-radio/icon-radio-toggle',
           'libs/components/src/linear-progress/linear-progress',
           'libs/components/src/list/check-list-item',


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
Add `cv-icon-lockup` component to the library. It displays text and icon side by side.

Design spec: [Figma](https://www.figma.com/design/KvXVAmYdCVAS7hzkOa73Em/Covalent-Principles?node-id=8401-43059&node-type=instance&m=dev)

### What's included?

<!-- List features included in this PR -->

`cv-icon-lockup` component with the below properties:
  - **covalentIcon**: (Boolean) - Determines whether the icon is a Covalent icon. Default is false.
  - **filledIcon**: (Boolean) - Indicates if the icon is filled. Default is false.
  - **icon**: (String) - Specifies the icon to display. Default is an empty string ''.
  - **scale**: (String) - Controls the scale of the component, affecting font-size and icon size. The default is "body1", but other values can be used to scale the component.
  - **state**: (String) - Defines the state of the component, allowing for different styles based on status. Can be one of 'primary' | 'positive' | 'negative' | 'caution' | null.  
  - **trailingIcon**: (Boolean) - When true, the icon is displayed after the text (trailing); when false, it is displayed before the text. Default is false.

**Slots**
- Default slot: For the text content.
- icon: For custom icons if needed. Ex: loading states.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run storybook`
- [ ] then navigate to Icon lockup
- [ ] Verify the component works as desired

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![icon-lockup](https://github.com/user-attachments/assets/06c23624-dc1a-49a1-bb7b-3f7e6df6887d)
