### PR TITLE
style(knapsack): adjusting style overrides for new update

### DIFF
--- a/apps/knapsack/dist/meta/ks-meta.json
+++ b/apps/knapsack/dist/meta/ks-meta.json
@@ -5,126 +5,126 @@
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "xrVH4M3t6W",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=xrVH4M3t6W&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=xrVH4M3t6W&assetSetId=default"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "xrVH4M3t6W",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=dark&demoId=xrVH4M3t6W&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=xrVH4M3t6W&assetSetId=dark"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "SBpuLooid9",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=SBpuLooid9&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=SBpuLooid9&assetSetId=default"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "SBpuLooid9",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=dark&demoId=SBpuLooid9&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=SBpuLooid9&assetSetId=dark"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "3ueuxC011k",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=3ueuxC011k&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=3ueuxC011k&assetSetId=default"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "3ueuxC011k",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=dark&demoId=3ueuxC011k&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=3ueuxC011k&assetSetId=dark"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "04wy8HmIJl",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=04wy8HmIJl&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=04wy8HmIJl&assetSetId=default"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "04wy8HmIJl",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=dark&demoId=04wy8HmIJl&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=04wy8HmIJl&assetSetId=dark"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "78JmyZgiv8",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=78JmyZgiv8&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=78JmyZgiv8&assetSetId=default"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "78JmyZgiv8",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=dark&demoId=78JmyZgiv8&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=78JmyZgiv8&assetSetId=dark"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "PX4CXlob7k",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=PX4CXlob7k&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=PX4CXlob7k&assetSetId=default"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "PX4CXlob7k",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=dark&demoId=PX4CXlob7k&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=PX4CXlob7k&assetSetId=dark"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "I15dIgeIM4",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=I15dIgeIM4&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=I15dIgeIM4&assetSetId=default"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "I15dIgeIM4",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=dark&demoId=I15dIgeIM4&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=I15dIgeIM4&assetSetId=dark"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "sNiAamckj3",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=sNiAamckj3&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=sNiAamckj3&assetSetId=default"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "sNiAamckj3",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=dark&demoId=sNiAamckj3&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=sNiAamckj3&assetSetId=dark"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "aQE9OP2U6t",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=default&demoId=aQE9OP2U6t&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=aQE9OP2U6t&assetSetId=default"
     },
     {
       "patternId": "action-ribbon",
       "templateId": "web-components-v3gk7O39kO",
       "demoId": "aQE9OP2U6t",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&assetSetId=dark&demoId=aQE9OP2U6t&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=action-ribbon&templateId=web-components-v3gk7O39kO&demoId=aQE9OP2U6t&assetSetId=dark"
     },
     {
       "patternId": "alert",
@@ -133,7 +133,7 @@
       "assetSetId": "default",
       "width": 806,
       "height": 94,
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=tnvgSz6pjh&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=tnvgSz6pjh&assetSetId=default"
     },
     {
       "patternId": "alert",
@@ -142,231 +142,231 @@
       "assetSetId": "dark",
       "width": 806,
       "height": 94,
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=dark&demoId=tnvgSz6pjh&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=tnvgSz6pjh&assetSetId=dark"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "vmDFzhOhSn",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=vmDFzhOhSn&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=vmDFzhOhSn&assetSetId=default"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "vmDFzhOhSn",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=dark&demoId=vmDFzhOhSn&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=vmDFzhOhSn&assetSetId=dark"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "S4K35ZGdnu",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=S4K35ZGdnu&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=S4K35ZGdnu&assetSetId=default"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "S4K35ZGdnu",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=dark&demoId=S4K35ZGdnu&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=S4K35ZGdnu&assetSetId=dark"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "WosGIC3IsN",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=WosGIC3IsN&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=WosGIC3IsN&assetSetId=default"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "WosGIC3IsN",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=dark&demoId=WosGIC3IsN&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=WosGIC3IsN&assetSetId=dark"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "t7e3P48Pkm",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=t7e3P48Pkm&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=t7e3P48Pkm&assetSetId=default"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "t7e3P48Pkm",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=dark&demoId=t7e3P48Pkm&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=t7e3P48Pkm&assetSetId=dark"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "pYd0j3oNrI",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=pYd0j3oNrI&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=pYd0j3oNrI&assetSetId=default"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "pYd0j3oNrI",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=dark&demoId=pYd0j3oNrI&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=pYd0j3oNrI&assetSetId=dark"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "xnEh2A2lis",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=xnEh2A2lis&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=xnEh2A2lis&assetSetId=default"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "xnEh2A2lis",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=dark&demoId=xnEh2A2lis&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=xnEh2A2lis&assetSetId=dark"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "LATgTeg21H",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=LATgTeg21H&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=LATgTeg21H&assetSetId=default"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "LATgTeg21H",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=dark&demoId=LATgTeg21H&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=LATgTeg21H&assetSetId=dark"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "yf2q5F2Jyk",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=yf2q5F2Jyk&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=yf2q5F2Jyk&assetSetId=default"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "yf2q5F2Jyk",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=dark&demoId=yf2q5F2Jyk&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=yf2q5F2Jyk&assetSetId=dark"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "CE5x5TaMa2",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=CE5x5TaMa2&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=CE5x5TaMa2&assetSetId=default"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "CE5x5TaMa2",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=dark&demoId=CE5x5TaMa2&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=CE5x5TaMa2&assetSetId=dark"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "s8Ci4Cd08W",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=default&demoId=s8Ci4Cd08W&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=s8Ci4Cd08W&assetSetId=default"
     },
     {
       "patternId": "alert",
       "templateId": "web-components-4qjJYWsUZi",
       "demoId": "s8Ci4Cd08W",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=alert&templateId=web-components-4qjJYWsUZi&assetSetId=dark&demoId=s8Ci4Cd08W&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=alert&templateId=web-components-4qjJYWsUZi&demoId=s8Ci4Cd08W&assetSetId=dark"
     },
     {
       "patternId": "app-shell",
       "templateId": "web-components-z8r4uoVkf",
       "demoId": "5lBJhPKvTj",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=app-shell&templateId=web-components-z8r4uoVkf&assetSetId=default&demoId=5lBJhPKvTj&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=app-shell&templateId=web-components-z8r4uoVkf&demoId=5lBJhPKvTj&assetSetId=default"
     },
     {
       "patternId": "app-shell",
       "templateId": "web-components-z8r4uoVkf",
       "demoId": "5lBJhPKvTj",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=app-shell&templateId=web-components-z8r4uoVkf&assetSetId=dark&demoId=5lBJhPKvTj&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=app-shell&templateId=web-components-z8r4uoVkf&demoId=5lBJhPKvTj&assetSetId=dark"
     },
     {
       "patternId": "badge",
       "templateId": "web-components-40aOlYC6I9",
       "demoId": "NAoDoFXI-A",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=badge&templateId=web-components-40aOlYC6I9&assetSetId=default&demoId=NAoDoFXI-A&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=badge&templateId=web-components-40aOlYC6I9&demoId=NAoDoFXI-A&assetSetId=default"
     },
     {
       "patternId": "badge",
       "templateId": "web-components-40aOlYC6I9",
       "demoId": "NAoDoFXI-A",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=badge&templateId=web-components-40aOlYC6I9&assetSetId=dark&demoId=NAoDoFXI-A&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=badge&templateId=web-components-40aOlYC6I9&demoId=NAoDoFXI-A&assetSetId=dark"
     },
     {
       "patternId": "badge",
       "templateId": "web-components-40aOlYC6I9",
       "demoId": "laNQ9RRdMn",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=badge&templateId=web-components-40aOlYC6I9&assetSetId=default&demoId=laNQ9RRdMn&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=badge&templateId=web-components-40aOlYC6I9&demoId=laNQ9RRdMn&assetSetId=default"
     },
     {
       "patternId": "badge",
       "templateId": "web-components-40aOlYC6I9",
       "demoId": "laNQ9RRdMn",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=badge&templateId=web-components-40aOlYC6I9&assetSetId=dark&demoId=laNQ9RRdMn&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=badge&templateId=web-components-40aOlYC6I9&demoId=laNQ9RRdMn&assetSetId=dark"
     },
     {
       "patternId": "badge",
       "templateId": "web-components-40aOlYC6I9",
       "demoId": "uhaHv83YYx",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=badge&templateId=web-components-40aOlYC6I9&assetSetId=default&demoId=uhaHv83YYx&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=badge&templateId=web-components-40aOlYC6I9&demoId=uhaHv83YYx&assetSetId=default"
     },
     {
       "patternId": "badge",
       "templateId": "web-components-40aOlYC6I9",
       "demoId": "uhaHv83YYx",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=badge&templateId=web-components-40aOlYC6I9&assetSetId=dark&demoId=uhaHv83YYx&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=badge&templateId=web-components-40aOlYC6I9&demoId=uhaHv83YYx&assetSetId=dark"
     },
     {
       "patternId": "button",
       "templateId": "web-components-raE1x4tYL",
       "demoId": "LVG5iF-p9d",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=button&templateId=web-components-raE1x4tYL&assetSetId=default&demoId=LVG5iF-p9d&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=button&templateId=web-components-raE1x4tYL&demoId=LVG5iF-p9d&assetSetId=default"
     },
     {
       "patternId": "button",
       "templateId": "web-components-raE1x4tYL",
       "demoId": "LVG5iF-p9d",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=button&templateId=web-components-raE1x4tYL&assetSetId=dark&demoId=LVG5iF-p9d&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=button&templateId=web-components-raE1x4tYL&demoId=LVG5iF-p9d&assetSetId=dark"
     },
     {
       "patternId": "button",
       "templateId": "web-components-raE1x4tYL",
       "demoId": "E5ymzzEPs",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=button&templateId=web-components-raE1x4tYL&assetSetId=default&demoId=E5ymzzEPs&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=button&templateId=web-components-raE1x4tYL&demoId=E5ymzzEPs&assetSetId=default"
     },
     {
       "patternId": "button",
       "templateId": "web-components-raE1x4tYL",
       "demoId": "E5ymzzEPs",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=button&templateId=web-components-raE1x4tYL&assetSetId=dark&demoId=E5ymzzEPs&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=button&templateId=web-components-raE1x4tYL&demoId=E5ymzzEPs&assetSetId=dark"
     },
     {
       "patternId": "button",
@@ -375,7 +375,7 @@
       "assetSetId": "default",
       "width": 111,
       "height": 54,
-      "url": "/api/v1/render?patternId=button&templateId=web-components-raE1x4tYL&assetSetId=default&demoId=wJJ2tksHEK&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=button&templateId=web-components-raE1x4tYL&demoId=wJJ2tksHEK&assetSetId=default"
     },
     {
       "patternId": "button",
@@ -384,833 +384,833 @@
       "assetSetId": "dark",
       "width": 111,
       "height": 54,
-      "url": "/api/v1/render?patternId=button&templateId=web-components-raE1x4tYL&assetSetId=dark&demoId=wJJ2tksHEK&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=button&templateId=web-components-raE1x4tYL&demoId=wJJ2tksHEK&assetSetId=dark"
     },
     {
       "patternId": "button",
       "templateId": "angular-i3OR9O7kXg",
       "demoId": "CRFHBobaZj",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=button&templateId=angular-i3OR9O7kXg&assetSetId=default&demoId=CRFHBobaZj&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=button&templateId=angular-i3OR9O7kXg&demoId=CRFHBobaZj&assetSetId=default"
     },
     {
       "patternId": "button",
       "templateId": "angular-i3OR9O7kXg",
       "demoId": "CRFHBobaZj",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=button&templateId=angular-i3OR9O7kXg&assetSetId=dark&demoId=CRFHBobaZj&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=button&templateId=angular-i3OR9O7kXg&demoId=CRFHBobaZj&assetSetId=dark"
     },
     {
       "patternId": "button",
       "templateId": "angular-i3OR9O7kXg",
       "demoId": "eIOsBgDEvJ",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=button&templateId=angular-i3OR9O7kXg&assetSetId=default&demoId=eIOsBgDEvJ&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=button&templateId=angular-i3OR9O7kXg&demoId=eIOsBgDEvJ&assetSetId=default"
     },
     {
       "patternId": "button",
       "templateId": "angular-i3OR9O7kXg",
       "demoId": "eIOsBgDEvJ",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=button&templateId=angular-i3OR9O7kXg&assetSetId=dark&demoId=eIOsBgDEvJ&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=button&templateId=angular-i3OR9O7kXg&demoId=eIOsBgDEvJ&assetSetId=dark"
     },
     {
       "patternId": "card",
       "templateId": "web-components-mU8MX1FHrF",
       "demoId": "pTyIIHqJtL",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=card&templateId=web-components-mU8MX1FHrF&assetSetId=default&demoId=pTyIIHqJtL&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=card&templateId=web-components-mU8MX1FHrF&demoId=pTyIIHqJtL&assetSetId=default"
     },
     {
       "patternId": "card",
       "templateId": "web-components-mU8MX1FHrF",
       "demoId": "pTyIIHqJtL",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=card&templateId=web-components-mU8MX1FHrF&assetSetId=dark&demoId=pTyIIHqJtL&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=card&templateId=web-components-mU8MX1FHrF&demoId=pTyIIHqJtL&assetSetId=dark"
     },
     {
       "patternId": "card",
       "templateId": "web-components-mU8MX1FHrF",
       "demoId": "sNLUIRYsNz",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=card&templateId=web-components-mU8MX1FHrF&assetSetId=default&demoId=sNLUIRYsNz&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=card&templateId=web-components-mU8MX1FHrF&demoId=sNLUIRYsNz&assetSetId=default"
     },
     {
       "patternId": "card",
       "templateId": "web-components-mU8MX1FHrF",
       "demoId": "sNLUIRYsNz",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=card&templateId=web-components-mU8MX1FHrF&assetSetId=dark&demoId=sNLUIRYsNz&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=card&templateId=web-components-mU8MX1FHrF&demoId=sNLUIRYsNz&assetSetId=dark"
     },
     {
       "patternId": "card",
       "templateId": "angular-K2H0Gg5PuL",
       "demoId": "nrW1VpRzc",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=card&templateId=angular-K2H0Gg5PuL&assetSetId=default&demoId=nrW1VpRzc&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=card&templateId=angular-K2H0Gg5PuL&demoId=nrW1VpRzc&assetSetId=default"
     },
     {
       "patternId": "card",
       "templateId": "angular-K2H0Gg5PuL",
       "demoId": "nrW1VpRzc",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=card&templateId=angular-K2H0Gg5PuL&assetSetId=dark&demoId=nrW1VpRzc&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=card&templateId=angular-K2H0Gg5PuL&demoId=nrW1VpRzc&assetSetId=dark"
     },
     {
       "patternId": "check-list-item",
       "templateId": "web-components-M18BFFHM3h",
       "demoId": "CvFKcI1eN0",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=check-list-item&templateId=web-components-M18BFFHM3h&assetSetId=default&demoId=CvFKcI1eN0&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=check-list-item&templateId=web-components-M18BFFHM3h&demoId=CvFKcI1eN0&assetSetId=default"
     },
     {
       "patternId": "check-list-item",
       "templateId": "web-components-M18BFFHM3h",
       "demoId": "CvFKcI1eN0",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=check-list-item&templateId=web-components-M18BFFHM3h&assetSetId=dark&demoId=CvFKcI1eN0&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=check-list-item&templateId=web-components-M18BFFHM3h&demoId=CvFKcI1eN0&assetSetId=dark"
     },
     {
       "patternId": "checkbox",
       "templateId": "web-components-29FbeDQWhM",
       "demoId": "ee2EneFvzS",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=checkbox&templateId=web-components-29FbeDQWhM&assetSetId=default&demoId=ee2EneFvzS&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=checkbox&templateId=web-components-29FbeDQWhM&demoId=ee2EneFvzS&assetSetId=default"
     },
     {
       "patternId": "checkbox",
       "templateId": "web-components-29FbeDQWhM",
       "demoId": "ee2EneFvzS",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=checkbox&templateId=web-components-29FbeDQWhM&assetSetId=dark&demoId=ee2EneFvzS&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=checkbox&templateId=web-components-29FbeDQWhM&demoId=ee2EneFvzS&assetSetId=dark"
     },
     {
       "patternId": "chip",
       "templateId": "web-components-7wYRPSnEZH",
       "demoId": "HyZJsWXVOc",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=chip&templateId=web-components-7wYRPSnEZH&assetSetId=default&demoId=HyZJsWXVOc&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=chip&templateId=web-components-7wYRPSnEZH&demoId=HyZJsWXVOc&assetSetId=default"
     },
     {
       "patternId": "chip",
       "templateId": "web-components-7wYRPSnEZH",
       "demoId": "HyZJsWXVOc",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=chip&templateId=web-components-7wYRPSnEZH&assetSetId=dark&demoId=HyZJsWXVOc&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=chip&templateId=web-components-7wYRPSnEZH&demoId=HyZJsWXVOc&assetSetId=dark"
     },
     {
       "patternId": "chip-item",
       "templateId": "web-components-vegaZgkE47",
       "demoId": "zDg2SpdOHk",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=chip-item&templateId=web-components-vegaZgkE47&assetSetId=default&demoId=zDg2SpdOHk&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=chip-item&templateId=web-components-vegaZgkE47&demoId=zDg2SpdOHk&assetSetId=default"
     },
     {
       "patternId": "chip-item",
       "templateId": "web-components-vegaZgkE47",
       "demoId": "zDg2SpdOHk",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=chip-item&templateId=web-components-vegaZgkE47&assetSetId=dark&demoId=zDg2SpdOHk&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=chip-item&templateId=web-components-vegaZgkE47&demoId=zDg2SpdOHk&assetSetId=dark"
     },
     {
       "patternId": "chip-item",
       "templateId": "web-components-vegaZgkE47",
       "demoId": "DINJPi6iZ",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=chip-item&templateId=web-components-vegaZgkE47&assetSetId=default&demoId=DINJPi6iZ&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=chip-item&templateId=web-components-vegaZgkE47&demoId=DINJPi6iZ&assetSetId=default"
     },
     {
       "patternId": "chip-item",
       "templateId": "web-components-vegaZgkE47",
       "demoId": "DINJPi6iZ",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=chip-item&templateId=web-components-vegaZgkE47&assetSetId=dark&demoId=DINJPi6iZ&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=chip-item&templateId=web-components-vegaZgkE47&demoId=DINJPi6iZ&assetSetId=dark"
     },
     {
       "patternId": "circular-progress",
       "templateId": "web-components-rw6v6c4fnU",
       "demoId": "gMTyjmInaG",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=circular-progress&templateId=web-components-rw6v6c4fnU&assetSetId=default&demoId=gMTyjmInaG&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=circular-progress&templateId=web-components-rw6v6c4fnU&demoId=gMTyjmInaG&assetSetId=default"
     },
     {
       "patternId": "circular-progress",
       "templateId": "web-components-rw6v6c4fnU",
       "demoId": "gMTyjmInaG",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=circular-progress&templateId=web-components-rw6v6c4fnU&assetSetId=dark&demoId=gMTyjmInaG&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=circular-progress&templateId=web-components-rw6v6c4fnU&demoId=gMTyjmInaG&assetSetId=dark"
     },
     {
       "patternId": "code-editor",
       "templateId": "web-components-JulJ63YyUz",
       "demoId": "t1CfBDrtut",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=code-editor&templateId=web-components-JulJ63YyUz&assetSetId=default&demoId=t1CfBDrtut&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=code-editor&templateId=web-components-JulJ63YyUz&demoId=t1CfBDrtut&assetSetId=default"
     },
     {
       "patternId": "code-editor",
       "templateId": "web-components-JulJ63YyUz",
       "demoId": "t1CfBDrtut",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=code-editor&templateId=web-components-JulJ63YyUz&assetSetId=dark&demoId=t1CfBDrtut&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=code-editor&templateId=web-components-JulJ63YyUz&demoId=t1CfBDrtut&assetSetId=dark"
     },
     {
       "patternId": "code-snippet",
       "templateId": "web-components-MmKtwF24Vv",
       "demoId": "HJPgdqmwj",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=code-snippet&templateId=web-components-MmKtwF24Vv&assetSetId=default&demoId=HJPgdqmwj&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=code-snippet&templateId=web-components-MmKtwF24Vv&demoId=HJPgdqmwj&assetSetId=default"
     },
     {
       "patternId": "code-snippet",
       "templateId": "web-components-MmKtwF24Vv",
       "demoId": "HJPgdqmwj",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=code-snippet&templateId=web-components-MmKtwF24Vv&assetSetId=dark&demoId=HJPgdqmwj&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=code-snippet&templateId=web-components-MmKtwF24Vv&demoId=HJPgdqmwj&assetSetId=dark"
     },
     {
       "patternId": "dialog",
       "templateId": "web-components-S9Ia0KOrya",
       "demoId": "yovRt8o986",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=dialog&templateId=web-components-S9Ia0KOrya&assetSetId=default&demoId=yovRt8o986&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=dialog&templateId=web-components-S9Ia0KOrya&demoId=yovRt8o986&assetSetId=default"
     },
     {
       "patternId": "dialog",
       "templateId": "web-components-S9Ia0KOrya",
       "demoId": "yovRt8o986",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=dialog&templateId=web-components-S9Ia0KOrya&assetSetId=dark&demoId=yovRt8o986&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=dialog&templateId=web-components-S9Ia0KOrya&demoId=yovRt8o986&assetSetId=dark"
     },
     {
       "patternId": "empty-state",
       "templateId": "web-components-E0GwXgHJv",
       "demoId": "8QAZfNvobo",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=empty-state&templateId=web-components-E0GwXgHJv&assetSetId=default&demoId=8QAZfNvobo&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=empty-state&templateId=web-components-E0GwXgHJv&demoId=8QAZfNvobo&assetSetId=default"
     },
     {
       "patternId": "empty-state",
       "templateId": "web-components-E0GwXgHJv",
       "demoId": "8QAZfNvobo",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=empty-state&templateId=web-components-E0GwXgHJv&assetSetId=dark&demoId=8QAZfNvobo&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=empty-state&templateId=web-components-E0GwXgHJv&demoId=8QAZfNvobo&assetSetId=dark"
     },
     {
       "patternId": "expansion-panel",
       "templateId": "web-components-Vj98q2D8hw",
       "demoId": "Yu7DvlfMdG",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=expansion-panel&templateId=web-components-Vj98q2D8hw&assetSetId=default&demoId=Yu7DvlfMdG&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=expansion-panel&templateId=web-components-Vj98q2D8hw&demoId=Yu7DvlfMdG&assetSetId=default"
     },
     {
       "patternId": "expansion-panel",
       "templateId": "web-components-Vj98q2D8hw",
       "demoId": "Yu7DvlfMdG",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=expansion-panel&templateId=web-components-Vj98q2D8hw&assetSetId=dark&demoId=Yu7DvlfMdG&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=expansion-panel&templateId=web-components-Vj98q2D8hw&demoId=Yu7DvlfMdG&assetSetId=dark"
     },
     {
       "patternId": "expansion-panel",
       "templateId": "web-components-Vj98q2D8hw",
       "demoId": "noRKlgh7xK",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=expansion-panel&templateId=web-components-Vj98q2D8hw&assetSetId=default&demoId=noRKlgh7xK&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=expansion-panel&templateId=web-components-Vj98q2D8hw&demoId=noRKlgh7xK&assetSetId=default"
     },
     {
       "patternId": "expansion-panel",
       "templateId": "web-components-Vj98q2D8hw",
       "demoId": "noRKlgh7xK",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=expansion-panel&templateId=web-components-Vj98q2D8hw&assetSetId=dark&demoId=noRKlgh7xK&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=expansion-panel&templateId=web-components-Vj98q2D8hw&demoId=noRKlgh7xK&assetSetId=dark"
     },
     {
       "patternId": "expansion-panel-item",
       "templateId": "web-components-vBLifAApG",
       "demoId": "w0H1gm2jvp",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=expansion-panel-item&templateId=web-components-vBLifAApG&assetSetId=default&demoId=w0H1gm2jvp&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=expansion-panel-item&templateId=web-components-vBLifAApG&demoId=w0H1gm2jvp&assetSetId=default"
     },
     {
       "patternId": "expansion-panel-item",
       "templateId": "web-components-vBLifAApG",
       "demoId": "w0H1gm2jvp",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=expansion-panel-item&templateId=web-components-vBLifAApG&assetSetId=dark&demoId=w0H1gm2jvp&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=expansion-panel-item&templateId=web-components-vBLifAApG&demoId=w0H1gm2jvp&assetSetId=dark"
     },
     {
       "patternId": "expansion-panel-item",
       "templateId": "web-components-vBLifAApG",
       "demoId": "6tUMrwwjoe",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=expansion-panel-item&templateId=web-components-vBLifAApG&assetSetId=default&demoId=6tUMrwwjoe&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=expansion-panel-item&templateId=web-components-vBLifAApG&demoId=6tUMrwwjoe&assetSetId=default"
     },
     {
       "patternId": "expansion-panel-item",
       "templateId": "web-components-vBLifAApG",
       "demoId": "6tUMrwwjoe",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=expansion-panel-item&templateId=web-components-vBLifAApG&assetSetId=dark&demoId=6tUMrwwjoe&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=expansion-panel-item&templateId=web-components-vBLifAApG&demoId=6tUMrwwjoe&assetSetId=dark"
     },
     {
       "patternId": "focused-page",
       "templateId": "web-components-waQVQEThJD",
       "demoId": "BNl6rXNkee",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=focused-page&templateId=web-components-waQVQEThJD&assetSetId=default&demoId=BNl6rXNkee&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=focused-page&templateId=web-components-waQVQEThJD&demoId=BNl6rXNkee&assetSetId=default"
     },
     {
       "patternId": "focused-page",
       "templateId": "web-components-waQVQEThJD",
       "demoId": "BNl6rXNkee",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=focused-page&templateId=web-components-waQVQEThJD&assetSetId=dark&demoId=BNl6rXNkee&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=focused-page&templateId=web-components-waQVQEThJD&demoId=BNl6rXNkee&assetSetId=dark"
     },
     {
       "patternId": "form-field",
       "templateId": "web-components-I5Sx1HQnJ",
       "demoId": "pmwAMIY3TV",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=form-field&templateId=web-components-I5Sx1HQnJ&assetSetId=default&demoId=pmwAMIY3TV&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=form-field&templateId=web-components-I5Sx1HQnJ&demoId=pmwAMIY3TV&assetSetId=default"
     },
     {
       "patternId": "form-field",
       "templateId": "web-components-I5Sx1HQnJ",
       "demoId": "pmwAMIY3TV",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=form-field&templateId=web-components-I5Sx1HQnJ&assetSetId=dark&demoId=pmwAMIY3TV&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=form-field&templateId=web-components-I5Sx1HQnJ&demoId=pmwAMIY3TV&assetSetId=dark"
     },
     {
       "patternId": "form-field",
       "templateId": "web-components-I5Sx1HQnJ",
       "demoId": "0n-okWquA",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=form-field&templateId=web-components-I5Sx1HQnJ&assetSetId=default&demoId=0n-okWquA&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=form-field&templateId=web-components-I5Sx1HQnJ&demoId=0n-okWquA&assetSetId=default"
     },
     {
       "patternId": "form-field",
       "templateId": "web-components-I5Sx1HQnJ",
       "demoId": "0n-okWquA",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=form-field&templateId=web-components-I5Sx1HQnJ&assetSetId=dark&demoId=0n-okWquA&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=form-field&templateId=web-components-I5Sx1HQnJ&demoId=0n-okWquA&assetSetId=dark"
     },
     {
       "patternId": "form-field",
       "templateId": "web-components-I5Sx1HQnJ",
       "demoId": "1cr3GRlfdT",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=form-field&templateId=web-components-I5Sx1HQnJ&assetSetId=default&demoId=1cr3GRlfdT&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=form-field&templateId=web-components-I5Sx1HQnJ&demoId=1cr3GRlfdT&assetSetId=default"
     },
     {
       "patternId": "form-field",
       "templateId": "web-components-I5Sx1HQnJ",
       "demoId": "1cr3GRlfdT",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=form-field&templateId=web-components-I5Sx1HQnJ&assetSetId=dark&demoId=1cr3GRlfdT&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=form-field&templateId=web-components-I5Sx1HQnJ&demoId=1cr3GRlfdT&assetSetId=dark"
     },
     {
       "patternId": "full-screen-dialog",
       "templateId": "web-components-HeDCLBaQf9",
       "demoId": "DJycXyA-3c",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=full-screen-dialog&templateId=web-components-HeDCLBaQf9&assetSetId=default&demoId=DJycXyA-3c&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=full-screen-dialog&templateId=web-components-HeDCLBaQf9&demoId=DJycXyA-3c&assetSetId=default"
     },
     {
       "patternId": "full-screen-dialog",
       "templateId": "web-components-HeDCLBaQf9",
       "demoId": "DJycXyA-3c",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=full-screen-dialog&templateId=web-components-HeDCLBaQf9&assetSetId=dark&demoId=DJycXyA-3c&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=full-screen-dialog&templateId=web-components-HeDCLBaQf9&demoId=DJycXyA-3c&assetSetId=dark"
     },
     {
       "patternId": "icon",
       "templateId": "web-components-N8bzRbfpuX",
       "demoId": "bn4zy44TYR",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=default&demoId=bn4zy44TYR&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon&templateId=web-components-N8bzRbfpuX&demoId=bn4zy44TYR&assetSetId=default"
     },
     {
       "patternId": "icon",
       "templateId": "web-components-N8bzRbfpuX",
       "demoId": "bn4zy44TYR",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=dark&demoId=bn4zy44TYR&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon&templateId=web-components-N8bzRbfpuX&demoId=bn4zy44TYR&assetSetId=dark"
     },
     {
       "patternId": "icon",
       "templateId": "web-components-N8bzRbfpuX",
       "demoId": "Xr7IHJQ1",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=default&demoId=Xr7IHJQ1&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon&templateId=web-components-N8bzRbfpuX&demoId=Xr7IHJQ1&assetSetId=default"
     },
     {
       "patternId": "icon",
       "templateId": "web-components-N8bzRbfpuX",
       "demoId": "Xr7IHJQ1",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=dark&demoId=Xr7IHJQ1&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon&templateId=web-components-N8bzRbfpuX&demoId=Xr7IHJQ1&assetSetId=dark"
     },
     {
       "patternId": "icon",
       "templateId": "web-components-N8bzRbfpuX",
       "demoId": "8VqxwwTyJ",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=default&demoId=8VqxwwTyJ&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon&templateId=web-components-N8bzRbfpuX&demoId=8VqxwwTyJ&assetSetId=default"
     },
     {
       "patternId": "icon",
       "templateId": "web-components-N8bzRbfpuX",
       "demoId": "8VqxwwTyJ",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=dark&demoId=8VqxwwTyJ&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon&templateId=web-components-N8bzRbfpuX&demoId=8VqxwwTyJ&assetSetId=dark"
     },
     {
       "patternId": "icon",
       "templateId": "web-components-N8bzRbfpuX",
       "demoId": "ezyQjAA-T1",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=default&demoId=ezyQjAA-T1&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon&templateId=web-components-N8bzRbfpuX&demoId=ezyQjAA-T1&assetSetId=default"
     },
     {
       "patternId": "icon",
       "templateId": "web-components-N8bzRbfpuX",
       "demoId": "ezyQjAA-T1",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-N8bzRbfpuX&assetSetId=dark&demoId=ezyQjAA-T1&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon&templateId=web-components-N8bzRbfpuX&demoId=ezyQjAA-T1&assetSetId=dark"
     },
     {
       "patternId": "icon",
       "templateId": "web-components-Pnw8Nf0oOd",
       "demoId": "iPghK4UYBt",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-Pnw8Nf0oOd&assetSetId=default&demoId=iPghK4UYBt&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon&templateId=web-components-Pnw8Nf0oOd&demoId=iPghK4UYBt&assetSetId=default"
     },
     {
       "patternId": "icon",
       "templateId": "web-components-Pnw8Nf0oOd",
       "demoId": "iPghK4UYBt",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon&templateId=web-components-Pnw8Nf0oOd&assetSetId=dark&demoId=iPghK4UYBt&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon&templateId=web-components-Pnw8Nf0oOd&demoId=iPghK4UYBt&assetSetId=dark"
     },
     {
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "BueNSFTYn",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=default&demoId=BueNSFTYn&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button&templateId=web-components-ctiCe2sAX&demoId=BueNSFTYn&assetSetId=default"
     },
     {
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "BueNSFTYn",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=dark&demoId=BueNSFTYn&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button&templateId=web-components-ctiCe2sAX&demoId=BueNSFTYn&assetSetId=dark"
     },
     {
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "IxXMQMFkBT",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=default&demoId=IxXMQMFkBT&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button&templateId=web-components-ctiCe2sAX&demoId=IxXMQMFkBT&assetSetId=default"
     },
     {
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "IxXMQMFkBT",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=dark&demoId=IxXMQMFkBT&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button&templateId=web-components-ctiCe2sAX&demoId=IxXMQMFkBT&assetSetId=dark"
     },
     {
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "MQBKTe4GON",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=default&demoId=MQBKTe4GON&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button&templateId=web-components-ctiCe2sAX&demoId=MQBKTe4GON&assetSetId=default"
     },
     {
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "MQBKTe4GON",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=dark&demoId=MQBKTe4GON&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button&templateId=web-components-ctiCe2sAX&demoId=MQBKTe4GON&assetSetId=dark"
     },
     {
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "i-aFgnERP",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=default&demoId=i-aFgnERP&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button&templateId=web-components-ctiCe2sAX&demoId=i-aFgnERP&assetSetId=default"
     },
     {
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "i-aFgnERP",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=dark&demoId=i-aFgnERP&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button&templateId=web-components-ctiCe2sAX&demoId=i-aFgnERP&assetSetId=dark"
     },
     {
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "MWNDJ0YT9M",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=default&demoId=MWNDJ0YT9M&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button&templateId=web-components-ctiCe2sAX&demoId=MWNDJ0YT9M&assetSetId=default"
     },
     {
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "MWNDJ0YT9M",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=dark&demoId=MWNDJ0YT9M&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button&templateId=web-components-ctiCe2sAX&demoId=MWNDJ0YT9M&assetSetId=dark"
     },
     {
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "iyfHwphwcs",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=default&demoId=iyfHwphwcs&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button&templateId=web-components-ctiCe2sAX&demoId=iyfHwphwcs&assetSetId=default"
     },
     {
       "patternId": "icon-button",
       "templateId": "web-components-ctiCe2sAX",
       "demoId": "iyfHwphwcs",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-button&templateId=web-components-ctiCe2sAX&assetSetId=dark&demoId=iyfHwphwcs&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button&templateId=web-components-ctiCe2sAX&demoId=iyfHwphwcs&assetSetId=dark"
     },
     {
       "patternId": "icon-button-toggle",
       "templateId": "web-components-6kGMXrj-eP",
       "demoId": "O5OSKRluI9",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-button-toggle&templateId=web-components-6kGMXrj-eP&assetSetId=default&demoId=O5OSKRluI9&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button-toggle&templateId=web-components-6kGMXrj-eP&demoId=O5OSKRluI9&assetSetId=default"
     },
     {
       "patternId": "icon-button-toggle",
       "templateId": "web-components-6kGMXrj-eP",
       "demoId": "O5OSKRluI9",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-button-toggle&templateId=web-components-6kGMXrj-eP&assetSetId=dark&demoId=O5OSKRluI9&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-button-toggle&templateId=web-components-6kGMXrj-eP&demoId=O5OSKRluI9&assetSetId=dark"
     },
     {
       "patternId": "icon-checkbox",
       "templateId": "web-components-jTiv8OpG9M",
       "demoId": "FTt0oVydi1",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-checkbox&templateId=web-components-jTiv8OpG9M&assetSetId=default&demoId=FTt0oVydi1&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-checkbox&templateId=web-components-jTiv8OpG9M&demoId=FTt0oVydi1&assetSetId=default"
     },
     {
       "patternId": "icon-checkbox",
       "templateId": "web-components-jTiv8OpG9M",
       "demoId": "FTt0oVydi1",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-checkbox&templateId=web-components-jTiv8OpG9M&assetSetId=dark&demoId=FTt0oVydi1&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-checkbox&templateId=web-components-jTiv8OpG9M&demoId=FTt0oVydi1&assetSetId=dark"
     },
     {
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "6A9yqTSh6x",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=default&demoId=6A9yqTSh6x&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&demoId=6A9yqTSh6x&assetSetId=default"
     },
     {
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "6A9yqTSh6x",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=dark&demoId=6A9yqTSh6x&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&demoId=6A9yqTSh6x&assetSetId=dark"
     },
     {
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "YIH9EOiP",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=default&demoId=YIH9EOiP&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&demoId=YIH9EOiP&assetSetId=default"
     },
     {
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "YIH9EOiP",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=dark&demoId=YIH9EOiP&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&demoId=YIH9EOiP&assetSetId=dark"
     },
     {
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "cGWFzjIg8i",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=default&demoId=cGWFzjIg8i&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&demoId=cGWFzjIg8i&assetSetId=default"
     },
     {
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "cGWFzjIg8i",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=dark&demoId=cGWFzjIg8i&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&demoId=cGWFzjIg8i&assetSetId=dark"
     },
     {
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "fekA6wwl9K",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=default&demoId=fekA6wwl9K&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&demoId=fekA6wwl9K&assetSetId=default"
     },
     {
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "fekA6wwl9K",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=dark&demoId=fekA6wwl9K&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&demoId=fekA6wwl9K&assetSetId=dark"
     },
     {
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "8mt1FePOgA",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=default&demoId=8mt1FePOgA&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&demoId=8mt1FePOgA&assetSetId=default"
     },
     {
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "8mt1FePOgA",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=dark&demoId=8mt1FePOgA&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&demoId=8mt1FePOgA&assetSetId=dark"
     },
     {
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "mnXbWmndnd",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=default&demoId=mnXbWmndnd&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&demoId=mnXbWmndnd&assetSetId=default"
     },
     {
       "patternId": "icon-lockup",
       "templateId": "web-components-RPcggDLyDK",
       "demoId": "mnXbWmndnd",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&assetSetId=dark&demoId=mnXbWmndnd&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-lockup&templateId=web-components-RPcggDLyDK&demoId=mnXbWmndnd&assetSetId=dark"
     },
     {
       "patternId": "icon-radio",
       "templateId": "web-components-gmBL6Mhy4",
       "demoId": "3VTw68n4F5",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=icon-radio&templateId=web-components-gmBL6Mhy4&assetSetId=default&demoId=3VTw68n4F5&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-radio&templateId=web-components-gmBL6Mhy4&demoId=3VTw68n4F5&assetSetId=default"
     },
     {
       "patternId": "icon-radio",
       "templateId": "web-components-gmBL6Mhy4",
       "demoId": "3VTw68n4F5",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=icon-radio&templateId=web-components-gmBL6Mhy4&assetSetId=dark&demoId=3VTw68n4F5&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=icon-radio&templateId=web-components-gmBL6Mhy4&demoId=3VTw68n4F5&assetSetId=dark"
     },
     {
       "patternId": "linear-progress",
       "templateId": "web-components-2ew8-hMQkv",
       "demoId": "lXYaxeRM4L",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=linear-progress&templateId=web-components-2ew8-hMQkv&assetSetId=default&demoId=lXYaxeRM4L&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=linear-progress&templateId=web-components-2ew8-hMQkv&demoId=lXYaxeRM4L&assetSetId=default"
     },
     {
       "patternId": "linear-progress",
       "templateId": "web-components-2ew8-hMQkv",
       "demoId": "lXYaxeRM4L",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=linear-progress&templateId=web-components-2ew8-hMQkv&assetSetId=dark&demoId=lXYaxeRM4L&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=linear-progress&templateId=web-components-2ew8-hMQkv&demoId=lXYaxeRM4L&assetSetId=dark"
     },
     {
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "R-bXJMtJi",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=default&demoId=R-bXJMtJi&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=list&templateId=web-components-fObxCsu2i8&demoId=R-bXJMtJi&assetSetId=default"
     },
     {
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "R-bXJMtJi",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=dark&demoId=R-bXJMtJi&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=list&templateId=web-components-fObxCsu2i8&demoId=R-bXJMtJi&assetSetId=dark"
     },
     {
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "kyAJAxMx7u",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=default&demoId=kyAJAxMx7u&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=list&templateId=web-components-fObxCsu2i8&demoId=kyAJAxMx7u&assetSetId=default"
     },
     {
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "kyAJAxMx7u",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=dark&demoId=kyAJAxMx7u&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=list&templateId=web-components-fObxCsu2i8&demoId=kyAJAxMx7u&assetSetId=dark"
     },
     {
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "kaReFY5Pwj",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=default&demoId=kaReFY5Pwj&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=list&templateId=web-components-fObxCsu2i8&demoId=kaReFY5Pwj&assetSetId=default"
     },
     {
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "kaReFY5Pwj",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=dark&demoId=kaReFY5Pwj&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=list&templateId=web-components-fObxCsu2i8&demoId=kaReFY5Pwj&assetSetId=dark"
     },
     {
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "hjXCY4fSqY",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=default&demoId=hjXCY4fSqY&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=list&templateId=web-components-fObxCsu2i8&demoId=hjXCY4fSqY&assetSetId=default"
     },
     {
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "hjXCY4fSqY",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=dark&demoId=hjXCY4fSqY&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=list&templateId=web-components-fObxCsu2i8&demoId=hjXCY4fSqY&assetSetId=dark"
     },
     {
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "SIyOkmonoE",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=default&demoId=SIyOkmonoE&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=list&templateId=web-components-fObxCsu2i8&demoId=SIyOkmonoE&assetSetId=default"
     },
     {
       "patternId": "list",
       "templateId": "web-components-fObxCsu2i8",
       "demoId": "SIyOkmonoE",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=list&templateId=web-components-fObxCsu2i8&assetSetId=dark&demoId=SIyOkmonoE&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=list&templateId=web-components-fObxCsu2i8&demoId=SIyOkmonoE&assetSetId=dark"
     },
     {
       "patternId": "list-item",
       "templateId": "web-components-ytRTf8wtxn",
       "demoId": "qgGc8WUNHQ",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=list-item&templateId=web-components-ytRTf8wtxn&assetSetId=default&demoId=qgGc8WUNHQ&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=list-item&templateId=web-components-ytRTf8wtxn&demoId=qgGc8WUNHQ&assetSetId=default"
     },
     {
       "patternId": "list-item",
       "templateId": "web-components-ytRTf8wtxn",
       "demoId": "qgGc8WUNHQ",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=list-item&templateId=web-components-ytRTf8wtxn&assetSetId=dark&demoId=qgGc8WUNHQ&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=list-item&templateId=web-components-ytRTf8wtxn&demoId=qgGc8WUNHQ&assetSetId=dark"
     },
     {
       "patternId": "menu",
       "templateId": "web-components-hY3y1MyhrP",
       "demoId": "boILoye9Gi",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=menu&templateId=web-components-hY3y1MyhrP&assetSetId=default&demoId=boILoye9Gi&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=menu&templateId=web-components-hY3y1MyhrP&demoId=boILoye9Gi&assetSetId=default"
     },
     {
       "patternId": "menu",
       "templateId": "web-components-hY3y1MyhrP",
       "demoId": "boILoye9Gi",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=menu&templateId=web-components-hY3y1MyhrP&assetSetId=dark&demoId=boILoye9Gi&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=menu&templateId=web-components-hY3y1MyhrP&demoId=boILoye9Gi&assetSetId=dark"
     },
     {
       "patternId": "navigation-list-item",
       "templateId": "web-components-Qtmmi7N-aL",
       "demoId": "E5NLCltz6",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=navigation-list-item&templateId=web-components-Qtmmi7N-aL&assetSetId=default&demoId=E5NLCltz6&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=navigation-list-item&templateId=web-components-Qtmmi7N-aL&demoId=E5NLCltz6&assetSetId=default"
     },
     {
       "patternId": "navigation-list-item",
       "templateId": "web-components-Qtmmi7N-aL",
       "demoId": "E5NLCltz6",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=navigation-list-item&templateId=web-components-Qtmmi7N-aL&assetSetId=dark&demoId=E5NLCltz6&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=navigation-list-item&templateId=web-components-Qtmmi7N-aL&demoId=E5NLCltz6&assetSetId=dark"
     },
     {
       "patternId": "navigation-list-item",
       "templateId": "web-components-Qtmmi7N-aL",
       "demoId": "v3IaS3HWdf",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=navigation-list-item&templateId=web-components-Qtmmi7N-aL&assetSetId=default&demoId=v3IaS3HWdf&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=navigation-list-item&templateId=web-components-Qtmmi7N-aL&demoId=v3IaS3HWdf&assetSetId=default"
     },
     {
       "patternId": "navigation-list-item",
       "templateId": "web-components-Qtmmi7N-aL",
       "demoId": "v3IaS3HWdf",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=navigation-list-item&templateId=web-components-Qtmmi7N-aL&assetSetId=dark&demoId=v3IaS3HWdf&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=navigation-list-item&templateId=web-components-Qtmmi7N-aL&demoId=v3IaS3HWdf&assetSetId=dark"
     },
     {
       "patternId": "notebook-cell",
       "templateId": "web-components-dlfSUMV1v",
       "demoId": "tMM8dM4L3g",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=notebook-cell&templateId=web-components-dlfSUMV1v&assetSetId=default&demoId=tMM8dM4L3g&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=notebook-cell&templateId=web-components-dlfSUMV1v&demoId=tMM8dM4L3g&assetSetId=default"
     },
     {
       "patternId": "notebook-cell",
       "templateId": "web-components-dlfSUMV1v",
       "demoId": "tMM8dM4L3g",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=notebook-cell&templateId=web-components-dlfSUMV1v&assetSetId=dark&demoId=tMM8dM4L3g&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=notebook-cell&templateId=web-components-dlfSUMV1v&demoId=tMM8dM4L3g&assetSetId=dark"
     },
     {
       "patternId": "notebook-cell",
       "templateId": "web-components-dlfSUMV1v",
       "demoId": "H-H7-TnR4K",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=notebook-cell&templateId=web-components-dlfSUMV1v&assetSetId=default&demoId=H-H7-TnR4K&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=notebook-cell&templateId=web-components-dlfSUMV1v&demoId=H-H7-TnR4K&assetSetId=default"
     },
     {
       "patternId": "notebook-cell",
       "templateId": "web-components-dlfSUMV1v",
       "demoId": "H-H7-TnR4K",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=notebook-cell&templateId=web-components-dlfSUMV1v&assetSetId=dark&demoId=H-H7-TnR4K&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=notebook-cell&templateId=web-components-dlfSUMV1v&demoId=H-H7-TnR4K&assetSetId=dark"
     },
     {
       "patternId": "radio",
       "templateId": "web-components-qk2MWcBipT",
       "demoId": "RMPpKHlzd",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=radio&templateId=web-components-qk2MWcBipT&assetSetId=default&demoId=RMPpKHlzd&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=radio&templateId=web-components-qk2MWcBipT&demoId=RMPpKHlzd&assetSetId=default"
     },
     {
       "patternId": "radio",
       "templateId": "web-components-qk2MWcBipT",
       "demoId": "RMPpKHlzd",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=radio&templateId=web-components-qk2MWcBipT&assetSetId=dark&demoId=RMPpKHlzd&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=radio&templateId=web-components-qk2MWcBipT&demoId=RMPpKHlzd&assetSetId=dark"
     },
     {
       "patternId": "radio-list-item",
       "templateId": "web-components-fwKtEBOnv",
       "demoId": "MzuUqdOHZA",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=radio-list-item&templateId=web-components-fwKtEBOnv&assetSetId=default&demoId=MzuUqdOHZA&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=radio-list-item&templateId=web-components-fwKtEBOnv&demoId=MzuUqdOHZA&assetSetId=default"
     },
     {
       "patternId": "radio-list-item",
       "templateId": "web-components-fwKtEBOnv",
       "demoId": "MzuUqdOHZA",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=radio-list-item&templateId=web-components-fwKtEBOnv&assetSetId=dark&demoId=MzuUqdOHZA&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=radio-list-item&templateId=web-components-fwKtEBOnv&demoId=MzuUqdOHZA&assetSetId=dark"
     },
     {
       "patternId": "select",
       "templateId": "web-components-qWXTtv81jY",
       "demoId": "sWH6jqeBc",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=select&templateId=web-components-qWXTtv81jY&assetSetId=default&demoId=sWH6jqeBc&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=select&templateId=web-components-qWXTtv81jY&demoId=sWH6jqeBc&assetSetId=default"
     },
     {
       "patternId": "select",
       "templateId": "web-components-qWXTtv81jY",
       "demoId": "sWH6jqeBc",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=select&templateId=web-components-qWXTtv81jY&assetSetId=dark&demoId=sWH6jqeBc&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=select&templateId=web-components-qWXTtv81jY&demoId=sWH6jqeBc&assetSetId=dark"
     },
     {
       "patternId": "side-sheet",
@@ -1219,7 +1219,7 @@
       "assetSetId": "default",
       "width": 895,
       "height": 502,
-      "url": "/api/v1/render?patternId=side-sheet&templateId=web-components-UMR43JQszt&assetSetId=default&demoId=F84crA5Gx4&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=side-sheet&templateId=web-components-UMR43JQszt&demoId=F84crA5Gx4&assetSetId=default"
     },
     {
       "patternId": "side-sheet",
@@ -1228,385 +1228,385 @@
       "assetSetId": "dark",
       "width": 895,
       "height": 502,
-      "url": "/api/v1/render?patternId=side-sheet&templateId=web-components-UMR43JQszt&assetSetId=dark&demoId=F84crA5Gx4&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=side-sheet&templateId=web-components-UMR43JQszt&demoId=F84crA5Gx4&assetSetId=dark"
     },
     {
       "patternId": "slider",
       "templateId": "web-components-LpKATlK5H",
       "demoId": "x9f-h1BpY",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=slider&templateId=web-components-LpKATlK5H&assetSetId=default&demoId=x9f-h1BpY&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=slider&templateId=web-components-LpKATlK5H&demoId=x9f-h1BpY&assetSetId=default"
     },
     {
       "patternId": "slider",
       "templateId": "web-components-LpKATlK5H",
       "demoId": "x9f-h1BpY",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=slider&templateId=web-components-LpKATlK5H&assetSetId=dark&demoId=x9f-h1BpY&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=slider&templateId=web-components-LpKATlK5H&demoId=x9f-h1BpY&assetSetId=dark"
     },
     {
       "patternId": "slider",
       "templateId": "web-components-33Z9-C4Qs",
       "demoId": "HY3BFMh0AM",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=slider&templateId=web-components-33Z9-C4Qs&assetSetId=default&demoId=HY3BFMh0AM&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=slider&templateId=web-components-33Z9-C4Qs&demoId=HY3BFMh0AM&assetSetId=default"
     },
     {
       "patternId": "slider",
       "templateId": "web-components-33Z9-C4Qs",
       "demoId": "HY3BFMh0AM",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=slider&templateId=web-components-33Z9-C4Qs&assetSetId=dark&demoId=HY3BFMh0AM&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=slider&templateId=web-components-33Z9-C4Qs&demoId=HY3BFMh0AM&assetSetId=dark"
     },
     {
       "patternId": "snackbar",
       "templateId": "web-components-3ERE1Ai9lo",
       "demoId": "5aKkBtql-E",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=snackbar&templateId=web-components-3ERE1Ai9lo&assetSetId=default&demoId=5aKkBtql-E&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=snackbar&templateId=web-components-3ERE1Ai9lo&demoId=5aKkBtql-E&assetSetId=default"
     },
     {
       "patternId": "snackbar",
       "templateId": "web-components-3ERE1Ai9lo",
       "demoId": "5aKkBtql-E",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=snackbar&templateId=web-components-3ERE1Ai9lo&assetSetId=dark&demoId=5aKkBtql-E&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=snackbar&templateId=web-components-3ERE1Ai9lo&demoId=5aKkBtql-E&assetSetId=dark"
     },
     {
       "patternId": "status-dialog",
       "templateId": "web-components-klayJh8gA",
       "demoId": "ugxYH4hy3",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=status-dialog&templateId=web-components-klayJh8gA&assetSetId=default&demoId=ugxYH4hy3&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=status-dialog&templateId=web-components-klayJh8gA&demoId=ugxYH4hy3&assetSetId=default"
     },
     {
       "patternId": "status-dialog",
       "templateId": "web-components-klayJh8gA",
       "demoId": "ugxYH4hy3",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=status-dialog&templateId=web-components-klayJh8gA&assetSetId=dark&demoId=ugxYH4hy3&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=status-dialog&templateId=web-components-klayJh8gA&demoId=ugxYH4hy3&assetSetId=dark"
     },
     {
       "patternId": "status-dialog",
       "templateId": "web-components-klayJh8gA",
       "demoId": "zKTIBgFUtF",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=status-dialog&templateId=web-components-klayJh8gA&assetSetId=default&demoId=zKTIBgFUtF&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=status-dialog&templateId=web-components-klayJh8gA&demoId=zKTIBgFUtF&assetSetId=default"
     },
     {
       "patternId": "status-dialog",
       "templateId": "web-components-klayJh8gA",
       "demoId": "zKTIBgFUtF",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=status-dialog&templateId=web-components-klayJh8gA&assetSetId=dark&demoId=zKTIBgFUtF&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=status-dialog&templateId=web-components-klayJh8gA&demoId=zKTIBgFUtF&assetSetId=dark"
     },
     {
       "patternId": "status-header",
       "templateId": "web-components-UDLnfGbB2W",
       "demoId": "1OH1Dga5C0",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=status-header&templateId=web-components-UDLnfGbB2W&assetSetId=default&demoId=1OH1Dga5C0&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=status-header&templateId=web-components-UDLnfGbB2W&demoId=1OH1Dga5C0&assetSetId=default"
     },
     {
       "patternId": "status-header",
       "templateId": "web-components-UDLnfGbB2W",
       "demoId": "1OH1Dga5C0",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=status-header&templateId=web-components-UDLnfGbB2W&assetSetId=dark&demoId=1OH1Dga5C0&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=status-header&templateId=web-components-UDLnfGbB2W&demoId=1OH1Dga5C0&assetSetId=dark"
     },
     {
       "patternId": "status-header-item",
       "templateId": "web-components-55FkYSafco",
       "demoId": "YHuTizup8",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=status-header-item&templateId=web-components-55FkYSafco&assetSetId=default&demoId=YHuTizup8&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=status-header-item&templateId=web-components-55FkYSafco&demoId=YHuTizup8&assetSetId=default"
     },
     {
       "patternId": "status-header-item",
       "templateId": "web-components-55FkYSafco",
       "demoId": "YHuTizup8",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=status-header-item&templateId=web-components-55FkYSafco&assetSetId=dark&demoId=YHuTizup8&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=status-header-item&templateId=web-components-55FkYSafco&demoId=YHuTizup8&assetSetId=dark"
     },
     {
       "patternId": "switch",
       "templateId": "web-components-tGj2TvSrpD",
       "demoId": "U89p0LyOsP",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=switch&templateId=web-components-tGj2TvSrpD&assetSetId=default&demoId=U89p0LyOsP&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=switch&templateId=web-components-tGj2TvSrpD&demoId=U89p0LyOsP&assetSetId=default"
     },
     {
       "patternId": "switch",
       "templateId": "web-components-tGj2TvSrpD",
       "demoId": "U89p0LyOsP",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=switch&templateId=web-components-tGj2TvSrpD&assetSetId=dark&demoId=U89p0LyOsP&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=switch&templateId=web-components-tGj2TvSrpD&demoId=U89p0LyOsP&assetSetId=dark"
     },
     {
       "patternId": "tab",
       "templateId": "web-components-1-Bf2NwL1T",
       "demoId": "3HxZQWfBi9",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=tab&templateId=web-components-1-Bf2NwL1T&assetSetId=default&demoId=3HxZQWfBi9&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=tab&templateId=web-components-1-Bf2NwL1T&demoId=3HxZQWfBi9&assetSetId=default"
     },
     {
       "patternId": "tab",
       "templateId": "web-components-1-Bf2NwL1T",
       "demoId": "3HxZQWfBi9",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=tab&templateId=web-components-1-Bf2NwL1T&assetSetId=dark&demoId=3HxZQWfBi9&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=tab&templateId=web-components-1-Bf2NwL1T&demoId=3HxZQWfBi9&assetSetId=dark"
     },
     {
       "patternId": "tabs",
       "templateId": "web-components-kjFGUA31tg",
       "demoId": "GOJxN1FZx",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=tabs&templateId=web-components-kjFGUA31tg&assetSetId=default&demoId=GOJxN1FZx&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=tabs&templateId=web-components-kjFGUA31tg&demoId=GOJxN1FZx&assetSetId=default"
     },
     {
       "patternId": "tabs",
       "templateId": "web-components-kjFGUA31tg",
       "demoId": "GOJxN1FZx",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=tabs&templateId=web-components-kjFGUA31tg&assetSetId=dark&demoId=GOJxN1FZx&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=tabs&templateId=web-components-kjFGUA31tg&demoId=GOJxN1FZx&assetSetId=dark"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "RV5V-zEoUJ",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=RV5V-zEoUJ&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=RV5V-zEoUJ&assetSetId=default"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "RV5V-zEoUJ",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=dark&demoId=RV5V-zEoUJ&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=RV5V-zEoUJ&assetSetId=dark"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "uKKiquKOJq",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=uKKiquKOJq&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=uKKiquKOJq&assetSetId=default"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "uKKiquKOJq",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=dark&demoId=uKKiquKOJq&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=uKKiquKOJq&assetSetId=dark"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "XqxbTjPFZB",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=XqxbTjPFZB&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=XqxbTjPFZB&assetSetId=default"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "XqxbTjPFZB",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=dark&demoId=XqxbTjPFZB&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=XqxbTjPFZB&assetSetId=dark"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "CkH7TzkgbA",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=CkH7TzkgbA&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=CkH7TzkgbA&assetSetId=default"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "CkH7TzkgbA",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=dark&demoId=CkH7TzkgbA&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=CkH7TzkgbA&assetSetId=dark"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "iH3DCGMPTw",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=iH3DCGMPTw&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=iH3DCGMPTw&assetSetId=default"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "iH3DCGMPTw",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=dark&demoId=iH3DCGMPTw&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=iH3DCGMPTw&assetSetId=dark"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "oY0W5ALQ1q",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=oY0W5ALQ1q&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=oY0W5ALQ1q&assetSetId=default"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "oY0W5ALQ1q",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=dark&demoId=oY0W5ALQ1q&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=oY0W5ALQ1q&assetSetId=dark"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "pvszcppjX8",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=default&demoId=pvszcppjX8&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=pvszcppjX8&assetSetId=default"
     },
     {
       "patternId": "text",
       "templateId": "web-components-FXCMXD35mF",
       "demoId": "pvszcppjX8",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=text&templateId=web-components-FXCMXD35mF&assetSetId=dark&demoId=pvszcppjX8&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text&templateId=web-components-FXCMXD35mF&demoId=pvszcppjX8&assetSetId=dark"
     },
     {
       "patternId": "text-area",
       "templateId": "web-components-48rzn99y9G",
       "demoId": "L87CMmCK4T",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=text-area&templateId=web-components-48rzn99y9G&assetSetId=default&demoId=L87CMmCK4T&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text-area&templateId=web-components-48rzn99y9G&demoId=L87CMmCK4T&assetSetId=default"
     },
     {
       "patternId": "text-area",
       "templateId": "web-components-48rzn99y9G",
       "demoId": "L87CMmCK4T",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=text-area&templateId=web-components-48rzn99y9G&assetSetId=dark&demoId=L87CMmCK4T&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text-area&templateId=web-components-48rzn99y9G&demoId=L87CMmCK4T&assetSetId=dark"
     },
     {
       "patternId": "text-lockup",
       "templateId": "web-components-4Aa-qjh3vF",
       "demoId": "WWgMBRroJw",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=text-lockup&templateId=web-components-4Aa-qjh3vF&assetSetId=default&demoId=WWgMBRroJw&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text-lockup&templateId=web-components-4Aa-qjh3vF&demoId=WWgMBRroJw&assetSetId=default"
     },
     {
       "patternId": "text-lockup",
       "templateId": "web-components-4Aa-qjh3vF",
       "demoId": "WWgMBRroJw",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=text-lockup&templateId=web-components-4Aa-qjh3vF&assetSetId=dark&demoId=WWgMBRroJw&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=text-lockup&templateId=web-components-4Aa-qjh3vF&demoId=WWgMBRroJw&assetSetId=dark"
     },
     {
       "patternId": "textfield",
       "templateId": "web-components-M4zyalwdNJ",
       "demoId": "zYujvGxjlZ",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=textfield&templateId=web-components-M4zyalwdNJ&assetSetId=default&demoId=zYujvGxjlZ&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=textfield&templateId=web-components-M4zyalwdNJ&demoId=zYujvGxjlZ&assetSetId=default"
     },
     {
       "patternId": "textfield",
       "templateId": "web-components-M4zyalwdNJ",
       "demoId": "zYujvGxjlZ",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=textfield&templateId=web-components-M4zyalwdNJ&assetSetId=dark&demoId=zYujvGxjlZ&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=textfield&templateId=web-components-M4zyalwdNJ&demoId=zYujvGxjlZ&assetSetId=dark"
     },
     {
       "patternId": "textfield",
       "templateId": "web-components-M4zyalwdNJ",
       "demoId": "tU8Ze3Af9p",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=textfield&templateId=web-components-M4zyalwdNJ&assetSetId=default&demoId=tU8Ze3Af9p&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=textfield&templateId=web-components-M4zyalwdNJ&demoId=tU8Ze3Af9p&assetSetId=default"
     },
     {
       "patternId": "textfield",
       "templateId": "web-components-M4zyalwdNJ",
       "demoId": "tU8Ze3Af9p",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=textfield&templateId=web-components-M4zyalwdNJ&assetSetId=dark&demoId=tU8Ze3Af9p&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=textfield&templateId=web-components-M4zyalwdNJ&demoId=tU8Ze3Af9p&assetSetId=dark"
     },
     {
       "patternId": "toolbar",
       "templateId": "web-components-A6-16QhSaM",
       "demoId": "NXMdeiHjKO",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=toolbar&templateId=web-components-A6-16QhSaM&assetSetId=default&demoId=NXMdeiHjKO&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=toolbar&templateId=web-components-A6-16QhSaM&demoId=NXMdeiHjKO&assetSetId=default"
     },
     {
       "patternId": "toolbar",
       "templateId": "web-components-A6-16QhSaM",
       "demoId": "NXMdeiHjKO",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=toolbar&templateId=web-components-A6-16QhSaM&assetSetId=dark&demoId=NXMdeiHjKO&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=toolbar&templateId=web-components-A6-16QhSaM&demoId=NXMdeiHjKO&assetSetId=dark"
     },
     {
       "patternId": "tooltip",
       "templateId": "web-components-erhVvpq9vk",
       "demoId": "V1YF-oKSJk",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=tooltip&templateId=web-components-erhVvpq9vk&assetSetId=default&demoId=V1YF-oKSJk&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=tooltip&templateId=web-components-erhVvpq9vk&demoId=V1YF-oKSJk&assetSetId=default"
     },
     {
       "patternId": "tooltip",
       "templateId": "web-components-erhVvpq9vk",
       "demoId": "V1YF-oKSJk",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=tooltip&templateId=web-components-erhVvpq9vk&assetSetId=dark&demoId=V1YF-oKSJk&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=tooltip&templateId=web-components-erhVvpq9vk&demoId=V1YF-oKSJk&assetSetId=dark"
     },
     {
       "patternId": "top-app-bar",
       "templateId": "web-components-bdJKZJwv0h",
       "demoId": "R8F5cdPVrq",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=top-app-bar&templateId=web-components-bdJKZJwv0h&assetSetId=default&demoId=R8F5cdPVrq&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=top-app-bar&templateId=web-components-bdJKZJwv0h&demoId=R8F5cdPVrq&assetSetId=default"
     },
     {
       "patternId": "top-app-bar",
       "templateId": "web-components-bdJKZJwv0h",
       "demoId": "R8F5cdPVrq",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=top-app-bar&templateId=web-components-bdJKZJwv0h&assetSetId=dark&demoId=R8F5cdPVrq&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=top-app-bar&templateId=web-components-bdJKZJwv0h&demoId=R8F5cdPVrq&assetSetId=dark"
     },
     {
       "patternId": "top-app-bar-fixed",
       "templateId": "web-components-d0oZXgy7Uj",
       "demoId": "RQLhdtbJlh",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=top-app-bar-fixed&templateId=web-components-d0oZXgy7Uj&assetSetId=default&demoId=RQLhdtbJlh&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=top-app-bar-fixed&templateId=web-components-d0oZXgy7Uj&demoId=RQLhdtbJlh&assetSetId=default"
     },
     {
       "patternId": "top-app-bar-fixed",
       "templateId": "web-components-d0oZXgy7Uj",
       "demoId": "RQLhdtbJlh",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=top-app-bar-fixed&templateId=web-components-d0oZXgy7Uj&assetSetId=dark&demoId=RQLhdtbJlh&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=top-app-bar-fixed&templateId=web-components-d0oZXgy7Uj&demoId=RQLhdtbJlh&assetSetId=dark"
     },
     {
       "patternId": "tree-list",
       "templateId": "web-components-Ue0Hy3Asb",
       "demoId": "RjMe6Q4mA",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=tree-list&templateId=web-components-Ue0Hy3Asb&assetSetId=default&demoId=RjMe6Q4mA&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=tree-list&templateId=web-components-Ue0Hy3Asb&demoId=RjMe6Q4mA&assetSetId=default"
     },
     {
       "patternId": "tree-list",
       "templateId": "web-components-Ue0Hy3Asb",
       "demoId": "RjMe6Q4mA",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=tree-list&templateId=web-components-Ue0Hy3Asb&assetSetId=dark&demoId=RjMe6Q4mA&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=tree-list&templateId=web-components-Ue0Hy3Asb&demoId=RjMe6Q4mA&assetSetId=dark"
     },
     {
       "patternId": "tree-list-item",
       "templateId": "web-components-1jOFYZB9ms",
       "demoId": "7gFch0E4yr",
       "assetSetId": "default",
-      "url": "/api/v1/render?patternId=tree-list-item&templateId=web-components-1jOFYZB9ms&assetSetId=default&demoId=7gFch0E4yr&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=tree-list-item&templateId=web-components-1jOFYZB9ms&demoId=7gFch0E4yr&assetSetId=default"
     },
     {
       "patternId": "tree-list-item",
       "templateId": "web-components-1jOFYZB9ms",
       "demoId": "7gFch0E4yr",
       "assetSetId": "dark",
-      "url": "/api/v1/render?patternId=tree-list-item&templateId=web-components-1jOFYZB9ms&assetSetId=dark&demoId=7gFch0E4yr&isInIframe=false&wrapHtml=true"
+      "url": "/api/v1/render-demo-id?patternId=tree-list-item&templateId=web-components-1jOFYZB9ms&demoId=7gFch0E4yr&assetSetId=dark"
     }
   ]
 }

--- a/apps/knapsack/public/ks-overrides.css
+++ b/apps/knapsack/public/ks-overrides.css
@@ -14,12 +14,18 @@ html {
 }
 
 /* Elements that depend on a parent to have a width*/
+/* Partial width */
 .knapsack-wrapper.knapsack-pattern-direct-parent:has(
     > cv-alert,
     > cv-linear-progress,
     > cv-slider,
     > cv-slider-range
   ) {
+  min-width: 80vw;
+}
+
+/* Full-width */
+.knapsack-wrapper.knapsack-pattern-direct-parent:has(> cv-alert[inline]) {
   min-width: 100vw;
 }
 

--- a/apps/knapsack/public/ks-overrides.css
+++ b/apps/knapsack/public/ks-overrides.css
@@ -1,5 +1,26 @@
-body {
+body,
+html {
   background-color: var(--mdc-theme-background);
+}
+
+/* Elements that depend on a parent to have a width and height */
+.knapsack-wrapper.knapsack-pattern-direct-parent:has(
+    > cv-action-ribbon,
+    > cv-top-app-bar,
+    > cv-toolbar
+  ) {
+  min-width: 100vw;
+  min-height: 100vh;
+}
+
+/* Elements that depend on a parent to have a width*/
+.knapsack-wrapper.knapsack-pattern-direct-parent:has(
+    > cv-alert,
+    > cv-linear-progress,
+    > cv-slider,
+    > cv-slider-range
+  ) {
+  min-width: 100vw;
 }
 
 cv-app-shell {


### PR DESCRIPTION
## Description

This pull request includes changes to the `apps/knapsack/public/ks-overrides.css` file to improve the layout and responsiveness of the application. The most important changes include adding HTML to the body selector for background color consistency and introducing new CSS rules to ensure certain elements have appropriate minimum width and height based on their parent elements.

### What's included?

* Added `html` to the `body` selector to ensure the background color is applied consistently across the entire page.
* Introduced a new CSS rule for elements with the class `knapsack-wrapper` and `knapsack-pattern-direct-parent` to ensure they have a minimum width and height of 100vw and 100vh respectively when they contain specific child elements like `cv-action-ribbon`, `cv-top-app-bar`, or `cv-toolbar`.
* Added another CSS rule for `knapsack-wrapper` elements to ensure a minimum width of 100vw when they contain child elements such as `cv-alert`, `cv-linear-progress`, `cv-slider`, or `cv-slider-range`.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `nx run knapsack:serve`
- [ ] then open knapsack locally and test the action ribbon component

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![Screenshot 2025-02-05 at 7 17 33 PM](https://github.com/user-attachments/assets/14b91157-d8f4-49b9-a1ca-74830e723e54)
