### PR TITLE
feat(divider): enhance divider styles and update stories layout

### DIFF
--- a/libs/components/src/app-shell/app-shell.scss
+++ b/libs/components/src/app-shell/app-shell.scss
@@ -23,6 +23,9 @@
   --cv-list-item-expansion-icon-size: 0;
   --cv-list-item-selected-background-color: var(--cv-theme-primary-24);
   --cv-list-item-selected-color: var(--cv-theme-primary);
+  --cv-divider-margin: 0 0 0 -6px;
+  --cv-divider-padding-left: 12px;
+  --cv-divider-padding-right: 24px;
 }
 
 :host([open]) .navigation {
@@ -38,6 +41,8 @@
     --cv-theme-on-surface-variant-8
   );
   --cv-list-item-selected-color: var(--cv-theme-on-surface-variant);
+  --cv-divider-margin: 0;
+  --cv-divider-padding-right: 20px;
 }
 
 :host([helpOpen]) {

--- a/libs/components/src/app-shell/app-shell.stories.js
+++ b/libs/components/src/app-shell/app-shell.stories.js
@@ -14,6 +14,7 @@ import '../toolbar/toolbar';
 import '../button/button';
 import '../textfield/textfield';
 import '../typography/typography';
+import '../divider/divider';
 
 import { MDCDataTable, events } from '@material/data-table';
 
@@ -160,6 +161,9 @@ const Template = ({
           <span>Data Protections</span>
           <cv-icon slot="graphic">settings_backup_restore</cv-icon>
         </cv-nav-list-item>
+
+        <cv-divider size="inset"></cv-divider>
+
         <cv-nav-list-item graphic="avatar">
           <span>Identity</span>
           <cv-icon slot="graphic">contacts</cv-icon>
@@ -172,7 +176,9 @@ const Template = ({
         <cv-icon>arrow_drop_down</cv-icon>
        </span>
 
-       <cv-textfield slot="actionItems" icon="forum" placeholder="Message ask.ai" style="margin-right: 8px" dense></cv-textfield>
+       <cv-icon-button slot="actionItems" icon="forum"></cv-icon-button>
+       <cv-divider slot="actionItems" direction="vertical" size="icon"></cv-divider>
+
        <cv-icon-button slot="actionItems" icon="notifications"></cv-icon-button>
        <cv-icon-button-toggle slot="actionItems" onIcon="help" offIcon="help" class="help-item"></cv-icon-button-toggle>
        <cv-icon-button slot="actionItems" icon="person" style="margin-right: -12px"></cv-icon-button>

--- a/libs/components/src/divider/divider.component.scss
+++ b/libs/components/src/divider/divider.component.scss
@@ -24,8 +24,13 @@
 }
 
 :host([size='inset']) {
-  padding-left: 16px;
-  padding-right: 16px;
+  padding-left: var(--cv-divider-padding-left, 16px);
+  padding-right: var(--cv-divider-padding-right, 16px);
+}
+
+:host([size='inset'])::before {
+  left: var(--cv-divider-padding-left, 16px);
+  right: var(--cv-divider-padding-right, 16px);
 }
 
 :host([direction='vertical'][size='inset']) {
@@ -79,11 +84,6 @@
   right: auto;
   bottom: auto;
   transform: translateX(-50%) translateY(-50%);
-}
-
-:host([size='inset'])::before {
-  left: 16px;
-  right: 16px;
 }
 
 :host([direction='vertical'][size='inset'])::before {

--- a/libs/components/src/divider/divider.stories.js
+++ b/libs/components/src/divider/divider.stories.js
@@ -1,6 +1,13 @@
 import './divider';
 import './divider.scss';
 
+import '../card/card';
+import '../list/list';
+import '../list/list-item';
+import '../typography/typography';
+import '../icon-button/icon-button';
+import { TmplAstBlockNode } from '@angular/compiler';
+
 export default {
   title: 'Components/Divider',
   argTypes: {
@@ -23,191 +30,79 @@ export default {
   },
 };
 
-const Template = ({ direction, size, flush }) => {
+const BasicTemplate = ({ direction, size, flush }) => {
   return `
-    <section class="horizontal-section">
-      <h1>Horizontal dividers</h1>
-
-      <div class="card horizontal">
-        <p><strong>Default:</strong></p>
-        <pre><code>&lt;cv-divider&gt;&lt;/cv-divider&gt;</code></pre>
-        <ul>
-          <li>Sample list item</li>
-          <li>Sample list item</li>
-          <cv-divider></cv-divider>
-          <li>Sample list item</li>
-          <li>Sample list item</li>
-        </ul>
-      </div>
-
-      <div class="card horizontal">
-        <p><strong>Flush:</strong></p>
-        <pre><code>&lt;cv-divider
-     flush&gt;
-&lt;/cv-divider&gt;</code></pre>
-        <ul>
-          <li>Sample list item</li>
-          <li>Sample list item</li>
-          <cv-divider flush></cv-divider>
-          <li>Sample list item</li>
-          <li>Sample list item</li>
-        </ul>
-      </div>
-
-      <div class="card horizontal">
-        <p><strong>Inset:</strong></p>
-        <pre><code>&lt;cv-divider
-     size="inset"&gt;
-&lt;/cv-divider&gt;</code></pre>
-        <ul>
-          <li>Sample list item</li>
-          <li>Sample list item</li>
-          <cv-divider size="inset"></cv-divider>
-          <li>Sample list item</li>
-          <li>Sample list item</li>
-        </ul>
-      </div>
-
-      <div class="card horizontal">
-        <p><strong>Inset + flush:</strong></p>
-        <pre><code>&lt;cv-divider
-     size="inset"
-     flush&gt;
-&lt;/cv-divider&gt;</code></pre>
-        <ul>
-          <li>Sample list item</li>
-          <li>Sample list item</li>
-          <cv-divider size="inset" flush></cv-divider>
-          <li>Sample list item</li>
-          <li>Sample list item</li>
-        </ul>
-      </div>
-
-      <div class="card horizontal icon-demo">
-        <p><strong>Icon width:</strong></p>
-        <pre><code>&lt;cv-divider
-     size="icon"&gt;
-&lt;/cv-divider&gt;</code></pre>
-        <ul>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-          <cv-divider size="icon"></cv-divider>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-        </ul>
-      </div>
-
-      <div class="card horizontal icon-demo">
-        <p><strong>Icon + flush:</strong></p>
-        <pre><code>&lt;cv-divider
-     size="icon"
-     flush&gt;
-&lt;/cv-divider&gt;</code></pre>
-        <ul>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-          <cv-divider size="icon" flush></cv-divider>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-        </ul>
-      </div>
-    </section>
-
-    <section class="vertical-section">
-      <h1>Vertical dividers</h1>
-
-      <div class="card vertical">
-        <p><strong>Default:</strong></p>
-        <pre><code>&lt;cv-divider
-     direction="vertical"&gt;
-&lt;/cv-divider&gt;</code></pre>
-        <ul>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-          <cv-divider direction="vertical"></cv-divider>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-        </ul>
-      </div>
-
-      <div class="card vertical">
-        <p><strong>Flush:</strong></p>
-        <pre><code>&lt;cv-divider
-     direction="vertical"
-     flush&gt;
-&lt;/cv-divider&gt;</code></pre>
-        <ul>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-          <cv-divider direction="vertical" flush></cv-divider>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-        </ul>
-      </div>
-
-      <div class="card vertical">
-        <p><strong>Inset:</strong></p>
-        <pre><code>&lt;cv-divider
-     direction="vertical"
-     size="inset"&gt;
-&lt;/cv-divider&gt;</code></pre>
-        <ul>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-          <cv-divider direction="vertical" size="inset"></cv-divider>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-        </ul>
-      </div>
-
-      <div class="card vertical">
-        <p><strong>Inset + flush:</strong></p>
-        <pre><code>&lt;cv-divider
-     direction="vertical"
-     size="inset"
-     flush&gt;
-&lt;/cv-divider&gt;</code></pre>
-        <ul>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-          <cv-divider direction="vertical" size="inset" flush></cv-divider>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-        </ul>
-      </div>
-
-      <div class="card vertical">
-        <p><strong>Icon height:</strong></p>
-        <pre><code>&lt;cv-divider
-     direction="vertical"
-     size="icon"&gt;
-&lt;/cv-divider&gt;</code></pre>
-        <ul>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-          <cv-divider direction="vertical" size="icon"></cv-divider>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-        </ul>
-      </div>
-
-      <div class="card vertical">
-        <p><strong>Icon + flush:</strong></p>
-        <pre><code>&lt;cv-divider
-     direction="vertical"
-     size="icon"
-     flush&gt;
-&lt;/cv-divider&gt;</code></pre>
-        <ul>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-          <cv-divider direction="vertical" size="icon" flush></cv-divider>
-          <li><div class="placeholder-icon"></div></li>
-          <li><div class="placeholder-icon"></div></li>
-        </ul>
-      </div>
-    </section>
+    <cv-card>
+      <cv-list>
+        <cv-list-item>Lorem ipsum dolor sit amet, consectetur</cv-list-item>
+        <cv-list-item>Lorem ipsum dolor sit amet, consectetur</cv-list-item>
+        <cv-divider
+          direction="${direction}"
+          size="${size}"
+          ${flush ? 'flush' : ''}>
+        </cv-divider>
+        <cv-list-item>Lorem ipsum dolor sit amet, consectetur</cv-list-item>
+        <cv-list-item>Lorem ipsum dolor sit amet, consectetur</cv-list-item>
+      </cv-list>      
+    </cv-card>
   `;
 };
 
-export const Basic = Template.bind({});
+const IconTemplate = ({ direction = 'horizontal', size, flush }) => {
+  return `
+    <style>
+      cv-icon-button {
+        display: block;
+      }
+      ${direction == 'vertical' ? '#storybook-root { display: flex }' : ''}
+    </style>   
+    <cv-icon-button icon="person" aria-label="Add item"></cv-icon-button>
+    <cv-icon-button icon="houseboat" aria-label="Add item"></cv-icon-button>
+    <cv-divider
+      direction="${direction}"      
+      size="${size}"
+      ${flush ? 'flush' : ''}>
+    </cv-divider>
+    <cv-icon-button icon="shield" aria-label="Add item"></cv-icon-button>
+    <cv-icon-button icon="settings" aria-label="Add item"></cv-icon-button>
+  `;
+};
+
+export const Basic = BasicTemplate.bind({});
+
+export const Inset = BasicTemplate.bind({});
+Inset.args = {
+  size: 'inset',
+};
+
+export const Flush = BasicTemplate.bind({});
+Flush.args = {
+  flush: true,
+};
+
+export const Icon = IconTemplate.bind({});
+Icon.args = {
+  direction: 'horizontal',
+  size: 'icon',
+};
+
+export const IconFlush = IconTemplate.bind({});
+IconFlush.args = {
+  direction: 'horizontal',
+  size: 'icon',
+  flush: true,
+};
+
+export const Vertical = IconTemplate.bind({});
+Vertical.args = {
+  direction: 'vertical',
+  size: 'icon',
+  flush: false,
+};
+
+export const VerticalFlush = IconTemplate.bind({});
+VerticalFlush.args = {
+  direction: 'vertical',
+  size: 'icon',
+  flush: true,
+};

--- a/libs/components/src/divider/divider.stories.js
+++ b/libs/components/src/divider/divider.stories.js
@@ -54,7 +54,7 @@ const IconTemplate = ({ direction = 'horizontal', size, flush }) => {
       cv-icon-button {
         display: block;
       }
-      ${direction == 'vertical' ? '#storybook-root { display: flex }' : ''}
+      ${direction == 'vertical' ? '#storybook-root, #story--components-divider--vertical-inner, #story--components-divider--vertical-flush-inner { display: flex }' : ''}
     </style>   
     <cv-icon-button icon="person" aria-label="Add item"></cv-icon-button>
     <cv-icon-button icon="houseboat" aria-label="Add item"></cv-icon-button>


### PR DESCRIPTION
## Description


Adding some adjustment to the divider when used within the appshell navigation. Also adjusting the storybook layouts to integrate better with our current components


### What's included?

- Adjusted divider when used in apshell navigation area
- Added better story layout for divider to show all examples

#### Test Steps

- [ ] `npm run storybook`
- [ ] then navigate to the appshell and divider stories
- [ ] finally test them out!

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="470" height="448" alt="Screenshot 2025-07-29 at 3 19 12 PM" src="https://github.com/user-attachments/assets/2d75f51e-3531-47f9-990b-a7f84d5b2219" />
<img width="1278" height="567" alt="Screenshot 2025-07-29 at 3 19 27 PM" src="https://github.com/user-attachments/assets/1e83c177-b021-45a3-ba38-a9f7cf3d02ef" />
