### PR TITLE
Fix/app shell z index

### DIFF
--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -231,7 +231,7 @@
   position: sticky;
   top: 0;
   display: block;
-  z-index: 1;
+  z-index: var(--cv-app-shell-user-menu-z-index, 1);
 }
 
 [name='mini-list'] {
@@ -264,6 +264,7 @@ nav.navigation {
   border-right: 0;
   position: fixed;
   background-color: var(--mdc-theme-background);
+  z-index: var(--cv-app-shell-navigation-z-index, 2);
 
   .toggle-drawer {
     margin: 8px auto;

--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -264,7 +264,10 @@ nav.navigation {
   border-right: 0;
   position: fixed;
   background-color: var(--mdc-theme-background);
-  z-index: var(--cv-app-shell-navigation-z-index, 2);
+  z-index: var(
+    --cv-app-shell-navigation-z-index,
+    2
+  ); // must be greater than --cv-app-shell-user-menu-z-index
 
   .toggle-drawer {
     margin: 8px auto;


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- Add an option to set the z-index values for user menu and left-nav/side bar in app-shell.

### What's included?

<!-- List features included in this PR -->

- `--cv-app-shell-user-menu-z-index`: Sets the z-index value for the user menu at the top. Default value is 1.
- `--cv-app-shell-navigation-z-index`: Sets the z-index value for the side nav to the left. Default value is 2. It should be greater that the user menu z-index to render correctly.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run storybook`
- [ ] then hover on the burger icon
- [ ] left nav should open correctly

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="780" alt="Screenshot 2024-12-11 at 5 14 33 PM" src="https://github.com/user-attachments/assets/274281d3-94cf-4456-9bb0-447c72fe24fd" />
<img width="780" alt="Screenshot 2024-12-11 at 5 14 52 PM" src="https://github.com/user-attachments/assets/900eabd2-5dfd-4026-88b8-b4ded2aebdd1" />
