### PR TITLE
fix(icon-radio): add ability to change text alignment

### DIFF
--- a/libs/components/src/icon-radio/icon-radio.scss
+++ b/libs/components/src/icon-radio/icon-radio.scss
@@ -16,10 +16,10 @@
 
 .mdc-radio {
   display: flex;
-  justify-content: center;
-  align-items: center;
+  justify-content: var(--cv-icon-radio-horizontal-alignment, center);
+  align-items: var(--cv-icon-radio-vertical-alignment, center);
   flex-direction: column;
-  text-align: center;
+  text-align: var(--cv-icon-radio-text-alignment, center);
   row-gap: 8px;
   width: var(--cv-icon-radio-width, 200px);
   height: var(--cv-icon-radio-height, 160px);

--- a/libs/components/src/icon-radio/icon-radio.stories.js
+++ b/libs/components/src/icon-radio/icon-radio.stories.js
@@ -22,3 +22,47 @@ export const Template = ({ iconOnly }) => {
       </cv-radio-icon>
   `;
 };
+
+// Story for text only radio icons
+export const TextOnly = () => {
+  document.addEventListener('DOMContentLoaded', () => {
+    const textRadioContainer = document.getElementById('text-radio-demo');
+    textRadioContainer.style.setProperty(
+      '--cv-icon-radio-horizontal-alignment',
+      'start',
+    );
+    textRadioContainer.style.setProperty(
+      '--cv-icon-radio-vertical-alignment',
+      'start',
+    );
+    textRadioContainer.style.setProperty(
+      '--cv-icon-radio-text-alignment',
+      'left',
+    );
+    textRadioContainer.style.setProperty('--cv-icon-radio-height', '120px');
+  });
+  return `
+    <div id="text-radio-demo">
+      <cv-radio-icon>
+        <div slot="text">Basic</div>
+        <div slot="text">
+          <cv-typography scale="body2">Best for simple, consistently formatted documents.</cv-typography>
+          <cv-typography scale="caption" style="margin-top: 16px;">May split mid-sentence or lose structure in complex formats.</cv-typography>
+        </div>
+      </cv-radio-icon>
+      <cv-radio-icon>
+        <div slot="text">SherpaLLM</div>
+        <div slot="text">
+          <cv-typography scale="body2">Best for structured, formatted, PDF documents.</cv-typography>
+          <cv-typography scale="caption" style="margin-top: 16px;">May struggle with irregular formatting or images.</cv-typography>
+        </div>
+      </cv-radio-icon>
+      <cv-radio-icon>
+        <div slot="text">Vector-Distance</div>
+        <div slot="text">
+          <cv-typography scale="body2">Best for high-dimensional, large-scale datasets where fast nearest-neighbor search is required</cv-typography>
+        </div>
+      </cv-radio-icon>
+    </div>
+  `;
+};


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- Need the ability to support text only variants of `cv-radio-icon` as part of [VAC-2545](https://teradata-pe.atlassian.net/browse/VAC-2545).
- We can achieve this by not providing the `icon` slot. But the existing component only supports centrally aligned content. This change provides the ability to set the horizontal, vertical and text alignment of the content within `cv-radio-icon` 

### What's included?

<!-- List features included in this PR -->

- Added new custom CSS properties to change alignment:
  - `--cv-icon-radio-horizontal-alignment`: sets the horizontal alignment of content
  - `--cv-icon-radio-vertical-alignment`: sets the vertical alignment of content
  - `--cv-icon-radio-text-alignment`: sets the text alignment of content

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run storybook`
- [ ] then navigate to `Icon radio` -> `Text Only` tab
- [ ] finally explore the text only variants of `cv-radio-icon` 

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1498" height="819" alt="Screenshot 2025-07-21 at 4 31 33 PM" src="https://github.com/user-attachments/assets/459c31e1-f73b-470d-96ad-c4424b574aac" />
