### PR TITLE
fix(components): import fix for icon in alert

### DIFF
--- a/libs/components/src/alert/alert-base.ts
+++ b/libs/components/src/alert/alert-base.ts
@@ -8,6 +8,8 @@ import { html, LitElement, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { property, query, state } from 'lit/decorators.js';
 
+import '../icon/icon';
+
 export class AlertBase extends LitElement {
   protected mdcFoundation!: MDCBannerFoundation;
   protected readonly mdcFoundationClass = MDCBannerFoundation;


### PR DESCRIPTION
## Description

Fixing import required for icon used in the alert banner

#### Test Steps

- [ ] `npm run storybook`
- [ ] then directly acccess the first alert story 
- [ ] finally verify the icon is loading

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker


![Screenshot 2025-03-19 at 2 04 15 PM](https://github.com/user-attachments/assets/d099941d-2285-4295-842d-fab2c0d1568d)
