### PR TITLE
Fix/release GitHub workflow for v6.x.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Use Node.js 18
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm
       - name: Install dependencies
-        run: npx ci
+        run: npm ci
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GH }}


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
Update checkout and setup-node actions to v4 to avoid caching issues during release.

### What's included?

<!-- List features included in this PR -->

- Update actions/checkout@v4 and actions/setup-node@v4

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] Upon merging this PR
- [ ] Release workflow should be triggered and run successfully

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
Fix for this issue:
<img width="1150" alt="Screenshot 2025-06-11 at 12 39 35 PM" src="https://github.com/user-attachments/assets/cce7d510-327c-4363-8079-429fc4a92041" />
