### PR TITLE
fix(markdown-navigator): matListItem directives for Angular Material 15

### DIFF
--- a/libs/markdown-navigator/src/markdown-navigator.component.html
+++ b/libs/markdown-navigator/src/markdown-navigator.component.html
@@ -90,10 +90,10 @@
           matTooltipPosition="before"
           matTooltipShowDelay="500"
         >
-          <mat-icon matListIcon>
+          <mat-icon matListItemIcon>
             {{ getIcon(item) }}
           </mat-icon>
-          <span matListItemLine class="truncate">
+          <span matListItemTitle class="truncate">
             {{ getTitle(item) }}
           </span>
           <span matListItemLine class="truncate">{{ item.description }}</span>


### PR DESCRIPTION
## Description

Fix styling issue in markdown-navigator

### What's included?

Fix matListItem directives used in markdown-navigator per [Material docs](https://v15.material.angular.io/guide/mdc-migration#list)

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.
