### PR TITLE
fix(md-navigator): fix multilanguage support on md-navigator breadcrumbs

### DIFF
--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-multilanguage/markdown-navigator-demo-multilanguage.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-multilanguage/markdown-navigator-demo-multilanguage.component.html
@@ -1,0 +1,48 @@
+<div
+  class="language-selector"
+  style="
+    padding: 16px;
+    background: #f5f5f5;
+    margin-bottom: 16px;
+    border-radius: 4px;
+  "
+>
+  <h3 style="margin-top: 0">Language Selector</h3>
+  <div style="display: flex; gap: 8px">
+    <button
+      mat-raised-button
+      [color]="currentLanguage === 'en' ? 'primary' : undefined"
+      (click)="changeLanguage('en')"
+    >
+      🇬🇧 English
+    </button>
+    <button
+      mat-raised-button
+      [color]="currentLanguage === 'es' ? 'primary' : undefined"
+      (click)="changeLanguage('es')"
+    >
+      🇪🇸 Español
+    </button>
+    <button
+      mat-raised-button
+      [color]="currentLanguage === 'ja' ? 'primary' : undefined"
+      (click)="changeLanguage('ja')"
+    >
+      🇯🇵 日本語
+    </button>
+    <button
+      mat-raised-button
+      [color]="currentLanguage === 'de' ? 'primary' : undefined"
+      (click)="changeLanguage('de')"
+    >
+      🇩🇪 Deutsch
+    </button>
+  </div>
+</div>
+
+<td-markdown-navigator
+  [items]="items"
+  [labels]="labels"
+  [copyCodeToClipboard]="true"
+  [style.height.px]="600"
+></td-markdown-navigator>

--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-multilanguage/markdown-navigator-demo-multilanguage.component.scss
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-multilanguage/markdown-navigator-demo-multilanguage.component.scss
@@ -1,0 +1,14 @@
+:host {
+  display: block;
+}
+
+.language-selector {
+  h3 {
+    font-size: 16px;
+    font-weight: 500;
+  }
+
+  button {
+    min-width: 120px;
+  }
+}

--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-multilanguage/markdown-navigator-demo-multilanguage.component.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo-multilanguage/markdown-navigator-demo-multilanguage.component.ts
@@ -1,0 +1,289 @@
+import { Component } from '@angular/core';
+import {
+  IMarkdownNavigatorItem,
+  IMarkdownNavigatorLabels,
+} from '@covalent/markdown-navigator';
+
+@Component({
+  standalone: false,
+  selector: 'markdown-navigator-demo-multilanguage',
+  styleUrls: ['./markdown-navigator-demo-multilanguage.component.scss'],
+  templateUrl: './markdown-navigator-demo-multilanguage.component.html',
+})
+export class MarkdownNavigatorDemoMultilanguageComponent {
+  currentLanguage: 'en' | 'es' | 'ja' | 'de' = 'en';
+
+  // English items
+  englishItems: IMarkdownNavigatorItem[] = [
+    {
+      id: 'getting-started',
+      title: 'Getting Started Guide',
+      description: 'Learn the basics of using the platform',
+      icon: 'rocket_launch',
+      markdownString: `# Getting Started Guide
+
+Welcome! This guide will help you understand the core concepts and features.
+
+## What You'll Learn
+- Platform navigation
+- Creating your first project
+- Understanding the dashboard`,
+    },
+    {
+      id: 'tutorials',
+      title: 'Tutorials',
+      description: 'Step-by-step learning resources',
+      icon: 'school',
+      markdownString: `# Tutorials
+
+Hands-on tutorials to build your skills.`,
+      children: [
+        {
+          id: 'beginner',
+          title: 'Beginner Tutorial',
+          markdownString: `# Beginner Tutorial
+
+Perfect for first-time users. Learn the fundamentals step by step.`,
+        },
+        {
+          id: 'intermediate',
+          title: 'Intermediate Techniques',
+          markdownString: `# Intermediate Techniques
+
+Ready to level up? Explore advanced features and workflows.`,
+        },
+      ],
+    },
+    {
+      id: 'api-reference',
+      title: 'API Reference',
+      description: 'Complete API documentation',
+      icon: 'api',
+      markdownString: `# API Reference
+
+Comprehensive reference for all available APIs and endpoints.
+
+## Available Endpoints
+- Authentication
+- Data Management
+- Analytics`,
+    },
+  ];
+
+  // Spanish items
+  spanishItems: IMarkdownNavigatorItem[] = [
+    {
+      id: 'getting-started',
+      title: 'Guía de inicio',
+      description: 'Aprenda los conceptos básicos de la plataforma',
+      icon: 'rocket_launch',
+      markdownString: `# Guía de inicio
+
+¡Bienvenido! Esta guía le ayudará a comprender las características principales.
+
+## Lo que aprenderá
+- Navegación de la plataforma
+- Crear su primer proyecto
+- Comprender el panel de control`,
+    },
+    {
+      id: 'tutorials',
+      title: 'Tutoriales',
+      description: 'Recursos de aprendizaje paso a paso',
+      icon: 'school',
+      markdownString: `# Tutoriales
+
+Tutoriales prácticos para desarrollar sus habilidades.`,
+      children: [
+        {
+          id: 'beginner',
+          title: 'Tutorial para principiantes',
+          markdownString: `# Tutorial para principiantes
+
+Perfecto para usuarios nuevos. Aprenda los fundamentos paso a paso.`,
+        },
+        {
+          id: 'intermediate',
+          title: 'Técnicas intermedias',
+          markdownString: `# Técnicas intermedias
+
+¿Listo para avanzar? Explore características y flujos de trabajo avanzados.`,
+        },
+      ],
+    },
+    {
+      id: 'api-reference',
+      title: 'Referencia de API',
+      description: 'Documentación completa de la API',
+      icon: 'api',
+      markdownString: `# Referencia de API
+
+Referencia completa para todas las API y puntos finales disponibles.
+
+## Puntos finales disponibles
+- Autenticación
+- Gestión de datos
+- Análisis`,
+    },
+  ];
+
+  // Japanese items
+  japaneseItems: IMarkdownNavigatorItem[] = [
+    {
+      id: 'getting-started',
+      title: '初めてのガイド',
+      description: 'プラットフォームの基本を学ぶ',
+      icon: 'rocket_launch',
+      markdownString: `# 初めてのガイド
+
+ようこそ！このガイドは、コア機能の理解を助けます。
+
+## 学習内容
+- プラットフォームのナビゲーション
+- 最初のプロジェクトの作成
+- ダッシュボードの理解`,
+    },
+    {
+      id: 'tutorials',
+      title: 'チュートリアル',
+      description: 'ステップバイステップの学習リソース',
+      icon: 'school',
+      markdownString: `# チュートリアル
+
+スキルを構築するための実践的なチュートリアル。`,
+      children: [
+        {
+          id: 'beginner',
+          title: '初心者向けチュートリアル',
+          markdownString: `# 初心者向けチュートリアル
+
+初めてのユーザーに最適です。基礎をステップバイステップで学びます。`,
+        },
+        {
+          id: 'intermediate',
+          title: '中級テクニック',
+          markdownString: `# 中級テクニック
+
+レベルアップの準備はできましたか？高度な機能とワークフローを探索します。`,
+        },
+      ],
+    },
+    {
+      id: 'api-reference',
+      title: 'APIリファレンス',
+      description: '完全なAPIドキュメント',
+      icon: 'api',
+      markdownString: `# APIリファレンス
+
+利用可能なすべてのAPIとエンドポイントの包括的なリファレンス。
+
+## 利用可能なエンドポイント
+- 認証
+- データ管理
+- 分析`,
+    },
+  ];
+
+  // German items
+  germanItems: IMarkdownNavigatorItem[] = [
+    {
+      id: 'getting-started',
+      title: 'Erste Schritte',
+      description: 'Lernen Sie die Grundlagen der Plattform',
+      icon: 'rocket_launch',
+      markdownString: `# Erste Schritte
+
+Willkommen! Dieser Leitfaden hilft Ihnen, die Kernfunktionen zu verstehen.
+
+## Was Sie lernen werden
+- Plattform-Navigation
+- Ihr erstes Projekt erstellen
+- Das Dashboard verstehen`,
+    },
+    {
+      id: 'tutorials',
+      title: 'Anleitungen',
+      description: 'Schritt-für-Schritt-Lernressourcen',
+      icon: 'school',
+      markdownString: `# Anleitungen
+
+Praktische Anleitungen zum Aufbau Ihrer Fähigkeiten.`,
+      children: [
+        {
+          id: 'beginner',
+          title: 'Anfänger-Tutorial',
+          markdownString: `# Anfänger-Tutorial
+
+Perfekt für Erstbenutzer. Lernen Sie die Grundlagen Schritt für Schritt.`,
+        },
+        {
+          id: 'intermediate',
+          title: 'Fortgeschrittene Techniken',
+          markdownString: `# Fortgeschrittene Techniken
+
+Bereit für den nächsten Schritt? Erkunden Sie erweiterte Funktionen und Workflows.`,
+        },
+      ],
+    },
+    {
+      id: 'api-reference',
+      title: 'API-Referenz',
+      description: 'Vollständige API-Dokumentation',
+      icon: 'api',
+      markdownString: `# API-Referenz
+
+Umfassende Referenz für alle verfügbaren APIs und Endpunkte.
+
+## Verfügbare Endpunkte
+- Authentifizierung
+- Datenverwaltung
+- Analytik`,
+    },
+  ];
+
+  get items(): IMarkdownNavigatorItem[] {
+    switch (this.currentLanguage) {
+      case 'es':
+        return this.spanishItems;
+      case 'ja':
+        return this.japaneseItems;
+      case 'de':
+        return this.germanItems;
+      default:
+        return this.englishItems;
+    }
+  }
+
+  get labels(): IMarkdownNavigatorLabels {
+    switch (this.currentLanguage) {
+      case 'es':
+        return {
+          goHome: 'Inicio',
+          goBack: 'Volver',
+          emptyState: 'No hay elementos para mostrar',
+        };
+      case 'ja':
+        return {
+          goHome: 'ホーム',
+          goBack: '戻る',
+          emptyState: '表示する項目がありません',
+        };
+      case 'de':
+        return {
+          goHome: 'Startseite',
+          goBack: 'Zurück',
+          emptyState: 'Keine Elemente anzuzeigen',
+        };
+      default:
+        return {
+          goHome: 'Home',
+          goBack: 'Go back',
+          emptyState: 'No item(s) to display',
+        };
+    }
+  }
+
+  changeLanguage(lang: 'en' | 'es' | 'ja' | 'de'): void {
+    this.currentLanguage = lang;
+  }
+}

--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.component.html
@@ -88,3 +88,10 @@
 >
   <markdown-navigator-demo-mixed-navigation></markdown-navigator-demo-mixed-navigation>
 </demo-component>
+
+<demo-component
+  [demoId]="'markdown-navigator-demo-multilanguage'"
+  [demoTitle]="'Multilanguage Support (i18n)'"
+>
+  <markdown-navigator-demo-multilanguage></markdown-navigator-demo-multilanguage>
+</demo-component>

--- a/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.module.ts
+++ b/apps/docs-app/src/app/content/components/component-demos/markdown-navigator/demos/markdown-navigator-demo.module.ts
@@ -6,6 +6,7 @@ import { MarkdownNavigatorDemoRoutingModule } from './markdown-navigator-demo-ro
 import { DemoModule } from '../../../../../components/shared/demo-tools/demo.module';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
 import {
   MarkdownNavigatorDemoFooterComponent,
   MarkdownNavigatorDemoFooterGlobalExampleComponent,
@@ -28,6 +29,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MarkdownNavigatorDemoChildrenUrlStartAtComponent } from './markdown-navigator-demo-children-url-start-at/markdown-navigator-demo-children-url-start-at.component';
 import { MarkdownNavigatorDemoStartAtOnclickChildrenUrlComponent } from './markdown-navigator-demo-start-at-onclick-children-url/markdown-navigator-demo-start-at-onclick-children-url.component';
 import { MarkdownNavigatorDemoMixedNavigationComponent } from './markdown-navigator-demo-mixed-navigation/markdown-navigator-demo-mixed-navigation.component';
+import { MarkdownNavigatorDemoMultilanguageComponent } from './markdown-navigator-demo-multilanguage/markdown-navigator-demo-multilanguage.component';
 
 @NgModule({
   declarations: [
@@ -46,6 +48,7 @@ import { MarkdownNavigatorDemoMixedNavigationComponent } from './markdown-naviga
     MarkdownNavigatorDemoChildrenUrlStartAtComponent,
     MarkdownNavigatorDemoStartAtOnclickChildrenUrlComponent,
     MarkdownNavigatorDemoMixedNavigationComponent,
+    MarkdownNavigatorDemoMultilanguageComponent,
   ],
   imports: [
     DemoModule,
@@ -58,6 +61,7 @@ import { MarkdownNavigatorDemoMixedNavigationComponent } from './markdown-naviga
     CommonModule,
     MatButtonModule,
     MatCardModule,
+    MatIconModule,
     MatListModule,
     MatButtonToggleModule,
     MatSlideToggleModule,

--- a/libs/markdown-navigator/src/markdown-navigator.component.html
+++ b/libs/markdown-navigator/src/markdown-navigator.component.html
@@ -11,7 +11,7 @@
         [matTooltip]="goHomeLabel ?? ''"
         (click)="reset()"
         [attr.data-test]="'home-button'"
-        >Home</a
+        >{{ goHomeLabel }}</a
       >
       <ng-container
         *ngFor="


### PR DESCRIPTION
## Description
<!-- Talk about the great work you've done! -->
Fix hardcoded `home` label in markdown navigator component

### What's included?
<!-- List features included in this PR -->

- Fix to use `labels` prop for support internazionalization
#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start`
- [ ] then navigate to markdown-navigator component
- [ ] select "Example" tab and scroll down to the last example

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm run stylelint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="968" height="566" alt="image" src="https://github.com/user-attachments/assets/d84b25bc-a99c-4c81-9616-ae3d31457848" />

