### PR TITLE
docs(knapsack): getting back adapting tone page

### DIFF
--- a/apps/knapsack/data/blocks/block.3nK9KuZ4DN.json
+++ b/apps/knapsack/data/blocks/block.3nK9KuZ4DN.json
@@ -1,0 +1,36 @@
+{
+  "id": "3nK9KuZ4DN",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "The UI makes clear what the user needs to do before they select ",
+              "type": "text"
+            },
+            {
+              "text": "Add provider",
+              "type": "text",
+              "marks": [
+                {
+                  "type": "bold"
+                }
+              ]
+            },
+            {
+              "text": ". ",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.5xYWkMJtI.json
+++ b/apps/knapsack/data/blocks/block.5xYWkMJtI.json
@@ -1,0 +1,54 @@
+{
+  "id": "5xYWkMJtI",
+  "data": {
+    "gridStyles": {
+      "columns": "2",
+      "centered": true
+    },
+    "guidelines": [
+      {
+        "id": "DOFCYTlw5p",
+        "type": "do",
+        "content": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "An identity provider stores, secures, and authenticates the digital identities of users.",
+                  "type": "text"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "id": "TbKgEi84d9",
+        "type": "dont",
+        "content": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "An identity provider stores, secures, and authenticates the digital identities of users, devices, or applications.",
+                  "type": "text"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "tileStyles": {
+      "imageSize": "none",
+      "imageRounded": true,
+      "imageOutlined": true,
+      "headerBeforeImage": false
+    }
+  },
+  "blockType": "guidelines"
+}

--- a/apps/knapsack/data/blocks/block.7TZEfGqFM.json
+++ b/apps/knapsack/data/blocks/block.7TZEfGqFM.json
@@ -1,0 +1,69 @@
+{
+  "id": "7TZEfGqFM",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "heading",
+          "attrs": {
+            "level": 1,
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Tone spectrum",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "The tone spectrum is a mental model for you as you choose the right tone according to your user's situation in their product experience. The sliding gradient represents all possible situations throughout the user journey. We can't describe them all, because so many factors are at play. ",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "We call out 3 example points on the spectrum, and each aligns with a situation and tone guideline. The three points are not absolute. ",
+              "type": "text"
+            },
+            {
+              "text": "The right tone could come from a combination of them or points in between.",
+              "type": "text",
+              "marks": [
+                {
+                  "type": "bold"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Use the guidelines to help you apply the right tone to common situations users encounter, and adapt them to other situations along the spectrum. Ultimately, use what you know about the user in the specific situation, and be ready to make a judgement call with the many factors at play. ",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.A4rHmg9Khg.json
+++ b/apps/knapsack/data/blocks/block.A4rHmg9Khg.json
@@ -1,0 +1,23 @@
+{
+  "id": "A4rHmg9Khg",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "The job to be done that this task supports is setting up single sign-on. Users are relevant, but devices and applications are not.",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.Ew3EmXiXyW.json
+++ b/apps/knapsack/data/blocks/block.Ew3EmXiXyW.json
@@ -1,0 +1,89 @@
+{
+  "id": "Ew3EmXiXyW",
+  "data": {
+    "gridStyles": {
+      "columns": "2",
+      "centered": true
+    },
+    "guidelines": [
+      {
+        "id": "TbKgEi84d9",
+        "type": "do",
+        "content": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "Complete the information, then select ",
+                  "type": "text"
+                },
+                {
+                  "text": "Add provider",
+                  "type": "text",
+                  "marks": [
+                    {
+                      "type": "bold"
+                    }
+                  ]
+                },
+                {
+                  "text": ".",
+                  "type": "text"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "id": "DOFCYTlw5p",
+        "type": "dont",
+        "content": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "Complete the information, then map the required claims (for OpenID Connect) or attribute values (for SAML).",
+                  "type": "text"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "Select ",
+                  "type": "text"
+                },
+                {
+                  "text": "Add provider",
+                  "type": "text",
+                  "marks": [
+                    {
+                      "type": "bold"
+                    }
+                  ]
+                },
+                {
+                  "text": ".",
+                  "type": "text"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "tileStyles": {
+      "imageSize": "none",
+      "imageRounded": true,
+      "imageOutlined": true,
+      "headerBeforeImage": false
+    }
+  },
+  "blockType": "guidelines"
+}

--- a/apps/knapsack/data/blocks/block.K4Bfb-xLFz.json
+++ b/apps/knapsack/data/blocks/block.K4Bfb-xLFz.json
@@ -1,0 +1,36 @@
+{
+  "id": "K4Bfb-xLFz",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "heading",
+          "attrs": {
+            "level": 2,
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Transparent and neutral",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Situation: While using a product, a user encounters an error.",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.KfeIuYKj2w.json
+++ b/apps/knapsack/data/blocks/block.KfeIuYKj2w.json
@@ -1,0 +1,35 @@
+{
+  "id": "KfeIuYKj2w",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "We don’t want users to feel they have a lot to read. To help them complete tasks efficiently and feel good about it, write only what they need.",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Let's look at the example more closely.",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.KpBSWEGwUa.json
+++ b/apps/knapsack/data/blocks/block.KpBSWEGwUa.json
@@ -1,0 +1,60 @@
+{
+  "id": "KpBSWEGwUa",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "heading",
+          "attrs": {
+            "level": 1,
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Meeting users in the moment",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "We converse with different types of users at different stages of their journey, from onboarding to business as usual to new-feature adoption, and points in between. We strive to understand a user’s needs in a situation, and we guide them using a tone that helps them then and there.",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Naturally, along their journey users have different feelings. We’re mindful of that, without being presumptuous, when we choose our tone. But we can never truly know a user’s emotional state. That’s why we don’t imply that we know it in attempts to engage them.",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Moment to moment, we use tone to engage users by meeting their needs while staying credible and authentic.",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.M27kwgYyE.json
+++ b/apps/knapsack/data/blocks/block.M27kwgYyE.json
@@ -1,0 +1,23 @@
+{
+  "id": "M27kwgYyE",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Don’t say it’s easy. Show it. Empower users with facts that support a feature’s ease of use. That makes it real. Sounding like you’re trying to convince them that it’s easy might backfire.",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.NTmTFKxXmZ.json
+++ b/apps/knapsack/data/blocks/block.NTmTFKxXmZ.json
@@ -1,0 +1,5 @@
+{
+  "id": "NTmTFKxXmZ",
+  "data": {},
+  "blockType": "divider-block"
+}

--- a/apps/knapsack/data/blocks/block.O2FSrtamNm.json
+++ b/apps/knapsack/data/blocks/block.O2FSrtamNm.json
@@ -1,0 +1,54 @@
+{
+  "id": "O2FSrtamNm",
+  "data": {
+    "gridStyles": {
+      "columns": "2",
+      "centered": true
+    },
+    "guidelines": [
+      {
+        "id": "TbKgEi84d9",
+        "type": "do",
+        "content": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "Examples include Azure Active Directory, Okta, and Ping.",
+                  "type": "text"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "id": "DOFCYTlw5p",
+        "type": "dont",
+        "content": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "Examples include Azure Active Directory, Okta, Ping, Google, Facebook, and Twitter.",
+                  "type": "text"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "tileStyles": {
+      "imageSize": "none",
+      "imageRounded": true,
+      "imageOutlined": true,
+      "headerBeforeImage": false
+    }
+  },
+  "blockType": "guidelines"
+}

--- a/apps/knapsack/data/blocks/block.QUPzNPWapk.json
+++ b/apps/knapsack/data/blocks/block.QUPzNPWapk.json
@@ -1,0 +1,127 @@
+{
+  "id": "QUPzNPWapk",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "table",
+          "attrs": {
+            "equalColumns": true
+          },
+          "content": [
+            {
+              "type": "tableRow",
+              "content": [
+                {
+                  "type": "tableHeader",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "This",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "bold"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableHeader",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "Not this",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "bold"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "tableRow",
+              "content": [
+                {
+                  "type": "tableCell",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "You can now share datasets between users in the same environment. No data movement or duplication is required.",
+                          "type": "text"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableCell",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "You can now easily share datasets between users of the same environment.",
+                          "type": "text"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "table"
+}

--- a/apps/knapsack/data/blocks/block.UXLjbRrKsm.json
+++ b/apps/knapsack/data/blocks/block.UXLjbRrKsm.json
@@ -1,0 +1,23 @@
+{
+  "id": "UXLjbRrKsm",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "During onboarding, inspire users and increase their confidence by being real. Empower them by telling them what they can do. Don’t overpromise or use hyperbole. That’s not real. And that’s about the product, not the user.",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.Urkj-jpFb.json
+++ b/apps/knapsack/data/blocks/block.Urkj-jpFb.json
@@ -1,0 +1,140 @@
+{
+  "id": "Urkj-jpFb",
+  "data": {
+    "gridStyles": {
+      "columns": "2",
+      "centered": true
+    },
+    "guidelines": [
+      {
+        "id": "GhA5i8rLJy",
+        "type": "do",
+        "content": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "VantageCloud Lake supports these provider types:",
+                  "type": "text"
+                }
+              ]
+            },
+            {
+              "type": "bulletList",
+              "content": [
+                {
+                  "type": "listItem",
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "content": [
+                        {
+                          "text": "OpenID Connect",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "underline"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "listItem",
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "content": [
+                        {
+                          "text": "SAML",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "underline"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "id": "DOFCYTlw5p",
+        "type": "dont",
+        "content": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "An authentication protocol is a set of rules and procedures that determine how entities prove their identities to each other. VantageCloud Lake supports these authentication protocols:",
+                  "type": "text"
+                }
+              ]
+            },
+            {
+              "type": "bulletList",
+              "content": [
+                {
+                  "type": "listItem",
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "content": [
+                        {
+                          "text": "OpenID Connect",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "underline"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "listItem",
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "content": [
+                        {
+                          "text": "SAML",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "underline"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "tileStyles": {
+      "imageSize": "none",
+      "imageRounded": true,
+      "imageOutlined": true,
+      "headerBeforeImage": false
+    }
+  },
+  "blockType": "guidelines"
+}

--- a/apps/knapsack/data/blocks/block.Y-JVxTUya.json
+++ b/apps/knapsack/data/blocks/block.Y-JVxTUya.json
@@ -1,0 +1,114 @@
+{
+  "id": "Y-JVxTUya",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "heading",
+          "attrs": {
+            "level": 1,
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Things to consider",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "type": "bulletList",
+          "content": [
+            {
+              "type": "listItem",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "attrs": {
+                    "textAlign": "left"
+                  },
+                  "content": [
+                    {
+                      "text": "What is the user context?",
+                      "type": "text"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "attrs": {
+                    "textAlign": "left"
+                  },
+                  "content": [
+                    {
+                      "text": "What did they do before, and what will they do after?",
+                      "type": "text"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "attrs": {
+                    "textAlign": "left"
+                  },
+                  "content": [
+                    {
+                      "text": "What does the user need now? How might they be feeling?",
+                      "type": "text"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "attrs": {
+                    "textAlign": "left"
+                  },
+                  "content": [
+                    {
+                      "text": "What do you want, and not want, to convey?",
+                      "type": "text"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "content": [
+                {
+                  "type": "paragraph",
+                  "attrs": {
+                    "textAlign": "left"
+                  },
+                  "content": [
+                    {
+                      "text": "How do you know when you've gone too far?",
+                      "type": "text"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.a1XY2Aqt3.json
+++ b/apps/knapsack/data/blocks/block.a1XY2Aqt3.json
@@ -1,0 +1,58 @@
+{
+  "id": "a1XY2Aqt3",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "In error messages, be transparent. Stay neutral to avoid escalating an already tense or unsatisfactory experience. Focus on communicating helpful information and avoid expressing feelings. For instance, avoid using words or phrases such as “we’re sorry.” See ",
+              "type": "text"
+            },
+            {
+              "text": "Errors",
+              "type": "text",
+              "marks": [
+                {
+                  "type": "link",
+                  "attrs": {
+                    "rel": "noopener noreferrer nofollow",
+                    "href": "/pages/errors",
+                    "class": null
+                  }
+                },
+                {
+                  "type": "underline"
+                }
+              ]
+            },
+            {
+              "text": " ",
+              "type": "text",
+              "marks": [
+                {
+                  "type": "link",
+                  "attrs": {
+                    "rel": "noopener noreferrer nofollow",
+                    "href": "/pages/errors",
+                    "class": null
+                  }
+                }
+              ]
+            },
+            {
+              "text": "for more error message guidelines.",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.e0PZuHL0Fl.json
+++ b/apps/knapsack/data/blocks/block.e0PZuHL0Fl.json
@@ -1,0 +1,54 @@
+{
+  "id": "e0PZuHL0Fl",
+  "data": {
+    "gridStyles": {
+      "columns": "2",
+      "centered": true
+    },
+    "guidelines": [
+      {
+        "id": "TbKgEi84d9",
+        "type": "do",
+        "content": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "Sign in to the VantageCloud Lake Console.",
+                  "type": "text"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "id": "DOFCYTlw5p",
+        "type": "dont",
+        "content": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [
+                {
+                  "text": "Sign in to the VantageCloud Lake Console with your username and password.",
+                  "type": "text"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "tileStyles": {
+      "imageSize": "none",
+      "imageRounded": true,
+      "imageOutlined": true,
+      "headerBeforeImage": false
+    }
+  },
+  "blockType": "guidelines"
+}

--- a/apps/knapsack/data/blocks/block.f-TlOFP3R8.json
+++ b/apps/knapsack/data/blocks/block.f-TlOFP3R8.json
@@ -1,0 +1,36 @@
+{
+  "id": "f-TlOFP3R8",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "heading",
+          "attrs": {
+            "level": 2,
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Empowering and real",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Situation: A user  sees this sentence at the beginning of a product's getting started guide.",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.iFOVuyz8Pc.json
+++ b/apps/knapsack/data/blocks/block.iFOVuyz8Pc.json
@@ -1,0 +1,23 @@
+{
+  "id": "iFOVuyz8Pc",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Situation: A user sees this information in a new feature announcement.",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.jDBUIKk744.json
+++ b/apps/knapsack/data/blocks/block.jDBUIKk744.json
@@ -1,0 +1,127 @@
+{
+  "id": "jDBUIKk744",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "table",
+          "attrs": {
+            "equalColumns": true
+          },
+          "content": [
+            {
+              "type": "tableRow",
+              "content": [
+                {
+                  "type": "tableHeader",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "This",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "bold"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableHeader",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "Not this",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "bold"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "tableRow",
+              "content": [
+                {
+                  "type": "tableCell",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "You can explore and analyze large datasets in a Jupyter notebook using  ClearScape Analytics™ functions—on a self-service, on-demand basis.",
+                          "type": "text"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableCell",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "You can explore and analyze large datasets to achieve limitless innovation.",
+                          "type": "text"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "table"
+}

--- a/apps/knapsack/data/blocks/block.ne8zZdjDIn.json
+++ b/apps/knapsack/data/blocks/block.ne8zZdjDIn.json
@@ -1,0 +1,13 @@
+{
+  "id": "ne8zZdjDIn",
+  "data": {
+    "imageSize": "full",
+    "images": [
+      {
+        "src": "https://knapsack.imgix.net/site/covalent/tone-spectrum-b-ahvrjqvcrrpng",
+        "caption": "tone spectrum b.png"
+      }
+    ]
+  },
+  "blockType": "image-block"
+}

--- a/apps/knapsack/data/blocks/block.qebw1cvH7j.json
+++ b/apps/knapsack/data/blocks/block.qebw1cvH7j.json
@@ -1,0 +1,23 @@
+{
+  "id": "qebw1cvH7j",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "The user, an organization admin who already set up their VantageCloud Lake account, expects to use a username and password. Besides, that's conventional.",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.rrrSJEFzUH.json
+++ b/apps/knapsack/data/blocks/block.rrrSJEFzUH.json
@@ -1,0 +1,612 @@
+{
+  "id": "rrrSJEFzUH",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "table",
+          "attrs": {
+            "equalColumns": true
+          },
+          "content": [
+            {
+              "type": "tableRow",
+              "content": [
+                {
+                  "type": "tableHeader",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "This",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "bold"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableHeader",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "Not this",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "bold"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "tableRow",
+              "content": [
+                {
+                  "type": "tableCell",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "Add an identity provider",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "bold"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      }
+                    },
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "An identity provider stores, secures, and authenticates the digital identities of users. Examples include Azure Active Directory, Okta, and Ping.",
+                          "type": "text"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      }
+                    },
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "VantageCloud Lake supports these provider types:",
+                          "type": "text"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "bulletList",
+                      "content": [
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "OpenID Connect",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "underline"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "SAML",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "underline"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "orderedList",
+                      "attrs": {
+                        "start": 1
+                      },
+                      "content": [
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "Sign in to the VantageCloud Lake Console.",
+                                  "type": "text"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "In ",
+                                  "type": "text"
+                                },
+                                {
+                                  "text": "Manage access",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "bold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "text": ", select ",
+                                  "type": "text"
+                                },
+                                {
+                                  "text": "Identity providers",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "bold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "text": ".",
+                                  "type": "text"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "Select ",
+                                  "type": "text"
+                                },
+                                {
+                                  "text": "Add identity provider",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "bold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "text": ", then the ",
+                                  "type": "text"
+                                },
+                                {
+                                  "text": "Provider type",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "bold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "text": ".",
+                                  "type": "text"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "Complete the information, then select ",
+                                  "type": "text"
+                                },
+                                {
+                                  "text": "Add provider",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "bold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "text": ".",
+                                  "type": "text"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableCell",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "Add an identity provider",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "bold"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      }
+                    },
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "An identity provider stores, secures, and authenticates the digital identities of users, devices, or applications. Examples include Azure Active Directory, Okta, Ping, Google, Facebook, and Twitter.",
+                          "type": "text"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      }
+                    },
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "An authentication protocol is a set of rules and procedures that determine how entities prove their identities to each other. VantageCloud Lake supports these authentication protocols:",
+                          "type": "text"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "bulletList",
+                      "content": [
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "OpenID Connect",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "underline"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "SAML",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "underline"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "orderedList",
+                      "attrs": {
+                        "start": 1
+                      },
+                      "content": [
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "Sign in to the VantageCloud Lake Console with your username and password.",
+                                  "type": "text"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "In ",
+                                  "type": "text"
+                                },
+                                {
+                                  "text": "Manage access",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "bold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "text": ", select ",
+                                  "type": "text"
+                                },
+                                {
+                                  "text": "Identity providers",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "bold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "text": ".",
+                                  "type": "text"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "Select ",
+                                  "type": "text"
+                                },
+                                {
+                                  "text": "Add identity provider",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "bold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "text": " and the ",
+                                  "type": "text"
+                                },
+                                {
+                                  "text": "Provider type",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "bold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "text": ".",
+                                  "type": "text"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "Complete the information, then map the required claim mappings (for OpenID Connect) or attribute values (for SAML).",
+                                  "type": "text"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "listItem",
+                          "content": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "textAlign": "left"
+                              },
+                              "content": [
+                                {
+                                  "text": "Select ",
+                                  "type": "text"
+                                },
+                                {
+                                  "text": "Add provider",
+                                  "type": "text",
+                                  "marks": [
+                                    {
+                                      "type": "bold"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "text": ".",
+                                  "type": "text"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "table"
+}

--- a/apps/knapsack/data/blocks/block.ruEwieJfwN.json
+++ b/apps/knapsack/data/blocks/block.ruEwieJfwN.json
@@ -1,0 +1,225 @@
+{
+  "id": "ruEwieJfwN",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "table",
+          "attrs": {
+            "equalColumns": true
+          },
+          "content": [
+            {
+              "type": "tableRow",
+              "content": [
+                {
+                  "type": "tableHeader",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "This",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "bold"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableHeader",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "Not this",
+                          "type": "text",
+                          "marks": [
+                            {
+                              "type": "bold"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "tableRow",
+              "content": [
+                {
+                  "type": "tableCell",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "Couldn’t create an environment",
+                          "type": "text"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableCell",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "Failed to create an environment",
+                          "type": "text"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "tableRow",
+              "content": [
+                {
+                  "type": "tableCell",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "Your role doesn’t have access to this.",
+                          "type": "text"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableCell",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "There was a problem.",
+                          "type": "text"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "tableRow",
+              "content": [
+                {
+                  "type": "tableCell",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "The system timed out. Please try again.",
+                          "type": "text"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableCell",
+                  "attrs": {
+                    "colspan": 1,
+                    "rowspan": 1,
+                    "colwidth": null
+                  },
+                  "content": [
+                    {
+                      "type": "paragraph",
+                      "attrs": {
+                        "textAlign": "left"
+                      },
+                      "content": [
+                        {
+                          "text": "We’re sorry, but the system timed out.",
+                          "type": "text"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "table"
+}

--- a/apps/knapsack/data/blocks/block.u-2Q9Ua9Z4.json
+++ b/apps/knapsack/data/blocks/block.u-2Q9Ua9Z4.json
@@ -1,0 +1,26 @@
+{
+  "id": "u-2Q9Ua9Z4",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "horizontalRule"
+        },
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Our customers are not likely to use social identity providers. Including only identity providers they are likely to use keeps the sentence brief.",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.yyvAnHItNj.json
+++ b/apps/knapsack/data/blocks/block.yyvAnHItNj.json
@@ -1,0 +1,36 @@
+{
+  "id": "yyvAnHItNj",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "heading",
+          "attrs": {
+            "level": 2,
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Straightforward and brief",
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Situation: A user encounters a Help article (in the product) on how to complete a task. ",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/blocks/block.z9Yo6rbBdE.json
+++ b/apps/knapsack/data/blocks/block.z9Yo6rbBdE.json
@@ -1,0 +1,36 @@
+{
+  "id": "z9Yo6rbBdE",
+  "data": {
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "paragraph",
+          "attrs": {
+            "textAlign": "left"
+          },
+          "content": [
+            {
+              "text": "Maybe the user who completes this task already understands what an authentication protocol is. But either way, for this job to be done, the most straightforward approach is to abstract that as the ",
+              "type": "text"
+            },
+            {
+              "text": "provider type ",
+              "type": "text",
+              "marks": [
+                {
+                  "type": "italic"
+                }
+              ]
+            },
+            {
+              "text": "and avoid the jargon.",
+              "type": "text"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "blockType": "text-editor"
+}

--- a/apps/knapsack/data/knapsack.custom-page.adapting-tone-by-situation.yml
+++ b/apps/knapsack/data/knapsack.custom-page.adapting-tone-by-situation.yml
@@ -1,0 +1,31 @@
+id: adapting-tone-by-situation
+title: Adapting tone by situation
+blockIds:
+  - KpBSWEGwUa
+  - Y-JVxTUya
+  - 7TZEfGqFM
+  - ne8zZdjDIn
+  - yyvAnHItNj
+  - rrrSJEFzUH
+  - KfeIuYKj2w
+  - 5xYWkMJtI
+  - A4rHmg9Khg
+  - O2FSrtamNm
+  - u-2Q9Ua9Z4
+  - Urkj-jpFb
+  - z9Yo6rbBdE
+  - e0PZuHL0Fl
+  - qebw1cvH7j
+  - Ew3EmXiXyW
+  - 3nK9KuZ4DN
+  - f-TlOFP3R8
+  - jDBUIKk744
+  - UXLjbRrKsm
+  - NTmTFKxXmZ
+  - iFOVuyz8Pc
+  - QUPzNPWapk
+  - M27kwgYyE
+  - K4Bfb-xLFz
+  - ruEwieJfwN
+  - a1XY2Aqt3
+description: Our voice is stable because it’s our identity. Our tone adapts to what a user needs in a specific situation.

--- a/apps/knapsack/data/knapsack.navs.yml
+++ b/apps/knapsack/data/knapsack.navs.yml
@@ -9,6 +9,11 @@ byId:
     name: Action ribbon
     parentId: components
     path: /pattern/action-ribbon
+  adapting-tone-by-situation:
+    id: adapting-tone-by-situation
+    name: Adapting tone by situation
+    parentId: voice-and-tone
+    path: /pages/adapting-tone-by-situation
   alert:
     id: alert
     name: Alert
@@ -478,6 +483,7 @@ order:
   - typography
   - content
   - voice-and-tone
+  - adapting-tone-by-situation
   - product-and-ui
   - error-messages
   - video


### PR DESCRIPTION
## Description

Getting back the "Adapting tone by situation" page that was lost in a previous merge

### What's included?

- Restoring the adapting tone page and its content blocks under Voice and Tone section

#### Test Steps

- [ ] `npx nx run knapsack:serve `
- [ ] then open locally and go to the Content section and click Voice and Tone to see page

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

<img width="1698" alt="Screenshot 2025-01-13 at 5 24 11 PM" src="https://github.com/user-attachments/assets/00c0bbab-c969-4b04-b28c-579078e6319e" />

