### PR TITLE
fix(docs): fix theming docs for angular components

### DIFF
--- a/apps/docs-app/src/app/content/docs/angular-material/angular-material.component.html
+++ b/apps/docs-app/src/app/content/docs/angular-material/angular-material.component.html
@@ -31,11 +31,14 @@
     mat-button
     color="accent"
     target="_blank"
-    href="https://material.angular.io/components"
+    href="https://v17.material.angular.io/components/categories"
   >
     Components
   </a>
-  <a mat-button target="_blank" href="https://github.com/angular/material2"
+  <a
+    mat-button
+    target="_blank"
+    href="https://github.com/angular/components/releases/tag/17.3.6"
     >Github repo</a
   >
 </section>
@@ -52,18 +55,9 @@
       <span matListItemLine>Why Angular Material?</span>
     </a>
     <mat-divider></mat-divider>
-    <a mat-list-item href="https://material.angular.io/" target="_blank">
+    <a mat-list-item href="https://v17.material.angular.io/" target="_blank">
       <mat-icon matListItemIcon>launch</mat-icon>
       <span matListItemLine>Angular Material Docs Site</span>
-    </a>
-    <mat-divider></mat-divider>
-    <a
-      mat-list-item
-      href="https://github.com/angular/material2#available-features"
-      target="_blank"
-    >
-      <mat-icon matListItemIcon>launch</mat-icon>
-      <span matListItemLine>Angular Material Feature Status</span>
     </a>
   </mat-nav-list>
 </mat-card>

--- a/apps/docs-app/src/app/content/docs/theme/theme.component.html
+++ b/apps/docs-app/src/app/content/docs/theme/theme.component.html
@@ -16,7 +16,9 @@
   </td-highlight>
   <p>
     Color palettes and hues follow the official
-    <a href="https://material.google.com/style/color.html" target="_blank"
+    <a
+      href="https://m2.material.io/design/color/the-color-system.html"
+      target="_blank"
       >Material Design Spec</a
     >
     .
@@ -26,7 +28,7 @@
     mat-button
     color="accent"
     target="_blank"
-    href="https://material.angular.io/guide/theming"
+    href="https://v17.material.angular.io/guide/theming"
   >
     Theming docs
   </a>

--- a/apps/docs-app/src/app/content/docs/theme/theme.component.ts
+++ b/apps/docs-app/src/app/content/docs/theme/theme.component.ts
@@ -13,38 +13,55 @@ export class ThemeComponent {
   @HostBinding('class.td-route-animation') classAnimation = true;
   themeScss = `
   @use '@angular/material' as mat;
-  @use '@covalent/core/theming/all-theme' as cov;
+
+  // (optional) Additional themes
   @use '@covalent/markdown/markdown-theme' as markdown;
   @use '@covalent/highlight/highlight-theme' as highlight;
+  @import '@covalent/flavored-markdown/flavored-markdown-theme';
+
+  // Covalent core themes
+  @import '@covalent/core/theming/all-theme';
+  @import '@covalent/core/theming/teradata-theme';
+
   // Plus imports for other components in your app.
-  
+
+  @include mat.core();
+
   // Define a custom typography config that overrides the font-family
   // or any typography level.
   $typography: mat.define-typography-config(
     $font-family: 'Inter, monospace',
-    $headline: mat.define-typography-level(32px, 48px, 700)
+    $headline-1: mat.define-typography-level(32px, 48px, 700),
   );
-  
-  @include mat.core($typography); // $typography is an **optional** argument for the mat-core
-  
+
   // Define the palettes for your theme using the Material Design palettes available in palette.scss
   // (imported above). For each palette, you can optionally specify a default, lighter, and darker
   // hue.
   $primary: mat.define-palette($mat-blue, 700);
-  $accent:  mat.define-palette($mat-orange, 800, A100, A400);
-  
+  $accent: mat.define-palette($mat-orange, 800, A100, A400);
+
   // The warn palette is optional (defaults to red).
-  $warn:    mat.define-palette($mat-red, 600);
-  
+  $warn: mat.define-palette($mat-red, 600);
+
   // Create the theme object (a Sass map containing all of the palettes).
-  $theme: mat.define-light-theme($primary, $accent, $warn);
-  
+  $theme: mat.define-light-theme(
+    (
+      color: (
+        primary: $primary,
+        accent: $accent,
+        warn: $warn,
+      ),
+      typography: $typography,
+    )
+  );
+
+  // Include the Angular Material styles using the custom theme
+  @include mat.all-component-themes($theme);
+
   // Include theme styles for core and each component used in your app.
-  // Alternatively, you can import and @include the theme mixins for each component
-  // that you are using.
-  mat.angular-material-theme($theme);
-  cov.covalent-theme($theme, $typography); // $typography is an **optional** argument for the covalent-theme
-  markdown.covalent-markdown-theme($theme);
-  highlight.covalent-highlight-theme();
+  @include covalent-theme($theme);
+  @include markdown.covalent-markdown-theme($theme);
+  @include covalent-flavored-markdown-theme($theme);
+  @include highlight.covalent-highlight-theme($theme);
   `;
 }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,12 +2,12 @@
 
 Get started with Covalent using the Angular CLI.
 
-See the [material getting started](https://github.com/angular/material2/blob/master/guides/getting-started.md) for instructions.
+See the [material getting started](https://v17.material.angular.io/guide/getting-started) for instructions.
 
 ## Install the CLI
 
 ```bash
-npm install -g @angular/cli@latest
+npm install -g @angular/cli@17.3.6
 ```
 
 ## Create a new project
@@ -21,9 +21,9 @@ The new command creates a project with a build system for your Angular app.
 ## Install Covalent Core module
 
 ```bash
-npm install --save @covalent/core
+npm install --save @covalent/core @covalent/tokens
 ## (optional) Additional Covalent Modules installs
-npm install --save @covalent/highlight @covalent/markdown @covalent/dynamic-forms @covalent/echarts
+npm install --save @covalent/highlight @covalent/markdown @covalent/flavored-markdown @covalent/dynamic-forms @covalent/echarts
 ```
 
 To test (**only for testing!**) the latest changes from develop, install the nightly build:
@@ -35,7 +35,7 @@ npm install --save https://github.com/Teradata/covalent-echarts-nightly.git
 
 ## Import the Covalent Core NgModule
 
-**src/app/app.module.ts**
+**In a module: src/app/app.module.ts**
 
 ```ts
 import { CovalentLayoutModule } from '@covalent/core/layout';
@@ -44,6 +44,7 @@ import { CovalentStepsModule  } from '@covalent/core/steps';
 // (optional) Additional Covalent Modules imports
 import { CovalentHighlightModule } from '@covalent/highlight';
 import { CovalentMarkdownModule } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
 import { CovalentDynamicFormsModule } from '@covalent/dynamic-forms';
 import { CovalentBaseEchartsModule } from '@covalent/echarts/base';
 // other imports
@@ -54,6 +55,7 @@ import { CovalentBaseEchartsModule } from '@covalent/echarts/base';
     // (optional) Additional Covalent Modules imports
     CovalentHighlightModule,
     CovalentMarkdownModule,
+    CovalentFlavoredMarkdownModule,
     CovalentDynamicFormsModule,
     CovalentBaseEchartsModule,
   ],
@@ -62,53 +64,86 @@ import { CovalentBaseEchartsModule } from '@covalent/echarts/base';
 export class AppModule { }
 ```
 
+**In a standalone component: src/app/app.component.ts**
+
+```ts
+import { Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+// Import any core or optional modules
+import { CovalentMarkdownModule } from '@covalent/markdown';
+import { CovalentFlavoredMarkdownModule } from '@covalent/flavored-markdown';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [
+    RouterOutlet,
+    // Add them to imports
+    CovalentMarkdownModule,
+    CovalentFlavoredMarkdownModule,
+  ],
+  templateUrl: './app.component.html',
+  styleUrl: './app.component.scss',
+})
+export class AppComponent {
+  title = 'Covalent';
+}
+```
+
 ## Include the core, theme and typography:
 
 This is **required** to apply all of the core, theme and typography styles to your application.
 
-See the [material theming guide](https://github.com/angular/material2/blob/master/guides/theming.md) and the [material typography guide](https://github.com/angular/material2/blob/master/guides/typography.md) for instructions.
+See the [material theming guide](https://v17.material.angular.io/guide/theming) and the [material typography guide](https://v17.material.angular.io/guide/typography) for instructions.
 
 A theme file is a simple Sass file that defines your palettes and passes them to mixins that output the corresponding styles. A typical theme file will look something like this:
 
 ```scss
 @use '@angular/material' as mat;
-@use '@covalent/core/theming/all-theme' as cov;
 
 // (optional) Additional themes
 @use '@covalent/markdown/markdown-theme' as markdown;
 @use '@covalent/highlight/highlight-theme' as highlight;
+@import '@covalent/flavored-markdown/flavored-markdown-theme';
+
+// Covalent core themes
+@import '@covalent/core/theming/all-theme';
+@import '@covalent/core/theming/teradata-theme';
+
+@include mat.core();
 
 // Define a custom typography config that overrides the font-family
 // or any typography level.
 $typography: mat.define-typography-config(
   $font-family: 'Inter, monospace',
-  $headline: mat.define-typography-level(32px, 48px, 700)
+  $headline-1: mat.define-typography-level(32px, 48px, 700),
 );
 
-mat.core(
-  $typography
-); // $typography is an **optional** argument for the mat-core
+$primary: mat.define-palette($mat-blue, 700);
+$accent: mat.define-palette($mat-orange, 800, A100, A400);
+$warn: mat.define-palette($mat-red, 600);
 
-$primary: mat.define-palette($mat-orange, 800, 100, 900);
-$accent: mat.define-palette($mat-light-blue, 600, 100, 900);
-$warn: mat.define-palette($mat-red, 600, 100, 900);
+$theme: mat.define-light-theme(
+  (
+    color: (
+      primary: $primary,
+      accent: $accent,
+      warn: $warn,
+    ),
+    typography: $typography,
+  )
+);
 
-$theme: mat.define-light-theme($primary, $accent, $warn);
+// Include the Angular Material styles using the custom theme
+@include mat.all-component-themes($theme);
 
-mat.angular-material-theme($theme);
-cov.covalent-theme(
-  $theme,
-  $typography
-); // $typography is an **optional** argument for the covalent-theme
+@include covalent-theme($theme);
 
 // (optional) Additional themes
-markdown.covalent-markdown-theme($theme);
-highligh.covalent-highlight-theme();
+@include markdown.covalent-markdown-theme($theme);
+@include covalent-flavored-markdown-theme($theme);
+@include highlight.covalent-highlight-theme($theme);
 ```
-
-You only need this single Sass file; you do not need to use Sass to style the rest of your app.
-
-If you are using the Angular CLI, support for compiling Sass to css is built-in but you have to add a new entry to the "styles" list in .angular-cli.json pointing to the theme file and the platform.css as follows:
 
 ## Covalent Utility Classes
 
@@ -116,21 +151,17 @@ This is an **optional** set of CSS classes that will help to speed up developmen
 
 ### Add via platform.css
 
-The covalent utility CSS classes can be included via `platform.css` file either in your `index.html` or as a new entry to the "styles" list in .angular-cli.json
-
-**src/index.html**
-
-```html
-<link href="../node_modules/@covalent/core/common/platform.css" rel="stylesheet" />
-```
-
-or
+The covalent utility CSS classes can be included via `platform.css` file as a new entry to the "styles" list in .angular-cli.json
 
 **.angular-cli.json**
 
 ```json
 "styles": [
-  "../node_modules/@covalent/core/common/platform.scss"
+  {
+    "input": "node_modules/@covalent/core/common/platform.css",
+    "bundleName": "covalent-styles",
+    "inject": true
+  }
 ],
 ```
 
@@ -138,6 +169,6 @@ This also includes the `material icons` by default.
 
 #### Not interested in using ALL the CSS?
 
-Click [here](https://teradata.github.io/covalent/#/docs/theming/utility-sass-mixins) if you want to cherry pick the utility classes instead of loading the `platform.css`
+Click [here](https://teradata.github.io/covalent/v8/#/docs/theming/sass-mixins) if you want to cherry pick the utility classes instead of loading the `platform.css`
 
 ---

--- a/docs/UTILITY_MIXINS.md
+++ b/docs/UTILITY_MIXINS.md
@@ -5,7 +5,7 @@ You can cherry pick the `utility` classes that fit your needs with our `scss` mi
 After adding the `all-theme.scss`, the mixins will be available for usage:
 
 ```scss
-@import '@covalent/core/theming/all-theme' as cov;
+@import '@covalent/core/theming/all-theme';
 ```
 
 ### Core Styles Mixin
@@ -14,15 +14,14 @@ Covalent includes out of the box some styles to make your application look bette
 
 ```scss
 // Include the core styles for Covalent
-cov.covalent-core();
+@include covalent-core();
 ```
 
 We also bundle the material icons
 
 ```scss
 // Include pre-bundled material-icons
-$mat-font-url: './';
-cov.covalent-material-icons();
+@include covalent-material-icons();
 // Alternative way to include material-icons
 // @import '../node_modules/@covalent/core/common/material-icons.css';
 ```
@@ -33,7 +32,7 @@ To include [utility classes](https://teradata.github.io/covalent/#/utilities/sty
 
 ```scss
 // Include covalent utility classes
-cov.covalent-utilities();
+@include covalent-utilities();
 ```
 
 ### Flex Layout Mixin
@@ -42,7 +41,7 @@ To include flex layout, add the following:
 
 ```scss
 // Include flex layout classes
-cov.covalent-layout();
+@include covalent-layout();
 ```
 
 ### Colors Mixin
@@ -51,31 +50,30 @@ To include the color classes, add the following:
 
 ```scss
 // Include covalent color classes
-cov.covalent-colors();
+@include covalent-colors();
 ```
 
 ### Example including every single mixin
 
-If you want to include everything, include the following snippet (or just include the `platform.css` as described in the [getting started](https://teradata.github.io/covalent/#/docs) docs)
+If you want to include everything, include the following snippet (or just include the `platform.css` as described in the [getting started](https://teradata.github.io/covalent/v8/#/docs/get-started/overview) docs)
 
 ```scss
-@use '@covalent/core/theming/all-theme' as cov;
+@import '@covalent/core/theming/all-theme';
 
 // Include the core styles for Covalent
-cov.covalent-core();
+@include covalent-core();
 
 // Include pre-bundled material-icons
-$mat-font-url: '../node_modules/@covalent/core/common/styles/font/';
-cov.covalent-material-icons();
+@include covalent-material-icons();
 // Alternative way to include material-icons
 // @import '../node_modules/@covalent/core/common/material-icons.css';
 
 // Include covalent utility classes
-cov.covalent-utilities();
+@include covalent-utilities();
 
 // Include flex layout classes
-cov.covalent-layout();
+@include covalent-layout();
 
 // Include covalent color classes
-cov.covalent-colors();
+@include covalent-colors();
 ```

--- a/docs/WHAT_IS_COVALENT.md
+++ b/docs/WHAT_IS_COVALENT.md
@@ -4,6 +4,12 @@ Covalent is a UI Platform focused on solving common enterprise needs. Covalent f
 
 <br/>
 
+## Compatibility
+
+The latest version of Covalent is now fully compatible with [**Angular 17**](https://v17.angular.io/start).
+
+<br/>
+
 ## What is included?
 
 Covalent modules live in separated npm packages:


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- Fix the instructions for theming in angular docs

### What's included?

<!-- List features included in this PR -->

- Edit the Getting started, Theming docs to make sure they work.
- Change external links to point to Angular 17 docs instead of the latest version.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npx nx serve docs-app`
- [ ] then check the Getting started and Theming docs
- [ ] ensure the instructions work

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![docs](https://github.com/user-attachments/assets/37260370-ba34-426b-98bc-1d4de4fad26e)
