### PR TITLE
docs(knapsack): fix to knapsack asset set reference

### DIFF
--- a/apps/knapsack/data/knapsack.asset-sets.json
+++ b/apps/knapsack/data/knapsack.asset-sets.json
@@ -1,8 +1,8 @@
 {
-  "globalAssetSetIds": ["light", "dark"],
+  "globalAssetSetIds": ["default", "dark"],
   "allAssetSets": {
-    "light": {
-      "id": "light",
+    "default": {
+      "id": "default",
       "title": "Light",
       "assets": [
         {

--- a/apps/knapsack/dist/meta/ks-meta.json
+++ b/apps/knapsack/dist/meta/ks-meta.json
@@ -4,8 +4,8 @@
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "xrVH4M3t6W",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=light&demoId=xrVH4M3t6W&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=xrVH4M3t6W&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "action-ribbon",
@@ -18,8 +18,8 @@
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "SBpuLooid9",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=light&demoId=SBpuLooid9&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=SBpuLooid9&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "action-ribbon",
@@ -32,8 +32,8 @@
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "3ueuxC011k",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=light&demoId=3ueuxC011k&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=3ueuxC011k&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "action-ribbon",
@@ -46,8 +46,8 @@
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "04wy8HmIJl",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=light&demoId=04wy8HmIJl&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=04wy8HmIJl&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "action-ribbon",
@@ -60,8 +60,8 @@
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "78JmyZgiv8",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=light&demoId=78JmyZgiv8&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=78JmyZgiv8&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "action-ribbon",
@@ -74,8 +74,8 @@
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "PX4CXlob7k",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=light&demoId=PX4CXlob7k&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=PX4CXlob7k&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "action-ribbon",
@@ -88,8 +88,8 @@
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "I15dIgeIM4",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=light&demoId=I15dIgeIM4&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=I15dIgeIM4&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "action-ribbon",
@@ -102,8 +102,8 @@
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "sNiAamckj3",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=light&demoId=sNiAamckj3&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=sNiAamckj3&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "action-ribbon",
@@ -116,8 +116,8 @@
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "aQE9OP2U6t",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=light&demoId=aQE9OP2U6t&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=aQE9OP2U6t&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "action-ribbon",
@@ -130,10 +130,10 @@
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "tnvgSz6pjh",
-      "assetSetId": "light",
+      "assetSetId": "default",
       "width": 806,
       "height": 94,
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=light&demoId=tnvgSz6pjh&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=tnvgSz6pjh&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "alert",
@@ -148,8 +148,8 @@
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "vmDFzhOhSn",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=light&demoId=vmDFzhOhSn&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=vmDFzhOhSn&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "alert",
@@ -162,8 +162,8 @@
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "S4K35ZGdnu",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=light&demoId=S4K35ZGdnu&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=S4K35ZGdnu&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "alert",
@@ -176,8 +176,8 @@
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "WosGIC3IsN",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=light&demoId=WosGIC3IsN&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=WosGIC3IsN&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "alert",
@@ -190,8 +190,8 @@
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "t7e3P48Pkm",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=light&demoId=t7e3P48Pkm&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=t7e3P48Pkm&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "alert",
@@ -204,8 +204,8 @@
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "pYd0j3oNrI",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=light&demoId=pYd0j3oNrI&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=pYd0j3oNrI&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "alert",
@@ -218,8 +218,8 @@
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "xnEh2A2lis",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=light&demoId=xnEh2A2lis&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=xnEh2A2lis&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "alert",
@@ -232,8 +232,8 @@
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "LATgTeg21H",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=light&demoId=LATgTeg21H&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=LATgTeg21H&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "alert",
@@ -246,8 +246,8 @@
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "yf2q5F2Jyk",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=light&demoId=yf2q5F2Jyk&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=yf2q5F2Jyk&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "alert",
@@ -260,8 +260,8 @@
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "CE5x5TaMa2",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=light&demoId=CE5x5TaMa2&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=CE5x5TaMa2&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "alert",
@@ -274,8 +274,8 @@
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "s8Ci4Cd08W",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=light&demoId=s8Ci4Cd08W&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=s8Ci4Cd08W&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "alert",
@@ -288,8 +288,8 @@
       "patternId": "app-shell",
       "templateId": "web-components-z8r4uoVkf",
       "demoId": "5lBJhPKvTj",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=app-shell&templateId=web-components-z8r4uoVkf&assetSetId=light&demoId=5lBJhPKvTj&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=app-shell&templateId=web-components-z8r4uoVkf&assetSetId=default&demoId=5lBJhPKvTj&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "app-shell",
@@ -302,8 +302,8 @@
       "patternId": "badge",
       "templateId": "web-components-40aOlYC6I9",
       "demoId": "NAoDoFXI-A",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=badge&templateId=web-components-40aOlYC6I9&assetSetId=light&demoId=NAoDoFXI-A&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=badge&templateId=web-components-40aOlYC6I9&assetSetId=default&demoId=NAoDoFXI-A&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "badge",
@@ -316,8 +316,8 @@
       "patternId": "badge",
       "templateId": "web-components-40aOlYC6I9",
       "demoId": "laNQ9RRdMn",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=badge&templateId=web-components-40aOlYC6I9&assetSetId=light&demoId=laNQ9RRdMn&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=badge&templateId=web-components-40aOlYC6I9&assetSetId=default&demoId=laNQ9RRdMn&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "badge",
@@ -330,8 +330,8 @@
       "patternId": "badge",
       "templateId": "web-components-40aOlYC6I9",
       "demoId": "uhaHv83YYx",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=badge&templateId=web-components-40aOlYC6I9&assetSetId=light&demoId=uhaHv83YYx&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=badge&templateId=web-components-40aOlYC6I9&assetSetId=default&demoId=uhaHv83YYx&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "badge",
@@ -344,8 +344,8 @@
       "patternId": "button",
       "templateId": "web-components-raE1x4tYL",
       "demoId": "LVG5iF-p9d",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=button&templateId=web-components-raE1x4tYL&assetSetId=light&demoId=LVG5iF-p9d&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=button&templateId=web-components-raE1x4tYL&assetSetId=default&demoId=LVG5iF-p9d&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "button",
@@ -358,8 +358,8 @@
       "patternId": "button",
       "templateId": "web-components-raE1x4tYL",
       "demoId": "E5ymzzEPs",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=button&templateId=web-components-raE1x4tYL&assetSetId=light&demoId=E5ymzzEPs&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=button&templateId=web-components-raE1x4tYL&assetSetId=default&demoId=E5ymzzEPs&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "button",
@@ -372,10 +372,10 @@
       "patternId": "button",
       "templateId": "web-components-raE1x4tYL",
       "demoId": "wJJ2tksHEK",
-      "assetSetId": "light",
+      "assetSetId": "default",
       "width": 111,
       "height": 54,
-      "url": "/api/v1/render?patternId=button&templateId=web-components-raE1x4tYL&assetSetId=light&demoId=wJJ2tksHEK&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render?patternId=button&templateId=web-components-raE1x4tYL&assetSetId=default&demoId=wJJ2tksHEK&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "button",
@@ -390,8 +390,8 @@
       "patternId": "button",
       "templateId": "angular-i3OR9O7kXg",
       "demoId": "CRFHBobaZj",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=button&templateId=angular-i3OR9O7kXg&assetSetId=light&demoId=CRFHBobaZj&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=button&templateId=angular-i3OR9O7kXg&assetSetId=default&demoId=CRFHBobaZj&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "button",
@@ -404,8 +404,8 @@
       "patternId": "button",
       "templateId": "angular-i3OR9O7kXg",
       "demoId": "eIOsBgDEvJ",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=button&templateId=angular-i3OR9O7kXg&assetSetId=light&demoId=eIOsBgDEvJ&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=button&templateId=angular-i3OR9O7kXg&assetSetId=default&demoId=eIOsBgDEvJ&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "button",
@@ -418,8 +418,8 @@
       "patternId": "card",
       "templateId": "web-components-mU8MX1FHrF",
       "demoId": "pTyIIHqJtL",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=card&templateId=web-components-mU8MX1FHrF&assetSetId=light&demoId=pTyIIHqJtL&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=card&templateId=web-components-mU8MX1FHrF&assetSetId=default&demoId=pTyIIHqJtL&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "card",
@@ -432,8 +432,8 @@
       "patternId": "card",
       "templateId": "web-components-mU8MX1FHrF",
       "demoId": "sNLUIRYsNz",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=card&templateId=web-components-mU8MX1FHrF&assetSetId=light&demoId=sNLUIRYsNz&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=card&templateId=web-components-mU8MX1FHrF&assetSetId=default&demoId=sNLUIRYsNz&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "card",
@@ -446,8 +446,8 @@
       "patternId": "card",
       "templateId": "angular-K2H0Gg5PuL",
       "demoId": "nrW1VpRzc",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=card&templateId=angular-K2H0Gg5PuL&assetSetId=light&demoId=nrW1VpRzc&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=card&templateId=angular-K2H0Gg5PuL&assetSetId=default&demoId=nrW1VpRzc&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "card",
@@ -460,8 +460,8 @@
       "patternId": "check-list-item",
       "templateId": "web-components-M18BFFHM3h",
       "demoId": "CvFKcI1eN0",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=check-list-item&templateId=web-components-M18BFFHM3h&assetSetId=light&demoId=CvFKcI1eN0&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=check-list-item&templateId=web-components-M18BFFHM3h&assetSetId=default&demoId=CvFKcI1eN0&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "check-list-item",
@@ -474,8 +474,8 @@
       "patternId": "checkbox",
       "templateId": "web-components-29FbeDQWhM",
       "demoId": "ee2EneFvzS",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=checkbox&templateId=web-components-29FbeDQWhM&assetSetId=light&demoId=ee2EneFvzS&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=checkbox&templateId=web-components-29FbeDQWhM&assetSetId=default&demoId=ee2EneFvzS&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "checkbox",
@@ -488,8 +488,8 @@
       "patternId": "chip",
       "templateId": "web-components-7wYRPSnEZH",
       "demoId": "HyZJsWXVOc",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=chip&templateId=web-components-7wYRPSnEZH&assetSetId=light&demoId=HyZJsWXVOc&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=chip&templateId=web-components-7wYRPSnEZH&assetSetId=default&demoId=HyZJsWXVOc&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "chip",
@@ -502,8 +502,8 @@
       "patternId": "chip-item",
       "templateId": "web-components-vegaZgkE47",
       "demoId": "zDg2SpdOHk",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=chip-item&templateId=web-components-vegaZgkE47&assetSetId=light&demoId=zDg2SpdOHk&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=chip-item&templateId=web-components-vegaZgkE47&assetSetId=default&demoId=zDg2SpdOHk&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "chip-item",
@@ -516,8 +516,8 @@
       "patternId": "chip-item",
       "templateId": "web-components-vegaZgkE47",
       "demoId": "DINJPi6iZ",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=chip-item&templateId=web-components-vegaZgkE47&assetSetId=light&demoId=DINJPi6iZ&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=chip-item&templateId=web-components-vegaZgkE47&assetSetId=default&demoId=DINJPi6iZ&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "chip-item",
@@ -530,8 +530,8 @@
       "patternId": "circular-progress",
       "templateId": "web-components-rw6v6c4fnU",
       "demoId": "gMTyjmInaG",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=circular-progress&templateId=web-components-rw6v6c4fnU&assetSetId=light&demoId=gMTyjmInaG&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=circular-progress&templateId=web-components-rw6v6c4fnU&assetSetId=default&demoId=gMTyjmInaG&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "circular-progress",
@@ -544,8 +544,8 @@
       "patternId": "code-editor",
       "templateId": "web-components-JulJ63YyUz",
       "demoId": "t1CfBDrtut",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=code-editor&templateId=web-components-JulJ63YyUz&assetSetId=light&demoId=t1CfBDrtut&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=code-editor&templateId=web-components-JulJ63YyUz&assetSetId=default&demoId=t1CfBDrtut&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "code-editor",
@@ -558,8 +558,8 @@
       "patternId": "code-snippet",
       "templateId": "web-components-MmKtwF24Vv",
       "demoId": "HJPgdqmwj",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=code-snippet&templateId=web-components-MmKtwF24Vv&assetSetId=light&demoId=HJPgdqmwj&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=code-snippet&templateId=web-components-MmKtwF24Vv&assetSetId=default&demoId=HJPgdqmwj&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "code-snippet",
@@ -572,8 +572,8 @@
       "patternId": "dialog",
       "templateId": "web-components-S9Ia0KOrya",
       "demoId": "yovRt8o986",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=dialog&templateId=web-components-S9Ia0KOrya&assetSetId=light&demoId=yovRt8o986&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=dialog&templateId=web-components-S9Ia0KOrya&assetSetId=default&demoId=yovRt8o986&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "dialog",
@@ -586,8 +586,8 @@
       "patternId": "empty-state",
       "templateId": "web-components-E0GwXgHJv",
       "demoId": "8QAZfNvobo",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=empty-state&templateId=web-components-E0GwXgHJv&assetSetId=light&demoId=8QAZfNvobo&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=empty-state&templateId=web-components-E0GwXgHJv&assetSetId=default&demoId=8QAZfNvobo&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "empty-state",
@@ -600,8 +600,8 @@
       "patternId": "expansion-panel",
       "templateId": "web-components-Vj98q2D8hw",
       "demoId": "Yu7DvlfMdG",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=expansion-panel&templateId=web-components-Vj98q2D8hw&assetSetId=light&demoId=Yu7DvlfMdG&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=expansion-panel&templateId=web-components-Vj98q2D8hw&assetSetId=default&demoId=Yu7DvlfMdG&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "expansion-panel",
@@ -614,8 +614,8 @@
       "patternId": "expansion-panel",
       "templateId": "web-components-Vj98q2D8hw",
       "demoId": "noRKlgh7xK",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=expansion-panel&templateId=web-components-Vj98q2D8hw&assetSetId=light&demoId=noRKlgh7xK&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=expansion-panel&templateId=web-components-Vj98q2D8hw&assetSetId=default&demoId=noRKlgh7xK&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "expansion-panel",
@@ -628,8 +628,8 @@
       "patternId": "expansion-panel-item",
       "templateId": "web-components-vBLifAApG",
       "demoId": "w0H1gm2jvp",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=expansion-panel-item&templateId=web-components-vBLifAApG&assetSetId=light&demoId=w0H1gm2jvp&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=expansion-panel-item&templateId=web-components-vBLifAApG&assetSetId=default&demoId=w0H1gm2jvp&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "expansion-panel-item",
@@ -642,8 +642,8 @@
       "patternId": "expansion-panel-item",
       "templateId": "web-components-vBLifAApG",
       "demoId": "6tUMrwwjoe",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=expansion-panel-item&templateId=web-components-vBLifAApG&assetSetId=light&demoId=6tUMrwwjoe&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=expansion-panel-item&templateId=web-components-vBLifAApG&assetSetId=default&demoId=6tUMrwwjoe&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "expansion-panel-item",
@@ -656,8 +656,8 @@
       "patternId": "focused-page",
       "templateId": "web-components-waQVQEThJD",
       "demoId": "BNl6rXNkee",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=focused-page&templateId=web-components-waQVQEThJD&assetSetId=light&demoId=BNl6rXNkee&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=focused-page&templateId=web-components-waQVQEThJD&assetSetId=default&demoId=BNl6rXNkee&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "focused-page",
@@ -670,8 +670,8 @@
       "patternId": "form-field",
       "templateId": "web-components-I5Sx1HQnJ",
       "demoId": "pmwAMIY3TV",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=form-field&templateId=web-components-I5Sx1HQnJ&assetSetId=light&demoId=pmwAMIY3TV&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=form-field&templateId=web-components-I5Sx1HQnJ&assetSetId=default&demoId=pmwAMIY3TV&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "form-field",
@@ -684,8 +684,8 @@
       "patternId": "form-field",
       "templateId": "web-components-I5Sx1HQnJ",
       "demoId": "0n-okWquA",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=form-field&templateId=web-components-I5Sx1HQnJ&assetSetId=light&demoId=0n-okWquA&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=form-field&templateId=web-components-I5Sx1HQnJ&assetSetId=default&demoId=0n-okWquA&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "form-field",
@@ -698,8 +698,8 @@
       "patternId": "form-field",
       "templateId": "web-components-I5Sx1HQnJ",
       "demoId": "1cr3GRlfdT",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=form-field&templateId=web-components-I5Sx1HQnJ&assetSetId=light&demoId=1cr3GRlfdT&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=form-field&templateId=web-components-I5Sx1HQnJ&assetSetId=default&demoId=1cr3GRlfdT&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "form-field",
@@ -712,8 +712,8 @@
       "patternId": "full-screen-dialog",
       "templateId": "web-components-HeDCLBaQf9",
       "demoId": "DJycXyA-3c",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=full-screen-dialog&templateId=web-components-HeDCLBaQf9&assetSetId=light&demoId=DJycXyA-3c&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=full-screen-dialog&templateId=web-components-HeDCLBaQf9&assetSetId=default&demoId=DJycXyA-3c&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "full-screen-dialog",
@@ -726,8 +726,8 @@
       "patternId": "icon",
       "templateId": "web-components-N8bzRbfpuX",
       "demoId": "bn4zy44TYR",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=light&demoId=bn4zy44TYR&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=default&demoId=bn4zy44TYR&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon",
@@ -740,8 +740,8 @@
       "patternId": "icon",
       "templateId": "web-components-N8bzRbfpuX",
       "demoId": "Xr7IHJQ1",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=light&demoId=Xr7IHJQ1&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=default&demoId=Xr7IHJQ1&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon",
@@ -754,8 +754,8 @@
       "patternId": "icon",
       "templateId": "web-components-N8bzRbfpuX",
       "demoId": "8VqxwwTyJ",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=light&demoId=8VqxwwTyJ&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=default&demoId=8VqxwwTyJ&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon",
@@ -768,8 +768,8 @@
       "patternId": "icon",
       "templateId": "web-components-N8bzRbfpuX",
       "demoId": "ezyQjAA-T1",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=light&demoId=ezyQjAA-T1&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=default&demoId=ezyQjAA-T1&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon",
@@ -782,8 +782,8 @@
       "patternId": "icon",
       "templateId": "web-components-Pnw8Nf0oOd",
       "demoId": "iPghK4UYBt",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-Pnw8Nf0oOd&assetSetId=light&demoId=iPghK4UYBt&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon&templateId=web-components-Pnw8Nf0oOd&assetSetId=default&demoId=iPghK4UYBt&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon",
@@ -796,8 +796,8 @@
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "BueNSFTYn",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=light&demoId=BueNSFTYn&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=default&demoId=BueNSFTYn&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-button",
@@ -810,8 +810,8 @@
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "IxXMQMFkBT",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=light&demoId=IxXMQMFkBT&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=default&demoId=IxXMQMFkBT&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-button",
@@ -824,8 +824,8 @@
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "MQBKTe4GON",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=light&demoId=MQBKTe4GON&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=default&demoId=MQBKTe4GON&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-button",
@@ -838,8 +838,8 @@
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "i-aFgnERP",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=light&demoId=i-aFgnERP&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=default&demoId=i-aFgnERP&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-button",
@@ -852,8 +852,8 @@
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "MWNDJ0YT9M",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=light&demoId=MWNDJ0YT9M&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=default&demoId=MWNDJ0YT9M&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-button",
@@ -866,8 +866,8 @@
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "iyfHwphwcs",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=light&demoId=iyfHwphwcs&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=default&demoId=iyfHwphwcs&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-button",
@@ -880,8 +880,8 @@
       "patternId": "icon-button-toggle",
       "templateId": "web-components-6kGMXrj-eP",
       "demoId": "O5OSKRluI9",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-button-toggle&templateId=web-components-6kGMXrj-eP&assetSetId=light&demoId=O5OSKRluI9&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-button-toggle&templateId=web-components-6kGMXrj-eP&assetSetId=default&demoId=O5OSKRluI9&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-button-toggle",
@@ -894,8 +894,8 @@
       "patternId": "icon-checkbox",
       "templateId": "web-components-jTiv8OpG9M",
       "demoId": "FTt0oVydi1",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-checkbox&templateId=web-components-jTiv8OpG9M&assetSetId=light&demoId=FTt0oVydi1&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-checkbox&templateId=web-components-jTiv8OpG9M&assetSetId=default&demoId=FTt0oVydi1&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-checkbox",
@@ -908,8 +908,8 @@
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "6A9yqTSh6x",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=light&demoId=6A9yqTSh6x&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=default&demoId=6A9yqTSh6x&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-lockup",
@@ -922,8 +922,8 @@
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "YIH9EOiP",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=light&demoId=YIH9EOiP&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=default&demoId=YIH9EOiP&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-lockup",
@@ -936,8 +936,8 @@
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "cGWFzjIg8i",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=light&demoId=cGWFzjIg8i&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=default&demoId=cGWFzjIg8i&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-lockup",
@@ -950,8 +950,8 @@
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "fekA6wwl9K",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=light&demoId=fekA6wwl9K&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=default&demoId=fekA6wwl9K&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-lockup",
@@ -964,8 +964,8 @@
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "8mt1FePOgA",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=light&demoId=8mt1FePOgA&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=default&demoId=8mt1FePOgA&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-lockup",
@@ -978,8 +978,8 @@
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "mnXbWmndnd",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=light&demoId=mnXbWmndnd&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=default&demoId=mnXbWmndnd&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-lockup",
@@ -992,8 +992,8 @@
       "patternId": "icon-radio",
       "templateId": "web-components-gmBL6Mhy4",
       "demoId": "3VTw68n4F5",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=icon-radio&templateId=web-components-gmBL6Mhy4&assetSetId=light&demoId=3VTw68n4F5&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=icon-radio&templateId=web-components-gmBL6Mhy4&assetSetId=default&demoId=3VTw68n4F5&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "icon-radio",
@@ -1006,8 +1006,8 @@
       "patternId": "linear-progress",
       "templateId": "web-components-2ew8-hMQkv",
       "demoId": "lXYaxeRM4L",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=linear-progress&templateId=web-components-2ew8-hMQkv&assetSetId=light&demoId=lXYaxeRM4L&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=linear-progress&templateId=web-components-2ew8-hMQkv&assetSetId=default&demoId=lXYaxeRM4L&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "linear-progress",
@@ -1020,8 +1020,8 @@
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "R-bXJMtJi",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=light&demoId=R-bXJMtJi&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=default&demoId=R-bXJMtJi&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "list",
@@ -1034,8 +1034,8 @@
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "kyAJAxMx7u",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=light&demoId=kyAJAxMx7u&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=default&demoId=kyAJAxMx7u&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "list",
@@ -1048,8 +1048,8 @@
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "kaReFY5Pwj",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=light&demoId=kaReFY5Pwj&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=default&demoId=kaReFY5Pwj&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "list",
@@ -1062,8 +1062,8 @@
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "hjXCY4fSqY",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=light&demoId=hjXCY4fSqY&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=default&demoId=hjXCY4fSqY&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "list",
@@ -1076,8 +1076,8 @@
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "SIyOkmonoE",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=light&demoId=SIyOkmonoE&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=default&demoId=SIyOkmonoE&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "list",
@@ -1090,8 +1090,8 @@
       "patternId": "list-item",
       "templateId": "web-components-ytRTf8wtxn",
       "demoId": "qgGc8WUNHQ",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=list-item&templateId=web-components-ytRTf8wtxn&assetSetId=light&demoId=qgGc8WUNHQ&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=list-item&templateId=web-components-ytRTf8wtxn&assetSetId=default&demoId=qgGc8WUNHQ&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "list-item",
@@ -1104,8 +1104,8 @@
       "patternId": "menu",
       "templateId": "web-components-hY3y1MyhrP",
       "demoId": "boILoye9Gi",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=menu&templateId=web-components-hY3y1MyhrP&assetSetId=light&demoId=boILoye9Gi&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=menu&templateId=web-components-hY3y1MyhrP&assetSetId=default&demoId=boILoye9Gi&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "menu",
@@ -1118,8 +1118,8 @@
       "patternId": "navigation-list-item",
       "templateId": "web-components-Qtmmi7N-aL",
       "demoId": "E5NLCltz6",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=navigation-list-item&templateId=web-components-Qtmmi7N-aL&assetSetId=light&demoId=E5NLCltz6&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=navigation-list-item&templateId=web-components-Qtmmi7N-aL&assetSetId=default&demoId=E5NLCltz6&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "navigation-list-item",
@@ -1132,8 +1132,8 @@
       "patternId": "navigation-list-item",
       "templateId": "web-components-Qtmmi7N-aL",
       "demoId": "v3IaS3HWdf",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=navigation-list-item&templateId=web-components-Qtmmi7N-aL&assetSetId=light&demoId=v3IaS3HWdf&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=navigation-list-item&templateId=web-components-Qtmmi7N-aL&assetSetId=default&demoId=v3IaS3HWdf&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "navigation-list-item",
@@ -1146,8 +1146,8 @@
       "patternId": "notebook-cell",
       "templateId": "web-components-dlfSUMV1v",
       "demoId": "tMM8dM4L3g",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=notebook-cell&templateId=web-components-dlfSUMV1v&assetSetId=light&demoId=tMM8dM4L3g&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=notebook-cell&templateId=web-components-dlfSUMV1v&assetSetId=default&demoId=tMM8dM4L3g&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "notebook-cell",
@@ -1160,8 +1160,8 @@
       "patternId": "notebook-cell",
       "templateId": "web-components-dlfSUMV1v",
       "demoId": "H-H7-TnR4K",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=notebook-cell&templateId=web-components-dlfSUMV1v&assetSetId=light&demoId=H-H7-TnR4K&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=notebook-cell&templateId=web-components-dlfSUMV1v&assetSetId=default&demoId=H-H7-TnR4K&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "notebook-cell",
@@ -1174,8 +1174,8 @@
       "patternId": "radio",
       "templateId": "web-components-qk2MWcBipT",
       "demoId": "RMPpKHlzd",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=radio&templateId=web-components-qk2MWcBipT&assetSetId=light&demoId=RMPpKHlzd&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=radio&templateId=web-components-qk2MWcBipT&assetSetId=default&demoId=RMPpKHlzd&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "radio",
@@ -1188,8 +1188,8 @@
       "patternId": "radio-list-item",
       "templateId": "web-components-fwKtEBOnv",
       "demoId": "MzuUqdOHZA",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=radio-list-item&templateId=web-components-fwKtEBOnv&assetSetId=light&demoId=MzuUqdOHZA&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=radio-list-item&templateId=web-components-fwKtEBOnv&assetSetId=default&demoId=MzuUqdOHZA&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "radio-list-item",
@@ -1202,8 +1202,8 @@
       "patternId": "select",
       "templateId": "web-components-qWXTtv81jY",
       "demoId": "sWH6jqeBc",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=select&templateId=web-components-qWXTtv81jY&assetSetId=light&demoId=sWH6jqeBc&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=select&templateId=web-components-qWXTtv81jY&assetSetId=default&demoId=sWH6jqeBc&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "select",
@@ -1216,10 +1216,10 @@
       "patternId": "side-sheet",
       "templateId": "web-components-UMR43JQszt",
       "demoId": "F84crA5Gx4",
-      "assetSetId": "light",
+      "assetSetId": "default",
       "width": 895,
       "height": 502,
-      "url": "/api/v1/render?patternId=side-sheet&templateId=web-components-UMR43JQszt&assetSetId=light&demoId=F84crA5Gx4&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render?patternId=side-sheet&templateId=web-components-UMR43JQszt&assetSetId=default&demoId=F84crA5Gx4&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "side-sheet",
@@ -1234,8 +1234,8 @@
       "patternId": "slider",
       "templateId": "web-components-LpKATlK5H",
       "demoId": "x9f-h1BpY",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=slider&templateId=web-components-LpKATlK5H&assetSetId=light&demoId=x9f-h1BpY&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=slider&templateId=web-components-LpKATlK5H&assetSetId=default&demoId=x9f-h1BpY&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "slider",
@@ -1248,8 +1248,8 @@
       "patternId": "slider",
       "templateId": "web-components-33Z9-C4Qs",
       "demoId": "HY3BFMh0AM",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=slider&templateId=web-components-33Z9-C4Qs&assetSetId=light&demoId=HY3BFMh0AM&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=slider&templateId=web-components-33Z9-C4Qs&assetSetId=default&demoId=HY3BFMh0AM&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "slider",
@@ -1262,8 +1262,8 @@
       "patternId": "snackbar",
       "templateId": "web-components-3ERE1Ai9lo",
       "demoId": "5aKkBtql-E",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=snackbar&templateId=web-components-3ERE1Ai9lo&assetSetId=light&demoId=5aKkBtql-E&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=snackbar&templateId=web-components-3ERE1Ai9lo&assetSetId=default&demoId=5aKkBtql-E&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "snackbar",
@@ -1276,8 +1276,8 @@
       "patternId": "status-dialog",
       "templateId": "web-components-klayJh8gA",
       "demoId": "ugxYH4hy3",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=status-dialog&templateId=web-components-klayJh8gA&assetSetId=light&demoId=ugxYH4hy3&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=status-dialog&templateId=web-components-klayJh8gA&assetSetId=default&demoId=ugxYH4hy3&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "status-dialog",
@@ -1290,8 +1290,8 @@
       "patternId": "status-dialog",
       "templateId": "web-components-klayJh8gA",
       "demoId": "zKTIBgFUtF",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=status-dialog&templateId=web-components-klayJh8gA&assetSetId=light&demoId=zKTIBgFUtF&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=status-dialog&templateId=web-components-klayJh8gA&assetSetId=default&demoId=zKTIBgFUtF&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "status-dialog",
@@ -1304,8 +1304,8 @@
       "patternId": "status-header",
       "templateId": "web-components-UDLnfGbB2W",
       "demoId": "1OH1Dga5C0",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=status-header&templateId=web-components-UDLnfGbB2W&assetSetId=light&demoId=1OH1Dga5C0&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=status-header&templateId=web-components-UDLnfGbB2W&assetSetId=default&demoId=1OH1Dga5C0&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "status-header",
@@ -1318,8 +1318,8 @@
       "patternId": "status-header-item",
       "templateId": "web-components-55FkYSafco",
       "demoId": "YHuTizup8",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=status-header-item&templateId=web-components-55FkYSafco&assetSetId=light&demoId=YHuTizup8&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=status-header-item&templateId=web-components-55FkYSafco&assetSetId=default&demoId=YHuTizup8&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "status-header-item",
@@ -1332,8 +1332,8 @@
       "patternId": "switch",
       "templateId": "web-components-tGj2TvSrpD",
       "demoId": "U89p0LyOsP",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=switch&templateId=web-components-tGj2TvSrpD&assetSetId=light&demoId=U89p0LyOsP&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=switch&templateId=web-components-tGj2TvSrpD&assetSetId=default&demoId=U89p0LyOsP&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "switch",
@@ -1346,8 +1346,8 @@
       "patternId": "tab",
       "templateId": "web-components-1-Bf2NwL1T",
       "demoId": "3HxZQWfBi9",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=tab&templateId=web-components-1-Bf2NwL1T&assetSetId=light&demoId=3HxZQWfBi9&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=tab&templateId=web-components-1-Bf2NwL1T&assetSetId=default&demoId=3HxZQWfBi9&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "tab",
@@ -1360,8 +1360,8 @@
       "patternId": "tabs",
       "templateId": "web-components-kjFGUA31tg",
       "demoId": "GOJxN1FZx",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=tabs&templateId=web-components-kjFGUA31tg&assetSetId=light&demoId=GOJxN1FZx&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=tabs&templateId=web-components-kjFGUA31tg&assetSetId=default&demoId=GOJxN1FZx&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "tabs",
@@ -1374,8 +1374,8 @@
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "RV5V-zEoUJ",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=light&demoId=RV5V-zEoUJ&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=RV5V-zEoUJ&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "text",
@@ -1388,8 +1388,8 @@
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "uKKiquKOJq",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=light&demoId=uKKiquKOJq&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=uKKiquKOJq&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "text",
@@ -1402,8 +1402,8 @@
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "XqxbTjPFZB",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=light&demoId=XqxbTjPFZB&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=XqxbTjPFZB&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "text",
@@ -1416,8 +1416,8 @@
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "CkH7TzkgbA",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=light&demoId=CkH7TzkgbA&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=CkH7TzkgbA&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "text",
@@ -1430,8 +1430,8 @@
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "iH3DCGMPTw",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=light&demoId=iH3DCGMPTw&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=iH3DCGMPTw&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "text",
@@ -1444,8 +1444,8 @@
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "oY0W5ALQ1q",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=light&demoId=oY0W5ALQ1q&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=oY0W5ALQ1q&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "text",
@@ -1458,8 +1458,8 @@
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "pvszcppjX8",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=light&demoId=pvszcppjX8&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=pvszcppjX8&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "text",
@@ -1472,8 +1472,8 @@
       "patternId": "text-area",
       "templateId": "web-components-48rzn99y9G",
       "demoId": "L87CMmCK4T",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=text-area&templateId=web-components-48rzn99y9G&assetSetId=light&demoId=L87CMmCK4T&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=text-area&templateId=web-components-48rzn99y9G&assetSetId=default&demoId=L87CMmCK4T&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "text-area",
@@ -1486,8 +1486,8 @@
       "patternId": "text-lockup",
       "templateId": "web-components-4Aa-qjh3vF",
       "demoId": "WWgMBRroJw",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=text-lockup&templateId=web-components-4Aa-qjh3vF&assetSetId=light&demoId=WWgMBRroJw&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=text-lockup&templateId=web-components-4Aa-qjh3vF&assetSetId=default&demoId=WWgMBRroJw&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "text-lockup",
@@ -1500,8 +1500,8 @@
       "patternId": "textfield",
       "templateId": "web-components-M4zyalwdNJ",
       "demoId": "zYujvGxjlZ",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=textfield&templateId=web-components-M4zyalwdNJ&assetSetId=light&demoId=zYujvGxjlZ&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=textfield&templateId=web-components-M4zyalwdNJ&assetSetId=default&demoId=zYujvGxjlZ&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "textfield",
@@ -1514,8 +1514,8 @@
       "patternId": "textfield",
       "templateId": "web-components-M4zyalwdNJ",
       "demoId": "tU8Ze3Af9p",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=textfield&templateId=web-components-M4zyalwdNJ&assetSetId=light&demoId=tU8Ze3Af9p&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=textfield&templateId=web-components-M4zyalwdNJ&assetSetId=default&demoId=tU8Ze3Af9p&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "textfield",
@@ -1528,8 +1528,8 @@
       "patternId": "toolbar",
       "templateId": "web-components-A6-16QhSaM",
       "demoId": "NXMdeiHjKO",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=toolbar&templateId=web-components-A6-16QhSaM&assetSetId=light&demoId=NXMdeiHjKO&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=toolbar&templateId=web-components-A6-16QhSaM&assetSetId=default&demoId=NXMdeiHjKO&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "toolbar",
@@ -1542,8 +1542,8 @@
       "patternId": "tooltip",
       "templateId": "web-components-erhVvpq9vk",
       "demoId": "V1YF-oKSJk",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=tooltip&templateId=web-components-erhVvpq9vk&assetSetId=light&demoId=V1YF-oKSJk&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=tooltip&templateId=web-components-erhVvpq9vk&assetSetId=default&demoId=V1YF-oKSJk&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "tooltip",
@@ -1556,8 +1556,8 @@
       "patternId": "top-app-bar",
       "templateId": "web-components-bdJKZJwv0h",
       "demoId": "R8F5cdPVrq",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=top-app-bar&templateId=web-components-bdJKZJwv0h&assetSetId=light&demoId=R8F5cdPVrq&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=top-app-bar&templateId=web-components-bdJKZJwv0h&assetSetId=default&demoId=R8F5cdPVrq&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "top-app-bar",
@@ -1570,8 +1570,8 @@
       "patternId": "top-app-bar-fixed",
       "templateId": "web-components-d0oZXgy7Uj",
       "demoId": "RQLhdtbJlh",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=top-app-bar-fixed&templateId=web-components-d0oZXgy7Uj&assetSetId=light&demoId=RQLhdtbJlh&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=top-app-bar-fixed&templateId=web-components-d0oZXgy7Uj&assetSetId=default&demoId=RQLhdtbJlh&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "top-app-bar-fixed",
@@ -1584,8 +1584,8 @@
       "patternId": "tree-list",
       "templateId": "web-components-Ue0Hy3Asb",
       "demoId": "RjMe6Q4mA",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=tree-list&templateId=web-components-Ue0Hy3Asb&assetSetId=light&demoId=RjMe6Q4mA&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=tree-list&templateId=web-components-Ue0Hy3Asb&assetSetId=default&demoId=RjMe6Q4mA&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "tree-list",
@@ -1598,8 +1598,8 @@
       "patternId": "tree-list-item",
       "templateId": "web-components-1jOFYZB9ms",
       "demoId": "7gFch0E4yr",
-      "assetSetId": "light",
-      "url": "/api/v1/render?patternId=tree-list-item&templateId=web-components-1jOFYZB9ms&assetSetId=light&demoId=7gFch0E4yr&isInIframe=false&wrapHtml=true"
+      "assetSetId": "default",
+      "url": "/api/v1/render?patternId=tree-list-item&templateId=web-components-1jOFYZB9ms&assetSetId=default&demoId=7gFch0E4yr&isInIframe=false&wrapHtml=true"
     },
     {
       "patternId": "tree-list-item",


### PR DESCRIPTION
## Description

using default id from knapsack documentation. This seems to fix the reference issue causing all of the icons to fail

### What's included?

- adjusted the default id for the light theme per knapsack documentation

#### Test Steps

- [ ]  `nx run knapsack:build`
- [ ] then navigate to the browser opened
- [ ] finally test the icon web components example and any example using icons

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
