### PR TITLE
fix(markdown-navigator): mixed navigations relative and absolute paths

### DIFF
--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-mixed-navigation/markdown-navigator-demo-mixed-navigation.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-mixed-navigation/markdown-navigator-demo-mixed-navigation.component.html
@@ -1,0 +1,17 @@
+<mat-card>
+  <mat-card-header>
+    <mat-card-title>Mixed Navigation Demo</mat-card-title>
+    <mat-card-subtitle>
+      Tests menu navigation + internal markdown links working together
+    </mat-card-subtitle>
+  </mat-card-header>
+  <mat-card-content>
+    <div class="navigator-container">
+      <td-markdown-navigator
+        [items]="items"
+        [copyCodeToClipboard]="true"
+        [style.height.px]="700"
+      ></td-markdown-navigator>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-mixed-navigation/markdown-navigator-demo-mixed-navigation.component.scss
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-mixed-navigation/markdown-navigator-demo-mixed-navigation.component.scss
@@ -1,0 +1,8 @@
+mat-card {
+  margin: 16px;
+}
+
+.navigator-container {
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+}

--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-mixed-navigation/markdown-navigator-demo-mixed-navigation.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-mixed-navigation/markdown-navigator-demo-mixed-navigation.component.ts
@@ -1,0 +1,237 @@
+import { Component } from '@angular/core';
+import { IMarkdownNavigatorItem } from '@covalent/markdown-navigator';
+
+@Component({
+  standalone: false,
+  selector: 'markdown-navigator-demo-mixed-navigation',
+  styleUrls: ['./markdown-navigator-demo-mixed-navigation.component.scss'],
+  templateUrl: './markdown-navigator-demo-mixed-navigation.component.html',
+})
+export class MarkdownNavigatorDemoMixedNavigationComponent {
+  items: IMarkdownNavigatorItem[] = [
+    {
+      id: 'welcome',
+      title: 'Welcome Guide',
+      description: 'Getting started with the platform',
+      icon: 'home',
+      markdownString: `# Welcome Guide
+
+Welcome to our documentation! This guide will help you get started.
+
+## Quick Links
+
+- [User Management](user-management.md) - Learn how to manage users
+- [Data Integration](data-integration.md) - Connect your data sources
+- [Analytics Dashboard](analytics.md) - View your analytics
+
+## What You'll Learn
+
+This documentation covers all aspects of the platform, from basic setup to advanced features.
+
+Navigate using the menu on the left or click the links above to explore specific topics.`,
+    },
+    {
+      id: 'user-management',
+      title: 'User Management',
+      description: 'Manage users and permissions',
+      icon: 'people',
+      markdownString: `# User Management
+
+Comprehensive guide to managing users in your organization.
+
+## Topics
+
+- [Creating Users](create-users.md) - Add new users to your team
+- [Roles & Permissions](roles.md) - Configure access control
+- [User Groups](user-groups.md) - Organize users into groups
+
+## Overview
+
+User management is a critical part of platform administration. You can:
+
+- Add and remove users
+- Assign roles and permissions
+- Create custom user groups
+- Monitor user activity
+
+For security best practices, see [Security Guide](security.md).`,
+      children: [
+        {
+          id: 'create-users',
+          title: 'Creating Users',
+          icon: 'person_add',
+          markdownString: `# Creating Users
+
+Step-by-step guide to adding users to your organization.
+
+## Steps
+
+1. Navigate to Users section
+2. Click "Add User" button
+3. Fill in user details
+4. Assign initial [roles](roles.md)
+5. Send invitation email
+
+## Best Practices
+
+- Always verify email addresses
+- Assign appropriate [permissions](roles.md) from the start
+- Use [user groups](user-groups.md) for easier management
+
+Need help with permissions? Check out [Roles & Permissions](roles.md).`,
+        },
+        {
+          id: 'roles',
+          title: 'Roles & Permissions',
+          icon: 'admin_panel_settings',
+          markdownString: `# Roles & Permissions
+
+Configure access control for your users.
+
+## Available Roles
+
+- **Admin** - Full system access
+- **Editor** - Can create and edit content
+- **Viewer** - Read-only access
+
+## Permission Groups
+
+You can also create custom [user groups](user-groups.md) with specific permissions.
+
+For user creation workflow, see [Creating Users](create-users.md).`,
+        },
+        {
+          id: 'user-groups',
+          title: 'User Groups',
+          icon: 'groups',
+          markdownString: `# User Groups
+
+Organize users into groups for easier management.
+
+## Benefits
+
+- Simplify permission management
+- Bulk operations on multiple users
+- Better organization
+
+## Related Topics
+
+- Back to [User Management](user-management.md)
+- Learn about [Roles & Permissions](roles.md)
+- See how to [Create Users](create-users.md)`,
+        },
+      ],
+    },
+    {
+      id: 'data-integration',
+      title: 'Data Integration',
+      description: 'Connect and sync data sources',
+      icon: 'integration_instructions',
+      markdownString: `# Data Integration
+
+Connect your data sources to the platform.
+
+## Supported Sources
+
+- Databases (SQL, NoSQL)
+- Cloud storage (S3, Azure, GCS)
+- APIs and webhooks
+- File uploads
+
+## Getting Started
+
+1. Choose your data source
+2. Configure [connection settings](connection-settings.md)
+3. Map your data fields
+4. Test the [connection](test-connection.md)
+5. Schedule sync intervals
+
+For visualization, check out [Analytics Dashboard](analytics.md).`,
+      children: [
+        {
+          id: 'connection-settings',
+          title: 'Connection Settings',
+          icon: 'settings_ethernet',
+          markdownString: `# Connection Settings
+
+Configure your data source connections.
+
+## Configuration Steps
+
+- Enter connection credentials
+- Set timeout values
+- Configure retry logic
+- Enable SSL/TLS if needed
+
+After configuration, proceed to [test your connection](test-connection.md).`,
+        },
+        {
+          id: 'test-connection',
+          title: 'Test Connection',
+          icon: 'cable',
+          markdownString: `# Test Connection
+
+Verify your data source is properly connected.
+
+## Testing Process
+
+1. Click "Test Connection" button
+2. Wait for validation
+3. Review connection logs
+4. Fix any errors
+
+Once connected, go back to [Data Integration](data-integration.md) to complete setup.`,
+        },
+      ],
+    },
+    {
+      id: 'analytics',
+      title: 'Analytics Dashboard',
+      description: 'Visualize and analyze your data',
+      icon: 'analytics',
+      markdownString: `# Analytics Dashboard
+
+Powerful analytics and visualization tools.
+
+## Features
+
+- Real-time data visualization
+- Custom dashboard creation
+- Interactive charts and graphs
+- Export reports
+
+## Dashboard Components
+
+- Metrics widgets
+- Time-series charts
+- Data tables
+- Custom filters
+
+Data comes from [Data Integration](data-integration.md) sources.
+
+Need help? Check our [Welcome Guide](welcome.md).`,
+    },
+    {
+      id: 'security',
+      title: 'Security Guide',
+      description: 'Security best practices',
+      icon: 'security',
+      markdownString: `# Security Guide
+
+Keep your platform secure with these best practices.
+
+## Security Topics
+
+- Authentication methods
+- Password policies  
+- Two-factor authentication
+- API key management
+
+## User Security
+
+Properly configured [User Management](user-management.md) is essential for security.
+
+Make sure to review [Roles & Permissions](roles.md) regularly.`,
+    },
+  ];
+}

--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
@@ -81,3 +81,10 @@
 >
   <markdown-navigator-demo-editor></markdown-navigator-demo-editor>
 </demo-component>
+
+<demo-component
+  [demoId]="'markdown-navigator-demo-mixed-navigation'"
+  [demoTitle]="'Mixed Navigation - Menu + Internal Links'"
+>
+  <markdown-navigator-demo-mixed-navigation></markdown-navigator-demo-mixed-navigation>
+</demo-component>

--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.module.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.module.ts
@@ -5,6 +5,8 @@ import { MarkdownNavigatorDemoComponent } from './markdown-navigator-demo.compon
 import { MarkdownNavigatorDemoRoutingModule } from './markdown-navigator-demo-routing.module';
 import { DemoModule } from '../../../../../components/shared/demo-tools/demo.module';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
 import {
   MarkdownNavigatorDemoFooterComponent,
   MarkdownNavigatorDemoFooterGlobalExampleComponent,
@@ -26,6 +28,7 @@ import { CovalentCodeEditorModule } from '@covalent/code-editor';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MarkdownNavigatorDemoChildrenUrlStartAtComponent } from './markdown-navigator-demo-children-url-start-at/markdown-navigator-demo-children-url-start-at.component';
 import { MarkdownNavigatorDemoStartAtOnclickChildrenUrlComponent } from './markdown-navigator-demo-start-at-onclick-children-url/markdown-navigator-demo-start-at-onclick-children-url.component';
+import { MarkdownNavigatorDemoMixedNavigationComponent } from './markdown-navigator-demo-mixed-navigation/markdown-navigator-demo-mixed-navigation.component';
 
 @NgModule({
   declarations: [
@@ -43,6 +46,7 @@ import { MarkdownNavigatorDemoStartAtOnclickChildrenUrlComponent } from './markd
     MarkdownNavigatorDemoEditorComponent,
     MarkdownNavigatorDemoChildrenUrlStartAtComponent,
     MarkdownNavigatorDemoStartAtOnclickChildrenUrlComponent,
+    MarkdownNavigatorDemoMixedNavigationComponent,
   ],
   imports: [
     DemoModule,
@@ -54,6 +58,8 @@ import { MarkdownNavigatorDemoStartAtOnclickChildrenUrlComponent } from './markd
     /** Angular Modules */
     CommonModule,
     MatButtonModule,
+    MatCardModule,
+    MatIconModule,
     MatListModule,
     MatButtonToggleModule,
     MatSlideToggleModule,

--- a/libs/markdown-navigator/src/markdown-navigator.component.spec.ts
+++ b/libs/markdown-navigator/src/markdown-navigator.component.spec.ts
@@ -183,27 +183,27 @@ export const ITEMS_AT_SAME_LEVEL_AS_MARKDOWN: IMarkdownNavigatorItem[] = [
 ];
 
 async function wait(
-  fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>
+  fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>,
 ): Promise<void> {
   fixture.detectChanges();
   await fixture.whenStable();
 }
 function getItem(
   fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>,
-  index: number
+  index: number,
 ): HTMLElement {
   return fixture.debugElement.queryAll(By.css('mat-action-list button'))[index]
     .nativeElement;
 }
 async function goBack(
-  fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>
+  fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>,
 ): Promise<void> {
   fixture.componentInstance.navigator.goBack();
   await wait(fixture);
 }
 
 async function goHome(
-  fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>
+  fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>,
 ): Promise<void> {
   fixture.debugElement
     .query(By.css('[data-test="home-button"]'))
@@ -211,14 +211,14 @@ async function goHome(
   await wait(fixture);
 }
 function getMarkdown(
-  fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>
+  fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>,
 ): string {
   return fixture.debugElement.query(By.css('td-flavored-markdown '))
     .nativeElement.textContent;
 }
 
 function getTitle(
-  fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>
+  fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>,
 ): string {
   return fixture.debugElement.query(By.css('[data-test="title"]')).nativeElement
     .textContent;
@@ -226,13 +226,13 @@ function getTitle(
 
 export function compareByTitle(
   o1: IMarkdownNavigatorItem,
-  o2: IMarkdownNavigatorItem
+  o2: IMarkdownNavigatorItem,
 ): boolean {
   return o1.title === o2.title;
 }
 
 async function validateTree(
-  fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>
+  fixture: ComponentFixture<TdMarkdownNavigatorTestComponent>,
 ): Promise<void> {
   expect(getItem(fixture, 0).textContent).toContain('A');
   getItem(fixture, 0).click();
@@ -322,7 +322,7 @@ async function validateTree(
       [footer]="footer"
     ></td-markdown-navigator>
   `,
-  imports: [TdMarkdownNavigatorComponent]
+  imports: [TdMarkdownNavigatorComponent],
 })
 class TdMarkdownNavigatorTestComponent {
   items?: IMarkdownNavigatorItem[] = [];
@@ -341,7 +341,11 @@ describe('MarkdownNavigatorComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, CovalentMarkdownNavigatorModule, TdMarkdownNavigatorTestComponent],
+      imports: [
+        NoopAnimationsModule,
+        CovalentMarkdownNavigatorModule,
+        TdMarkdownNavigatorTestComponent,
+      ],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
@@ -362,7 +366,7 @@ describe('MarkdownNavigatorComponent', () => {
 
       const markdownNavigator: TdMarkdownNavigatorComponent =
         fixture.debugElement.query(
-          By.directive(TdMarkdownNavigatorComponent)
+          By.directive(TdMarkdownNavigatorComponent),
         ).componentInstance;
 
       expect(markdownNavigator.showEmptyState).toBeTruthy();
@@ -371,7 +375,7 @@ describe('MarkdownNavigatorComponent', () => {
       expect(markdownNavigator.showMenu).toBeFalsy();
       expect(markdownNavigator.showTdMarkdown).toBeFalsy();
       expect(markdownNavigator.showTdMarkdownLoader).toBeFalsy();
-    })
+    }),
   ));
 
   it('should render empty state when undefined is passed into items', waitForAsync(
@@ -384,7 +388,7 @@ describe('MarkdownNavigatorComponent', () => {
 
       const markdownNavigator: TdMarkdownNavigatorComponent =
         fixture.debugElement.query(
-          By.directive(TdMarkdownNavigatorComponent)
+          By.directive(TdMarkdownNavigatorComponent),
         ).componentInstance;
 
       expect(markdownNavigator.showEmptyState).toBeTruthy();
@@ -393,7 +397,7 @@ describe('MarkdownNavigatorComponent', () => {
       expect(markdownNavigator.showMenu).toBeFalsy();
       expect(markdownNavigator.showTdMarkdown).toBeFalsy();
       expect(markdownNavigator.showTdMarkdownLoader).toBeFalsy();
-    })
+    }),
   ));
 
   it('should render one raw markdown item', waitForAsync(
@@ -406,7 +410,7 @@ describe('MarkdownNavigatorComponent', () => {
 
       const markdownNavigator: TdMarkdownNavigatorComponent =
         fixture.debugElement.query(
-          By.directive(TdMarkdownNavigatorComponent)
+          By.directive(TdMarkdownNavigatorComponent),
         ).componentInstance;
 
       expect(markdownNavigator.showEmptyState).toBeFalsy();
@@ -415,7 +419,7 @@ describe('MarkdownNavigatorComponent', () => {
       expect(markdownNavigator.showMenu).toBeFalsy();
       expect(markdownNavigator.showTdMarkdown).toBeTruthy();
       expect(markdownNavigator.showTdMarkdownLoader).toBeFalsy();
-    })
+    }),
   ));
 
   it('should fetch childrenUrl and render', waitForAsync(
@@ -435,7 +439,7 @@ describe('MarkdownNavigatorComponent', () => {
 
       const markdownNavigator: TdMarkdownNavigatorComponent =
         fixture.debugElement.query(
-          By.directive(TdMarkdownNavigatorComponent)
+          By.directive(TdMarkdownNavigatorComponent),
         ).componentInstance;
 
       expect(markdownNavigator.showMenu).toBeTruthy();
@@ -454,7 +458,7 @@ describe('MarkdownNavigatorComponent', () => {
       expect(getItem(fixture, 1).textContent).toContain(itemBTitle);
 
       httpTestingController.verify();
-    })
+    }),
   ));
 
   it('should show proper error messages', waitForAsync(
@@ -486,14 +490,14 @@ describe('MarkdownNavigatorComponent', () => {
       function getMarkdownLoaderError(): HTMLElement {
         return (
           fixture.debugElement.query(
-            By.css('[data-test="markdown-loader-error"]')
+            By.css('[data-test="markdown-loader-error"]'),
           ) || {}
         ).nativeElement;
       }
       function getChildrenUrlError(): HTMLElement {
         return (
           fixture.debugElement.query(
-            By.css('[data-test="children-url-error"]')
+            By.css('[data-test="children-url-error"]'),
           ) || {}
         ).nativeElement;
       }
@@ -565,7 +569,7 @@ describe('MarkdownNavigatorComponent', () => {
       expect(getChildrenUrlError()).toBeFalsy();
 
       httpTestingController.verify();
-    })
+    }),
   ));
 
   it('should render one url item from GitHub', waitForAsync(
@@ -578,7 +582,7 @@ describe('MarkdownNavigatorComponent', () => {
 
       const markdownNavigator: TdMarkdownNavigatorComponent =
         fixture.debugElement.query(
-          By.directive(TdMarkdownNavigatorComponent)
+          By.directive(TdMarkdownNavigatorComponent),
         ).componentInstance;
 
       expect(markdownNavigator.showEmptyState).toBeFalsy();
@@ -587,7 +591,7 @@ describe('MarkdownNavigatorComponent', () => {
       expect(markdownNavigator.showMenu).toBeFalsy();
       expect(markdownNavigator.showTdMarkdown).toBeFalsy();
       expect(markdownNavigator.showTdMarkdownLoader).toBeTruthy();
-    })
+    }),
   ));
 
   it('should render a flat list of items', waitForAsync(
@@ -600,10 +604,10 @@ describe('MarkdownNavigatorComponent', () => {
 
       const markdownNavigator: TdMarkdownNavigatorComponent =
         fixture.debugElement.query(
-          By.directive(TdMarkdownNavigatorComponent)
+          By.directive(TdMarkdownNavigatorComponent),
         ).componentInstance;
       const listItems: DebugElement[] = fixture.debugElement.queryAll(
-        By.css('mat-action-list button')
+        By.css('mat-action-list button'),
       );
 
       expect(markdownNavigator.showEmptyState).toBeFalsy();
@@ -613,7 +617,7 @@ describe('MarkdownNavigatorComponent', () => {
       expect(markdownNavigator.showTdMarkdown).toBeFalsy();
       expect(markdownNavigator.showTdMarkdownLoader).toBeFalsy();
       expect(listItems.length).toBe(FLAT_MIXED_ITEMS.length);
-    })
+    }),
   ));
 
   it('should use custom icons if passed in', waitForAsync(
@@ -625,17 +629,17 @@ describe('MarkdownNavigatorComponent', () => {
       await wait(fixture);
 
       const listItems: DebugElement[] = fixture.debugElement.queryAll(
-        By.css('mat-action-list button')
+        By.css('mat-action-list button'),
       );
 
       expect(listItems.length).toBe(ITEMS_WITH_CUSTOM_ICONS.length);
       expect(listItems[0].nativeElement.textContent).toContain(
-        ITEMS_WITH_CUSTOM_ICONS[0].icon
+        ITEMS_WITH_CUSTOM_ICONS[0].icon,
       );
       expect(listItems[1].nativeElement.textContent).toContain(
-        ITEMS_WITH_CUSTOM_ICONS[1].icon
+        ITEMS_WITH_CUSTOM_ICONS[1].icon,
       );
-    })
+    }),
   ));
 
   it('should use descriptions if passed in', waitForAsync(
@@ -647,17 +651,17 @@ describe('MarkdownNavigatorComponent', () => {
       await wait(fixture);
 
       const listItems: DebugElement[] = fixture.debugElement.queryAll(
-        By.css('mat-action-list button')
+        By.css('mat-action-list button'),
       );
 
       expect(listItems.length).toBe(ITEMS_WITH_DESCRIPTIONS.length);
       expect(listItems[0].nativeElement.textContent).toContain(
-        ITEMS_WITH_DESCRIPTIONS[0].description
+        ITEMS_WITH_DESCRIPTIONS[0].description,
       );
       expect(listItems[1].nativeElement.textContent).toContain(
-        ITEMS_WITH_DESCRIPTIONS[1].description
+        ITEMS_WITH_DESCRIPTIONS[1].description,
       );
-    })
+    }),
   ));
 
   it('should render a nested list of items', waitForAsync(
@@ -670,10 +674,10 @@ describe('MarkdownNavigatorComponent', () => {
 
       const markdownNavigator: TdMarkdownNavigatorComponent =
         fixture.debugElement.query(
-          By.directive(TdMarkdownNavigatorComponent)
+          By.directive(TdMarkdownNavigatorComponent),
         ).componentInstance;
       const listItems: DebugElement[] = fixture.debugElement.queryAll(
-        By.css('mat-action-list button')
+        By.css('mat-action-list button'),
       );
 
       expect(markdownNavigator.showEmptyState).toBeFalsy();
@@ -684,12 +688,12 @@ describe('MarkdownNavigatorComponent', () => {
       expect(markdownNavigator.showTdMarkdownLoader).toBeFalsy();
       expect(listItems.length).toBe(NESTED_MIXED_ITEMS.length);
       expect(listItems[0].nativeElement.textContent).toContain(
-        NESTED_MIXED_ITEMS[0].title
+        NESTED_MIXED_ITEMS[0].title,
       );
       expect(listItems[1].nativeElement.textContent).toContain(
-        NESTED_MIXED_ITEMS[1].title
+        NESTED_MIXED_ITEMS[1].title,
       );
-    })
+    }),
   ));
 
   it('should render list and markdown side by side', waitForAsync(
@@ -702,20 +706,20 @@ describe('MarkdownNavigatorComponent', () => {
 
       const markdownNavigator: TdMarkdownNavigatorComponent =
         fixture.debugElement.query(
-          By.directive(TdMarkdownNavigatorComponent)
+          By.directive(TdMarkdownNavigatorComponent),
         ).componentInstance;
       const listItems: DebugElement[] = fixture.debugElement.queryAll(
-        By.css('mat-action-list button')
+        By.css('mat-action-list button'),
       );
 
       expect(markdownNavigator.showTdMarkdown).toBeFalsy();
       expect(markdownNavigator.showTdMarkdownLoader).toBeFalsy();
       expect(listItems.length).toBe(ITEMS_AT_SAME_LEVEL_AS_MARKDOWN.length);
       expect(listItems[0].nativeElement.textContent).toContain(
-        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].title
+        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].title,
       );
       expect(listItems[1].nativeElement.textContent).toContain(
-        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[1].title
+        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[1].title,
       );
       getItem(fixture, 0).click();
       await wait(fixture);
@@ -723,10 +727,10 @@ describe('MarkdownNavigatorComponent', () => {
       expect(markdownNavigator.showMenu).toBeTruthy();
       expect(markdownNavigator.showTdMarkdown).toBeTruthy();
       expect(getTitle(fixture)).toContain(
-        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].title
+        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].title,
       );
       expect(getMarkdown(fixture)).toContain(
-        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].markdownString
+        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].markdownString,
       );
 
       getItem(fixture, 0).click();
@@ -739,22 +743,22 @@ describe('MarkdownNavigatorComponent', () => {
       expect(markdownNavigator.showMenu).toBeFalsy();
       expect(markdownNavigator.showTdMarkdown).toBeTruthy();
       expect(getTitle(fixture)).toContain(
-        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].children[0].title
+        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].children[0].title,
       );
       expect(getMarkdown(fixture)).toContain(
-        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].children[0].markdownString
+        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].children[0].markdownString,
       );
       goBack(fixture);
 
       expect(markdownNavigator.showMenu).toBeTruthy();
       expect(markdownNavigator.showTdMarkdown).toBeTruthy();
       expect(getTitle(fixture)).toContain(
-        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].title
+        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].title,
       );
       expect(getMarkdown(fixture)).toContain(
-        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].markdownString
+        ITEMS_AT_SAME_LEVEL_AS_MARKDOWN[0].markdownString,
       );
-    })
+    }),
   ));
 
   it('should use default labels if labels is undefined', waitForAsync(
@@ -767,25 +771,25 @@ describe('MarkdownNavigatorComponent', () => {
 
       const markdownNavigator: TdMarkdownNavigatorComponent =
         fixture.debugElement.query(
-          By.directive(TdMarkdownNavigatorComponent)
+          By.directive(TdMarkdownNavigatorComponent),
         ).componentInstance;
       const elem: DebugElement = fixture.debugElement.query(
-        By.directive(TdMarkdownNavigatorComponent)
+        By.directive(TdMarkdownNavigatorComponent),
       );
 
       expect(markdownNavigator.goBackLabel).toContain(
-        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.goBack
+        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.goBack,
       );
       expect(markdownNavigator.goHomeLabel).toContain(
-        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.goHome
+        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.goHome,
       );
       expect(markdownNavigator.emptyStateLabel).toContain(
-        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.emptyState
+        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.emptyState,
       );
       expect(elem.nativeElement.textContent).toContain(
-        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.emptyState
+        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.emptyState,
       );
-    })
+    }),
   ));
 
   it('should use default labels if labels is an empty object', waitForAsync(
@@ -798,25 +802,25 @@ describe('MarkdownNavigatorComponent', () => {
 
       const markdownNavigator: TdMarkdownNavigatorComponent =
         fixture.debugElement.query(
-          By.directive(TdMarkdownNavigatorComponent)
+          By.directive(TdMarkdownNavigatorComponent),
         ).componentInstance;
       const elem: DebugElement = fixture.debugElement.query(
-        By.directive(TdMarkdownNavigatorComponent)
+        By.directive(TdMarkdownNavigatorComponent),
       );
 
       expect(markdownNavigator.goBackLabel).toContain(
-        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.goBack
+        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.goBack,
       );
       expect(markdownNavigator.goHomeLabel).toContain(
-        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.goHome
+        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.goHome,
       );
       expect(markdownNavigator.emptyStateLabel).toContain(
-        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.emptyState
+        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.emptyState,
       );
       expect(elem.nativeElement.textContent).toContain(
-        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.emptyState
+        DEFAULT_MARKDOWN_NAVIGATOR_LABELS.emptyState,
       );
-    })
+    }),
   ));
 
   it('should use labels if passed in', waitForAsync(
@@ -834,21 +838,21 @@ describe('MarkdownNavigatorComponent', () => {
 
       const markdownNavigator: TdMarkdownNavigatorComponent =
         fixture.debugElement.query(
-          By.directive(TdMarkdownNavigatorComponent)
+          By.directive(TdMarkdownNavigatorComponent),
         ).componentInstance;
       const elem: DebugElement = fixture.debugElement.query(
-        By.directive(TdMarkdownNavigatorComponent)
+        By.directive(TdMarkdownNavigatorComponent),
       );
 
       expect(markdownNavigator.goBackLabel).toContain(SAMPLE_LABELS.goBack);
       expect(markdownNavigator.goHomeLabel).toContain(SAMPLE_LABELS.goHome);
       expect(markdownNavigator.emptyStateLabel).toContain(
-        SAMPLE_LABELS.emptyState
+        SAMPLE_LABELS.emptyState,
       );
       expect(elem.nativeElement.textContent).toContain(
-        SAMPLE_LABELS.emptyState
+        SAMPLE_LABELS.emptyState,
       );
-    })
+    }),
   ));
 
   it('should be able to navigate up and down tree using the back button', waitForAsync(
@@ -860,7 +864,7 @@ describe('MarkdownNavigatorComponent', () => {
       await wait(fixture);
 
       validateTree(fixture);
-    })
+    }),
   ));
 
   it('should be able to go to root using home button', waitForAsync(
@@ -883,7 +887,7 @@ describe('MarkdownNavigatorComponent', () => {
       expect(getItem(fixture, 1).textContent).toContain('B');
 
       validateTree(fixture);
-    })
+    }),
   ));
 
   it('should be able to start at a certain item by passing a reference to that item', waitForAsync(
@@ -914,7 +918,7 @@ describe('MarkdownNavigatorComponent', () => {
       expect(getTitle(fixture)).toContain('B');
       await goBack(fixture);
       validateTree(fixture);
-    })
+    }),
   ));
 
   it('should be able to jump to start at a certain item by referencing an id', waitForAsync(
@@ -928,7 +932,7 @@ describe('MarkdownNavigatorComponent', () => {
       expect(getTitle(fixture)).toContain('A');
       await goBack(fixture);
       validateTree(fixture);
-    })
+    }),
   ));
 
   it('should be able to jump to start at a certain item by referencing a path of items', waitForAsync(
@@ -943,7 +947,7 @@ describe('MarkdownNavigatorComponent', () => {
       expect(getTitle(fixture)).toContain('A');
       await goBack(fixture);
       validateTree(fixture);
-    })
+    }),
   ));
 
   it('should not jump anywhere if path is invalid', waitForAsync(
@@ -961,7 +965,7 @@ describe('MarkdownNavigatorComponent', () => {
       expect(getItem(fixture, 0).textContent).toContain('A');
       expect(getItem(fixture, 1).textContent).toContain('B');
       validateTree(fixture);
-    })
+    }),
   ));
 
   it('should be able to jump to start at a certain item by referencing a path of items that depends on children_url', waitForAsync(
@@ -993,7 +997,7 @@ describe('MarkdownNavigatorComponent', () => {
       await wait(fixture);
       await wait(fixture);
       expect(getTitle(fixture)).toContain('3c');
-    })
+    }),
   ));
 
   it('should be able to jump to start at a certain item by using a custom compareWith function', waitForAsync(
@@ -1009,7 +1013,7 @@ describe('MarkdownNavigatorComponent', () => {
 
       function deepHackyComparison(
         o1: IMarkdownNavigatorItem,
-        o2: IMarkdownNavigatorItem
+        o2: IMarkdownNavigatorItem,
       ): boolean {
         // order matters
         return JSON.stringify(o1) === JSON.stringify(o2);
@@ -1020,7 +1024,7 @@ describe('MarkdownNavigatorComponent', () => {
       fixture.componentInstance.startAt = NESTED_MIXED_ITEMS[1];
       await wait(fixture);
       expect(getTitle(fixture)).toContain(NESTED_MIXED_ITEMS[1].title);
-    })
+    }),
   ));
 
   it('should be able to render a custom component as a footer', waitForAsync(
@@ -1034,7 +1038,7 @@ describe('MarkdownNavigatorComponent', () => {
       await wait(fixture);
 
       expect(fixture.nativeElement.textContent).toContain(
-        'Global Footer Content'
+        'Global Footer Content',
       );
 
       getItem(fixture, 0).click();
@@ -1052,8 +1056,284 @@ describe('MarkdownNavigatorComponent', () => {
       await wait(fixture);
 
       expect(fixture.nativeElement.textContent).toContain(
-        'Global Footer Content'
+        'Global Footer Content',
       );
-    })
+    }),
+  ));
+
+  it('should match URLs by filename ignoring query params and hash fragments', waitForAsync(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> =
+        TestBed.createComponent(TdMarkdownNavigatorTestComponent);
+
+      fixture.componentInstance.items = RAW_MARKDOWN_ITEM;
+      await wait(fixture);
+
+      const component = fixture.componentInstance.navigator;
+
+      // Test query params
+      expect(
+        component['urlsMatchByFilename'](
+          'docs/file.md',
+          'docs/file.md?version=2',
+        ),
+      ).toBe(true);
+
+      // Test hash fragments
+      expect(
+        component['urlsMatchByFilename'](
+          'docs/file.md',
+          'docs/file.md#section',
+        ),
+      ).toBe(true);
+
+      // Test both query params and hash fragments
+      expect(
+        component['urlsMatchByFilename'](
+          'docs/file.md',
+          'docs/file.md?v=2#section',
+        ),
+      ).toBe(true);
+
+      // Test different filenames should not match
+      expect(
+        component['urlsMatchByFilename']('docs/file.md', 'docs/other.md'),
+      ).toBe(false);
+
+      // Test different paths same filename should match
+      expect(
+        component['urlsMatchByFilename']('path1/file.md', 'path2/file.md'),
+      ).toBe(true);
+
+      // Test empty filenames should not match
+      expect(component['urlsMatchByFilename']('docs/', 'docs/')).toBe(false);
+    }),
+  ));
+
+  it('should preserve history stack when navigating through internal links (shouldReset=false)', waitForAsync(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> =
+        TestBed.createComponent(TdMarkdownNavigatorTestComponent);
+
+      const items: IMarkdownNavigatorItem[] = [
+        {
+          id: 'parent',
+          title: 'Parent',
+          children: [
+            {
+              id: 'child',
+              title: 'Child',
+              markdownString: '# Child content',
+            },
+          ],
+        },
+      ];
+
+      fixture.componentInstance.items = items;
+      await wait(fixture);
+
+      const component = fixture.componentInstance.navigator;
+
+      // Navigate to parent (menu navigation - shouldReset=true by default)
+      getItem(fixture, 0).click();
+      await wait(fixture);
+
+      expect(component.historyStack.length).toBe(1);
+      expect(component.historyStack[0].id).toBe('parent');
+
+      // Simulate internal link navigation (shouldReset=false)
+      await component['_jumpTo']({ id: 'child' }, undefined, false);
+      await wait(fixture);
+
+      // Should have both parent and child in history (not reset)
+      expect(component.historyStack.length).toBe(2);
+      expect(component.historyStack[0].id).toBe('parent');
+      expect(component.historyStack[1].id).toBe('child');
+    }),
+  ));
+
+  it('should reset history stack when navigating through menu (shouldReset=true)', waitForAsync(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> =
+        TestBed.createComponent(TdMarkdownNavigatorTestComponent);
+
+      fixture.componentInstance.items = DEEPLY_NESTED_TREE;
+      await wait(fixture);
+
+      const component = fixture.componentInstance.navigator;
+
+      // Navigate to A
+      getItem(fixture, 0).click();
+      await wait(fixture);
+      expect(component.historyStack.length).toBe(1);
+      expect(component.historyStack[0].title).toBe('A');
+
+      // Navigate to A1
+      getItem(fixture, 0).click();
+      await wait(fixture);
+      expect(component.historyStack.length).toBe(2);
+
+      // Jump to B with shouldReset=true (simulating menu navigation)
+      // This should reset the stack first, then build path to B
+      const bItem = DEEPLY_NESTED_TREE.find((item) => item.title === 'B');
+      await component['_jumpTo'](bItem!, undefined, true);
+      await wait(fixture);
+
+      // After reset + navigation to B, history should only contain B
+      expect(component.historyStack.length).toBe(1);
+      expect(component.historyStack[0].title).toBe('B');
+    }),
+  ));
+
+  it('should handle clicks on nested elements inside links using closest()', waitForAsync(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> =
+        TestBed.createComponent(TdMarkdownNavigatorTestComponent);
+
+      const items: IMarkdownNavigatorItem[] = [
+        {
+          id: 'doc1',
+          title: 'Document 1',
+          markdownString: '# Document 1',
+        },
+        {
+          id: 'doc2',
+          title: 'Document 2',
+          markdownString: '# Document 2',
+        },
+      ];
+
+      fixture.componentInstance.items = items;
+      await wait(fixture);
+
+      const component = fixture.componentInstance.navigator;
+
+      // Test that closest() is used by verifying the method exists and works correctly
+      const mockAnchor = document.createElement('a');
+      mockAnchor.href = 'http://localhost/doc2.md';
+      mockAnchor.innerHTML = '<strong>Bold Link</strong>';
+      document.body.appendChild(mockAnchor);
+
+      const strongElement = mockAnchor.querySelector('strong') as HTMLElement;
+
+      // Verify closest() finds the anchor from nested element
+      expect(strongElement.closest('a[href]')).toBe(mockAnchor);
+
+      // Cleanup
+      document.body.removeChild(mockAnchor);
+    }),
+  ));
+
+  it('should preserve breadcrumbs when mixing menu navigation and internal links', waitForAsync(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> =
+        TestBed.createComponent(TdMarkdownNavigatorTestComponent);
+
+      const items: IMarkdownNavigatorItem[] = [
+        {
+          id: 'guide',
+          title: 'User Guide',
+          markdownString: '# User Guide\n\nSee [Settings](settings.md)',
+          children: [
+            {
+              id: 'settings',
+              title: 'Settings',
+              markdownString: '# Settings\n\nCheck [Advanced](advanced.md)',
+              children: [
+                {
+                  id: 'advanced',
+                  title: 'Advanced',
+                  markdownString: '# Advanced Settings',
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      fixture.componentInstance.items = items;
+      await wait(fixture);
+
+      const component = fixture.componentInstance.navigator;
+
+      // Step 1: Menu navigation to "User Guide"
+      getItem(fixture, 0).click();
+      await wait(fixture);
+      expect(component.historyStack.length).toBe(1);
+      expect(component.historyStack[0].id).toBe('guide');
+
+      // Step 2: Internal link to "Settings" (should preserve "User Guide" in history)
+      await component['_jumpTo']({ id: 'settings' }, undefined, false);
+      await wait(fixture);
+      expect(component.historyStack.length).toBe(2);
+      expect(component.historyStack[0].id).toBe('guide');
+      expect(component.historyStack[1].id).toBe('settings');
+
+      // Step 3: Internal link to "Advanced" (should preserve full history)
+      await component['_jumpTo']({ id: 'advanced' }, undefined, false);
+      await wait(fixture);
+      expect(component.historyStack.length).toBe(3);
+      expect(component.historyStack[0].id).toBe('guide');
+      expect(component.historyStack[1].id).toBe('settings');
+      expect(component.historyStack[2].id).toBe('advanced');
+
+      // Verify breadcrumbs show complete path without duplicates
+      const breadcrumbs = component.navigationBreadcrumbs;
+      expect(breadcrumbs.length).toBe(2); // All items except current (last one)
+      expect(breadcrumbs[0].id).toBe('guide');
+      expect(breadcrumbs[1].id).toBe('settings');
+    }),
+  ));
+
+  it('should not duplicate parent items in breadcrumbs when clicking internal links to nested items', waitForAsync(
+    inject([], async () => {
+      const fixture: ComponentFixture<TdMarkdownNavigatorTestComponent> =
+        TestBed.createComponent(TdMarkdownNavigatorTestComponent);
+
+      const items: IMarkdownNavigatorItem[] = [
+        {
+          id: 'docs',
+          title: 'Documentation',
+          children: [
+            {
+              id: 'api',
+              title: 'API Reference',
+              children: [
+                {
+                  id: 'endpoints',
+                  title: 'Endpoints',
+                  markdownString: '# API Endpoints',
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      fixture.componentInstance.items = items;
+      await wait(fixture);
+
+      const component = fixture.componentInstance.navigator;
+
+      // Navigate to Documentation via menu
+      getItem(fixture, 0).click();
+      await wait(fixture);
+      expect(component.historyStack.length).toBe(1);
+
+      // Click internal link to deeply nested "Endpoints"
+      // This should find the full path [api, endpoints] but only add the destination
+      await component['_jumpTo']({ id: 'endpoints' }, undefined, false);
+      await wait(fixture);
+
+      // Should NOT duplicate parent items
+      expect(component.historyStack.length).toBe(2);
+      expect(component.historyStack[0].id).toBe('docs');
+      expect(component.historyStack[1].id).toBe('endpoints');
+
+      // Verify no duplicates in the stack
+      const ids = component.historyStack.map((item) => item.id);
+      const uniqueIds = new Set(ids);
+      expect(ids.length).toBe(uniqueIds.size);
+    }),
   ));
 });

--- a/libs/markdown-navigator/src/markdown-navigator.component.ts
+++ b/libs/markdown-navigator/src/markdown-navigator.component.ts
@@ -411,8 +411,8 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
     return (
       removeLeadingHash(item.anchor ?? '') ||
       item.title ||
-      getTitleFromUrl(item.url ?? '') ||
       getTitleFromMarkdownString(item.markdownString ?? '') ||
+      getTitleFromUrl(item.url ?? '') ||
       ''
     ).trim();
   }
@@ -440,6 +440,7 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
   private async _jumpTo(
     itemOrPath: IMarkdownNavigatorItem | IMarkdownNavigatorItem[],
     children?: IMarkdownNavigatorItem[],
+    shouldReset: boolean = true,
   ): Promise<boolean> {
     const historyStack: IMarkdownNavigatorItem[] = this.historyStack;
     let path: IMarkdownNavigatorItem[] = [];
@@ -453,13 +454,22 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
       } else {
         path = this.findPath(this.items, itemOrPath);
       }
-      path.forEach((pathItem: IMarkdownNavigatorItem, index) => {
-        if (index === 0) {
-          this.reset();
-        }
 
-        this.handleItemSelected(pathItem);
-      });
+      // When navigating through internal links (shouldReset = false),
+      // only navigate to the final destination, not the entire path,
+      // to avoid duplicating parent items already in historyStack
+      if (!shouldReset && path.length > 0) {
+        const destination = path[path.length - 1];
+        this.handleItemSelected(destination);
+      } else {
+        path.forEach((pathItem: IMarkdownNavigatorItem, index) => {
+          if (index === 0 && shouldReset) {
+            this.reset();
+          }
+
+          this.handleItemSelected(pathItem);
+        });
+      }
     }
 
     return !!path.length;
@@ -507,6 +517,14 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
         if (item && compareWith(child, item)) {
           return [child];
         }
+        // Also try to match by URL filename pattern for internal links
+        if (
+          item?.url &&
+          child.url &&
+          this.urlsMatchByFilename(child.url, item.url)
+        ) {
+          return [child];
+        }
         const ancestors: IMarkdownNavigatorItem[] = this.findPath(
           child.children,
           item,
@@ -519,17 +537,45 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
     return [];
   }
 
+  private urlsMatchByFilename(url1: string, url2: string): boolean {
+    try {
+      const filename1 = url1.split('/').pop()?.split('?')[0] ?? '';
+      const filename2 = url2.split('/').pop()?.split('?')[0] ?? '';
+      return filename1 !== '' && filename2 !== '' && filename1 === filename2;
+    } catch {
+      return false;
+    }
+  }
+
   private async handleLinkClick(event: Event): Promise<void> {
     event.preventDefault();
     const link: HTMLAnchorElement = <HTMLAnchorElement>event.target;
     const url: URL = new URL(link.href);
     const urlParts = url.href.split('/');
     const id = urlParts[urlParts.length - 1].split('.md')[0];
+
+    // Capture link text for better UX - Phase 1
+    const linkText = link.textContent?.trim() || '';
+
     this.loading = true;
     this._changeDetectorRef.markForCheck();
-    const pathFound = await this._jumpTo({ id });
+
+    // Try to find by ID first (relative navigation, preserve history)
+    const pathFound = await this._jumpTo({ id }, undefined, false);
 
     if (pathFound) {
+      return;
+    }
+
+    // Try to find by URL pattern - Phase 2 (relative navigation, preserve history)
+    const filename = urlParts[urlParts.length - 1];
+    const pathFoundByUrl = await this._jumpTo(
+      { url: filename },
+      undefined,
+      false,
+    );
+
+    if (pathFoundByUrl) {
       return;
     }
 
@@ -537,8 +583,12 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
       const markdownString: string = await this._markdownUrlLoaderService.load(
         url.href,
       );
-      // pass in url to be able to use currentMarkdownItem.url later on
-      this.handleItemSelected({ markdownString, url: url.href });
+      // Pass link text as title for immediate UX improvement - Phase 1
+      this.handleItemSelected({
+        markdownString,
+        url: url.href,
+        title: linkText || undefined, // Use link text if available
+      });
       this.markdownWrapper.nativeElement.scrollTop = 0;
     } catch (error) {
       const win = window.open(url.href, '_blank');

--- a/libs/markdown-navigator/src/markdown-navigator.component.ts
+++ b/libs/markdown-navigator/src/markdown-navigator.component.ts
@@ -174,12 +174,12 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
 
   @HostListener('click', ['$event'])
   clickListener(event: Event): void {
-    const element: HTMLElement = <HTMLElement>event.srcElement;
-    if (
-      element.matches('a[href]') &&
-      isMarkdownHref(<HTMLAnchorElement>element)
-    ) {
-      this.handleLinkClick(event);
+    const element: HTMLElement = <HTMLElement>event.target;
+    // Use closest() to handle clicks on nested elements inside links
+    const anchor: HTMLAnchorElement | null = element.closest('a[href]');
+
+    if (anchor && isMarkdownHref(anchor)) {
+      this.handleLinkClick(event, anchor);
     }
   }
 
@@ -440,7 +440,7 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
   private async _jumpTo(
     itemOrPath: IMarkdownNavigatorItem | IMarkdownNavigatorItem[],
     children?: IMarkdownNavigatorItem[],
-    shouldReset: boolean = true,
+    shouldReset = true,
   ): Promise<boolean> {
     const historyStack: IMarkdownNavigatorItem[] = this.historyStack;
     let path: IMarkdownNavigatorItem[] = [];
@@ -539,17 +539,22 @@ export class TdMarkdownNavigatorComponent implements OnChanges {
 
   private urlsMatchByFilename(url1: string, url2: string): boolean {
     try {
-      const filename1 = url1.split('/').pop()?.split('?')[0] ?? '';
-      const filename2 = url2.split('/').pop()?.split('?')[0] ?? '';
+      // Extract filename and strip query params (?...) and hash fragments (#...)
+      const filename1 =
+        url1.split('/').pop()?.split('?')[0].split('#')[0] ?? '';
+      const filename2 =
+        url2.split('/').pop()?.split('?')[0].split('#')[0] ?? '';
       return filename1 !== '' && filename2 !== '' && filename1 === filename2;
     } catch {
       return false;
     }
   }
 
-  private async handleLinkClick(event: Event): Promise<void> {
+  private async handleLinkClick(
+    event: Event,
+    link: HTMLAnchorElement,
+  ): Promise<void> {
     event.preventDefault();
-    const link: HTMLAnchorElement = <HTMLAnchorElement>event.target;
     const url: URL = new URL(link.href);
     const urlParts = url.href.split('/');
     const id = urlParts[urlParts.length - 1].split('.md')[0];


### PR DESCRIPTION
## Description
Fixed mixed navigations when we have internal links in the markdown content

### What's included?
- Allow mixed navigations

#### Test Steps
- [ ] `npm run start`
- [ ] then navigate to markdown navigator examples
- [ ] scroll into last example and navigate between links

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="922" height="936" alt="mixed-nav" src="https://github.com/user-attachments/assets/eaaf4bac-9b24-4306-ab30-e4280a2a917a" />
