### PR TITLE
fix: covalent-markdown-navigator-typography for Angular Material 15

### DIFF
--- a/apps/docs-app/src/styles.scss
+++ b/apps/docs-app/src/styles.scss
@@ -85,7 +85,7 @@ $background: map-get($theme, background);
 @import 'highlight.js/styles/vs.css';
 @include covalent-flavored-markdown-theme($theme);
 @include covalent-markdown-navigator-theme($theme);
-@include covalent-markdown-navigator-typography($custom-typography);
+@include covalent-markdown-navigator-typography($my-typography);
 @include covalent-guided-tour-theme($theme);
 @include teradata-brand($theme);
 

--- a/libs/markdown-navigator/_markdon-navigator-theme.scss
+++ b/libs/markdown-navigator/_markdon-navigator-theme.scss
@@ -7,7 +7,7 @@
     }
 
     .breadcrumb-current-title {
-      @include mat.typography-level($fontConfig, headline);
+      @include mat.typography-level($fontConfig, headline-5);
     }
   }
 }


### PR DESCRIPTION
## Description

Fix the following error when using `@include markdown-navigator.covalent-markdown-navigator-typography($fontConfig);`

```
SassError: $map: null is not a map.
   ╷
10 │   @return map.get(map.get($config, $level), $name);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
  node_modules/@angular/material/core/typography/_typography-utils.scss 10:11   -mat-get-type-value()
  node_modules/@angular/material/core/typography/_typography-utils.scss 17:11   font-size()
  node_modules/@angular/material/core/typography/_typography-utils.scss 92:14   typography-level()
  node_modules/@covalent/markdown-navigator/_markdon-navigator-theme.scss 10:7  covalent-markdown-navigator-typography()
```

### What's included?

- Replace `headline` ([Material 14 typography level](https://v14.material.angular.io/guide/typography#typography-levels))  with `headline-5` (the corresponding [Material 15 typography level](https://v15.material.angular.io/guide/typography#typography-levels))

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.
