### PR TITLE
Fix/cv textfield loading

### DIFF
--- a/libs/angular/common/src/directives/web-components/form-control.directive.spec.ts
+++ b/libs/angular/common/src/directives/web-components/form-control.directive.spec.ts
@@ -68,7 +68,7 @@ describe('CovalentTextfieldValueAccessorDirective', () => {
   it('should update form control when textfield value changes', () => {
     const textfield = fixture.nativeElement.querySelector('cv-textfield');
     textfield.value = 'new value';
-    textfield.dispatchEvent(new Event('change'));
+    textfield.dispatchEvent(new Event('input'));
     fixture.detectChanges();
     expect(component.control.value).toBe('new value');
   });

--- a/libs/components/src/textfield/textfield.scss
+++ b/libs/components/src/textfield/textfield.scss
@@ -44,9 +44,21 @@
   color: var(--mdc-theme-text-icon-on-background);
 }
 
-.mdc-text-field--outlined.mdc-text-field--with-trailing-icon
-  .text-field-loading {
-  padding-right: 12px;
+// Styles for loading state
+.mdc-text-field--outlined:not(
+    .mdc-text-field--with-trailing-icon
+  ).cv-text-field--loading
+  .mdc-text-field__input {
+  width: calc(100% - 32px);
+}
+
+.mdc-text-field--outlined.mdc-text-field--with-trailing-icon.cv-text-field--loading {
+  padding-right: 48px;
+}
+
+.mdc-text-field--outlined.mdc-text-field--with-leading-icon.cv-text-field--loading
+  .mdc-text-field__input {
+  width: calc(100% - 80px);
 }
 
 .text-field-loading {
@@ -56,6 +68,8 @@
     var(--cv-theme-primary)
   );
 
+  position: absolute;
+  right: 0;
   align-self: center;
-  padding: 12px 0 12px 12px;
+  padding: 12px;
 }

--- a/libs/components/src/textfield/textfield.scss
+++ b/libs/components/src/textfield/textfield.scss
@@ -43,3 +43,19 @@
 .mdc-text-field:not(.mdc-text-field--disabled) .mdc-text-field__icon {
   color: var(--mdc-theme-text-icon-on-background);
 }
+
+.mdc-text-field--outlined.mdc-text-field--with-trailing-icon
+  .text-field-loading {
+  padding-right: 12px;
+}
+
+.text-field-loading {
+  // set the color of the circular progress spinner
+  --mdc-theme-primary: var(
+    --cv-text-field-loading-color,
+    var(--cv-theme-primary)
+  );
+
+  align-self: center;
+  padding: 12px 0 12px 12px;
+}

--- a/libs/components/src/textfield/textfield.stories.js
+++ b/libs/components/src/textfield/textfield.stories.js
@@ -11,6 +11,8 @@ export default {
   args: {
     style: 'outlined',
     disabled: false,
+    loading: false,
+    loaderDensity: -6,
   },
 };
 
@@ -22,6 +24,8 @@ const Template = ({
   disabled,
   required,
   helper,
+  loading,
+  loaderDensity,
 }) => {
   return `
         <cv-textfield 
@@ -31,12 +35,15 @@ const Template = ({
               iconTrailing && icon
                 ? `iconTrailing="${icon}"`
                 : icon
-                ? `icon="${icon}"`
-                : null
+                  ? `icon="${icon}"`
+                  : null
             }
             ${helper ? `helper="${helper}"` : null}
             ${disabled ? `disabled` : null}
-            ${required ? `required` : null}>
+            ${required ? `required` : null}
+            ${loading ? 'loading' : null}
+            ${loaderDensity ? `loaderDensity="${loaderDensity}"` : ''}
+            >
         </cv-textfield>`;
 };
 
@@ -57,4 +64,12 @@ export const HelperText = Template.bind({});
 HelperText.args = {
   label: 'Click to see helper text',
   helper: 'Helper Text',
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  label: 'Loading state',
+  icon: 'person',
+  loading: true,
+  loaderDensity: -6,
 };

--- a/libs/components/src/textfield/textfield.stories.js
+++ b/libs/components/src/textfield/textfield.stories.js
@@ -72,4 +72,5 @@ Loading.args = {
   icon: 'person',
   loading: true,
   loaderDensity: -6,
+  iconTrailing: false,
 };

--- a/libs/components/src/textfield/textfield.ts
+++ b/libs/components/src/textfield/textfield.ts
@@ -4,6 +4,7 @@ import { TextFieldBase } from '@material/mwc-textfield/mwc-textfield-base';
 import { styles as baseTextFieldStyles } from '@material/mwc-textfield/mwc-textfield.css';
 import '../circular-progress/circular-progress';
 import styles from './textfield.scss?inline';
+import { classMap } from 'lit/directives/class-map.js';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -33,6 +34,37 @@ export class CovalentTextField extends TextFieldBase {
   loaderDensity = -6;
 
   override outlined = true;
+
+  /**
+   * This method is identical to the base implementation,
+   * with the only difference being the addition of a class to handle the loading state.
+   */
+  override render() {
+    const shouldRenderCharCounter = this.charCounter && this.maxLength !== -1;
+    const shouldRenderHelperText =
+      !!this.helper || !!this.validationMessage || shouldRenderCharCounter;
+    /** @classMap */
+    const classes = {
+      'mdc-text-field--disabled': this.disabled,
+      'mdc-text-field--no-label': !this.label,
+      'mdc-text-field--filled': !this.outlined,
+      'mdc-text-field--outlined': this.outlined,
+      'mdc-text-field--with-leading-icon': this.icon,
+      'mdc-text-field--with-trailing-icon': this.iconTrailing,
+      'mdc-text-field--end-aligned': this.endAligned,
+      'cv-text-field--loading': this.loading,
+    };
+    return html`
+      <label class="mdc-text-field ${classMap(classes)}">
+        ${this.renderRipple()}
+        ${this.outlined ? this.renderOutline() : this.renderLabel()}
+        ${this.renderLeadingIcon()} ${this.renderPrefix()}
+        ${this.renderInput(shouldRenderHelperText)} ${this.renderSuffix()}
+        ${this.renderTrailingIcon()} ${this.renderLineRipple()}
+      </label>
+      ${this.renderHelperText(shouldRenderHelperText, shouldRenderCharCounter)}
+    `;
+  }
 
   protected override renderTrailingIcon(): TemplateResult | string {
     if (this.loading) {

--- a/libs/components/src/textfield/textfield.ts
+++ b/libs/components/src/textfield/textfield.ts
@@ -1,7 +1,8 @@
-import { css, unsafeCSS } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { css, html, TemplateResult, unsafeCSS } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { TextFieldBase } from '@material/mwc-textfield/mwc-textfield-base';
 import { styles as baseTextFieldStyles } from '@material/mwc-textfield/mwc-textfield.css';
+import '../circular-progress/circular-progress';
 import styles from './textfield.scss?inline';
 
 declare global {
@@ -19,7 +20,32 @@ export class CovalentTextField extends TextFieldBase {
     `,
   ];
 
+  /**
+   * Displays a loading spinner within the text input field.
+   */
+  @property({ type: Boolean, reflect: true })
+  loading = false;
+
+  /**
+   * Displays a loading spinner within the text input field.
+   */
+  @property({ type: Number })
+  loaderDensity = -6;
+
   override outlined = true;
+
+  protected override renderTrailingIcon(): TemplateResult | string {
+    if (this.loading) {
+      return html`<cv-circular-progress
+        class="text-field-loading"
+        indeterminate
+        progress="0"
+        density="${this.loaderDensity}"
+      >
+      </cv-circular-progress>`;
+    }
+    return this.iconTrailing ? this.renderIcon(this.iconTrailing, true) : '';
+  }
 }
 
 export default CovalentTextField;


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- Add support for a loading state in `cv-textfield`
- Support `updateOn` form control strategy in the `CovalentTextfieldValueAccessorDirective`

### What's included?

<!-- List features included in this PR -->

- Validators are applied based on the `updateOn` strategy provided in the form control
- `cv-textfield` supports a loading state with the below properties:
  - `loading`: boolean (sets the loading state)
  - `loaderDensity`: number (sets the size of the spinner)

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run storybook`
- [ ] then view Textfield -> Loading story
- [ ] finally verify the loading state

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![covalent-form](https://github.com/user-attachments/assets/edc2ae94-de5e-46e5-8f89-db91d7277c1d)

![textfield](https://github.com/user-attachments/assets/93d1c993-7a55-47d2-9df5-cbc0f79ab3cf)

