### PR TITLE
Style/snack bar

### DIFF
--- a/libs/components/src/snackbar/snackbar.scss
+++ b/libs/components/src/snackbar/snackbar.scss
@@ -6,6 +6,7 @@
   --mdc-theme-on-surface: var(--cv-theme-inverse-on-surface);
   --mdc-theme-surface: var(--cv-theme-inverse-surface);
   --mdc-snackbar-action-color: var(--cv-theme-inverse-on-surface);
+  --mdc-ripple-color: var(--cv-theme-inverse-primary);
 
   .mdc-snackbar__surface {
     background-color: var(--mdc-theme-surface);

--- a/libs/components/src/snackbar/snackbar.scss
+++ b/libs/components/src/snackbar/snackbar.scss
@@ -1,8 +1,0 @@
-:host {
-  --mdc-snackbar-action-color: var(--mdc-theme-text-primary-on-dark);
-  --mdc-theme-text-primary-on-background: var(--mdc-theme-text-primary-on-dark);
-  
-  ::slotted(cv-icon-button) {
-    color: var(--mdc-theme-text-icon-on-dark);
-  }
-}

--- a/libs/components/src/snackbar/snackbar.scss
+++ b/libs/components/src/snackbar/snackbar.scss
@@ -1,0 +1,18 @@
+:host {
+  --mdc-theme-text-primary-on-background: var(--cv-theme-inverse-on-surface);
+  --mdc-theme-text-icon-on-background: var(--cv-theme-inverse-on-surface);
+  --mdc-theme-primary: var(--cv-theme-inverse-primary);
+  --mdc-theme-on-primary: var(--cv-theme-on-inverse-primary);
+  --mdc-theme-on-surface: var(--cv-theme-inverse-on-surface);
+  --mdc-theme-surface: var(--cv-theme-inverse-surface);
+  --mdc-snackbar-action-color: var(--cv-theme-inverse-on-surface);
+
+  .mdc-snackbar__surface {
+    background-color: var(--mdc-theme-surface);
+    color: var(--mdc-theme-on-surface);
+  }
+
+  .mdc-snackbar__label {
+    color: var(--mdc-theme-on-surface);
+  }
+}


### PR DESCRIPTION
## Description

Added the covalent inverse tokens to use for snackbar surface and primary styling. Adjusted tokens per the Covalent Principles files in figma


#### Test Steps

- [ ] `npm run storybook`
- [ ] then navigate to the snackbar story
- [ ] finally test the snackbar and observe the correct tokens

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker

https://github.com/user-attachments/assets/b7432964-3b32-4ea7-ac38-bd26c255d16f

