### PR TITLE
fix(components): adjusting the height layout of alert on resize

### DIFF
--- a/libs/components/src/alert/alert-base.ts
+++ b/libs/components/src/alert/alert-base.ts
@@ -15,6 +15,8 @@ export class AlertBase extends LitElement {
 
   @query('.mdc-banner') protected mdcRoot!: HTMLElement;
   @query('.mdc-banner__content') protected mdcContent!: HTMLElement;
+  @query('.mdc-banner__graphic-text-wrapper')
+  protected mdcGraphicTextWrapper!: HTMLElement;
   @state() protected currentWidth = 0;
 
   @property({ type: Boolean, reflect: true })
@@ -166,6 +168,6 @@ export class AlertBase extends LitElement {
       this.mdcFoundation.open();
     }
     // Observe when element is resized
-    this._resizeObserver.observe(this.mdcRoot);
+    this._resizeObserver.observe(this.mdcGraphicTextWrapper);
   }
 }

--- a/libs/components/src/alert/alert.spec.ts
+++ b/libs/components/src/alert/alert.spec.ts
@@ -4,6 +4,21 @@
 import { it, describe, expect } from 'vitest';
 import { CovalentAlert } from './alert';
 
+global.ResizeObserver = class MockResizeObserver {
+  constructor() {
+    /**/
+  }
+  observe() {
+    /**/
+  }
+  unobserve() {
+    /**/
+  }
+  disconnect() {
+    /**/
+  }
+};
+
 describe('Alert', () => {
   it('should work', () => {
     expect(new CovalentAlert()).toBeDefined();


### PR DESCRIPTION
## Description

This pull request includes several changes to the `AlertBase` class in the `libs/components/src/alert/alert-base.ts` file to enhance its functionality and maintainability. The most important changes include adding a `ResizeObserver` to handle element resizing, updating the `render` method for better readability, and minor code formatting improvements.

### What's included?

* Added a `ResizeObserver` to the `AlertBase` class to observe and handle element resizing. This includes initializing the observer in the constructor, updating the `currentWidth` state, and handling cleanup in the `disconnectedCallback` method. [[1]](diffhunk://#diff-a57ce2a869eba60e2f74c61a2ff4654f9799ad1942a367eb3f41602c59d49124R46-R65) [[2]](diffhunk://#diff-a57ce2a869eba60e2f74c61a2ff4654f9799ad1942a367eb3f41602c59d49124R168-R169)

#### Test Steps

- [ ] `npm run storybook`
- [ ] then navigate to the alert story
- [ ] finally add a lot of text in the description and resize the screen

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

Uploading Screen Recording 2025-02-13 at 10.30.18 AM.mov…

