### PR TITLE
fix(tokens): update surface-container-highest to use neutral-22

### DIFF
--- a/libs/tokens/src/color/covalent-m3.json
+++ b/libs/tokens/src/color/covalent-m3.json
@@ -3311,7 +3311,7 @@
         "surface-container-highest": {
           "description": "",
           "type": "color",
-          "value": "{theme.dark.palettes.navy-24}"
+          "value": "{theme.dark.palettes.neutral-22}"
         },
         "on-surface": {
           "description": "",


### PR DESCRIPTION
## Description
Fix a `surface-container-highest` to use `neutral-22` instead of `navy-24`

### What's included?
- New token update

#### Test Steps
N/A

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
N/A