### PR TITLE
feat(icons): add product consumption icon to covalent icon list

### DIFF
--- a/libs/icons/icon-list.ts
+++ b/libs/icons/icon-list.ts
@@ -206,6 +206,8 @@ export const COV_ICON_LIST = [
   'product_appcenter_outlined',
   'product_console',
   'product_console_outlined',
+  'product_consumption',
+  'product_consumption_outlined',
   'product_cx',
   'product_cx_outlined',
   'product_editor',


### PR DESCRIPTION
## Description

Adds product-consumption icons to covalent icon list. This component already existed in the whole pipeline, so the changes don't follow the documented icon update process in `README.md`. the change just required the last step of adding it to the list of icons

### What's included?

- Added `product_consumption`, and  `product_consumption_outlined` icons to the Covalent icon list

#### Test Steps

- [ ] Run `npm run storybook`
- [ ] Navigate to **Components > Icon > Covalent Icon**
- [ ] Select the product_consumption icon and verify it renders correctly
- [ ] Confirm the icons render using their corresponding CSS classes

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm run stylelint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.
- [ ] 

##### Screenshots or link to StackBlitz/Plunker
<img width="2537" height="1022" alt="image" src="https://github.com/user-attachments/assets/92e305ff-8142-467d-acdb-43530d58fc31" />

