### PR TITLE
fix(components): fix icon-checkbox notch color

### DIFF
--- a/libs/components/src/icon-checkbox/icon-checkbox.scss
+++ b/libs/components/src/icon-checkbox/icon-checkbox.scss
@@ -8,7 +8,7 @@
     width: 15px;
     height: 15px;
     border: none;
-    color: var(--mdc-theme-text-icon-on-dark);
+    color: var(--mdc-theme-on-primary);
   }
 
   .mdc-toggle__checkmark-path {
@@ -58,7 +58,7 @@
 .cornerFill {
   background: linear-gradient(
     225deg,
-    var(--mdc-theme-secondary) 28px,
+    var(--mdc-theme-primary) 28px,
     transparent 0
   );
 }


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
Fix the notch color and checkmark color of icon checkbox for light and dark themes.

**Issue:**
<img width="423" alt="Screenshot 2024-12-30 at 11 44 20 AM" src="https://github.com/user-attachments/assets/1b57e87a-09ea-4fd5-9561-9463fe183fcf" />
<img width="423" alt="Screenshot 2024-12-30 at 11 44 25 AM" src="https://github.com/user-attachments/assets/d62b4ab3-8224-4720-965c-f970f73eea1d" />


### What's included?

<!-- List features included in this PR -->

- Change notch and checkmark colors for icon checkbox

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run storybook`
- [ ] then go to Icon checkbox
- [ ] finally check the notch and chekmark colors for both themes

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="423" alt="Screenshot 2024-12-30 at 11 47 01 AM" src="https://github.com/user-attachments/assets/5043a34c-d4f8-423a-bd0e-12fcbf8e5cb6" />
<img width="423" alt="Screenshot 2024-12-30 at 11 47 05 AM" src="https://github.com/user-attachments/assets/deec25b4-3ef4-4897-93fe-b9e0bffc88dd" />
