### PR TITLE
fix(alert): add adjustHeight

### DIFF
--- a/libs/components/src/alert/alert-base.ts
+++ b/libs/components/src/alert/alert-base.ts
@@ -147,6 +147,12 @@ export class AlertBase extends LitElement {
     this.adjustHeight();
   }
 
+  protected override updated(
+    changedProperties: Map<string | number | symbol, unknown>,
+  ): void {
+    super.updated(changedProperties);
+    this.adjustHeight();
+  }
   private adjustHeight() {
     if (window.innerWidth <= 430) {
       requestAnimationFrame(() => {

--- a/libs/components/src/alert/alert-base.ts
+++ b/libs/components/src/alert/alert-base.ts
@@ -24,6 +24,7 @@ export class AlertBase extends LitElement {
         this.mdcFoundation.close(this.reason);
         this.reason = CloseReason.UNSPECIFIED;
       }
+      this.adjustHeight();
     }
   })
   open = true;
@@ -53,7 +54,12 @@ export class AlertBase extends LitElement {
       active: this.state === 'active',
     };
     return html` <div class="${classMap(classes)}" role="banner">
-      <div class="mdc-banner__content" role="alertdialog" aria-live="assertive" aria-label="${this.titleText}">
+      <div
+        class="mdc-banner__content"
+        role="alertdialog"
+        aria-live="assertive"
+        aria-label="${this.titleText}"
+      >
         <div class="mdc-banner__graphic-text-wrapper">
           ${this.icon ? this.renderIcon() : ''}
           <div class="mdc-banner__text">
@@ -70,7 +76,11 @@ export class AlertBase extends LitElement {
 
   /** @soyTemplate */
   protected renderIcon(): TemplateResult {
-    return html` <div class="mdc-banner__graphic" role="img" aria-label="${this.iconAriaLabel}">
+    return html` <div
+      class="mdc-banner__graphic"
+      role="img"
+      aria-label="${this.iconAriaLabel}"
+    >
       <slot name="icon">
         <cv-icon class="mdc-banner__icon"> ${this.icon} </cv-icon>
       </slot>
@@ -98,7 +108,7 @@ export class AlertBase extends LitElement {
             bubbles: true,
             cancelable: true,
             detail: { reason: action },
-          })
+          }),
         ),
       notifyClosed: () => {
         /* */
@@ -133,6 +143,23 @@ export class AlertBase extends LitElement {
     this.mdcFoundation = new this.mdcFoundationClass(this.createAdapter());
     if (this.open) {
       this.mdcFoundation.open();
+    }
+    this.adjustHeight();
+  }
+
+  private adjustHeight() {
+    if (window.innerWidth <= 430) {
+      requestAnimationFrame(() => {
+        const contentHeight = this.mdcContent.offsetHeight;
+        this.mdcRoot.style.height = `${contentHeight + 20}px`;
+      });
+    } else if (window.innerWidth <= 768) {
+      requestAnimationFrame(() => {
+        const contentHeight = this.mdcContent.offsetHeight;
+        this.mdcRoot.style.height = `${contentHeight + 14}px`;
+      });
+    } else {
+      this.mdcRoot.style.height = '';
     }
   }
 }


### PR DESCRIPTION
## Description
- Improved the responsiveness of the Alert Banner by dynamically adjusting its height based on different screen widths. 

### What's included?
- Dynamic height adjustment for screen widths ≤ 430px and ≤ 768px.


#### Test Steps

- Resize the browser window to ≤ 430px and confirm the banner adjusts its height correctly.
- Resize to 431px–768px and verify the adjusted height remains consistent.
- Test on desktop resolutions (> 768px) to ensure the height resets properly.


#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![image](https://github.com/user-attachments/assets/2d57d5b8-aba9-4d70-b41f-2d191a34dc37)
![image](https://github.com/user-attachments/assets/94d3276a-9206-4a1d-84b2-5a00c5623d98)
