### PR TITLE
fix(angular): fixing dynamic menu open in new tab

### DIFF
--- a/libs/angular/dynamic-menu/src/dynamic-menu-item/dynamic-menu-item.component.html
+++ b/libs/angular/dynamic-menu/src/dynamic-menu-item/dynamic-menu-item.component.html
@@ -25,12 +25,10 @@
         <div class="group-label tc-td-secondary text-sm">{{ item.text }}</div>
       </ng-container>
       <ng-container *ngIf="item.link || item.action">
-        <div mat-menu-item class="pad-none">
-          <td-dynamic-menu-link
-            [item]="item"
-            (itemClicked)="emitClicked($event)"
-          ></td-dynamic-menu-link>
-        </div>
+        <td-dynamic-menu-link
+          [item]="item"
+          (itemClicked)="emitClicked($event)"
+        ></td-dynamic-menu-link>
       </ng-container>
     </ng-container>
   </ng-template>

--- a/libs/angular/dynamic-menu/src/dynamic-menu-item/dynamic-menu-link/dynamic-menu-link.component.html
+++ b/libs/angular/dynamic-menu/src/dynamic-menu-item/dynamic-menu-link/dynamic-menu-link.component.html
@@ -15,8 +15,10 @@
   <mat-icon *ngIf="item.icon" [class]="item.iconClasses">{{
     item.icon
   }}</mat-icon>
-  <span>{{ item.text }}</span>
-  <mat-icon *ngIf="item.newTab" class="new-tab-icon">launch</mat-icon>
+  <span class="item-link-text">
+    {{ item.text }}
+    <mat-icon *ngIf="item.newTab" class="new-tab-icon">launch</mat-icon>
+  </span>
 </a>
 <button
   *ngIf="item.action"

--- a/libs/angular/dynamic-menu/src/dynamic-menu-item/dynamic-menu-link/dynamic-menu-link.component.scss
+++ b/libs/angular/dynamic-menu/src/dynamic-menu-item/dynamic-menu-link/dynamic-menu-link.component.scss
@@ -10,6 +10,7 @@
   .new-tab-icon {
     margin: 0 0 0 16px;
   }
+
   .item-link-text {
     display: flex;
     align-items: center;

--- a/libs/angular/dynamic-menu/src/dynamic-menu-item/dynamic-menu-link/dynamic-menu-link.component.scss
+++ b/libs/angular/dynamic-menu/src/dynamic-menu-item/dynamic-menu-link/dynamic-menu-link.component.scss
@@ -10,4 +10,8 @@
   .new-tab-icon {
     margin: 0 0 0 16px;
   }
+  .item-link-text {
+    display: flex;
+    align-items: center;
+  }
 }


### PR DESCRIPTION
## Description

Adjusting the stylling for the dynamic menu item when its set to open in a new tab

### What's included?

- Fix styling for link opening in new tab

#### Test Steps

- [ ] `npm run start`
- [ ] then go to the dynamic menu examples under components
- [ ] finally test the examples

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

## Before
![Screenshot 2025-01-31 at 2 26 09 PM](https://github.com/user-attachments/assets/7a721a19-12b6-47b9-bf73-d051993d52fe)
![Screenshot 2025-01-31 at 2 26 01 PM](https://github.com/user-attachments/assets/77d4f394-1ea6-405b-a23c-b27ef3c333f0)

## After
![Screenshot 2025-01-31 at 2 25 44 PM](https://github.com/user-attachments/assets/6b3daf36-a91c-4fbe-a772-ba6351c67339)
![Screenshot 2025-01-31 at 2 25 38 PM](https://github.com/user-attachments/assets/91eea746-26a5-43ea-b78f-67ce615233a9)

