### PR TITLE
feat(componets): adding ng formControl directive

### DIFF
--- a/apps/knapsack/public/ks-overrides.css
+++ b/apps/knapsack/public/ks-overrides.css
@@ -3,14 +3,21 @@ html {
   background-color: var(--mdc-theme-background);
 }
 
+/* Stretch the canvas parent to always be 100% view height and width */
+.knapsack-wrapper.knapsack-pattern-direct-parent {
+  min-width: 100vw;
+  min-height: 100vh;
+}
+
 /* Elements that depend on a parent to have a width and height */
-.knapsack-wrapper.knapsack-pattern-direct-parent:has(
+.knapsack-wrapper.knapsack-pattern-direct-parent:not(
     > cv-action-ribbon,
     > cv-top-app-bar,
     > cv-toolbar
   ) {
-  min-width: 100vw;
-  min-height: 100vh;
+  justify-content: center;
+  align-items: center;
+  display: flex;
 }
 
 /* Elements that depend on a parent to have a width */

--- a/libs/angular/common/src/directives/web-components/form-control.directive.spec.ts
+++ b/libs/angular/common/src/directives/web-components/form-control.directive.spec.ts
@@ -1,0 +1,103 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { CovalentTextfieldValueAccessorDirective } from './form-control.directive';
+
+// Import the built output of the web components library
+import '../../../../../../dist/libs/components';
+
+@Component({
+  template: `
+    <cv-textfield [formControl]="control"></cv-textfield>
+    <cv-checkbox [formControl]="checkboxControl"></cv-checkbox>
+    <cv-radio [formControl]="radioControl" value="test"></cv-radio>
+  `,
+  imports: [ReactiveFormsModule, CovalentTextfieldValueAccessorDirective],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+class TestComponent {
+  control = new FormControl('test', {
+    validators: [() => ({ required: true })],
+  });
+  checkboxControl = new FormControl(false);
+  radioControl = new FormControl('');
+
+  constructor() {
+    this.control.setErrors({
+      required: true,
+    });
+  }
+}
+
+describe('CovalentTextfieldValueAccessorDirective', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should update textfield value when form control changes', () => {
+    const textfield = fixture.nativeElement.querySelector('cv-textfield');
+    component.control.setValue('test value');
+    fixture.detectChanges();
+    expect(textfield.value).toBe('test value');
+  });
+
+  it('should update form control when textfield value changes', () => {
+    const textfield = fixture.nativeElement.querySelector('cv-textfield');
+    textfield.value = 'new value';
+    textfield.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    expect(component.control.value).toBe('new value');
+  });
+
+  it('should mark control as touched on blur', () => {
+    const textfield = fixture.nativeElement.querySelector('cv-textfield');
+    expect(component.control.touched).toBe(false);
+    textfield.dispatchEvent(new Event('blur'));
+    expect(component.control.touched).toBe(true);
+  });
+
+  it('should handle checkbox value changes', () => {
+    const checkbox = fixture.nativeElement.querySelector('cv-checkbox');
+    checkbox.checked = true;
+    checkbox.value = 'true';
+    checkbox.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    expect(component.checkboxControl.value).toBe(true);
+  });
+
+  it('should handle radio button value changes', () => {
+    const radio = fixture.nativeElement.querySelector('cv-radio');
+    radio.checked = true;
+    radio.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    expect(component.radioControl.value).toBe('test');
+  });
+
+  it('should handle disabled state', () => {
+    const textfield = fixture.nativeElement.querySelector('cv-textfield');
+    component.control.disable();
+    fixture.detectChanges();
+    expect(textfield.disabled).toBe(true);
+  });
+
+  it('should update validity when form control has errors', () => {
+    component.control.setValue(null);
+    const textfield = fixture.nativeElement.querySelector('cv-textfield');
+    textfield.dispatchEvent(new Event('change'));
+    textfield.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+  });
+});

--- a/libs/angular/common/src/directives/web-components/form-control.directive.ts
+++ b/libs/angular/common/src/directives/web-components/form-control.directive.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @angular-eslint/directive-selector */
+import { Directive, ElementRef, HostListener } from '@angular/core';
+import { ControlValueAccessor, NgControl } from '@angular/forms';
+
+@Directive({
+  selector: `cv-textfield[formControl],
+     cv-textarea[formControl],
+     cv-select[formControl],
+     cv-textfield[formControlName],
+     cv-textarea[formControlName],
+     cv-select[formControlName],
+     cv-checkbox[formControl],
+     cv-checkbox-icon[formControl],
+     cv-radio[formControl], 
+     cv-radio-icon[formControl]`,
+})
+export class CovalentTextfieldValueAccessorDirective
+  implements ControlValueAccessor
+{
+  private _onChange: (value: any) => void = () => {};
+  private _onTouched: () => void = () => {};
+
+  constructor(
+    private _elementRef: ElementRef<any>,
+    public _ngControl: NgControl,
+  ) {
+    _ngControl.valueAccessor = this;
+  }
+
+  writeValue(value: string): void {
+    if (this._isCheckBox()) {
+      this._elementRef.nativeElement.value = value || '';
+      this._elementRef.nativeElement.checked =
+        this._elementRef.nativeElement.value === value;
+    } else if (this._isRadio()) {
+      this._elementRef.nativeElement.checked =
+        this._elementRef.nativeElement.value === value;
+    } else {
+      this._elementRef.nativeElement.value = value;
+    }
+  }
+
+  registerOnChange(fn: any): void {
+    this._onChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+    this._onTouched = fn;
+  }
+
+  @HostListener('change', ['$event'])
+  handleChange(event: Event): void {
+    const value = this._isCheckBox()
+      ? this._elementRef.nativeElement.checked
+      : this._elementRef.nativeElement.value;
+
+    this._onChange(value);
+    this._onTouched();
+    this._updateValidity();
+  }
+
+  @HostListener('blur')
+  handleBlur(): void {
+    this._onTouched();
+  }
+
+  // Optional: If you need to handle disabled states
+  setDisabledState(isDisabled: boolean): void {
+    this._elementRef.nativeElement.disabled = isDisabled;
+  }
+
+  private _isCheckBox() {
+    const tagName = this._elementRef.nativeElement.tagName.toLowerCase();
+    return tagName === 'cv-checkbox' || tagName === 'cv-checkbox-icon';
+  }
+
+  private _isRadio() {
+    const tagName = this._elementRef.nativeElement.tagName.toLowerCase();
+    return tagName === 'cv-radio' || tagName === 'cv-radio-icon';
+  }
+
+  private _updateValidity(): void {
+    const element = this._elementRef.nativeElement;
+    const control = this._ngControl.control;
+
+    if (this._isCheckBox() || this._isRadio()) {
+      return;
+    }
+
+    if (control?.errors) {
+      // Get the first validation error key (e.g., 'required', 'minlength')
+      element.validityTransform = () => {
+        return {
+          valid: !control.invalid,
+        };
+      };
+    }
+
+    // Set the web component's custom validity message
+    element.reportValidity();
+  }
+}

--- a/libs/angular/common/src/public_api.ts
+++ b/libs/angular/common/src/public_api.ts
@@ -20,6 +20,7 @@ export * from './behaviors/disable-ripple.mixin';
 // Directives
 export * from './forms/auto-trim/auto-trim.directive';
 export * from './directives/fullscreen/fullscreen.directive';
+export * from './directives/web-components/form-control.directive';
 
 // Validators
 export * from './forms/validators/validators';

--- a/libs/angular/project.json
+++ b/libs/angular/project.json
@@ -40,7 +40,13 @@
       "options": {
         "jestConfig": "libs/angular/jest.config.js",
         "passWithNoTests": true
-      }
+      },
+      "dependsOn": [
+        {
+          "projects": ["components"],
+          "target": "build"
+        }
+      ]
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/libs/components/src/icon-checkbox/icon-check-toggle.ts
+++ b/libs/components/src/icon-checkbox/icon-check-toggle.ts
@@ -1,5 +1,5 @@
 import { css, html, unsafeCSS } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { CheckboxBase } from '@material/mwc-checkbox/mwc-checkbox-base';
@@ -24,6 +24,9 @@ export class CovalentIconCheckToggle extends CheckboxBase {
   @property() width: number | string = '200';
   @property() height: number | string = '160';
   @property({ type: Boolean }) iconOnly = false;
+
+  @query('.container') protected override mdcRoot!: HTMLElement;
+
   override render() {
     const classes = {
       checked: this.checked,
@@ -41,10 +44,10 @@ export class CovalentIconCheckToggle extends CheckboxBase {
             <input type="checkbox" class="mdc-checkbox__native-control"></input>
             <div class="mdc-toggle__background">
                 <svg class="mdc-toggle__checkmark ${classMap(
-                  checkmark
+                  checkmark,
                 )}" viewBox="0 0 24 24">
                     <path class="mdc-toggle__checkmark-path ${classMap(
-                      checkmark
+                      checkmark,
                     )}" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"></path>
                 </svg>
             </div>
@@ -58,4 +61,4 @@ export class CovalentIconCheckToggle extends CheckboxBase {
   }
 }
 
-export default CovalentIconCheckToggle
+export default CovalentIconCheckToggle;


### PR DESCRIPTION
This pull request includes several changes aimed at improving the functionality and integration of form controls with Angular's reactive forms, as well as some minor CSS adjustments and project configuration updates.

closes #2468 

### Form Controls Integration:

* Added `CovalentTextfieldValueAccessorDirective` to handle form control bindings for custom web components (`cv-textfield`, `cv-checkbox`, `cv-radio`) in Angular reactive forms. This includes methods to handle changes, blur events, and disabled states. (`libs/angular/common/src/directives/web-components/form-control.directive.ts`, [libs/angular/common/src/directives/web-components/form-control.directive.tsR1-R102](diffhunk://#diff-327469beb5c616b5e9095618d6201269545f05a9d2904c962a745ff1eea47671R1-R102))
* Created a comprehensive test suite for `CovalentTextfieldValueAccessorDirective` to ensure correct behavior of form control bindings and state updates. (`libs/angular/common/src/directives/web-components/form-control.directive.spec.ts`, [libs/angular/common/src/directives/web-components/form-control.directive.spec.tsR1-R103](diffhunk://#diff-3901238b40c4865cdf83440147aaf61d03368b529105c1de9a14eb517243efc8R1-R103))
* Exported the new directive in the public API to make it available for use in other parts of the application. (`libs/angular/common/src/public_api.ts`, [libs/angular/common/src/public_api.tsR23](diffhunk://#diff-bcbdac4c5b73966131eb785aac7383e2932b3451b03ecb57325041b21d9e6110R23))

### CSS Adjustments:

* Updated the `.knapsack-wrapper.knapsack-pattern-direct-parent` class to always stretch to 100% view height and width, and adjusted child elements to be centered and displayed as flex. (`apps/knapsack/public/ks-overrides.css`, [apps/knapsack/public/ks-overrides.cssR6-R20](diffhunk://#diff-93ac491217ca9deffde4a471ba2adf5de79ac1fad2ba2a3420e5bd89686742ceR6-R20))

### Project Configuration:

* Added a dependency on the `components` project to ensure it is built before running tests in the `angular` project. (`libs/angular/project.json`, [libs/angular/project.jsonR43-R49](diffhunk://#diff-a221abcaeee7e092bfea6f29202a2fc8adf89f92cb0eefacad8d3817a6ba1eeaR43-R49))

### Minor Code Improvements:

* Added missing `query` decorator and corrected formatting in `CovalentIconCheckToggle` class. (`libs/components/src/icon-checkbox/icon-check-toggle.ts`, [[1]](diffhunk://#diff-76a7dffd5f5c74c880fd6ff37eb9f9013ccb8c73299dd083a22fcb9535f05298L2-R2) [[2]](diffhunk://#diff-76a7dffd5f5c74c880fd6ff37eb9f9013ccb8c73299dd083a22fcb9535f05298R27-R29) [[3]](diffhunk://#diff-76a7dffd5f5c74c880fd6ff37eb9f9013ccb8c73299dd083a22fcb9535f05298L44-R50) [[4]](diffhunk://#diff-76a7dffd5f5c74c880fd6ff37eb9f9013ccb8c73299dd083a22fcb9535f05298L61-R64)


#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
