### PR TITLE
Upgrade monaco editor in v6.x.x

### DIFF
--- a/libs/angular-code-editor/src/lib/code-editor.component.ts
+++ b/libs/angular-code-editor/src/lib/code-editor.component.ts
@@ -128,7 +128,7 @@ export class TdCodeEditorComponent
 
   applyValue(): void {
     if (!this._fromEditor) {
-      this._editor.setValue(this._value);
+      this._editor.setValue(this._value || '');
     }
     this._fromEditor = false;
     this.propagateChange(this._value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "echarts-wordcloud": "^2.0.0",
         "highlight.js": "^11.4.0",
         "lit": "^2.2.8",
-        "monaco-editor": "^0.34.1",
+        "monaco-editor": "^0.52.2",
         "rxjs": "^7.8.1",
         "shepherd.js": "^9.0.0",
         "showdown": "^2.0.3",
@@ -38827,7 +38827,9 @@
       "license": "MIT"
     },
     "node_modules/monaco-editor": {
-      "version": "0.34.1",
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
       "license": "MIT"
     },
     "node_modules/monaco-editor-webpack-plugin": {
@@ -80328,7 +80330,9 @@
       }
     },
     "monaco-editor": {
-      "version": "0.34.1"
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ=="
     },
     "monaco-editor-webpack-plugin": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "echarts-wordcloud": "^2.0.0",
     "highlight.js": "^11.4.0",
     "lit": "^2.2.8",
-    "monaco-editor": "^0.34.1",
+    "monaco-editor": "^0.52.2",
     "rxjs": "^7.8.1",
     "shepherd.js": "^9.0.0",
     "showdown": "^2.0.3",


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
Upgrade monaco editor to the latest version for covalent 6.x.x version. This version is being used by Lake and needs to be updated to address security concerns.

[CCP-10806](https://teradata-pe.atlassian.net/browse/CCP-10806)

### What's included?

<!-- List features included in this PR -->

- Upgrade monaco-editor to v0.52.2
- Pass an empty string to editor's setValue method if null values are passed.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start docs-app`
- [ ] then navigate to Code editor
- [ ] finally verify all functionalities work as needed

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="890" alt="Screenshot 2025-06-03 at 10 12 49 AM" src="https://github.com/user-attachments/assets/ac11eb0a-da55-4485-9b5e-13328e4c2bfe" />
