### PR TITLE
feat(components): adding text style to select

### DIFF
--- a/libs/components/src/app-shell/app-shell.stories.js
+++ b/libs/components/src/app-shell/app-shell.stories.js
@@ -1,6 +1,5 @@
 import tableRowSelectionContent from '../../stories/demos/table-row-selection.content.html?raw';
 import '../data-table/data-table.stories.scss';
-
 import './app-shell';
 import '../action-ribbon/action-ribbon';
 import '../icon/icon';
@@ -11,6 +10,8 @@ import '../list/list-item';
 import '../list/nav-list-item';
 import '../select/select';
 import '../toolbar/toolbar';
+import '../tab/tab-bar';
+import '../tab/tab';
 import '../button/button';
 import '../textfield/textfield';
 import '../typography/typography';
@@ -94,8 +95,24 @@ const Template = ({
 
   return `
     <style>
+
+    cv-select {
+        --cv-density-mode:-3;
+    }
+    cv-select cv-list-item {
+        --cv-density-mode:0;
+    }
+        
     .hidden-large {
         display: none;
+    }
+
+    .user-menu {
+      background: var(--mdc-theme-surface); 
+      display: flex;
+      justify-content:space-between;
+      align-items: between;
+      padding: 8px 0;
     }
 
     @media only screen and (max-width: 800px) {
@@ -179,19 +196,35 @@ const Template = ({
         </cv-nav-list-item>
       </cv-list>
 
-      <cv-toolbar slot="user-menu" sticky>
-       <span slot="title" style="display:flex; align-items: center">
-        <cv-typography scale="body1">All environments</cv-typography>
-        <cv-icon>arrow_drop_down</cv-icon>
-       </span>
 
-       <cv-icon-button slot="actionItems" icon="forum"></cv-icon-button>
-       <cv-divider slot="actionItems" direction="vertical" size="icon"></cv-divider>
+      <div class="user-menu" slot="user-menu" >
+        <cv-select icon="database" text slot="title" >
+          <cv-typography scale="subtitle2" style="margin:0px 16px 10px;">All environments</cv-typography>
+          <cv-divider flush></cv-divider>
+          <cv-list-item twoline selected graphic="icon" value="1">
+            Base user
+            <span slot="secondary">1 CPU, 2GB RAM</span>
+            <cv-icon slot="graphic">check</cv-icon>
+          </cv-list-item>
+          <cv-list-item twoline graphic="icon" value="1">
+            Advanced user
+            <span slot="secondary">2 CPU, 4GB RAM</span>
+          </cv-list-item>
+          <cv-list-item twoline graphic="icon" value="1">
+            Pro user
+            <span slot="secondary">4 CPU, 8GB RAM</span>
+          </cv-list-item>
+        </cv-select>
 
-       <cv-icon-button slot="actionItems" icon="notifications"></cv-icon-button>
-       <cv-icon-button-toggle slot="actionItems" onIcon="help" offIcon="help" class="help-item"></cv-icon-button-toggle>
-       <cv-icon-button slot="actionItems" icon="person" style="margin-right: -12px"></cv-icon-button>
-      </cv-toolbar>
+        <span>
+          <cv-icon-button slot="actionItems" icon="forum"></cv-icon-button>
+          <cv-divider slot="actionItems" direction="vertical" size="icon"></cv-divider>
+
+          <cv-icon-button slot="actionItems" icon="notifications"></cv-icon-button>
+          <cv-icon-button-toggle slot="actionItems" onIcon="help" offIcon="help" class="help-item"></cv-icon-button-toggle>
+          <cv-icon-button slot="actionItems" icon="person" style="margin-right: -12px"></cv-icon-button>
+        </span>
+      </div>
 
       <div slot="help" class="help-panel mdc-typography">
         <cv-toolbar sticky>

--- a/libs/components/src/select/select.scss
+++ b/libs/components/src/select/select.scss
@@ -55,19 +55,20 @@
 
   .mdc-select__selected-text-secondary {
     --mdc-icon-size: var(--mdc-typography-body2-font-size);
+
     font-family: var(
       --mdc-typography-body2-font-family,
       var(--mdc-typography-font-family, Roboto, sans-serif)
     );
     font-size: var(--mdc-typography-body2-font-size, 0.875rem);
     font-weight: var(--mdc-typography-body2-font-weight, 400);
-    letter-spacing: var(--mdc-typography-body2-letter-spacing, 0.0178571429em);
+    letter-spacing: var(--mdc-typography-body2-letter-spacing, 0.0179em);
     text-decoration: var(--mdc-typography-body2-text-decoration, inherit);
     text-transform: var(--mdc-typography-body2-text-transform, inherit);
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    margin-top: 0px;
+    margin-top: 0;
     line-height: normal;
     display: block;
     width: 100%;
@@ -78,8 +79,7 @@
     .mdc-select__selected-text-container,
   .mdc-select--filled .mdc-select__anchor .mdc-select__selected-text-container,
   .mdc-select--text .mdc-select__anchor .mdc-select__selected-text-container {
-    flex-direction: column;
-    flex-wrap: nowrap;
+    flex-flow: column nowrap;
     align-content: center;
     justify-content: center;
   }
@@ -91,6 +91,7 @@
 
   .mdc-select--text:not(.mdc-select--disabled) .mdc-select__anchor {
     --mdc-select-fill-color: transparent;
+
     border-radius: var(--mdc-shape-small);
   }
 }

--- a/libs/components/src/select/select.scss
+++ b/libs/components/src/select/select.scss
@@ -28,7 +28,7 @@
     color: var(--mdc-select-dropdown-icon-color);
   }
 
-  .mdc-select .mdc-select__anchor {
+  .mdc-select.mdc-select--outlined .mdc-select__anchor {
     height: density.density-height(56px);
 
     .mdc-floating-label--float-above {
@@ -37,8 +37,60 @@
     }
   }
 
-  .mdc-select.mdc-select--with-leading-icon .mdc-floating-label--float-above {
+  .mdc-select.mdc-select--text .mdc-select__anchor {
+    height: density.density-height(56px);
+  }
+
+  .mdc-select--with-twoline:not(.mdc-select--outlined)
+    .mdc-select__anchor
+    .mdc-floating-label--float-above {
+    transform: translateY(-106%) scale(0);
+  }
+
+  .mdc-select.mdc-select--outlined.mdc-select--with-leading-icon
+    .mdc-floating-label--float-above {
     transform: translateY(#{density.density-height(-37.25px, 0, -2px)})
       translateX(-32px) scale(1);
+  }
+
+  .mdc-select__selected-text-secondary {
+    --mdc-icon-size: var(--mdc-typography-body2-font-size);
+    font-family: var(
+      --mdc-typography-body2-font-family,
+      var(--mdc-typography-font-family, Roboto, sans-serif)
+    );
+    font-size: var(--mdc-typography-body2-font-size, 0.875rem);
+    font-weight: var(--mdc-typography-body2-font-weight, 400);
+    letter-spacing: var(--mdc-typography-body2-letter-spacing, 0.0178571429em);
+    text-decoration: var(--mdc-typography-body2-text-decoration, inherit);
+    text-transform: var(--mdc-typography-body2-text-transform, inherit);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin-top: 0px;
+    line-height: normal;
+    display: block;
+    width: 100%;
+  }
+
+  .mdc-select--outlined
+    .mdc-select__anchor
+    .mdc-select__selected-text-container,
+  .mdc-select--filled .mdc-select__anchor .mdc-select__selected-text-container,
+  .mdc-select--text .mdc-select__anchor .mdc-select__selected-text-container {
+    flex-direction: column;
+    flex-wrap: nowrap;
+    align-content: center;
+    justify-content: center;
+  }
+
+  .mdc-select--filled .mdc-select__anchor .mdc-select__selected-text-container {
+    align-self: center;
+    height: 100%;
+  }
+
+  .mdc-select--text:not(.mdc-select--disabled) .mdc-select__anchor {
+    --mdc-select-fill-color: transparent;
+    border-radius: var(--mdc-shape-small);
   }
 }

--- a/libs/components/src/select/select.stories.js
+++ b/libs/components/src/select/select.stories.js
@@ -1,11 +1,16 @@
 import './select';
+import '../typography/typography';
 import '../list/list-item';
+import '../button/button';
+import '../divider/divider';
+import '../icon/icon';
+import '../icon-lockup/icon-lockup';
 
 export default {
   title: 'Components/Select',
   argTypes: {
     style: {
-      options: ['outlined', 'filled'],
+      options: ['outlined', 'filled', 'text'],
       control: { type: 'radio' },
     },
   },
@@ -39,6 +44,48 @@ const Template = ({ icon, style, required, helper }) => {
         </cv-select>`;
 };
 
+const Advanced = ({ icon, style, required, helper }) => {
+  return `
+        <cv-select
+            label="${style}"
+            validationMessage="This Field is Required"
+            naturalMenuWidth
+            twoLine
+            ${style}
+            ${icon ? `icon="${icon}"` : null}
+            ${helper ? `helper="${helper}"` : null}
+            ${required ? `required` : null}>
+            <cv-icon-lockup slot="selected-secondary" icon="check" scale="caption" state="positive">online</cv-icon-lockup>
+            <cv-typography scale="subtitle2" style="margin:0px 16px 10px;">Select an Item</cv-typography>
+            <cv-divider flush></cv-divider>
+            <cv-list-item twoline selected hasMeta ${
+              icon ? `graphic="icon"` : null
+            } value="0">
+            Basic user
+            <cv-icon slot="graphic">check</cv-icon>
+            <span slot="secondary">1 CPU, 2GB RAM</span>
+            <cv-button slot="meta" label="start" outlined style="--cv-density-mode:-3; margin-left: 24px"></cv-button>
+          </cv-list-item>
+          <cv-list-item twoline selected ${
+            icon ? `graphic="icon"` : null
+          } value="1">
+            Advanced user
+            <span slot="secondary">2 CPU, 4GB RAM</span>
+          </cv-list-item>
+          <cv-list-item twoline ${icon ? `graphic="icon"` : null} value="2">
+            Pro user
+            <span slot="secondary">4 CPU, 8GB RAM</span>
+          </cv-list-item>
+          <cv-divider flush></cv-divider>
+          <div>
+            <cv-list-item graphic="icon" label="Add New" style="--mdc-theme-text-primary-on-background:var(--mdc-theme-primary);--mdc-theme-text-icon-on-background:var(--mdc-theme-primary);">
+              <cv-icon slot="graphic">add</cv-icon>
+              Add New
+            </cv-list-item>
+          </div>
+        </cv-select>`;
+};
+
 export const Basic = Template.bind({});
 
 export const Required = Template.bind({});
@@ -54,4 +101,10 @@ Icon.args = {
 export const HelperText = Template.bind({});
 HelperText.args = {
   helper: 'Helper Text',
+};
+
+export const twoLine = Advanced.bind({});
+twoLine.args = {
+  icon: 'power',
+  required: true,
 };

--- a/libs/components/src/select/select.ts
+++ b/libs/components/src/select/select.ts
@@ -1,5 +1,8 @@
-import { css, unsafeCSS } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { css, html, nothing, unsafeCSS } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { MDCSelectAdapter } from '@material/select';
 import { SelectBase } from '@material/mwc-select/mwc-select-base';
 import { styles as baseStyles } from '@material/mwc-select/mwc-select.css';
 import styles from './select.scss?inline';
@@ -12,7 +15,144 @@ declare global {
 
 @customElement('cv-select')
 export class CovalentSelect extends SelectBase {
-  static override styles = [css`${unsafeCSS(styles)}`, baseStyles];
+  static override styles = [
+    css`
+      ${unsafeCSS(styles)}
+    `,
+    baseStyles,
+  ];
+
+  /*
+    Use two line layout.
+  */
+  @property({ type: Boolean, reflect: true })
+  twoLine = false;
+
+  /*
+   Use the text style instead of outlined or filled.
+  */
+  @property({ type: Boolean, reflect: true })
+  text = false;
+
+  override render() {
+    const classes = {
+      'mdc-select--disabled': this.disabled,
+      'mdc-select--no-label': !this.label,
+      'mdc-select--filled': !this.outlined,
+      'mdc-select--outlined': this.outlined,
+      'mdc-select--text': this.text,
+      'mdc-select--with-twoline': this.twoLine,
+      'mdc-select--with-leading-icon': !!this.icon,
+      'mdc-select--required': this.required,
+      'mdc-select--invalid': !this.isUiValid,
+      'mdc-select--has-value': !!this.value,
+    };
+
+    const labelledby = !this.label ? 'label' : undefined;
+    const describedby = this.shouldRenderHelperText ? 'helper-text' : undefined;
+
+    return html` <div class="mdc-select ${classMap(classes)}">
+        <input
+          class="formElement"
+          name="${this.name}"
+          .value="${this.value}"
+          hidden
+          ?disabled="${this.disabled}"
+          ?required=${this.required}
+        />
+        <!-- @ts-ignore -->
+        <div
+          class="mdc-select__anchor"
+          aria-autocomplete="none"
+          role="combobox"
+          aria-expanded=${this.menuOpen}
+          aria-invalid=${!this.isUiValid}
+          aria-haspopup="listbox"
+          aria-labelledby=${ifDefined(labelledby)}
+          aria-required=${this.required}
+          aria-describedby=${ifDefined(describedby)}
+          @click=${this.onClick}
+          @focus=${this.onFocus}
+          @blur=${this.onBlur}
+          @keydown=${this.onKeydown}
+        >
+          ${this.renderRipple()}
+          ${this.outlined ? this.renderOutline() : this.renderLabel()}
+          ${this.renderLeadingIcon()}
+          <span class="mdc-select__selected-text-container">
+            ${this.renderSelectedText()}
+          </span>
+          <span class="mdc-select__dropdown-icon">
+            <svg
+              class="mdc-select__dropdown-icon-graphic"
+              viewBox="7 10 10 5"
+              focusable="false"
+            >
+              <polygon
+                class="mdc-select__dropdown-icon-inactive"
+                stroke="none"
+                fill-rule="evenodd"
+                points="7 10 12 15 17 10"
+              ></polygon>
+              <polygon
+                class="mdc-select__dropdown-icon-active"
+                stroke="none"
+                fill-rule="evenodd"
+                points="7 15 12 10 17 15"
+              ></polygon>
+            </svg>
+          </span>
+          ${!this.text ? this.renderLineRipple() : nothing}
+        </div>
+        ${this.renderMenu()}
+      </div>
+      ${this.renderHelperText()}`;
+  }
+
+  protected renderSelectedText() {
+    if (this.twoLine && this.selectedText) {
+      return html`
+        <span class="mdc-select__selected-text">${this.selectedText}</span>
+        <span class="mdc-select__selected-text-secondary"
+          ><slot name="selected-secondary"></slot
+        ></span>
+      `;
+    }
+    return html`<span class="mdc-select__selected-text"
+      >${this.selectedText}</span
+    >`;
+  }
+
+  protected createAdapter(): MDCSelectAdapter {
+    return {
+      ...super.createAdapter(),
+      getMenuItemTextAtIndex: (index) => {
+        const menuElement = this.menuElement;
+        if (!menuElement) {
+          return '';
+        }
+
+        const element = menuElement.items[index];
+
+        if (!element) {
+          return '';
+        }
+
+        if (element.hasAttribute('twoline')) {
+          let onlyRawText = '';
+          for (let i = 0; i < element.childNodes.length; i++) {
+            const node = element.childNodes[i];
+            const nodeText = node.textContent?.trim() ?? '';
+            if (node.nodeType === Node.TEXT_NODE && nodeText.length > 0) {
+              onlyRawText += node.textContent?.trim() + ' ';
+            }
+          }
+          return onlyRawText.trim();
+        }
+        return element.text;
+      },
+    };
+  }
 }
 
 export default CovalentSelect;


### PR DESCRIPTION
## Description

Adding text style and variant to support two lines for the select component.



### What's included?

- adding the property `text` that removes default fill style
- adding `twoline` variant that will enable space for a `secondary` slot
- updated select storybook with two line varient and text style updates

#### Test Steps

- [ ] `npm run storybook`
- [ ] then open the two line select story
- [ ] finally open the properties for the story and select "text" to see the new text style

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="642" height="290" alt="Screenshot 2025-09-02 at 4 45 52 PM" src="https://github.com/user-attachments/assets/12a3c4cb-9cd5-423c-85c7-314cfebbb491" />
<img width="1419" height="912" alt="Screenshot 2025-09-02 at 4 44 37 PM" src="https://github.com/user-attachments/assets/f8b17c7c-d6cd-4498-b083-c4bace59fea5" />
