### PR TITLE
fix: support updateOn strategy for form controls 10.x.x

### DIFF
--- a/libs/angular/common/src/directives/web-components/form-control.directive.spec.ts
+++ b/libs/angular/common/src/directives/web-components/form-control.directive.spec.ts
@@ -68,7 +68,7 @@ describe('CovalentTextfieldValueAccessorDirective', () => {
   it('should update form control when textfield value changes', () => {
     const textfield = fixture.nativeElement.querySelector('cv-textfield');
     textfield.value = 'new value';
-    textfield.dispatchEvent(new Event('change'));
+    textfield.dispatchEvent(new Event('input'));
     fixture.detectChanges();
     expect(component.control.value).toBe('new value');
   });

--- a/libs/angular/common/src/directives/web-components/form-control.directive.ts
+++ b/libs/angular/common/src/directives/web-components/form-control.directive.ts
@@ -49,7 +49,6 @@ export class CovalentTextfieldValueAccessorDirective
       this._ngControl.control.statusChanges
         .pipe(takeUntilDestroyed(this._destroyRef))
         .subscribe(() => {
-          this._onTouched();
           this._updateValidity();
         });
     }
@@ -76,31 +75,42 @@ export class CovalentTextfieldValueAccessorDirective
     this._onTouched = fn;
   }
 
+  /**
+   * Gets the updateOn strategy of the control.
+   * @returns The updateOn strategy of the control, defaulting to 'change' if not set.
+   */
+  private getUpdateOn(): 'change' | 'blur' | 'submit' {
+    return this._ngControl.control?.updateOn || 'change';
+  }
+
   @HostListener('input')
   handleInput(): void {
-    if (!this._isTextAreaOrField()) {
-      return;
+    // Update on 'input' event for textfields/textareas if updateOn strategy is 'change'
+    if (this._isTextAreaOrField() && this.getUpdateOn() === 'change') {
+      const value = this._elementRef.nativeElement.value;
+      this._onChange(value);
     }
-
-    const value = this._elementRef.nativeElement.value;
-    this._onChange(value);
-    this._onTouched();
-    this._updateValidity();
   }
 
   @HostListener('change', ['$event'])
-  handleChange(event: Event): void {
-    const value = this._isCheckBox()
-      ? this._elementRef.nativeElement.checked
-      : this._elementRef.nativeElement.value;
-
-    this._onChange(value);
-    this._onTouched();
-    this._updateValidity();
+  handleChange(): void {
+    // For textfields/textareas, handleInput covers 'change' event
+    if (!this._isTextAreaOrField()) {
+      const value = this._isCheckBox()
+        ? this._elementRef.nativeElement.checked
+        : this._elementRef.nativeElement.value;
+      this._onChange(value);
+      this._onTouched();
+    }
   }
 
   @HostListener('blur')
   handleBlur(): void {
+    // For textfields/textareas, update on 'blur' if updateOn strategy is 'blur'
+    if (this._isTextAreaOrField() && this.getUpdateOn() === 'blur') {
+      const value = this._elementRef.nativeElement.value;
+      this._onChange(value);
+    }
     this._onTouched();
   }
 


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- `CovalentTextfieldValueAccessorDirective` respects the `updateOn` strategy set in the form control

### What's included?

<!-- List features included in this PR -->

- Values in the form control are updated based on the `updateOn` strategy

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run build`
- [ ] then use the built lib in an angular app
- [ ] set `updateOn` value to 'blur' or 'change' in form control
- [ ] finally test if the values are updated

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
![covalent-form](https://github.com/user-attachments/assets/7254ee87-2288-4ca1-85ec-173172ffc832)
